### PR TITLE
fix: use try_init() for env_logger

### DIFF
--- a/core/src/memory/mod.rs
+++ b/core/src/memory/mod.rs
@@ -131,6 +131,7 @@ where
 mod tests {
     use std::collections::BTreeMap;
 
+    use log::debug;
     use p3_challenger::DuplexChallenger;
     use p3_dft::Radix2DitParallel;
     use p3_field::{AbstractField, Field};
@@ -235,7 +236,9 @@ mod tests {
 
     #[test]
     fn test_memory_lookup_interactions() {
-        env_logger::init();
+        if env_logger::try_init().is_err() {
+            debug!("Logger already initialized")
+        }
         let program = fibonacci_program();
         let mut runtime = Runtime::new(program);
         runtime.run();

--- a/core/src/prover/runtime.rs
+++ b/core/src/prover/runtime.rs
@@ -227,6 +227,7 @@ pub mod tests {
     use crate::runtime::tests::simple_program;
     use crate::runtime::Program;
     use crate::runtime::Runtime;
+    use log::debug;
     use p3_baby_bear::BabyBear;
     use p3_challenger::DuplexChallenger;
     use p3_commit::ExtensionMmcs;
@@ -304,7 +305,9 @@ pub mod tests {
 
     #[test]
     fn test_fibonnaci_prove() {
-        env_logger::init();
+        if env_logger::try_init().is_err() {
+            debug!("Logger already initialized")
+        }
         let program = fibonacci_program();
         prove(program);
     }

--- a/core/src/runtime/mod.rs
+++ b/core/src/runtime/mod.rs
@@ -750,6 +750,8 @@ impl Runtime {
 #[cfg(test)]
 pub mod tests {
 
+    use log::debug;
+
     use crate::runtime::Register;
 
     use super::{Instruction, Opcode, Program, Runtime};
@@ -777,7 +779,9 @@ pub mod tests {
 
     #[test]
     fn test_fibonacci_run() {
-        env_logger::init();
+        if env_logger::try_init().is_err() {
+            debug!("Logger already initialized")
+        }
         let program = fibonacci_program();
         let mut runtime = Runtime::new(program);
         runtime.run();


### PR DESCRIPTION
Some of our test cases were using `env_logger::init()`.  If this is called multiple times within a test run, then all non first invocations will panic.

`env_logger::try_init()` will instead return an error instead of panic, and the test cases can handle the error more gracefully.