### PR TITLE
feat: add instructions for docker usage and setup CI

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,98 @@
+# Source: https://raw.githubusercontent.com/foundry-rs/foundry/master/.github/workflows/docker-publish.yml
+name: docker
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  schedule:
+    - cron: "0 0 * * *"
+  # Trigger without any parameters a proactive rebuild
+  workflow_dispatch: {}
+  workflow_call:
+
+env:
+  REGISTRY: ghcr.io
+  # Will resolve to succinctlabs/sp1
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  container:
+    runs-on: ubuntu-latest
+    # https://docs.github.com/en/actions/reference/authentication-in-a-workflow
+    permissions:
+      id-token: write
+      packages: write
+      contents: read
+    timeout-minutes: 120
+    steps:
+      - name: Checkout repository
+        id: checkout
+        uses: actions/checkout@v4
+
+      - name: Install Docker BuildX
+        uses: docker/setup-buildx-action@v2
+        id: buildx
+        with:
+          install: true
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        # Ensure this doesn't trigger on PR's
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Creates an additional 'latest' or 'nightly' tag
+      # If the job is triggered via cron schedule, tag nightly and nightly-{SHA}
+      # If the job is triggered via workflow dispatch and on a master branch, tag branch and latest
+      # Otherwise, just tag as the branch name
+      - name: Finalize Docker Metadata
+        id: docker_tagging
+        run: |
+          if [[ "${{ github.event_name }}" == 'schedule' ]]; then
+            echo "cron trigger, assigning nightly tag"
+            echo "docker_tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:nightly,${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:nightly-${GITHUB_SHA}" >> $GITHUB_OUTPUT
+          elif [[ "${GITHUB_REF##*/}" == "main" ]] || [[ ${GITHUB_REF##*/} == "master" ]]; then
+            echo "manual trigger from master/main branch, assigning latest tag"
+            echo "docker_tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${GITHUB_REF##*/},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest" >> $GITHUB_OUTPUT
+          else
+            echo "Neither scheduled nor manual release from main branch. Just tagging as branch name"
+            echo "docker_tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
+          fi
+
+      # Log docker metadata to explicitly know what is being pushed
+      - name: Inspect Docker Metadata
+        run: |
+          echo "TAGS -> ${{ steps.docker_tagging.outputs.docker_tags }}"
+          echo "LABELS ->  ${{ steps.meta.outputs.labels }}"
+
+      # Build and push Docker image
+      # https://github.com/docker/build-push-action
+      # https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: ./cli/docker
+          file: ./cli/docker/Dockerfile
+          push: true
+          tags: ${{ steps.docker_tagging.outputs.docker_tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            BUILDTIME=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
+            VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+            REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}

--- a/book/getting-started/install.md
+++ b/book/getting-started/install.md
@@ -24,7 +24,7 @@ sp1up
 ```
 
 This will install support for the `riscv32im-succinct-zkvm-elf` compilation target within your Rust compiler
-and a `cargo prove` CLI tool that will let you compile provable programs and then prove their correctness. 
+and a `cargo prove` CLI tool that will let you compile provable programs and then prove their correctness.
 
 You can verify the installation by running `cargo prove --version`:
 
@@ -52,7 +52,7 @@ rm ~/.sp1/bin/cargo-prove
 
 Make sure you have installed the [dependencies](https://github.com/rust-lang/rust/blob/master/INSTALL.md#dependencies) needed to build the rust toolchain from source.
 
-Clone the `sp1` repository and navigate to the root directory. 
+Clone the `sp1` repository and navigate to the root directory.
 
 ```bash
 git clone git@github.com:succinctlabs/sp1.git
@@ -64,6 +64,7 @@ cargo prove build-toolchain
 ```
 
 Building the toolchain can take a while, ranging from 30 mins to an hour depending on your machine. If you're on a machine that we have prebuilt binaries for (ARM Mac or x86 or ARM Linux), you can use the following to download a prebuilt version.
+
 ```bash
 cargo prove install-toolchain
 ```
@@ -78,4 +79,29 @@ You can delete your existing installation of the toolchain with:
 
 ```bash
 rustup toolchain remove succinct
+```
+
+## Option 3: Using Docker
+
+SP1 can also be used entirely within a Docker container. If you don't have it, Docker can be
+installed directly from [Docker's website](https://docs.docker.com/get-docker/).
+
+Then you can use:
+
+```bash
+cargo prove --docker
+```
+
+to automatically use the latest image of SP1 in a container.
+
+Alternatively, it is possible to build the docker image locally by running:
+
+```bash
+docker build -t succinctlabs/sp1:latest ./cli/docker
+```
+
+You can then run the `cargo prove` command by mounting your program directory into the container:
+
+```bash
+docker run -v "$(pwd):/root/program" -it succinctlabs/sp1:latest prove build
 ```

--- a/cli/docker/Dockerfile
+++ b/cli/docker/Dockerfile
@@ -7,7 +7,7 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 RUN curl -L https://sp1.succinct.xyz | bash && ~/.sp1/bin/sp1up
 
 # Hack to fix openssl issue, will not be needed when toolchain is compiled with newer openssl
-RUN curl -L http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.21_amd64.deb -o libssl.deb && yes | dpkg -i libssl.deb
+# RUN curl -L http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.21_amd64.deb -o libssl.deb && yes | dpkg -i libssl.deb
 
 WORKDIR /root/program
 

--- a/cli/docker/Dockerfile
+++ b/cli/docker/Dockerfile
@@ -7,7 +7,7 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 RUN curl -L https://sp1.succinct.xyz | bash && ~/.sp1/bin/sp1up
 
 # Hack to fix openssl issue, will not be needed when toolchain is compiled with newer openssl
-# RUN curl -L http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.21_amd64.deb -o libssl.deb && yes | dpkg -i libssl.deb
+RUN curl -L http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.21_amd64.deb -o libssl.deb && yes | dpkg -i libssl.deb
 
 WORKDIR /root/program
 

--- a/cli/src/build.rs
+++ b/cli/src/build.rs
@@ -10,7 +10,7 @@ use std::{
 
 fn get_docker_image() -> String {
     // Get the docker image name from the environment variable
-    std::env::var("SP1_DOCKER_IMAGE").unwrap_or_else(|_| "succinctlabs/sp1:latest".to_string())
+    std::env::var("SP1_DOCKER_IMAGE").unwrap_or_else(|_| "ghcr.io/succinctlabs/sp1:latest".to_string())
 }
 
 #[derive(Parser)]


### PR DESCRIPTION
Sets up the same behavior for docker as [Foundry](https://book.getfoundry.sh/getting-started/installation?highlight=docker#using-foundry-with-docker) has, with the same CI for pushing `nightly`, `latest`, and `v*.*.*` images to GHCR.

To test, try:
```
docker pull ghcr.io/succinctlabs/sp1:latest
```
