### PR TITLE
fix: use bincode for sdk serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3824,28 +3824,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rmp"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9860a6cc38ed1da53456442089b4dfa35e7cedaa326df63017af88385e6b20"
-dependencies = [
- "byteorder",
- "num-traits",
- "paste",
-]
-
-[[package]]
-name = "rmp-serde"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bffea85eea980d8a74453e5d02a8d93028f3c34725de143085a844ebe953258a"
-dependencies = [
- "byteorder",
- "rmp",
- "serde",
-]
-
-[[package]]
 name = "rrs-lib"
 version = "0.1.0"
 source = "git+https://github.com/GregAC/rrs.git#b23afc16b4e6a1fb5c4a73eb1e337e9400816507"
@@ -4583,7 +4561,6 @@ dependencies = [
  "prost-types",
  "reqwest 0.11.27",
  "reqwest-middleware",
- "rmp-serde",
  "serde",
  "serde_json",
  "sp1-core",

--- a/examples/fibonacci-io/script/Cargo.lock
+++ b/examples/fibonacci-io/script/Cargo.lock
@@ -3329,28 +3329,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rmp"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9860a6cc38ed1da53456442089b4dfa35e7cedaa326df63017af88385e6b20"
-dependencies = [
- "byteorder",
- "num-traits",
- "paste",
-]
-
-[[package]]
-name = "rmp-serde"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bffea85eea980d8a74453e5d02a8d93028f3c34725de143085a844ebe953258a"
-dependencies = [
- "byteorder",
- "rmp",
- "serde",
-]
-
-[[package]]
 name = "rrs-lib"
 version = "0.1.0"
 source = "git+https://github.com/GregAC/rrs.git#b23afc16b4e6a1fb5c4a73eb1e337e9400816507"
@@ -3894,7 +3872,6 @@ dependencies = [
  "prost-types",
  "reqwest 0.11.27",
  "reqwest-middleware",
- "rmp-serde",
  "serde",
  "serde_json",
  "sp1-core",
@@ -4107,9 +4084,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.35"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef89ece63debf11bc32d1ed8d078ac870cbeb44da02afb02a9ff135ae7ca0582"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -18,7 +18,6 @@ anyhow = "1.0.80"
 sp1-core = { path = "../core" }
 futures = "0.3.30"
 bincode = "1.3.3"
-rmp-serde = "1.1.2"
 tokio = { version = "1.36.0", features = ["full"] }
 p3-matrix = { workspace = true }
 p3-commit = { workspace = true }


### PR DESCRIPTION
Removes `rmp-serde` usage in favor of bincode everywhere