### PR TITLE
refactor: Adapt Challenger type in crypto modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1505,7 +1505,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p3-air"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/plonky3.git#731ff62c311ebef7bb4bac1afd36934524f86d4f"
+source = "git+https://github.com/succinctlabs/plonky3.git#447c01ea849ebdce96b5ea8444e7810ddff0ba4a"
 dependencies = [
  "p3-field",
  "p3-matrix",
@@ -1514,7 +1514,7 @@ dependencies = [
 [[package]]
 name = "p3-baby-bear"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/plonky3.git#731ff62c311ebef7bb4bac1afd36934524f86d4f"
+source = "git+https://github.com/succinctlabs/plonky3.git#447c01ea849ebdce96b5ea8444e7810ddff0ba4a"
 dependencies = [
  "p3-field",
  "rand",
@@ -1524,7 +1524,7 @@ dependencies = [
 [[package]]
 name = "p3-blake3"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/plonky3.git#731ff62c311ebef7bb4bac1afd36934524f86d4f"
+source = "git+https://github.com/succinctlabs/plonky3.git#447c01ea849ebdce96b5ea8444e7810ddff0ba4a"
 dependencies = [
  "blake3",
  "p3-symmetric",
@@ -1533,7 +1533,7 @@ dependencies = [
 [[package]]
 name = "p3-challenger"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/plonky3.git#731ff62c311ebef7bb4bac1afd36934524f86d4f"
+source = "git+https://github.com/succinctlabs/plonky3.git#447c01ea849ebdce96b5ea8444e7810ddff0ba4a"
 dependencies = [
  "p3-field",
  "p3-maybe-rayon",
@@ -1545,7 +1545,7 @@ dependencies = [
 [[package]]
 name = "p3-commit"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/plonky3.git#731ff62c311ebef7bb4bac1afd36934524f86d4f"
+source = "git+https://github.com/succinctlabs/plonky3.git#447c01ea849ebdce96b5ea8444e7810ddff0ba4a"
 dependencies = [
  "p3-challenger",
  "p3-field",
@@ -1556,7 +1556,7 @@ dependencies = [
 [[package]]
 name = "p3-dft"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/plonky3.git#731ff62c311ebef7bb4bac1afd36934524f86d4f"
+source = "git+https://github.com/succinctlabs/plonky3.git#447c01ea849ebdce96b5ea8444e7810ddff0ba4a"
 dependencies = [
  "p3-field",
  "p3-matrix",
@@ -1567,7 +1567,7 @@ dependencies = [
 [[package]]
 name = "p3-field"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/plonky3.git#731ff62c311ebef7bb4bac1afd36934524f86d4f"
+source = "git+https://github.com/succinctlabs/plonky3.git#447c01ea849ebdce96b5ea8444e7810ddff0ba4a"
 dependencies = [
  "itertools 0.12.1",
  "p3-util",
@@ -1578,7 +1578,7 @@ dependencies = [
 [[package]]
 name = "p3-fri"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/plonky3.git#731ff62c311ebef7bb4bac1afd36934524f86d4f"
+source = "git+https://github.com/succinctlabs/plonky3.git#447c01ea849ebdce96b5ea8444e7810ddff0ba4a"
 dependencies = [
  "itertools 0.12.1",
  "p3-challenger",
@@ -1596,7 +1596,7 @@ dependencies = [
 [[package]]
 name = "p3-goldilocks"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/plonky3.git#731ff62c311ebef7bb4bac1afd36934524f86d4f"
+source = "git+https://github.com/succinctlabs/plonky3.git#447c01ea849ebdce96b5ea8444e7810ddff0ba4a"
 dependencies = [
  "p3-field",
  "p3-util",
@@ -1607,7 +1607,7 @@ dependencies = [
 [[package]]
 name = "p3-interpolation"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/plonky3.git#731ff62c311ebef7bb4bac1afd36934524f86d4f"
+source = "git+https://github.com/succinctlabs/plonky3.git#447c01ea849ebdce96b5ea8444e7810ddff0ba4a"
 dependencies = [
  "p3-field",
  "p3-matrix",
@@ -1617,7 +1617,7 @@ dependencies = [
 [[package]]
 name = "p3-keccak"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/plonky3.git#731ff62c311ebef7bb4bac1afd36934524f86d4f"
+source = "git+https://github.com/succinctlabs/plonky3.git#447c01ea849ebdce96b5ea8444e7810ddff0ba4a"
 dependencies = [
  "p3-symmetric",
  "tiny-keccak",
@@ -1626,7 +1626,7 @@ dependencies = [
 [[package]]
 name = "p3-keccak-air"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/plonky3.git#731ff62c311ebef7bb4bac1afd36934524f86d4f"
+source = "git+https://github.com/succinctlabs/plonky3.git#447c01ea849ebdce96b5ea8444e7810ddff0ba4a"
 dependencies = [
  "p3-air",
  "p3-field",
@@ -1638,7 +1638,7 @@ dependencies = [
 [[package]]
 name = "p3-matrix"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/plonky3.git#731ff62c311ebef7bb4bac1afd36934524f86d4f"
+source = "git+https://github.com/succinctlabs/plonky3.git#447c01ea849ebdce96b5ea8444e7810ddff0ba4a"
 dependencies = [
  "p3-field",
  "p3-maybe-rayon",
@@ -1650,7 +1650,7 @@ dependencies = [
 [[package]]
 name = "p3-maybe-rayon"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/plonky3.git#731ff62c311ebef7bb4bac1afd36934524f86d4f"
+source = "git+https://github.com/succinctlabs/plonky3.git#447c01ea849ebdce96b5ea8444e7810ddff0ba4a"
 dependencies = [
  "rayon",
 ]
@@ -1658,7 +1658,7 @@ dependencies = [
 [[package]]
 name = "p3-mds"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/plonky3.git#731ff62c311ebef7bb4bac1afd36934524f86d4f"
+source = "git+https://github.com/succinctlabs/plonky3.git#447c01ea849ebdce96b5ea8444e7810ddff0ba4a"
 dependencies = [
  "p3-baby-bear",
  "p3-dft",
@@ -1674,7 +1674,7 @@ dependencies = [
 [[package]]
 name = "p3-merkle-tree"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/plonky3.git#731ff62c311ebef7bb4bac1afd36934524f86d4f"
+source = "git+https://github.com/succinctlabs/plonky3.git#447c01ea849ebdce96b5ea8444e7810ddff0ba4a"
 dependencies = [
  "itertools 0.12.1",
  "p3-commit",
@@ -1690,7 +1690,7 @@ dependencies = [
 [[package]]
 name = "p3-mersenne-31"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/plonky3.git#731ff62c311ebef7bb4bac1afd36934524f86d4f"
+source = "git+https://github.com/succinctlabs/plonky3.git#447c01ea849ebdce96b5ea8444e7810ddff0ba4a"
 dependencies = [
  "itertools 0.12.1",
  "p3-dft",
@@ -1705,7 +1705,7 @@ dependencies = [
 [[package]]
 name = "p3-poseidon2"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/plonky3.git#731ff62c311ebef7bb4bac1afd36934524f86d4f"
+source = "git+https://github.com/succinctlabs/plonky3.git#447c01ea849ebdce96b5ea8444e7810ddff0ba4a"
 dependencies = [
  "p3-baby-bear",
  "p3-field",
@@ -1719,7 +1719,7 @@ dependencies = [
 [[package]]
 name = "p3-symmetric"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/plonky3.git#731ff62c311ebef7bb4bac1afd36934524f86d4f"
+source = "git+https://github.com/succinctlabs/plonky3.git#447c01ea849ebdce96b5ea8444e7810ddff0ba4a"
 dependencies = [
  "itertools 0.12.1",
  "p3-field",
@@ -1729,7 +1729,7 @@ dependencies = [
 [[package]]
 name = "p3-uni-stark"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/plonky3.git#731ff62c311ebef7bb4bac1afd36934524f86d4f"
+source = "git+https://github.com/succinctlabs/plonky3.git#447c01ea849ebdce96b5ea8444e7810ddff0ba4a"
 dependencies = [
  "itertools 0.12.1",
  "p3-air",
@@ -1747,7 +1747,7 @@ dependencies = [
 [[package]]
 name = "p3-util"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/plonky3.git#731ff62c311ebef7bb4bac1afd36934524f86d4f"
+source = "git+https://github.com/succinctlabs/plonky3.git#447c01ea849ebdce96b5ea8444e7810ddff0ba4a"
 dependencies = [
  "serde",
 ]

--- a/core/src/utils/prove.rs
+++ b/core/src/utils/prove.rs
@@ -325,7 +325,7 @@ pub(super) mod baby_bear_keccak {
 
     pub type Dft = Radix2DitParallel;
 
-    type Challenger = SerializingChallenger32<Val, HashChallenger<u8, ByteHash, 32>>;
+    type Challenger = SerializingChallenger32<Val, u8, HashChallenger<u8, ByteHash, 32>>;
 
     type Pcs =
         TwoAdicFriPcs<TwoAdicFriPcsConfig<Val, Challenge, Challenger, Dft, ValMmcs, ChallengeMmcs>>;
@@ -449,7 +449,7 @@ pub(super) mod baby_bear_blake3 {
 
     pub type Dft = Radix2DitParallel;
 
-    type Challenger = SerializingChallenger32<Val, HashChallenger<u8, ByteHash, 32>>;
+    type Challenger = SerializingChallenger32<Val, u8, HashChallenger<u8, ByteHash, 32>>;
 
     type Pcs =
         TwoAdicFriPcs<TwoAdicFriPcsConfig<Val, Challenge, Challenger, Dft, ValMmcs, ChallengeMmcs>>;


### PR DESCRIPTION
- updates the pointer to plonky3 in `Cargo.lock`,
- https://github.com/succinctlabs/plonky3/pull/27 updated `SerializingChallenger32` to take a type parameter for an initial `HashChallenger` state,
- Updates the `Challenger` type definition in the `baby_bear_keccak` and `baby_bear_blake3` modules to reflect what typed is used there (u8).

> [!NOTE]
> A [default type parameter](https://doc.rust-lang.org/book/ch19-03-advanced-traits.html#default-generic-type-parameters-and-operator-overloading), if used for `T`, may have made source changes unnecessary.