### PR TITLE
feat(recursion): add `RecursionAirBuilder` trait

### DIFF
--- a/recursion/core/src/air/builder.rs
+++ b/recursion/core/src/air/builder.rs
@@ -9,9 +9,9 @@ impl<AB: SP1AirBuilder> RecursionAirBuilder for AB {}
 
 pub trait RecursionAirBuilder: BaseAirBuilder {
     fn eval_memory_read_write<
-        EAddr,
         EPrevTimestamp,
         ETimestamp,
+        EAddr,
         EPrevValue,
         EValue,
         EMultiplicity,
@@ -24,9 +24,9 @@ pub trait RecursionAirBuilder: BaseAirBuilder {
         value: Block<EValue>,
         multiplicity: EMultiplicity,
     ) where
-        EAddr: Into<Self::Expr>,
         EPrevTimestamp: Into<Self::Expr>,
         ETimestamp: Into<Self::Expr>,
+        EAddr: Into<Self::Expr>,
         EPrevValue: Into<Self::Expr>,
         EValue: Into<Self::Expr>,
         EMultiplicity: Into<Self::Expr>,
@@ -63,7 +63,7 @@ pub trait RecursionAirBuilder: BaseAirBuilder {
         ));
     }
 
-    fn eval_memory_read<EAddr, EPrevTimestamp, ETimestamp, EValue, EMultiplicity>(
+    fn eval_memory_read<EPrevTimestamp, ETimestamp, EAddr, EValue, EMultiplicity>(
         &mut self,
         prev_timestamp: EPrevTimestamp,
         timestamp: ETimestamp,
@@ -71,9 +71,9 @@ pub trait RecursionAirBuilder: BaseAirBuilder {
         value: EValue,
         multiplicity: EMultiplicity,
     ) where
-        EAddr: Into<Self::Expr>,
         EPrevTimestamp: Into<Self::Expr>,
         ETimestamp: Into<Self::Expr>,
+        EAddr: Into<Self::Expr>,
         EValue: Into<Block<Self::Expr>>,
         EMultiplicity: Into<Self::Expr>,
     {

--- a/recursion/core/src/air/builder.rs
+++ b/recursion/core/src/air/builder.rs
@@ -1,4 +1,3 @@
-use p3_field::AbstractField;
 use sp1_core::{
     air::{AirInteraction, BaseAirBuilder, SP1AirBuilder},
     lookup::InteractionKind,

--- a/recursion/core/src/air/builder.rs
+++ b/recursion/core/src/air/builder.rs
@@ -9,7 +9,7 @@ use super::Block;
 impl<AB: SP1AirBuilder> RecursionAirBuilder for AB {}
 
 pub trait RecursionAirBuilder: BaseAirBuilder {
-    fn eval_memory_read_write_multiplicity<
+    fn eval_memory_read_write<
         EAddr,
         EPrevTimestamp,
         ETimestamp,
@@ -18,9 +18,9 @@ pub trait RecursionAirBuilder: BaseAirBuilder {
         EMultiplicity,
     >(
         &mut self,
-        addr: EAddr,
         prev_timestamp: EPrevTimestamp,
         timestamp: ETimestamp,
+        addr: EAddr,
         prev_value: Block<EPrevValue>,
         value: Block<EValue>,
         multiplicity: EMultiplicity,
@@ -32,10 +32,12 @@ pub trait RecursionAirBuilder: BaseAirBuilder {
         EValue: Into<Self::Expr>,
         EMultiplicity: Into<Self::Expr>,
     {
+        // TODO add timestamp checks once we have them implemented in recursion VM.
         let [prev_value_0, prev_value_1, prev_value_2, prev_value_3] = prev_value.0;
         let [value_0, value_1, value_2, value_3] = value.0;
         let addr = addr.into();
         let multiplicity = multiplicity.into();
+
         self.receive(AirInteraction::new(
             vec![
                 addr.clone(),
@@ -62,50 +64,29 @@ pub trait RecursionAirBuilder: BaseAirBuilder {
         ));
     }
 
-    fn eval_memory_read_write<EAddr, EPrevTimestamp, ETimestamp, EPrevValue, EValue>(
+    fn eval_memory_read<EAddr, EPrevTimestamp, ETimestamp, EValue, EMultiplicity>(
         &mut self,
-        addr: EAddr,
         prev_timestamp: EPrevTimestamp,
         timestamp: ETimestamp,
-        prev_value: Block<EPrevValue>,
-        value: Block<EValue>,
-    ) where
-        EAddr: Into<Self::Expr>,
-        EPrevTimestamp: Into<Self::Expr>,
-        ETimestamp: Into<Self::Expr>,
-        EPrevValue: Into<Self::Expr>,
-        EValue: Into<Self::Expr>,
-    {
-        self.eval_memory_read_write_multiplicity(
-            addr,
-            prev_timestamp,
-            timestamp,
-            prev_value,
-            value,
-            Self::Expr::one(),
-        )
-    }
-
-    fn eval_memory_read<EAddr, EPrevTimestamp, ETimestamp, EValue>(
-        &mut self,
         addr: EAddr,
-        prev_timestamp: EPrevTimestamp,
-        timestamp: ETimestamp,
         value: EValue,
+        multiplicity: EMultiplicity,
     ) where
         EAddr: Into<Self::Expr>,
         EPrevTimestamp: Into<Self::Expr>,
         ETimestamp: Into<Self::Expr>,
         EValue: Into<Block<Self::Expr>>,
+        EMultiplicity: Into<Self::Expr>,
     {
         let addr = addr.into();
         let value = value.into();
         self.eval_memory_read_write(
-            addr,
             prev_timestamp.into(),
             timestamp.into(),
+            addr,
             value.clone(),
             value,
+            multiplicity,
         )
     }
 }

--- a/recursion/core/src/air/builder.rs
+++ b/recursion/core/src/air/builder.rs
@@ -1,0 +1,111 @@
+use p3_field::AbstractField;
+use sp1_core::{
+    air::{AirInteraction, BaseAirBuilder, SP1AirBuilder},
+    lookup::InteractionKind,
+};
+
+use super::Block;
+
+pub trait Sp1RecursionAirBuilder: SP1AirBuilder + RecursionAirBuilder {}
+
+pub trait RecursionAirBuilder: BaseAirBuilder {
+    fn eval_memory_read_write_multiplicity<
+        EAddr,
+        EPrevTimestamp,
+        ETimestamp,
+        EPrevValue,
+        EValue,
+        EMultiplicity,
+    >(
+        &mut self,
+        addr: EAddr,
+        prev_timestamp: EPrevTimestamp,
+        timestamp: ETimestamp,
+        prev_value: Block<EPrevValue>,
+        value: Block<EValue>,
+        multiplicity: EMultiplicity,
+    ) where
+        EAddr: Into<Self::Expr>,
+        EPrevTimestamp: Into<Self::Expr>,
+        ETimestamp: Into<Self::Expr>,
+        EPrevValue: Into<Self::Expr>,
+        EValue: Into<Self::Expr>,
+        EMultiplicity: Into<Self::Expr>,
+    {
+        let [prev_value_0, prev_value_1, prev_value_2, prev_value_3] = prev_value.0;
+        let [value_0, value_1, value_2, value_3] = value.0;
+        let addr = addr.into();
+        let multiplicity = multiplicity.into();
+        self.receive(AirInteraction::new(
+            vec![
+                addr.clone(),
+                prev_timestamp.into(),
+                prev_value_0.into(),
+                prev_value_1.into(),
+                prev_value_2.into(),
+                prev_value_3.into(),
+            ],
+            multiplicity.clone(),
+            InteractionKind::Memory,
+        ));
+        self.send(AirInteraction::new(
+            vec![
+                addr,
+                timestamp.into(),
+                value_0.into(),
+                value_1.into(),
+                value_2.into(),
+                value_3.into(),
+            ],
+            multiplicity,
+            InteractionKind::Memory,
+        ));
+    }
+
+    fn eval_memory_read_write<EAddr, EPrevTimestamp, ETimestamp, EPrevValue, EValue>(
+        &mut self,
+        addr: EAddr,
+        prev_timestamp: EPrevTimestamp,
+        timestamp: ETimestamp,
+        prev_value: Block<EPrevValue>,
+        value: Block<EValue>,
+    ) where
+        EAddr: Into<Self::Expr>,
+        EPrevTimestamp: Into<Self::Expr>,
+        ETimestamp: Into<Self::Expr>,
+        EPrevValue: Into<Self::Expr>,
+        EValue: Into<Self::Expr>,
+    {
+        self.eval_memory_read_write_multiplicity(
+            addr,
+            prev_timestamp,
+            timestamp,
+            prev_value,
+            value,
+            Self::Expr::one(),
+        )
+    }
+
+    fn eval_memory_read<EAddr, EPrevTimestamp, ETimestamp, EValue>(
+        &mut self,
+        addr: EAddr,
+        prev_timestamp: EPrevTimestamp,
+        timestamp: ETimestamp,
+        value: EValue,
+    ) where
+        EAddr: Into<Self::Expr>,
+        EPrevTimestamp: Into<Self::Expr>,
+        ETimestamp: Into<Self::Expr>,
+        EValue: Into<Block<Self::Expr>>,
+    {
+        let addr = addr.into();
+        let value = value.into();
+        self.eval_memory_read_write(
+            addr,
+            prev_timestamp.into(),
+            timestamp.into(),
+            value.clone(),
+            value,
+        )
+    }
+}

--- a/recursion/core/src/air/builder.rs
+++ b/recursion/core/src/air/builder.rs
@@ -6,7 +6,7 @@ use sp1_core::{
 
 use super::Block;
 
-pub trait Sp1RecursionAirBuilder: SP1AirBuilder + RecursionAirBuilder {}
+impl<AB: SP1AirBuilder> RecursionAirBuilder for AB {}
 
 pub trait RecursionAirBuilder: BaseAirBuilder {
     fn eval_memory_read_write_multiplicity<

--- a/recursion/core/src/air/mod.rs
+++ b/recursion/core/src/air/mod.rs
@@ -1,9 +1,11 @@
 mod block;
+mod builder;
 mod extension;
 mod is_ext_zero;
 mod public_values;
 
 pub use block::*;
+pub use builder::*;
 pub use extension::*;
 pub use is_ext_zero::*;
 pub use public_values::*;

--- a/recursion/core/src/cpu/air.rs
+++ b/recursion/core/src/cpu/air.rs
@@ -264,30 +264,30 @@ where
         // );
 
         // Receive C.
-        builder.eval_memory_read_write_multiplicity(
-            local.c.addr,
+        builder.eval_memory_read_write(
             local.c.prev_timestamp,
             local.c.timestamp,
+            local.c.addr,
             local.c.prev_value,
             local.c.value,
             AB::Expr::one() - local.instruction.imm_c.into(),
         );
 
         // Receive B.
-        builder.eval_memory_read_write_multiplicity(
-            local.b.addr,
+        builder.eval_memory_read_write(
             local.b.prev_timestamp,
             local.b.timestamp,
+            local.b.addr,
             local.b.prev_value,
             local.b.value,
             AB::Expr::one() - local.instruction.imm_b.into(),
         );
 
         // Receive A.
-        builder.eval_memory_read_write_multiplicity(
-            local.a.addr,
+        builder.eval_memory_read_write(
             local.a.prev_timestamp,
             local.a.timestamp,
+            local.a.addr,
             local.a.prev_value,
             local.a.value,
             local.is_real.into(),

--- a/recursion/core/src/cpu/air.rs
+++ b/recursion/core/src/cpu/air.rs
@@ -1,5 +1,6 @@
 use crate::air::BinomialExtensionUtils;
 use crate::air::BlockBuilder;
+use crate::air::RecursionAirBuilder;
 use crate::cpu::CpuChip;
 use crate::runtime::RecursionProgram;
 use core::mem::size_of;
@@ -12,6 +13,7 @@ use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::Matrix;
 use sp1_core::air::BinomialExtension;
 use sp1_core::air::MachineAir;
+use sp1_core::air::SP1AirBuilder;
 use sp1_core::utils::indices_arr;
 use sp1_core::utils::pad_rows;
 use std::borrow::Borrow;
@@ -20,7 +22,6 @@ use std::mem::transmute;
 use tracing::instrument;
 
 use super::columns::CpuCols;
-use crate::air::Sp1RecursionAirBuilder;
 use crate::runtime::ExecutionRecord;
 
 pub const NUM_CPU_COLS: usize = size_of::<CpuCols<u8>>();
@@ -143,7 +144,7 @@ impl<F: Send + Sync> BaseAir<F> for CpuChip<F> {
 
 impl<AB> Air<AB> for CpuChip<AB::F>
 where
-    AB: Sp1RecursionAirBuilder,
+    AB: SP1AirBuilder,
 {
     fn eval(&self, builder: &mut AB) {
         // Constraints for the CPU chip.

--- a/recursion/core/src/cpu/air.rs
+++ b/recursion/core/src/cpu/air.rs
@@ -263,35 +263,13 @@ where
         //     local.is_real.into(),
         // );
 
-        // Receive C.
-        builder.eval_memory_read_write(
-            local.c.prev_timestamp,
-            local.c.timestamp,
-            local.c.addr,
-            local.c.prev_value,
-            local.c.value,
-            AB::Expr::one() - local.instruction.imm_c.into(),
-        );
+        let b_addr = local.fp + local.instruction.op_b[0];
+        // TODO: only evaluate the memory access when is_real * (1 - imm_b) is true.
+        builder.eval_memory_access(local.clk, b_addr, local.b, local.is_real.into());
 
-        // Receive B.
-        builder.eval_memory_read_write(
-            local.b.prev_timestamp,
-            local.b.timestamp,
-            local.b.addr,
-            local.b.prev_value,
-            local.b.value,
-            AB::Expr::one() - local.instruction.imm_b.into(),
-        );
+        let c_addr = local.fp + local.instruction.op_c[0];
 
-        // Receive A.
-        builder.eval_memory_read_write(
-            local.a.prev_timestamp,
-            local.a.timestamp,
-            local.a.addr,
-            local.a.prev_value,
-            local.a.value,
-            local.is_real.into(),
-        );
+        let a_addr = local.fp + local.instruction.op_a[0];
 
         // let mut prog_interaction_vals: Vec<AB::Expr> = vec![local.instruction.opcode.into()];
         // prog_interaction_vals.push(local.instruction.op_a.into());

--- a/recursion/core/src/cpu/columns/mod.rs
+++ b/recursion/core/src/cpu/columns/mod.rs
@@ -1,4 +1,5 @@
 use crate::{air::IsExtZeroOperation, memory::MemoryReadWriteCols};
+use sp1_core::memory::MemoryReadCols;
 use sp1_derive::AlignedBorrow;
 
 mod alu;
@@ -26,8 +27,8 @@ pub struct CpuCols<T: Copy> {
     pub selectors: OpcodeSelectorCols<T>,
 
     pub a: MemoryReadWriteCols<T>,
-    pub b: MemoryReadWriteCols<T>,
-    pub c: MemoryReadWriteCols<T>,
+    pub b: MemoryReadCols<T>,
+    pub c: MemoryReadCols<T>,
 
     pub opcode_specific: OpcodeSpecificCols<T>,
 

--- a/recursion/core/src/memory/columns.rs
+++ b/recursion/core/src/memory/columns.rs
@@ -10,3 +10,143 @@ pub struct MemoryInitCols<T> {
     pub value: Block<T>,
     pub is_real: T,
 }
+
+/// NOTE: These are very similar to core/src/memory/columns.rs
+/// The reason we cannot use those structs directly is that they use "shard".
+/// In our recursive VM, we don't have shards, we only have `clk` (i.e. timestamp).
+
+/// Memory read access.
+#[derive(AlignedBorrow, Default, Debug, Clone, Copy)]
+#[repr(C)]
+pub struct MemoryReadCols<T> {
+    pub access: MemoryAccessCols<T>,
+}
+
+/// Memory write access.
+#[derive(AlignedBorrow, Default, Debug, Clone, Copy)]
+#[repr(C)]
+pub struct MemoryWriteCols<T> {
+    pub prev_value: Word<T>,
+    pub access: MemoryAccessCols<T>,
+}
+
+/// Memory read-write access.
+#[derive(AlignedBorrow, Default, Debug, Clone, Copy)]
+#[repr(C)]
+pub struct MemoryReadWriteCols<T> {
+    pub prev_value: Word<T>,
+    pub access: MemoryAccessCols<T>,
+}
+
+#[derive(AlignedBorrow, Default, Debug, Clone, Copy)]
+#[repr(C)]
+pub struct MemoryAccessCols<T> {
+    /// The value of the memory access.
+    pub value: Word<T>,
+
+    /// The previous timestamp that this memory access is being read from.
+    pub prev_timestamp: T,
+
+    /// The following columns are decomposed limbs for the difference between the current access's timestamp
+    /// and the previous access's timestamp.  Note the actual value of the timestamp is either the
+    /// accesses' shard or clk depending on the value of compare_clk.
+
+    /// This column is the least significant 16 bit limb of current access timestamp - prev access timestamp.
+    pub diff_16bit_limb: T,
+
+    /// This column is the most signficant 8 bit limb of current access timestamp - prev access timestamp.
+    pub diff_8bit_limb: T,
+}
+
+/// The common columns for all memory access types.
+pub trait MemoryCols<T> {
+    fn access(&self) -> &MemoryAccessCols<T>;
+
+    fn access_mut(&mut self) -> &mut MemoryAccessCols<T>;
+
+    fn prev_value(&self) -> &Word<T>;
+
+    fn prev_value_mut(&mut self) -> &mut Word<T>;
+
+    fn value(&self) -> &Word<T>;
+
+    fn value_mut(&mut self) -> &mut Word<T>;
+}
+
+impl<T> MemoryCols<T> for MemoryReadCols<T> {
+    fn access(&self) -> &MemoryAccessCols<T> {
+        &self.access
+    }
+
+    fn access_mut(&mut self) -> &mut MemoryAccessCols<T> {
+        &mut self.access
+    }
+
+    fn prev_value(&self) -> &Word<T> {
+        &self.access.value
+    }
+
+    fn prev_value_mut(&mut self) -> &mut Word<T> {
+        &mut self.access.value
+    }
+
+    fn value(&self) -> &Word<T> {
+        &self.access.value
+    }
+
+    fn value_mut(&mut self) -> &mut Word<T> {
+        &mut self.access.value
+    }
+}
+
+impl<T> MemoryCols<T> for MemoryWriteCols<T> {
+    fn access(&self) -> &MemoryAccessCols<T> {
+        &self.access
+    }
+
+    fn access_mut(&mut self) -> &mut MemoryAccessCols<T> {
+        &mut self.access
+    }
+
+    fn prev_value(&self) -> &Word<T> {
+        &self.prev_value
+    }
+
+    fn prev_value_mut(&mut self) -> &mut Word<T> {
+        &mut self.prev_value
+    }
+
+    fn value(&self) -> &Word<T> {
+        &self.access.value
+    }
+
+    fn value_mut(&mut self) -> &mut Word<T> {
+        &mut self.access.value
+    }
+}
+
+impl<T> MemoryCols<T> for MemoryReadWriteCols<T> {
+    fn access(&self) -> &MemoryAccessCols<T> {
+        &self.access
+    }
+
+    fn access_mut(&mut self) -> &mut MemoryAccessCols<T> {
+        &mut self.access
+    }
+
+    fn prev_value(&self) -> &Word<T> {
+        &self.prev_value
+    }
+
+    fn prev_value_mut(&mut self) -> &mut Word<T> {
+        &mut self.prev_value
+    }
+
+    fn value(&self) -> &Word<T> {
+        &self.access.value
+    }
+
+    fn value_mut(&mut self) -> &mut Word<T> {
+        &mut self.access.value
+    }
+}

--- a/recursion/core/src/memory/mod.rs
+++ b/recursion/core/src/memory/mod.rs
@@ -2,34 +2,70 @@ mod air;
 mod columns;
 
 use crate::air::Block;
+use columns::*;
 use sp1_derive::AlignedBorrow;
 
+#[allow(clippy::manual_non_exhaustive)]
 #[derive(Debug, Clone)]
 pub struct MemoryRecord<F> {
     pub addr: F,
     pub value: Block<F>,
-    pub timestamp: F,
     pub prev_value: Block<F>,
+    pub timestamp: F,
     pub prev_timestamp: F,
+    _private: (),
 }
 
-#[derive(AlignedBorrow, Default, Debug, Clone)]
-#[repr(C)]
-pub struct MemoryReadWriteCols<T> {
-    pub addr: T,
-    pub value: Block<T>,
-    pub timestamp: T,
-    pub prev_value: Block<T>,
-    pub prev_timestamp: T,
+impl<F> MemoryRecord<F> {
+    pub fn new_write(
+        addr: F,
+        value: Block<F>,
+        timestamp: F,
+        prev_value: Block<F>,
+        prev_timestamp: F,
+    ) -> Self {
+        Self {
+            addr,
+            value,
+            prev_value,
+            timestamp,
+            prev_timestamp,
+            _private: (),
+        }
+    }
+
+    pub fn new_read(addr: F, value: Block<F>, timestamp: F, prev_timestamp: F) -> Self {
+        Self {
+            addr,
+            value,
+            prev_value: value,
+            timestamp,
+            prev_timestamp,
+            _private: (),
+        }
+    }
 }
 
 impl<T: Clone> MemoryReadWriteCols<T> {
     pub fn populate(&mut self, record: &MemoryRecord<T>) {
-        self.addr = record.addr.clone();
-        self.value = record.value.clone();
-        self.timestamp = record.timestamp.clone();
+        self.access.prev_timestamp = record.prev_timestamp.clone();
+        self.access.value = record.value.clone();
         self.prev_value = record.prev_value.clone();
-        self.prev_timestamp = record.prev_timestamp.clone();
+    }
+}
+
+impl<T: Clone> MemoryWriteCols<T> {
+    pub fn populate(&mut self, record: &MemoryRecord<T>) {
+        self.access.prev_timestamp = record.prev_timestamp.clone();
+        self.access.value = record.value.clone();
+        self.prev_value = record.prev_value.clone();
+    }
+}
+
+impl<T: Clone> MemoryReadCols<T> {
+    pub fn populate(&mut self, record: &MemoryRecord<T>) {
+        self.access.prev_timestamp = record.prev_timestamp.clone();
+        self.access.value = record.value.clone();
     }
 }
 

--- a/recursion/core/src/runtime/mod.rs
+++ b/recursion/core/src/runtime/mod.rs
@@ -220,13 +220,7 @@ where
             .entry(addr.as_canonical_u32() as usize)
             .or_default();
         let (prev_value, prev_timestamp) = (entry.value, entry.timestamp);
-        let record = MemoryRecord {
-            addr,
-            value: prev_value,
-            timestamp,
-            prev_value,
-            prev_timestamp,
-        };
+        let record = MemoryRecord::new_read(addr, prev_value, timestamp, prev_timestamp);
         *entry = MemoryEntry {
             value: prev_value,
             timestamp,
@@ -245,13 +239,7 @@ where
         let timestamp = self.timestamp(&position);
         let entry = self.memory.entry(addr_usize).or_default();
         let (prev_value, prev_timestamp) = (entry.value, entry.timestamp);
-        let record = MemoryRecord {
-            addr,
-            value,
-            timestamp,
-            prev_value,
-            prev_timestamp,
-        };
+        let record = MemoryRecord::new_write(addr, value, timestamp, prev_value, prev_timestamp);
         *entry = MemoryEntry { value, timestamp };
         match position {
             MemoryAccessPosition::A => self.access.a = Some(record),


### PR DESCRIPTION
- add trait with convenience methods for memory lookups similar to `eval_memory_access` in core sp1.