### PR TITLE
fix: Fix JALR and specification with x0. 

### DIFF
--- a/core/src/runtime/register.rs
+++ b/core/src/runtime/register.rs
@@ -1,7 +1,7 @@
 use core::fmt::{Display, Formatter};
 
 /// A register stores a 32-bit value used by operations.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Register {
     X0 = 0,
     X1 = 1,


### PR DESCRIPTION
This PR has two fixes:

1. `JALR rd, n(rs)` jumps to `n + {value stored in rs}` not `n`.
2. It turns out that you never write to `x0` although instructions that _ask_ you to write to `x0` are valid! For instance, `li	a0,0` is decoded to `addi x10, x0, 0` because `x0` is _supposed_ to be 0. This is also in the official specification as commented in the code.

