### PR TITLE
Fix typos

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/sp1.iml" filepath="$PROJECT_DIR$/.idea/sp1.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/sp1.iml
+++ b/.idea/sp1.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="EMPTY_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/core/src/memory/columns.rs
+++ b/core/src/memory/columns.rs
@@ -45,7 +45,7 @@ pub struct MemoryAccessCols<T> {
     /// This column is the least significant 16 bit limb of current access timestamp - prev access timestamp.
     pub diff_16bit_limb: T,
 
-    /// This column is the most signficant 8 bit limb of current access timestamp - prev access timestamp.
+    /// This column is the most significant 8 bit limb of current access timestamp - prev access timestamp.
     pub diff_8bit_limb: T,
 }
 

--- a/core/src/stark/machine.rs
+++ b/core/src/stark/machine.rs
@@ -153,7 +153,7 @@ impl<SC: StarkGenericConfig, A: MachineAir<Val<SC>>> StarkMachine<SC, A> {
     /// The setup preprocessing phase.
     ///
     /// Given a program, this function generates the proving and verifying keys. The keys correspond
-    /// to the program code and other preprocessed colunms such as lookup tables.
+    /// to the program code and other preprocessed columns such as lookup tables.
     pub fn setup(&self, program: &A::Program) -> (StarkProvingKey<SC>, StarkVerifyingKey<SC>) {
         let mut named_preprocessed_traces = self
             .chips()

--- a/core/src/stark/permutation.rs
+++ b/core/src/stark/permutation.rs
@@ -219,7 +219,7 @@ pub fn eval_permutation_constraints<F, AB>(
         // entry * \prod_i rlc_i = \sum_i m_i * \prod_{j!=i} rlc_j.
 
         // First, we calculate the random linear combinations and multiplicities with the correct
-        // sign depending on wetther the interaction is a send or a recieve.
+        // sign depending on whether the interaction is a send or a receive.
         let mut rlcs: Vec<AB::ExprEF> = Vec::with_capacity(batch_size);
         let mut multiplicities: Vec<AB::Expr> = Vec::with_capacity(batch_size);
         for (interaction, is_send) in chunk {

--- a/prover/scripts/fibonacci_sweep.rs
+++ b/prover/scripts/fibonacci_sweep.rs
@@ -33,7 +33,7 @@ fn main() {
         .finish()
         .init();
 
-    // Setup enviroment variables.
+    // Setup environment variables.
     std::env::set_var("RECONSTRUCT_COMMITMENTS", "false");
 
     // Initialize prover.

--- a/recursion/compiler/src/ir/instructions.rs
+++ b/recursion/compiler/src/ir/instructions.rs
@@ -1,7 +1,7 @@
 use super::{Array, FriFoldInput, MemIndex, Ptr, TracedVec};
 use super::{Config, Ext, Felt, Usize, Var};
 
-/// An intermeddiate instruction set for implementing programs.
+/// An intermediate instruction set for implementing programs.
 ///
 /// Programs written in the DSL can compile both to the recursive zkVM and the R1CS or Plonk-ish
 /// circuits.
@@ -114,9 +114,9 @@ pub enum DslIr<C: Config> {
     LoadE(Ext<C::F, C::EF>, Ptr<C::N>, MemIndex<C::N>),
     /// Store variable at address
     StoreV(Ptr<C::N>, Var<C::N>, MemIndex<C::N>),
-    /// Store field element at adress
+    /// Store field element at address
     StoreF(Ptr<C::N>, Felt<C::F>, MemIndex<C::N>),
-    /// Store extension field at adress
+    /// Store extension field at address
     StoreE(Ptr<C::N>, Ext<C::F, C::EF>, MemIndex<C::N>),
 
     // Bits.

--- a/recursion/program/src/fri/domain.rs
+++ b/recursion/program/src/fri/domain.rs
@@ -190,7 +190,7 @@ pub(crate) mod tests {
 
             let log_quotient_degree = 2;
 
-            // Initialize a reference doamin.
+            // Initialize a reference domain.
             let domain_val = natural_domain_for_degree(1 << log_d_val);
             let domain = builder.constant(domain_val);
 
@@ -219,7 +219,7 @@ pub(crate) mod tests {
                 zeta_val,
             );
 
-            // Now try splited domains
+            // Now try splitted domains
             let qc_domains_val = disjoint_domain_val.split_domains(1 << log_quotient_degree);
             for dom_val in qc_domains_val.iter() {
                 let dom = builder.constant(*dom_val);


### PR DESCRIPTION
Fixing typos, specifically: 

- in core/src/memory/columns.rs, correct "signficant" to "significant"
- in core/src/stark/machine.rs, correct "colunms" to "columns"
- in core/src/stark/permutation.rs, correct "wetther" to "whether"
- in prover/scripts/fibonacci_sweep.rs, correct "enviroment" to "environment"
- in recursion/compiler/src/ir/instructions.rs, correct "intermeddiate" to "intermediate" and "adress" to "address"
- in recursion/program/src/fri/domain.rs, correct "doamin" to "domain", correct "splited" to "splitted"