### PR TITLE
fix: rerun failed in build script

### DIFF
--- a/helper/src/lib.rs
+++ b/helper/src/lib.rs
@@ -21,7 +21,7 @@ pub fn build_program(path: &str) {
         program_dir.join("Cargo.lock"),
     ];
     for dir in dirs {
-        println!("cargo:rerun-if-changed={}", dir.display());
+        println!("cargo::rerun-if-changed={}", dir.display());
     }
 
     // Print a message so the user knows that their program was built. Cargo caches warnings emitted


### PR DESCRIPTION
# Background

Some break changes happened a few days ago. Like the `syscall code` changed: 
https://github.com/succinctlabs/sp1/commit/bde25d674d2f06acde6999ef5b507f44b6aa5fcd

```diff
-HALT = 0x01_00_00_00,
+HALT = 0x00_00_00_00,
```

So, when I update the dependency of SP1 to the newest one. Undefined Behavior happened.

```shell
panic: invalid syscall number: 1
```

This is usually because sp1 has encountered an unsupported instruction, but my program was compiled by the same version of SP1 with a rust build script. So, the mistakes happened in the script. When I was deep into the implementation. I found the misused of `cargo::rerun-if-changed` and the examples of SP1 always `cargo clean&&cargo build`manually. Therefore, there won't be any issues with examples.

https://github.com/succinctlabs/sp1/blob/main/examples/Makefile