### PR TITLE
fix: sha compress

### DIFF
--- a/core/src/syscall/precompiles/sha256/compress/mod.rs
+++ b/core/src/syscall/precompiles/sha256/compress/mod.rs
@@ -41,9 +41,10 @@ impl ShaCompressChip {
 pub mod compress_tests {
 
     use crate::{
+        lookup::{debug_interactions_with_all_chips, InteractionKind},
         runtime::{Instruction, Opcode, Program, Runtime},
         stark::{LocalProver, RiscvStark},
-        utils::{BabyBearPoseidon2, StarkUtils},
+        utils::{setup_logger, BabyBearPoseidon2, StarkUtils},
     };
 
     pub fn sha_compress_program() -> Program {
@@ -65,6 +66,7 @@ pub mod compress_tests {
 
     #[test]
     fn prove_babybear() {
+        setup_logger();
         let config = BabyBearPoseidon2::new();
         let mut challenger = config.challenger();
 
@@ -73,6 +75,12 @@ pub mod compress_tests {
         runtime.run();
 
         let machine = RiscvStark::new(config);
+
+        debug_interactions_with_all_chips(
+            &machine.chips(),
+            &runtime.record,
+            InteractionKind::all_kinds(),
+        );
 
         let (pk, _) = machine.setup(runtime.program.as_ref());
         machine.prove::<LocalProver<_>>(&pk, &mut runtime.record, &mut challenger);

--- a/core/src/syscall/precompiles/sha256/compress/mod.rs
+++ b/core/src/syscall/precompiles/sha256/compress/mod.rs
@@ -44,7 +44,7 @@ pub mod compress_tests {
         lookup::{debug_interactions_with_all_chips, InteractionKind},
         runtime::{Instruction, Opcode, Program, Runtime},
         stark::{LocalProver, RiscvStark},
-        utils::{setup_logger, BabyBearPoseidon2, StarkUtils},
+        utils::{run_test, setup_logger, BabyBearPoseidon2, StarkUtils},
     };
 
     pub fn sha_compress_program() -> Program {
@@ -71,6 +71,7 @@ pub mod compress_tests {
         let mut challenger = config.challenger();
 
         let program = sha_compress_program();
+        run_test(program.clone()).unwrap();
         let mut runtime = Runtime::new(program);
         runtime.run();
 

--- a/core/src/syscall/precompiles/sha256/compress/mod.rs
+++ b/core/src/syscall/precompiles/sha256/compress/mod.rs
@@ -41,10 +41,8 @@ impl ShaCompressChip {
 pub mod compress_tests {
 
     use crate::{
-        lookup::{debug_interactions_with_all_chips, InteractionKind},
-        runtime::{Instruction, Opcode, Program, Runtime},
-        stark::{LocalProver, RiscvStark},
-        utils::{run_test, setup_logger, BabyBearPoseidon2, StarkUtils},
+        runtime::{Instruction, Opcode, Program},
+        utils::{run_test, setup_logger},
     };
 
     pub fn sha_compress_program() -> Program {
@@ -67,23 +65,7 @@ pub mod compress_tests {
     #[test]
     fn prove_babybear() {
         setup_logger();
-        let config = BabyBearPoseidon2::new();
-        let mut challenger = config.challenger();
-
         let program = sha_compress_program();
-        run_test(program.clone()).unwrap();
-        let mut runtime = Runtime::new(program);
-        runtime.run();
-
-        let machine = RiscvStark::new(config);
-
-        debug_interactions_with_all_chips(
-            &machine.chips(),
-            &runtime.record,
-            InteractionKind::all_kinds(),
-        );
-
-        let (pk, _) = machine.setup(runtime.program.as_ref());
-        machine.prove::<LocalProver<_>>(&pk, &mut runtime.record, &mut challenger);
+        run_test(program).unwrap();
     }
 }

--- a/core/src/syscall/precompiles/sha256/compress/trace.rs
+++ b/core/src/syscall/precompiles/sha256/compress/trace.rs
@@ -139,6 +139,13 @@ impl<F: PrimeField> MachineAir<F> for ShaCompressChip {
                 // index, which is definitely feasible but we haven't gotten to yet. If we call
                 // Add5Operation::populate, it creates interactions, and without the matching eval
                 // call, it will cause a panic. We plan to fix this really soon.
+                //
+                // This is how we should call populate here.
+                //
+                // let temp1 = cols
+                // .temp1
+                // .populate(output, h, s1, ch, event.w[j], SHA_COMPRESS_K[j]);
+                //
                 let temp1 = h
                     .wrapping_add(s1)
                     .wrapping_add(ch)

--- a/core/src/syscall/precompiles/sha256/compress/trace.rs
+++ b/core/src/syscall/precompiles/sha256/compress/trace.rs
@@ -134,9 +134,17 @@ impl<F: PrimeField> MachineAir<F> for ShaCompressChip {
                 let e_not_and_g = cols.e_not_and_g.populate(output, e_not, g);
                 let ch = cols.ch.populate(output, e_and_f, e_not_and_g);
 
-                let temp1 = cols
-                    .temp1
-                    .populate(output, h, s1, ch, event.w[j], SHA_COMPRESS_K[j]);
+                // TODO: This is a hack to avoid calling Add5Operation::populate. We currently don't
+                // call Add5Operation::eval due to the complexity of getting the inputs at the right
+                // index, which is definitely feasible but we haven't gotten to yet. If we call
+                // Add5Operation::populate, it creates interactions, and without the matching eval
+                // call, it will cause a panic. We plan to fix this really soon.
+                let temp1 = h
+                    .wrapping_add(s1)
+                    .wrapping_add(ch)
+                    .wrapping_add(event.w[j])
+                    .wrapping_add(SHA_COMPRESS_K[j]);
+                cols.temp1.value = Word::from(temp1);
 
                 let a_rr_2 = cols.a_rr_2.populate(output, a, 2);
                 let a_rr_13 = cols.a_rr_13.populate(output, a, 13);

--- a/sha_compress_test.sh
+++ b/sha_compress_test.sh
@@ -1,1 +1,1 @@
-cargo test --package sp1-core --release --lib -- syscall::precompiles::sha256::compress::compress_tests::prove_babybear --exact --nocapture
+RUST_LOG=debug cargo test --package sp1-core --release --lib -- syscall::precompiles::sha256::compress::compress_tests::prove_babybear --exact --nocapture

--- a/sha_compress_test.sh
+++ b/sha_compress_test.sh
@@ -1,1 +1,0 @@
-RUST_LOG=debug cargo test --package sp1-core --release --lib -- syscall::precompiles::sha256::compress::compress_tests::prove_babybear --exact --nocapture

--- a/sha_compress_test.sh
+++ b/sha_compress_test.sh
@@ -1,0 +1,1 @@
+cargo test --package sp1-core --release --lib -- syscall::precompiles::sha256::compress::compress_tests::prove_babybear --exact --nocapture


### PR DESCRIPTION
https://github.com/succinctlabs/sp1/pull/216 introduces a range check for `Add5Operation`.

Sha compress doesn't call `eval` though it calls `populate`. This causes an interaction bug. 

It is a TODO item that we need to call `eval`, and we're trying to get it to asap. this is a temporary fix.