### PR TITLE
fix(sp1up): <- make that use `main` branch instead of `master`

### DIFF
--- a/sp1up/sp1up
+++ b/sp1up/sp1up
@@ -172,7 +172,7 @@ EOF
   # Install by cloning the repo with the provided branch/tag
   else
     need_cmd cargo
-    SP1UP_BRANCH=${SP1UP_BRANCH:-master}
+    SP1UP_BRANCH=${SP1UP_BRANCH:-main}
     REPO_PATH="$SP1_DIR/$SP1UP_REPO"
 
     # If repo path does not exist, grab the author from the repo, make a directory in .foundry, cd to it and clone.


### PR DESCRIPTION
...per title. 

Currently any commands to install versions of sp1 via specific commits, it errors thusly: 

```bash
user@archlinux:~/sp1|⇒ sp1up --commit 72cb1bac

.______  ._______ ._______ ._______ ._______ ._______ ._______ ._______ ._______

   _____  ____  ___
  / ___/ / __ \<  /
  \__ \ / /_/ // /                        A performant, 100% open-source,
 ___/ // ____// /                              general-purpose zkVM.
/____//_/    /_/

._______ ._______ ._______ ._______ ._______ ._______ ._______ ._______ ._______

Repo       : https://github.com/succinctlabs/sp1
Book       : https://succinctlabs.github.io/sp1
Telegram   : https://t.me/succinct_sp1

._______ ._______ ._______ ._______ ._______ ._______ ._______ ._______ ._______

Cloning into 'sp1'...
remote: Enumerating objects: 22185, done.
remote: Counting objects: 100% (5754/5754), done.
remote: Compressing objects: 100% (1465/1465), done.
remote: Total 22185 (delta 4578), reused 4925 (delta 4226), pack-reused 16431
Receiving objects: 100% (22185/22185), 87.45 MiB | 15.68 MiB/s, done.
Resolving deltas: 100% (13096/13096), done.
fatal: couldn't find remote ref master
sp1up: command failed: git fetch origin master:remotes/origin/master
```

This PR fixes that.