### PR TITLE
feat: added `--ignore-rust-version` to `cargo prove build`

### DIFF
--- a/cli/src/build.rs
+++ b/cli/src/build.rs
@@ -61,7 +61,7 @@ pub fn build_program(args: &BuildArgs) -> Result<Utf8PathBuf> {
             workspace_root_path.as_str(),
             image.as_str(),
             "prove",
-            "check",
+            "build",
         ];
         if args.ignore_rust_version {
             child_agrs.push("--ignore-rust-version");

--- a/cli/src/build.rs
+++ b/cli/src/build.rs
@@ -54,7 +54,7 @@ pub fn build_program(args: &BuildArgs) -> Result<Utf8PathBuf> {
         }
 
         let workspace_root_path = format!("{}:/root/program", metadata.workspace_root);
-        let mut child_agrs = vec![
+        let mut child_args = vec![
             "run",
             "--rm",
             "-v",
@@ -64,11 +64,11 @@ pub fn build_program(args: &BuildArgs) -> Result<Utf8PathBuf> {
             "build",
         ];
         if args.ignore_rust_version {
-            child_agrs.push("--ignore-rust-version");
+            child_args.push("--ignore-rust-version");
         }
 
         let mut child = Command::new("docker")
-            .args(&child_agrs)
+            .args(&child_args)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .spawn()


### PR DESCRIPTION
Subcommands like build allow ignoring the minimum rust version of dependencies by the --ignore-rust-version flag. Given that Sp1 locks on certain rustc version while the dependencies of zkvm guest code might often require a higher version, we should allow users to optimistically compile guests without this check.

Inspired by: https://github.com/rust-lang/cargo/issues/11718