### PR TITLE
style: clear semantics of variables

### DIFF
--- a/core/src/syscall/precompiles/keccak256/execute.rs
+++ b/core/src/syscall/precompiles/keccak256/execute.rs
@@ -5,7 +5,7 @@ use crate::{
 
 use p3_keccak_air::{NUM_ROUNDS, RC};
 
-use super::{KeccakPermuteChip, STATE_NUM_WORDS};
+use super::{KeccakPermuteChip, STATE_NUM_WORDS, STATE_SIZE};
 
 const RHO: [u32; 24] = [
     1, 3, 6, 10, 15, 21, 28, 36, 45, 55, 2, 14, 27, 41, 56, 8, 25, 43, 62, 18, 39, 61, 20, 44,
@@ -87,8 +87,7 @@ impl Syscall for KeccakPermuteChip {
         // Increment the clk by 1 before writing because we read from memory at start_clk.
         rt.clk += 1;
         let mut values_to_write = Vec::new();
-        // TODO: where does this 25 come from.
-        for i in 0..25 {
+        for i in 0..STATE_SIZE {
             let most_sig = ((state[i] >> 32) & 0xFFFFFFFF) as u32;
             let least_sig = (state[i] & 0xFFFFFFFF) as u32;
             values_to_write.push(least_sig);

--- a/core/src/syscall/precompiles/keccak256/mod.rs
+++ b/core/src/syscall/precompiles/keccak256/mod.rs
@@ -7,10 +7,10 @@ pub mod columns;
 mod execute;
 mod trace;
 
-const STATE_SIZE: usize = 25;
+pub(crate) const STATE_SIZE: usize = 25;
 
 // The permutation state is 25 u64's.  Our word size is 32 bits, so it is 50 words.
-const STATE_NUM_WORDS: usize = 25 * 2;
+const STATE_NUM_WORDS: usize = STATE_SIZE * 2;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct KeccakPermuteEvent {


### PR DESCRIPTION
# A little bit improvement of readable

When I read SP1's code, I found undefined literals that were meaningless. Therefore, I exported some constant definitions and reused them. This may be helpful for others.