### PR TITLE
perf: ltu trace gen optimization

### DIFF
--- a/core/src/alu/lt/mod.rs
+++ b/core/src/alu/lt/mod.rs
@@ -331,9 +331,9 @@ mod tests {
     #[test]
     fn generate_trace() {
         let mut shard = ExecutionRecord::default();
-        // Fill lt_events with 10^7 SLT events.
+        // Fill lt_events with 10^6 SLT events.
         let mut lt_events: Vec<AluEvent> = Vec::new();
-        for _ in 0..10i32.pow(7) {
+        for _ in 0..10i32.pow(6) {
             lt_events.push(AluEvent::new(0, Opcode::SLT, 0, 3, 2));
         }
         shard.lt_events = lt_events;


### PR DESCRIPTION
This isn't faster than the previous implementation, which just used `par_iter` directly.