### PR TITLE
fix: RUST_LOG log level in cycle-tracking section of book

### DIFF
--- a/book/writing-programs/cycle-tracking.md
+++ b/book/writing-programs/cycle-tracking.md
@@ -17,24 +17,27 @@ Note that to use the macro, you must add the `sp1-derive` crate to your dependen
 sp1-derive = { git = "https://github.com/succinctlabs/sp1.git" }
 ```
 
-In the script for proof generation, setup the logger with `utils::setup_logger()` and run the script with `RUST_LOG=info cargo run --release`. You should see the following output:
+In the script for proof generation, setup the logger with `utils::setup_logger()` and run the script with `RUST_LOG=debug cargo run --release`. You should see the following output:
 
 ```
-$ RUST_LOG=info cargo run --release
-    Finished release [optimized] target(s) in 0.61s
-    Running `target/release/cycle-tracking-script`
-2024-03-02T19:47:07.490898Z  INFO runtime.run(...):load memory: close time.busy=280µs time.idle=3.92µs
-2024-03-02T19:47:07.491085Z  INFO runtime.run(...): ┌╴setup
-2024-03-02T19:47:07.491531Z  INFO runtime.run(...): └╴4,398 cycles
-2024-03-02T19:47:07.491570Z  INFO runtime.run(...): ┌╴main-body
-2024-03-02T19:47:07.491607Z  INFO runtime.run(...): │ ┌╴expensive_function
-2024-03-02T19:47:07.491886Z  INFO runtime.run(...): │ └╴1,368 cycles
-2024-03-02T19:47:07.492045Z  INFO runtime.run(...): stdout: result: 5561
-2024-03-02T19:47:07.492112Z  INFO runtime.run(...): │ ┌╴expensive_function
-2024-03-02T19:47:07.492358Z  INFO runtime.run(...): │ └╴1,368 cycles
-2024-03-02T19:47:07.492501Z  INFO runtime.run(...): stdout: result: 2940
-2024-03-02T19:47:07.492560Z  INFO runtime.run(...): └╴5,766 cycles
-2024-03-02T19:47:07.494178Z  INFO runtime.run(...):postprocess: close time.busy=1.57ms time.idle=625ns
+$ RUST_LOG=debug cargo run --release
+    Finished release [optimized] target(s) in 0.21s
+     Running `target/release/cycle-tracking-script`
+2024-03-13T02:03:40.567500Z  INFO execute: loading memory image
+2024-03-13T02:03:40.567751Z  INFO execute: starting execution
+2024-03-13T02:03:40.567760Z  INFO execute: clk = 0 pc = 0x2013b8    
+2024-03-13T02:03:40.567822Z DEBUG execute: ┌╴setup    
+2024-03-13T02:03:40.568095Z DEBUG execute: └╴4,398 cycles    
+2024-03-13T02:03:40.568122Z DEBUG execute: ┌╴main-body    
+2024-03-13T02:03:40.568149Z DEBUG execute: │ ┌╴expensive_function    
+2024-03-13T02:03:40.568250Z DEBUG execute: │ └╴1,368 cycles    
+stdout: result: 5561
+2024-03-13T02:03:40.568373Z DEBUG execute: │ ┌╴expensive_function    
+2024-03-13T02:03:40.568470Z DEBUG execute: │ └╴1,368 cycles    
+stdout: result: 2940
+2024-03-13T02:03:40.568556Z DEBUG execute: └╴5,766 cycles    
+2024-03-13T02:03:40.568566Z  INFO execute: finished execution clk = 11127 pc = 0x0
+2024-03-13T02:03:40.569251Z  INFO execute: close time.busy=1.78ms time.idle=21.1µs
 ```
 
 Note that we elegantly handle nested cycle tracking, as you can see above.


### PR DESCRIPTION
The book currently instructs users to set RUST_LOG to 'info' for the cycle-tracker. However, in #363, the log level for the cycle-tracker was changed to 'debug'. 

This Pull Request updates the RUST_LOG level in the book from 'info' to 'debug', matching the actual setting in the code. This ensures that users following the book's instructions will see the expected logs.