### PR TITLE
perf(simd): gain huge performance improvement with AVX512

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -746,9 +746,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.0.0"
+version = "4.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f711ade317dd348950a9910f81c5947e3d8907ebd2b83f76203ff1807e6a2bc2"
+checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1044,9 +1044,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.1.20"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e825f6987101665dea6ec934c09ec6d721de7bc1bf92248e1d5810c8cd636b77"
+checksum = "c007b1ae3abe1cb6f85a16305acd418b7ca6343b953633fee2b76d8f108b830f"
 
 [[package]]
 name = "filetime"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,9 @@ p3-air = { git = "https://github.com/Plonky3/Plonky3.git", branch = "sp1" }
 p3-field = { git = "https://github.com/Plonky3/Plonky3.git", branch = "sp1" }
 p3-commit = { git = "https://github.com/Plonky3/Plonky3.git", branch = "sp1" }
 p3-matrix = { git = "https://github.com/Plonky3/Plonky3.git", branch = "sp1" }
-p3-baby-bear = { git = "https://github.com/Plonky3/Plonky3.git", branch = "sp1" }
+p3-baby-bear = { git = "https://github.com/Plonky3/Plonky3.git", branch = "sp1", features = [
+    "nightly-features",
+] }
 p3-util = { git = "https://github.com/Plonky3/Plonky3.git", branch = "sp1" }
 p3-challenger = { git = "https://github.com/Plonky3/Plonky3.git", branch = "sp1" }
 p3-dft = { git = "https://github.com/Plonky3/Plonky3.git", branch = "sp1" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -42,7 +42,7 @@ cfg-if = "1.0.0"
 generic-array = { version = "1.0.0", features = ["alloc"] }
 typenum = "1.17.0"
 clap = { version = "4.4.0", features = ["derive"] }
-curve25519-dalek = { version = "=4.0.0" }
+curve25519-dalek = { version = "4.1.2" }
 elliptic-curve = "0.13.8"
 flate2 = "1.0.28"
 hashbrown = "0.14.3"

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2024-01-25"
+channel = "nightly-2024-02-06"
 components = ["llvm-tools", "rustc-dev"]


### PR DESCRIPTION
The purpose of this PR is to enable AVX512 in SP1.

# Background 

The plonky3 supports AVX512 SIMD instructions.
https://github.com/Plonky3/Plonky3/blob/7881374a17d43b8c58b8ed146ca4e44a5cbab2a0/baby-bear/src/x86_64_avx512.rs
So, I tested it and gained a huge performance improvement.

# Testing Result

Tested zkVM program: https://github.com/taikoxyz/raiko (babybear+blake3)

## The time cost

| avx2|avx512|diff|
|------|------|----|
| 550s|290s|-47%|

It reduced 47% time cost of proving in my machine(Ryzen 7840HS).

# Tip

**You have to use cargo with `RUSTFLAGS` just like below to enable AVX512**

```shell
$  RUSTFLAGS='-C target-cpu=native --cfg curve25519_dalek_backend="simd"' cargo xxx
# or  RUSTFLAGS='-C target_feature=+avx512ifma,+avx512vl --cfg curve25519_dalek_backend="simd"' cargo xxx
```
`--cfg curve25519_dalek_backend="simd"` is needed by `curve25519-dalek` https://github.com/sp1-patches/curve25519-dalek/tree/main/curve25519-dalek#backends
