### PR TITLE
style: split `validate_memory_access` to avoid warnings in the release profile

### DIFF
--- a/core/src/runtime/mod.rs
+++ b/core/src/runtime/mod.rs
@@ -26,9 +26,6 @@ use std::rc::Rc;
 use std::sync::Arc;
 pub use syscall::*;
 
-use p3_baby_bear::BabyBear;
-use p3_field::AbstractField;
-
 use self::state::ExecutionState;
 
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -167,8 +164,11 @@ impl Runtime {
     }
 
     #[inline]
+    #[cfg(debug_assertions)]
     fn validate_memory_access(&self, addr: u32, position: AccessPosition) {
-        #[cfg(debug_assertions)]
+        use p3_baby_bear::BabyBear;
+        use p3_field::AbstractField;
+
         if position == AccessPosition::Memory {
             assert_eq!(addr % 4, 0, "addr is not aligned");
             let _ = BabyBear::from_canonical_u32(addr);
@@ -177,6 +177,9 @@ impl Runtime {
             let _ = Register::from_u32(addr);
         }
     }
+
+    #[cfg(not(debug_assertions))]
+    fn validate_memory_access(&self, _addr: u32, _position: AccessPosition) {}
 
     pub fn mr(&mut self, addr: u32, shard: u32, clk: u32) -> MemoryReadRecord {
         // Get the memory entry.


### PR DESCRIPTION
This is just one of several options, e.g. we could also suppress the unused var warnings with

    #[cfg_attr(not(debug_assertions), allow(unused_variables))]