### PR TITLE
refactor: `get_cycles`

### DIFF
--- a/core/src/utils/prove.rs
+++ b/core/src/utils/prove.rs
@@ -22,12 +22,6 @@ use crate::{
 
 const LOG_DEGREE_BOUND: usize = 31;
 
-pub fn get_cycles(program: Program) -> u64 {
-    let mut runtime = Runtime::new(program);
-    runtime.run();
-    runtime.state.global_clk as u64
-}
-
 /// Runs a program and returns the public values stream.
 pub fn run_test_io(
     program: Program,

--- a/eval/src/main.rs
+++ b/eval/src/main.rs
@@ -89,7 +89,6 @@ fn main() {
     // Load the program.
     let elf_path = &args.elf_path;
     let elf = fs::read(elf_path).expect("Failed to read ELF file");
-    let program = Program::from(&elf);
     let cycles = get_cycles(&elf);
 
     // Initialize total duration counters.
@@ -98,6 +97,7 @@ fn main() {
     let mut total_verify_duration = 0f64;
 
     // Perform runs.
+    let program = Program::from(&elf);
     for _ in 0..args.runs {
         let elf = fs::read(elf_path).expect("Failed to read ELF file");
         let (execution_duration, prove_duration, verify_duration) =

--- a/eval/src/main.rs
+++ b/eval/src/main.rs
@@ -7,6 +7,7 @@ use serde::Serialize;
 use sp1_core::runtime::{Program, Runtime};
 use sp1_core::utils::{prove_core, BabyBearBlake3, BabyBearKeccak, BabyBearPoseidon2};
 use sp1_prover::utils::get_cycles;
+use sp1_prover::SP1Stdin;
 use std::fmt;
 use std::fs::OpenOptions;
 use std::io;
@@ -89,7 +90,7 @@ fn main() {
     // Load the program.
     let elf_path = &args.elf_path;
     let elf = fs::read(elf_path).expect("Failed to read ELF file");
-    let cycles = get_cycles(&elf);
+    let cycles = get_cycles(&elf, &SP1Stdin::new());
 
     // Initialize total duration counters.
     let mut total_execution_duration = 0f64;

--- a/eval/src/main.rs
+++ b/eval/src/main.rs
@@ -132,7 +132,7 @@ fn main() {
 }
 
 fn run_evaluation(hashfn: &HashFnId, program: &Program, _elf: &[u8]) -> (f64, f64, f64) {
-    // TODO: While these benchmarks are useful for core proving, they are not useful for recursion
+    // Note: While these benchmarks are useful for core proving, they are not useful for recursion
     // or end to end proving as we only support Poseidon for now.
     match hashfn {
         HashFnId::Blake3 => {

--- a/eval/src/main.rs
+++ b/eval/src/main.rs
@@ -5,7 +5,8 @@ use clap::{command, Parser};
 use csv::WriterBuilder;
 use serde::Serialize;
 use sp1_core::runtime::{Program, Runtime};
-use sp1_core::utils::{get_cycles, prove_core, BabyBearBlake3, BabyBearKeccak, BabyBearPoseidon2};
+use sp1_core::utils::{prove_core, BabyBearBlake3, BabyBearKeccak, BabyBearPoseidon2};
+use sp1_prover::utils::get_cycles;
 use std::fmt;
 use std::fs::OpenOptions;
 use std::io;
@@ -87,8 +88,9 @@ fn main() {
 
     // Load the program.
     let elf_path = &args.elf_path;
-    let program = Program::from_elf(elf_path);
-    let cycles = get_cycles(program.clone());
+    let elf = fs::read(elf_path).expect("Failed to read ELF file");
+    let program = Program::from(&elf);
+    let cycles = get_cycles(&elf);
 
     // Initialize total duration counters.
     let mut total_execution_duration = 0f64;
@@ -130,6 +132,8 @@ fn main() {
 }
 
 fn run_evaluation(hashfn: &HashFnId, program: &Program, _elf: &[u8]) -> (f64, f64, f64) {
+    // TODO: While these benchmarks are useful for core proving, they are not useful for recursion
+    // or end to end proving as we only support Poseidon for now.
     match hashfn {
         HashFnId::Blake3 => {
             let mut runtime = Runtime::new(program.clone());

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::new_without_default)]
 
 mod types;
-mod utils;
+pub mod utils;
 mod verify;
 
 pub use types::*;

--- a/prover/src/utils.rs
+++ b/prover/src/utils.rs
@@ -1,7 +1,11 @@
-use std::fs;
+use std::{
+    fs::{self, File},
+    io::Read,
+};
 
 use sp1_core::{
     air::{MachineAir, Word},
+    runtime::{Program, Runtime},
     stark::{Dom, ShardProof, StarkGenericConfig, StarkMachine, StarkVerifyingKey, Val},
 };
 use sp1_recursion_program::stark::EMPTY;
@@ -14,6 +18,19 @@ impl SP1CoreProof {
         fs::write(path, data).unwrap();
         Ok(())
     }
+}
+
+pub fn get_cycles(elf: &[u8]) -> u64 {
+    let program = Program::from(elf);
+    let mut runtime = Runtime::new(program);
+    runtime.run();
+    runtime.state.global_clk
+}
+
+pub fn load_elf(path: &str) -> Result<Vec<u8>, std::io::Error> {
+    let mut elf_code = Vec::new();
+    File::open(path)?.read_to_end(&mut elf_code)?;
+    Ok(elf_code)
 }
 
 pub fn get_sorted_indices<SC: StarkGenericConfig, A: MachineAir<Val<SC>>>(

--- a/prover/src/utils.rs
+++ b/prover/src/utils.rs
@@ -20,6 +20,7 @@ impl SP1CoreProof {
     }
 }
 
+/// Get the number of cycles for a given program.
 pub fn get_cycles(elf: &[u8]) -> u64 {
     let program = Program::from(elf);
     let mut runtime = Runtime::new(program);
@@ -27,6 +28,7 @@ pub fn get_cycles(elf: &[u8]) -> u64 {
     runtime.state.global_clk
 }
 
+/// Load an ELF file from a given path.
 pub fn load_elf(path: &str) -> Result<Vec<u8>, std::io::Error> {
     let mut elf_code = Vec::new();
     File::open(path)?.read_to_end(&mut elf_code)?;

--- a/prover/src/utils.rs
+++ b/prover/src/utils.rs
@@ -5,6 +5,7 @@ use std::{
 
 use sp1_core::{
     air::{MachineAir, Word},
+    io::SP1Stdin,
     runtime::{Program, Runtime},
     stark::{Dom, ShardProof, StarkGenericConfig, StarkMachine, StarkVerifyingKey, Val},
 };
@@ -21,9 +22,10 @@ impl SP1CoreProof {
 }
 
 /// Get the number of cycles for a given program.
-pub fn get_cycles(elf: &[u8]) -> u64 {
+pub fn get_cycles(elf: &[u8], stdin: &SP1Stdin) -> u64 {
     let program = Program::from(elf);
     let mut runtime = Runtime::new(program);
+    runtime.write_vecs(&stdin.buffer);
     runtime.run();
     runtime.state.global_clk
 }


### PR DESCRIPTION
Move `get_cycles` utility method into `sp1-prover` for use in benchmarking.