### PR TITLE
fix: S-box in Poseidon2 config

### DIFF
--- a/core/src/utils/prove.rs
+++ b/core/src/utils/prove.rs
@@ -183,7 +183,7 @@ pub(super) mod baby_bear_poseidon2 {
 
     pub type Challenge = BinomialExtensionField<Val, 4>;
 
-    pub type Perm = Poseidon2<Val, DiffusionMatrixBabybear, 16, 5>;
+    pub type Perm = Poseidon2<Val, DiffusionMatrixBabybear, 16, 7>;
     pub type MyHash = PaddingFreeSponge<Perm, 16, 8, 8>;
 
     pub type MyCompress = TruncatedPermutation<Perm, 2, 8, 16>;


### PR DESCRIPTION
x^5 works with Mersenne31, but x^7 is the smallest permutation monomial over BabyBear. I think this mistake originates in some Plonky3 example code which had the same issue.