### PR TITLE
fix: use REMOTE_PROVE to check local or remote

### DIFF
--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -57,10 +57,11 @@ impl ProverClient {
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         dotenv::dotenv().ok();
-        let private_key = env::var("PRIVATE_KEY").unwrap_or_default();
-        if private_key.is_empty() {
+        if env::var("REMOTE_PROVING").is_err() {
             Self { client: None }
         } else {
+            let private_key =
+                env::var("PRIVATE_KEY").unwrap_or_else(|_| panic!("PRIVATE_KEY is not set"));
             Self {
                 client: Some(NetworkClient::new(&private_key)),
             }

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -57,9 +57,12 @@ impl ProverClient {
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         dotenv::dotenv().ok();
-        let remote_proving = env::var("REMOTE_PROVING").unwrap_or_else(|_| String::from("false"));
+        let remote_proving = env::var("REMOTE_PROVING")
+            .unwrap_or_else(|_| String::from("false"))
+            .parse::<bool>()
+            .unwrap_or(false);
 
-        if remote_proving == "true" {
+        if remote_proving {
             let private_key = env::var("PRIVATE_KEY")
                 .unwrap_or_else(|_| panic!("PRIVATE_KEY must be set for remote proving"));
             Self {

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -57,7 +57,7 @@ impl ProverClient {
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         dotenv::dotenv().ok();
-        let remote_proving = env::var("REMOTE_PROVING")
+        let remote_proving = env::var("REMOTE_PROVE")
             .unwrap_or_else(|_| String::from("false"))
             .parse::<bool>()
             .unwrap_or(false);

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -60,8 +60,8 @@ impl ProverClient {
         let remote_proving = env::var("REMOTE_PROVING").unwrap_or_else(|_| String::from("false"));
 
         if remote_proving == "true" {
-            let private_key =
-                env::var("PRIVATE_KEY").unwrap_or_else(|_| panic!("PRIVATE_KEY is not set"));
+            let private_key = env::var("PRIVATE_KEY")
+                .unwrap_or_else(|_| panic!("PRIVATE_KEY must be set for remote proving"));
             Self {
                 client: Some(NetworkClient::new(&private_key)),
             }

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -57,14 +57,16 @@ impl ProverClient {
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         dotenv::dotenv().ok();
-        if env::var("REMOTE_PROVING").is_err() {
-            Self { client: None }
-        } else {
+        let remote_proving = env::var("REMOTE_PROVING").unwrap_or_else(|_| String::from("false"));
+
+        if remote_proving == "true" {
             let private_key =
                 env::var("PRIVATE_KEY").unwrap_or_else(|_| panic!("PRIVATE_KEY is not set"));
             Self {
                 client: Some(NetworkClient::new(&private_key)),
             }
+        } else {
+            Self { client: None }
         }
     }
 


### PR DESCRIPTION
Instead of directly choosing to remote prove off of `PRIVATE_KEY`, check for `REMOTE_PROVING=true`.