### PR TITLE
fix: wrong workspace building error

### DIFF
--- a/book/getting-started/install.md
+++ b/book/getting-started/install.md
@@ -43,6 +43,7 @@ git clone git@github.com:succinctlabs/sp1.git
 cd sp1
 cd cli
 cargo install --locked --path .
+cd ~
 cargo prove build-toolchain
 ```
 


### PR DESCRIPTION
Fix issue https://github.com/succinctlabs/sp1/issues/256, with @puma314 and @ctian1 's help.


> Uma: the reason it's complaining is that it's trying to clone the Rust monorepo inside of sp1 and then it gets mad that the sp1 Cargo.toml doesn't have the rust subdirectory as a workspace.
So just do it in a fully clean folder that isn't a rust workspace (like your home directory or documents directory)