### PR TITLE
chore: Uncomment `debug_constraints` inside `prove`

### DIFF
--- a/core/src/prover/runtime.rs
+++ b/core/src/prover/runtime.rs
@@ -2,6 +2,7 @@ use crate::alu::divrem::DivRemChip;
 use crate::alu::mul::MulChip;
 use crate::bytes::ByteChip;
 use crate::memory::MemoryGlobalChip;
+use crate::prover::debug_constraints;
 
 use crate::alu::{AddChip, BitwiseChip, LeftShiftChip, LtChip, RightShiftChip, SubChip};
 use crate::cpu::CpuChip;
@@ -299,15 +300,15 @@ impl Prover {
             .into_iter()
             .unzip();
 
-        // // Check that the table-specific constraints are correct for each chip.
-        // for i in 0..chips.len() {
-        //     debug_constraints(
-        //         &*chips[i],
-        //         &traces[i],
-        //         &permutation_traces[i],
-        //         &permutation_challenges,
-        //     );
-        // }
+        // Check that the table-specific constraints are correct for each chip.
+        for i in 0..chips.len() {
+            debug_constraints(
+                &*chips[i],
+                &traces[i],
+                &permutation_traces[i],
+                &permutation_challenges,
+            );
+        }
 
         SegmentDebugProof {
             main_commit: main_data.main_commit.clone(),


### PR DESCRIPTION
It was commented out for performance reasons, but commenting this out makes untrue claims pass as we don't actually constrain them.

For instance, with `debug_constraints` commented out, if you include `assert_zero(one)` in the `eval` function of an ALU table & call `prove`, it still passes as we don't check the table specific constraints.