### PR TITLE
fix: downgrade `strum`

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -53,8 +53,8 @@ tempfile = "3.9.0"
 tracing = "0.1.40"
 tracing-forest = { version = "0.1.6", features = ["ansi", "smallvec"] }
 tracing-subscriber = { version = "0.3.17", features = ["std", "env-filter"] }
-strum_macros = { version = "0.26" }
-strum = { version = "0.26" }
+strum_macros = "0.26"
+strum = "0.26"
 web-time = "1.1.0"
 rayon-scan = "0.1.1"
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -53,8 +53,8 @@ tempfile = "3.9.0"
 tracing = "0.1.40"
 tracing-forest = { version = "0.1.6", features = ["ansi", "smallvec"] }
 tracing-subscriber = { version = "0.3.17", features = ["std", "env-filter"] }
-strum_macros = "0.26.2"
-strum = "0.26.2"
+strum_macros = "0.26.1"
+strum = "0.26.1"
 web-time = "1.1.0"
 rayon-scan = "0.1.1"
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -53,8 +53,8 @@ tempfile = "3.9.0"
 tracing = "0.1.40"
 tracing-forest = { version = "0.1.6", features = ["ansi", "smallvec"] }
 tracing-subscriber = { version = "0.3.17", features = ["std", "env-filter"] }
-strum_macros = "0.26.1"
-strum = "0.26.1"
+strum_macros = { version = "0.26" }
+strum = { version = "0.26" }
 web-time = "1.1.0"
 rayon-scan = "0.1.1"
 


### PR DESCRIPTION
Give more flexibility to libraries (such as `sp1-reth`) when resolving `strum`. Previously, the version of `0.26.2` was causing some dependency conflicts, as some libraries such as `alloy-chains` were locked to `0.26.1`.