### PR TITLE
feat: execute before `prove_remote_async`

### DIFF
--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -100,8 +100,8 @@ impl ProverClient {
     }
 
     // Generate a proof remotely using the Succinct Network in an async context.
-    // TODO: If the simulation of the runtime is expensive for user programs, add an optional flag to skip it. This
-    // shouldn't be the case for the vast majority of user programs.
+    // Note: If the simulation of the runtime is expensive for user programs, we can add an optional
+    // flag to skip it. This shouldn't be the case for the vast majority of user programs.
     pub async fn prove_remote_async(
         &self,
         elf: &[u8],

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -100,6 +100,8 @@ impl ProverClient {
     }
 
     // Generate a proof remotely using the Succinct Network in an async context.
+    // TODO: If the simulation of the runtime is expensive for user programs, add an optional flag to skip it. This
+    // shouldn't be the case for the vast majority of user programs.
     pub async fn prove_remote_async(
         &self,
         elf: &[u8],
@@ -114,6 +116,7 @@ impl ProverClient {
         let mut runtime = Runtime::new(Program::from(elf));
         runtime.write_vecs(&stdin.buffer);
         runtime.run();
+        println!("Simulation complete.");
 
         let proof_id = client.create_proof(elf, &stdin).await?;
         println!("proof_id: {:?}", proof_id);

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -110,6 +110,11 @@ impl ProverClient {
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("Network client not initialized"))?;
 
+        // Execute the ELF with the given stdin before creating the proof.
+        let mut runtime = Runtime::new(program);
+        runtime.write_vecs(&stdin.buffer);
+        runtime.run();
+
         let proof_id = client.create_proof(elf, &stdin).await?;
         println!("proof_id: {:?}", proof_id);
 

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -110,8 +110,8 @@ impl ProverClient {
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("Network client not initialized"))?;
 
-        // Execute the ELF with the given stdin before creating the proof.
-        let mut runtime = Runtime::new(program);
+        // Execute the runtime before creating the proof request.
+        let mut runtime = Runtime::new(Program::from(elf));
         runtime.write_vecs(&stdin.buffer);
         runtime.run();
 


### PR DESCRIPTION
Execute before `prove_remote_async` in the SDK. If a user attempts to request a proof with a failing runtime, it will be caught at this point.