### PR TITLE
refactor: avoid a few allocations in constraint code

### DIFF
--- a/core/src/air/builder.rs
+++ b/core/src/air/builder.rs
@@ -1,3 +1,4 @@
+use std::array;
 use std::iter::once;
 
 use itertools::Itertools;
@@ -53,6 +54,7 @@ pub trait BaseAirBuilder: AirBuilder + MessageBuilder<AirInteraction<Self::Expr>
 
     /// Will return `a` if `condition` is 1, else `b`.  This assumes that `condition` is already
     /// checked to be a boolean.
+    #[inline]
     fn if_else(
         &mut self,
         condition: impl Into<Self::Expr> + Clone,
@@ -207,11 +209,9 @@ pub trait WordAirBuilder: ByteAirBuilder {
         a: Word<impl Into<Self::Expr> + Clone>,
         b: Word<impl Into<Self::Expr> + Clone>,
     ) -> Word<Self::Expr> {
-        let mut res = vec![];
-        for i in 0..WORD_SIZE {
-            res.push(self.if_else(condition.clone(), a[i].clone(), b[i].clone()));
-        }
-        Word(res.try_into().unwrap())
+        Word(array::from_fn(|i| {
+            self.if_else(condition.clone(), a[i].clone(), b[i].clone())
+        }))
     }
 
     /// Check that each limb of the given slice is a u8.
@@ -401,7 +401,7 @@ pub trait MemoryAirBuilder: BaseAirBuilder {
             .chain(memory_access.value().clone().map(Into::into))
             .collect();
 
-        // The previous values get sent with multiplicity * 1, for "read".
+        // The previous values get sent with multiplicity = 1, for "read".
         self.send(AirInteraction::new(
             prev_values,
             do_check.clone(),
@@ -438,7 +438,7 @@ pub trait MemoryAirBuilder: BaseAirBuilder {
 
     /// Verifies the memory access timestamp.
     ///
-    /// This method verifies that the current memory access happend after the previous one's.  
+    /// This method verifies that the current memory access happened after the previous one's.
     /// Specifically it will ensure that if the current and previous access are in the same shard,
     /// then the current's clk val is greater than the previous's.  If they are not in the same
     /// shard, then it will ensure that the current's shard val is greater than the previous's.

--- a/core/src/air/public_values.rs
+++ b/core/src/air/public_values.rs
@@ -1,5 +1,6 @@
 use core::fmt::Debug;
 use core::mem::size_of;
+use std::array;
 use std::iter::once;
 
 use itertools::Itertools;
@@ -78,10 +79,7 @@ impl<T: Clone + Debug> PublicValues<Word<T>, T> {
     pub fn from_vec(data: Vec<T>) -> Self {
         let mut iter = data.iter().cloned();
 
-        let mut committed_value_digest = Vec::new();
-        for _ in 0..PV_DIGEST_NUM_WORDS {
-            committed_value_digest.push(Word::from_iter(&mut iter));
-        }
+        let committed_value_digest = array::from_fn(|_| Word::from_iter(&mut iter));
 
         let deferred_proofs_digest = iter
             .by_ref()
@@ -103,7 +101,7 @@ impl<T: Clone + Debug> PublicValues<Word<T>, T> {
         };
 
         Self {
-            committed_value_digest: committed_value_digest.try_into().unwrap(),
+            committed_value_digest,
             deferred_proofs_digest,
             start_pc: start_pc.to_owned(),
             next_pc: next_pc.to_owned(),

--- a/core/src/air/word.rs
+++ b/core/src/air/word.rs
@@ -99,14 +99,7 @@ impl<T> IndexMut<usize> for Word<T> {
 
 impl<F: AbstractField> From<u32> for Word<F> {
     fn from(value: u32) -> Self {
-        let inner = value
-            .to_le_bytes()
-            .into_iter()
-            .map(F::from_canonical_u8)
-            .collect::<Vec<_>>()
-            .try_into()
-            .unwrap();
-        Word(inner)
+        Word(value.to_le_bytes().map(F::from_canonical_u8))
     }
 }
 

--- a/core/src/operations/fixed_shift_right.rs
+++ b/core/src/operations/fixed_shift_right.rs
@@ -118,13 +118,13 @@ impl<F: Field> FixedShiftRightOperation<F> {
         let carry_multiplier = AB::F::from_canonical_u32(Self::carry_multiplier(rotation));
 
         // Perform the byte shift.
-        let mut word = vec![AB::Expr::zero(); WORD_SIZE];
-        for i in 0..WORD_SIZE {
+        let input_bytes_rotated = Word(std::array::from_fn(|i| {
             if i + nb_bytes_to_shift < WORD_SIZE {
-                word[i] = input[(i + nb_bytes_to_shift) % WORD_SIZE].into();
+                input[(i + nb_bytes_to_shift) % WORD_SIZE].into()
+            } else {
+                AB::Expr::zero()
             }
-        }
-        let input_bytes_rotated = Word(word.try_into().unwrap());
+        }));
 
         // For each byte, calculate the shift and carry. If it's not the first byte, calculate the
         // new byte value using the current shifted byte and the last carry.


### PR DESCRIPTION
Just some low-hanging fruit for now. Some allocations might be harder to avoid; we could also try
- inlining things (if they aren't already) as needed to help the compiler get rid of annotations
- using a user-space allocator like jemalloc, which seems a lot better than macOS system allocator at least