### PR TITLE
feat: Make proof types deserializable

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -36,7 +36,7 @@ use p3_commit::Pcs;
 use p3_matrix::dense::RowMajorMatrix;
 use runtime::{Program, Runtime};
 use serde::de::DeserializeOwned;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use stark::{OpeningProof, ProgramVerificationError, Proof, ShardMainData};
 use stark::{RiscvStark, StarkGenericConfig};
 use std::fs;
@@ -49,7 +49,7 @@ pub struct CurtaProver;
 pub struct CurtaVerifier;
 
 /// A proof of a RISCV ELF execution with given inputs and outputs.
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct CurtaProofWithIO<SC: StarkGenericConfig + Serialize> {
     #[serde(serialize_with = "serialize_proof")]
     pub proof: Proof<SC>,

--- a/core/src/stark/types.rs
+++ b/core/src/stark/types.rs
@@ -99,20 +99,20 @@ impl<SC: StarkGenericConfig> ShardMainDataWrapper<SC> {
     }
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ShardCommitment<C> {
     pub main_commit: C,
     pub permutation_commit: C,
     pub quotient_commit: C,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AirOpenedValues<T> {
     pub local: Vec<T>,
     pub next: Vec<T>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChipOpenedValues<T: Serialize> {
     pub preprocessed: AirOpenedValues<T>,
     pub main: AirOpenedValues<T>,
@@ -122,13 +122,13 @@ pub struct ChipOpenedValues<T: Serialize> {
     pub log_degree: usize,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ShardOpenedValues<T: Serialize> {
     pub chips: Vec<ChipOpenedValues<T>>,
 }
 
 #[cfg(feature = "perf")]
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct ShardProof<SC: StarkGenericConfig> {
     pub index: usize,
     pub commitment: ShardCommitment<Com<SC>>,
@@ -188,7 +188,7 @@ impl<SC: StarkGenericConfig> ShardProof<SC> {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct Proof<SC: StarkGenericConfig> {
     pub shard_proofs: Vec<ShardProof<SC>>,
 }


### PR DESCRIPTION
This proof adds `serde::Deserialize` derives to the following types: 
- `CurtaProofWithIO`
- `ShardCommitment`
- `AirOpenedValues`
- `ChipOpenedValues`
- `ShardOpenedValues`
- `ShardProof`
- `Proof`