### PR TITLE
docs: correct the OpenSSL version requirement

### DIFF
--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -29,3 +29,7 @@
 - [Basics](./generating-proofs/basics.md)
 
 - [Advanced](./generating-proofs/advanced.md)
+
+# FAQ
+
+- [Installing OpenSSL](./faq/installing-openssl.md)

--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -6,6 +6,8 @@
 
 - [Install](./getting-started/install.md)
 
+- [Install OpenSSL](./getting-started/openssl.md)
+
 - [Quickstart](./getting-started/quickstart.md)
 
 # Writing Programs

--- a/book/faq/installing-openssl.md
+++ b/book/faq/installing-openssl.md
@@ -1,0 +1,40 @@
+# Installing OpenSSL
+
+Currently, SP1 requires OpenSSL 1.1 and OpenSSL 3 as a dependencies. Your existing Linux/MacOs installation
+should already be shipped with either OpenSSL 1.1 or OpenSSL3. 
+
+## MacOS:
+
+OpenSSL 1.1:
+
+`brew install openssl@1.1`
+
+OpenSSL 3:
+
+`brew install openssl@3`
+
+## Linux
+
+Debian 12 / Ubuntu 22.04 or higher are shipped with OpenSSL 3.
+
+OpenSSL 1.1:
+
+```
+sudo apt update
+sudo apt install libssl-dev libz-dev build-essential
+```
+
+```
+wget https://ftp.openssl.org/source/old/1.1.1/openssl-1.1.1w.tar.gz
+tar -xzvf openssl-1.1.1w.tar.gz
+cd openssl-1.1.1w
+./config --prefix=/usr/local/ssl1.1 --openssldir=/usr/local/ssl1.1 --libdir=lib zlib-dynamic
+make
+make test
+sudo make install
+sudo ln -s /usr/local/ssl1.1/lib/libssl.so.1.1 /usr/local/lib/libssl.so.1.1
+sudo ln -s /usr/local/ssl1.1/lib/libcrypto.so.1.1 /usr/local/lib/libcrypto.so.1.1
+sudo ldconfig
+```
+
+These commands are borrowed from this [StackOverflow post](https://askubuntu.com/questions/1102803/how-to-upgrade-openssl-1-1-0-to-1-1-1-in-ubuntu-18-04).

--- a/book/getting-started/install.md
+++ b/book/getting-started/install.md
@@ -3,8 +3,7 @@
 SP1 currently runs on Linux and macOS. You can either use prebuilt binaries through sp1up or
 build the toolchain and CLI from source.
 
-Make sure you have [Rust](https://www.rust-lang.org/tools/install), OpenSSL 1.1 **and** OpenSSL 3 installed. 
-Go to [this section](./openssl.md) for more details on getting two OpenSSL versions.
+To install SP1, you will need [Rust](https://www.rust-lang.org/tools/install), [OpenSSL 1.1](../faq/installing-openssl.md), and [OpenSSL 3](../faq/installing-openssl.md).
 
 ## Option 1: Prebuilt Binaries (Recommended)
 

--- a/book/getting-started/install.md
+++ b/book/getting-started/install.md
@@ -3,7 +3,8 @@
 SP1 currently runs on Linux and macOS. You can either use prebuilt binaries through sp1up or
 build the toolchain and CLI from source.
 
-Make sure you have [Rust](https://www.rust-lang.org/tools/install) and OpenSSL 1.1 (`brew install openssl@1.1` or use this [guide](https://askubuntu.com/questions/1102803/how-to-upgrade-openssl-1-1-0-to-1-1-1-in-ubuntu-18-04)) installed.
+Make sure you have [Rust](https://www.rust-lang.org/tools/install), OpenSSL 1.1 **and** OpenSSL 3 installed. 
+Go to [this section](./openssl.md) for more details on getting two OpenSSL versions.
 
 ## Option 1: Prebuilt Binaries (Recommended)
 

--- a/book/getting-started/openssl.md
+++ b/book/getting-started/openssl.md
@@ -1,0 +1,41 @@
+# OpenSSL libraries installation
+
+Unfortunately, sp1 requires library files from both OpenSSL 1.1 and OpenSSL 3 for now.
+
+Your Linux distributions / macOS installation should be shipped with either OpenSSL 1.1 or OpenSSL 3.
+In order to minimize the pain, use a distribution that is shipped with OpenSSL 3 
+and manually compile the OpenSSL 1.1.1 library.
+
+Warning: a lot of system packages rely on the OpenSSL library with version that is originally shipped with.
+Our goal is just to obtain the missing library files (`libssl.so.1.1` and `libcrypto.so.1.1`)
+instead of replacing OpenSSL on your system. 
+So, do not install OpenSSL via your package manager,
+since your distribution **will not** officially provide two versions of OpenSSL.
+Also, do not manually install the OpenSSL package (e.g., `*.deb`, `*.rpm`) obtained from a different release of your distribution 
+unless you want to break the whole package management.
+
+## macOS
+`brew install openssl@1.1.1`
+
+## Debian / Ubuntu: 
+Debian 12 / Ubuntu 22.04 or higher are shipped with OpenSSL 3. Package `libssl3` should be already installed by default.
+
+First, install additional develop packages.
+```bash
+sudo apt update
+sudo apt install libssl-dev libz-dev build-essential
+```
+
+Then, compile and install OpenSSL 1.1.1 library.
+```bash
+wget https://ftp.openssl.org/source/old/1.1.1/openssl-1.1.1w.tar.gz
+tar -xzvf openssl-1.1.1w.tar.gz
+cd openssl-1.1.1w
+./config --prefix=/usr/local/ssl1.1 --openssldir=/usr/local/ssl1.1 --libdir=lib zlib-dynamic
+make
+make test
+sudo make install
+sudo ln -s /usr/local/ssl1.1/lib/libssl.so.1.1 /usr/local/lib/libssl.so.1.1
+sudo ln -s /usr/local/ssl1.1/lib/libcrypto.so.1.1 /usr/local/lib/libcrypto.so.1.1
+sudo ldconfig
+```


### PR DESCRIPTION
It appears that both OpenSSL 1.1 and OpenSSL 3 are required. `sp1up` requires OpenSSL 3 (`libssl.so.3`) while `cargo prove build` requires OpenSSL 1.1 (`libssl.so.1.1`)

This PR enhances the documentation about OpenSSL dependency.

See issue #263 for more details.
