### PR TITLE
fix(zkvm): libm math intrinsics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1146,6 +1146,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
 name = "libredox"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2363,6 +2369,7 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "k256",
+ "libm",
  "rand",
  "serde",
  "sp1-precompiles",

--- a/examples/chess/program/Cargo.lock
+++ b/examples/chess/program/Cargo.lock
@@ -322,6 +322,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
 name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,6 +572,7 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "k256",
+ "libm",
  "rand 0.8.5",
  "serde",
  "sp1-precompiles",

--- a/examples/ed25519/program/Cargo.lock
+++ b/examples/ed25519/program/Cargo.lock
@@ -299,6 +299,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,6 +488,7 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "k256",
+ "libm",
  "rand",
  "serde",
  "sp1-precompiles",

--- a/examples/fibonacci-io/program/Cargo.lock
+++ b/examples/fibonacci-io/program/Cargo.lock
@@ -236,6 +236,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,6 +404,7 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "k256",
+ "libm",
  "rand",
  "serde",
  "sp1-precompiles",

--- a/examples/fibonacci/program/Cargo.lock
+++ b/examples/fibonacci/program/Cargo.lock
@@ -236,6 +236,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,6 +404,7 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "k256",
+ "libm",
  "rand",
  "serde",
  "sp1-precompiles",

--- a/examples/json/program/Cargo.lock
+++ b/examples/json/program/Cargo.lock
@@ -243,6 +243,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,6 +428,7 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "k256",
+ "libm",
  "rand",
  "serde",
  "sp1-precompiles",

--- a/examples/regex/program/Cargo.lock
+++ b/examples/regex/program/Cargo.lock
@@ -238,6 +238,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
 name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -443,6 +449,7 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "k256",
+ "libm",
  "rand",
  "serde",
  "sp1-precompiles",

--- a/examples/rsa/program/Cargo.lock
+++ b/examples/rsa/program/Cargo.lock
@@ -596,6 +596,7 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "k256",
+ "libm",
  "rand",
  "serde",
  "sp1-precompiles",

--- a/examples/ssz-withdrawals/program/Cargo.lock
+++ b/examples/ssz-withdrawals/program/Cargo.lock
@@ -1337,6 +1337,7 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "k256",
+ "libm",
  "rand",
  "serde",
  "sp1-precompiles",

--- a/examples/tendermint/program/Cargo.lock
+++ b/examples/tendermint/program/Cargo.lock
@@ -419,6 +419,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
 name = "num-derive"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,6 +717,7 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "k256",
+ "libm",
  "rand",
  "serde",
  "sp1-precompiles",

--- a/tests/blake3-compress/Cargo.lock
+++ b/tests/blake3-compress/Cargo.lock
@@ -236,6 +236,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,6 +404,7 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "k256",
+ "libm",
  "rand",
  "serde",
  "sp1-precompiles",

--- a/tests/cycle-tracker/Cargo.lock
+++ b/tests/cycle-tracker/Cargo.lock
@@ -237,6 +237,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,6 +414,7 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "k256",
+ "libm",
  "rand",
  "serde",
  "sp1-precompiles",

--- a/tests/ecrecover/Cargo.lock
+++ b/tests/ecrecover/Cargo.lock
@@ -251,6 +251,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
 name = "num"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -476,6 +482,7 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "k256",
+ "libm",
  "rand",
  "serde",
  "sp1-precompiles",

--- a/tests/ed-add/Cargo.lock
+++ b/tests/ed-add/Cargo.lock
@@ -250,6 +250,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
 name = "num"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,6 +481,7 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "k256",
+ "libm",
  "rand",
  "serde",
  "sp1-precompiles",

--- a/tests/ed-decompress/Cargo.lock
+++ b/tests/ed-decompress/Cargo.lock
@@ -243,6 +243,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -405,6 +411,7 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "k256",
+ "libm",
  "rand",
  "serde",
  "sp1-precompiles",

--- a/tests/keccak-permute/Cargo.lock
+++ b/tests/keccak-permute/Cargo.lock
@@ -236,6 +236,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,6 +404,7 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "k256",
+ "libm",
  "rand",
  "serde",
  "sp1-precompiles",

--- a/tests/keccak256/Cargo.lock
+++ b/tests/keccak256/Cargo.lock
@@ -243,6 +243,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -405,6 +411,7 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "k256",
+ "libm",
  "rand",
  "serde",
  "sp1-precompiles",

--- a/tests/secp256k1-add/Cargo.lock
+++ b/tests/secp256k1-add/Cargo.lock
@@ -241,6 +241,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
 name = "num"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,6 +481,7 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "k256",
+ "libm",
  "rand",
  "serde",
  "sp1-precompiles",

--- a/tests/secp256k1-decompress/Cargo.lock
+++ b/tests/secp256k1-decompress/Cargo.lock
@@ -229,6 +229,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,6 +404,7 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "k256",
+ "libm",
  "rand",
  "serde",
  "sp1-precompiles",

--- a/tests/secp256k1-double/Cargo.lock
+++ b/tests/secp256k1-double/Cargo.lock
@@ -241,6 +241,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
 name = "num"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,6 +481,7 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "k256",
+ "libm",
  "rand",
  "serde",
  "sp1-precompiles",

--- a/tests/sha-compress/Cargo.lock
+++ b/tests/sha-compress/Cargo.lock
@@ -229,6 +229,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,6 +404,7 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "k256",
+ "libm",
  "rand",
  "serde",
  "sp1-precompiles",

--- a/tests/sha-extend/Cargo.lock
+++ b/tests/sha-extend/Cargo.lock
@@ -229,6 +229,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,6 +404,7 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "k256",
+ "libm",
  "rand",
  "serde",
  "sp1-precompiles",

--- a/tests/sha2/Cargo.lock
+++ b/tests/sha2/Cargo.lock
@@ -241,6 +241,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,6 +429,7 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "k256",
+ "libm",
  "rand",
  "serde",
  "sp1-precompiles",

--- a/zkvm/entrypoint/Cargo.toml
+++ b/zkvm/entrypoint/Cargo.toml
@@ -12,3 +12,8 @@ getrandom = { version = "0.2.12", features = ["custom"] }
 k256 = { version = "0.13.3", features = ["ecdsa", "std", "bits"] }
 rand = "0.8.5"
 serde = { version = "1.0.196", features = ["derive"] }
+libm = { version = "0.2.8", optional = true }
+
+[features]
+default = ["libm"]
+libm = ["dep:libm"]

--- a/zkvm/entrypoint/src/lib.rs
+++ b/zkvm/entrypoint/src/lib.rs
@@ -29,6 +29,9 @@ macro_rules! entrypoint {
     };
 }
 
+#[cfg(all(target_os = "zkvm", feature = "libm"))]
+mod libm;
+
 #[cfg(target_os = "zkvm")]
 mod zkvm {
     use crate::syscalls::syscall_halt;

--- a/zkvm/entrypoint/src/libm.rs
+++ b/zkvm/entrypoint/src/libm.rs
@@ -1,0 +1,559 @@
+#[no_mangle]
+pub extern "C" fn acos(x: f64) -> f64 {
+    libm::acos(x)
+}
+
+#[no_mangle]
+pub extern "C" fn acosf(x: f32) -> f32 {
+    libm::acosf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn acosh(x: f64) -> f64 {
+    libm::acosh(x)
+}
+
+#[no_mangle]
+pub extern "C" fn acoshf(x: f32) -> f32 {
+    libm::acoshf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn asin(x: f64) -> f64 {
+    libm::asin(x)
+}
+
+#[no_mangle]
+pub extern "C" fn asinf(x: f32) -> f32 {
+    libm::asinf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn asinh(x: f64) -> f64 {
+    libm::asinh(x)
+}
+
+#[no_mangle]
+pub extern "C" fn asinhf(x: f32) -> f32 {
+    libm::asinhf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn atan(x: f64) -> f64 {
+    libm::atan(x)
+}
+
+#[no_mangle]
+pub extern "C" fn atan2(y: f64, x: f64) -> f64 {
+    libm::atan2(y, x)
+}
+
+#[no_mangle]
+pub extern "C" fn atan2f(y: f32, x: f32) -> f32 {
+    libm::atan2f(y, x)
+}
+
+#[no_mangle]
+pub extern "C" fn atanf(x: f32) -> f32 {
+    libm::atanf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn atanh(x: f64) -> f64 {
+    libm::atanh(x)
+}
+
+#[no_mangle]
+pub extern "C" fn atanhf(x: f32) -> f32 {
+    libm::atanhf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn cbrt(x: f64) -> f64 {
+    libm::cbrt(x)
+}
+
+#[no_mangle]
+pub extern "C" fn cbrtf(x: f32) -> f32 {
+    libm::cbrtf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn ceil(x: f64) -> f64 {
+    libm::ceil(x)
+}
+
+#[no_mangle]
+pub extern "C" fn ceilf(x: f32) -> f32 {
+    libm::ceilf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn copysign(x: f64, y: f64) -> f64 {
+    libm::copysign(x, y)
+}
+
+#[no_mangle]
+pub extern "C" fn copysignf(x: f32, y: f32) -> f32 {
+    libm::copysignf(x, y)
+}
+
+#[no_mangle]
+pub extern "C" fn cos(x: f64) -> f64 {
+    libm::cos(x)
+}
+
+#[no_mangle]
+pub extern "C" fn cosf(x: f32) -> f32 {
+    libm::cosf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn cosh(x: f64) -> f64 {
+    libm::cosh(x)
+}
+
+#[no_mangle]
+pub extern "C" fn coshf(x: f32) -> f32 {
+    libm::coshf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn erf(x: f64) -> f64 {
+    libm::erf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn erfc(x: f64) -> f64 {
+    libm::erfc(x)
+}
+
+#[no_mangle]
+pub extern "C" fn erfcf(x: f32) -> f32 {
+    libm::erfcf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn erff(x: f32) -> f32 {
+    libm::erff(x)
+}
+
+#[no_mangle]
+pub extern "C" fn exp(x: f64) -> f64 {
+    libm::exp(x)
+}
+
+#[no_mangle]
+pub extern "C" fn exp2(x: f64) -> f64 {
+    libm::exp2(x)
+}
+
+#[no_mangle]
+pub extern "C" fn exp2f(x: f32) -> f32 {
+    libm::exp2f(x)
+}
+
+#[no_mangle]
+pub extern "C" fn exp10(x: f64) -> f64 {
+    libm::exp10(x)
+}
+
+#[no_mangle]
+pub extern "C" fn exp10f(x: f32) -> f32 {
+    libm::exp10f(x)
+}
+
+#[no_mangle]
+pub extern "C" fn expf(x: f32) -> f32 {
+    libm::expf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn expm1(x: f64) -> f64 {
+    libm::expm1(x)
+}
+
+#[no_mangle]
+pub extern "C" fn expm1f(x: f32) -> f32 {
+    libm::expm1f(x)
+}
+
+#[no_mangle]
+pub extern "C" fn fabs(x: f64) -> f64 {
+    libm::fabs(x)
+}
+
+#[no_mangle]
+pub extern "C" fn fabsf(x: f32) -> f32 {
+    libm::fabsf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn fdim(x: f64, y: f64) -> f64 {
+    libm::fdim(x, y)
+}
+
+#[no_mangle]
+pub extern "C" fn fdimf(x: f32, y: f32) -> f32 {
+    libm::fdimf(x, y)
+}
+
+#[no_mangle]
+pub extern "C" fn floor(x: f64) -> f64 {
+    libm::floor(x)
+}
+
+#[no_mangle]
+pub extern "C" fn floorf(x: f32) -> f32 {
+    libm::floorf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn fma(x: f64, y: f64, z: f64) -> f64 {
+    libm::fma(x, y, z)
+}
+
+#[no_mangle]
+pub extern "C" fn fmaf(x: f32, y: f32, z: f32) -> f32 {
+    libm::fmaf(x, y, z)
+}
+
+#[no_mangle]
+pub extern "C" fn fmax(x: f64, y: f64) -> f64 {
+    libm::fmax(x, y)
+}
+
+#[no_mangle]
+pub extern "C" fn fmaxf(x: f32, y: f32) -> f32 {
+    libm::fmaxf(x, y)
+}
+
+#[no_mangle]
+pub extern "C" fn fmin(x: f64, y: f64) -> f64 {
+    libm::fmin(x, y)
+}
+
+#[no_mangle]
+pub extern "C" fn fminf(x: f32, y: f32) -> f32 {
+    libm::fminf(x, y)
+}
+
+#[no_mangle]
+pub extern "C" fn fmod(x: f64, y: f64) -> f64 {
+    libm::fmod(x, y)
+}
+
+#[no_mangle]
+pub extern "C" fn fmodf(x: f32, y: f32) -> f32 {
+    libm::fmodf(x, y)
+}
+
+#[no_mangle]
+pub fn frexp(x: f64) -> (f64, i32) {
+    libm::frexp(x)
+}
+
+#[no_mangle]
+pub fn frexpf(x: f32) -> (f32, i32) {
+    libm::frexpf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn hypot(x: f64, y: f64) -> f64 {
+    libm::hypot(x, y)
+}
+
+#[no_mangle]
+pub extern "C" fn hypotf(x: f32, y: f32) -> f32 {
+    libm::hypotf(x, y)
+}
+
+#[no_mangle]
+pub extern "C" fn ilogb(x: f64) -> i32 {
+    libm::ilogb(x)
+}
+
+#[no_mangle]
+pub extern "C" fn ilogbf(x: f32) -> i32 {
+    libm::ilogbf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn j0(x: f64) -> f64 {
+    libm::j0(x)
+}
+
+#[no_mangle]
+pub extern "C" fn j0f(x: f32) -> f32 {
+    libm::j0f(x)
+}
+
+#[no_mangle]
+pub extern "C" fn j1(x: f64) -> f64 {
+    libm::j1(x)
+}
+
+#[no_mangle]
+pub extern "C" fn j1f(x: f32) -> f32 {
+    libm::j1f(x)
+}
+
+#[no_mangle]
+pub extern "C" fn jn(n: i32, x: f64) -> f64 {
+    libm::jn(n, x)
+}
+
+#[no_mangle]
+pub extern "C" fn jnf(n: i32, x: f32) -> f32 {
+    libm::jnf(n, x)
+}
+
+#[no_mangle]
+pub extern "C" fn ldexp(x: f64, n: i32) -> f64 {
+    libm::ldexp(x, n)
+}
+
+#[no_mangle]
+pub extern "C" fn ldexpf(x: f32, n: i32) -> f32 {
+    libm::ldexpf(x, n)
+}
+
+#[no_mangle]
+pub extern "C" fn lgamma(x: f64) -> f64 {
+    libm::lgamma(x)
+}
+
+#[no_mangle]
+pub fn lgamma_r(x: f64) -> (f64, i32) {
+    libm::lgamma_r(x)
+}
+
+#[no_mangle]
+pub fn lgammaf(x: f32) -> f32 {
+    libm::lgammaf(x)
+}
+
+#[no_mangle]
+pub fn lgammaf_r(x: f32) -> (f32, i32) {
+    libm::lgammaf_r(x)
+}
+
+#[no_mangle]
+pub extern "C" fn log(x: f64) -> f64 {
+    libm::log(x)
+}
+
+#[no_mangle]
+pub extern "C" fn log1p(x: f64) -> f64 {
+    libm::log1p(x)
+}
+
+#[no_mangle]
+pub extern "C" fn log1pf(x: f32) -> f32 {
+    libm::log1pf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn log2(x: f64) -> f64 {
+    libm::log2(x)
+}
+
+#[no_mangle]
+pub extern "C" fn log2f(x: f32) -> f32 {
+    libm::log2f(x)
+}
+
+#[no_mangle]
+pub extern "C" fn log10(x: f64) -> f64 {
+    libm::log10(x)
+}
+
+#[no_mangle]
+pub extern "C" fn log10f(x: f32) -> f32 {
+    libm::log10f(x)
+}
+
+#[no_mangle]
+pub extern "C" fn logf(x: f32) -> f32 {
+    libm::logf(x)
+}
+
+#[no_mangle]
+pub fn modf(x: f64) -> (f64, f64) {
+    libm::modf(x)
+}
+
+#[no_mangle]
+pub fn modff(x: f32) -> (f32, f32) {
+    libm::modff(x)
+}
+
+#[no_mangle]
+pub extern "C" fn nextafter(x: f64, y: f64) -> f64 {
+    libm::nextafter(x, y)
+}
+
+#[no_mangle]
+pub extern "C" fn nextafterf(x: f32, y: f32) -> f32 {
+    libm::nextafterf(x, y)
+}
+
+#[no_mangle]
+pub extern "C" fn pow(x: f64, y: f64) -> f64 {
+    libm::pow(x, y)
+}
+
+#[no_mangle]
+pub extern "C" fn powf(x: f32, y: f32) -> f32 {
+    libm::powf(x, y)
+}
+
+#[no_mangle]
+pub extern "C" fn remainder(x: f64, y: f64) -> f64 {
+    libm::remainder(x, y)
+}
+
+#[no_mangle]
+pub extern "C" fn remainderf(x: f32, y: f32) -> f32 {
+    libm::remainderf(x, y)
+}
+
+#[no_mangle]
+pub fn remquo(x: f64, y: f64) -> (f64, i32) {
+    libm::remquo(x, y)
+}
+
+#[no_mangle]
+pub fn remquof(x: f32, y: f32) -> (f32, i32) {
+    libm::remquof(x, y)
+}
+
+#[no_mangle]
+pub extern "C" fn round(x: f64) -> f64 {
+    libm::round(x)
+}
+
+#[no_mangle]
+pub extern "C" fn roundf(x: f32) -> f32 {
+    libm::roundf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn scalbn(x: f64, n: i32) -> f64 {
+    libm::scalbn(x, n)
+}
+
+#[no_mangle]
+pub extern "C" fn scalbnf(x: f32, n: i32) -> f32 {
+    libm::scalbnf(x, n)
+}
+
+#[no_mangle]
+pub extern "C" fn sin(x: f64) -> f64 {
+    libm::sin(x)
+}
+
+#[no_mangle]
+pub fn sincos(x: f64) -> (f64, f64) {
+    libm::sincos(x)
+}
+
+#[no_mangle]
+pub fn sincosf(x: f32) -> (f32, f32) {
+    libm::sincosf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn sinf(x: f32) -> f32 {
+    libm::sinf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn sinh(x: f64) -> f64 {
+    libm::sinh(x)
+}
+
+#[no_mangle]
+pub extern "C" fn sinhf(x: f32) -> f32 {
+    libm::sinhf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn sqrt(x: f64) -> f64 {
+    libm::sqrt(x)
+}
+
+#[no_mangle]
+pub extern "C" fn sqrtf(x: f32) -> f32 {
+    libm::sqrtf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn tan(x: f64) -> f64 {
+    libm::tan(x)
+}
+
+#[no_mangle]
+pub extern "C" fn tanf(x: f32) -> f32 {
+    libm::tanf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn tanh(x: f64) -> f64 {
+    libm::tanh(x)
+}
+
+#[no_mangle]
+pub extern "C" fn tanhf(x: f32) -> f32 {
+    libm::tanhf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn tgamma(x: f64) -> f64 {
+    libm::tgamma(x)
+}
+
+#[no_mangle]
+pub extern "C" fn tgammaf(x: f32) -> f32 {
+    libm::tgammaf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn trunc(x: f64) -> f64 {
+    libm::trunc(x)
+}
+
+#[no_mangle]
+pub extern "C" fn truncf(x: f32) -> f32 {
+    libm::truncf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn y0(x: f64) -> f64 {
+    libm::y0(x)
+}
+
+#[no_mangle]
+pub extern "C" fn y0f(x: f32) -> f32 {
+    libm::y0f(x)
+}
+
+#[no_mangle]
+pub extern "C" fn y1(x: f64) -> f64 {
+    libm::y1(x)
+}
+
+#[no_mangle]
+pub extern "C" fn y1f(x: f32) -> f32 {
+    libm::y1f(x)
+}
+
+#[no_mangle]
+pub extern "C" fn yn(n: i32, x: f64) -> f64 {
+    libm::yn(n, x)
+}
+
+#[no_mangle]
+pub extern "C" fn ynf(n: i32, x: f32) -> f32 {
+    libm::ynf(n, x)
+}


### PR DESCRIPTION
fixes "rust-lld" errors when using packages like statrs or bigint by adding math instrinsics from rust-lang/libm

in the future it might be possible to fix this in rust / compiler-builtins like for wasm: https://github.com/rust-lang/compiler-builtins/pull/248