### PR TITLE
fix: circuit sponge absorb rate

### DIFF
--- a/recursion/circuit/src/lib.rs
+++ b/recursion/circuit/src/lib.rs
@@ -16,7 +16,7 @@ pub mod witness;
 
 pub const SPONGE_SIZE: usize = 3;
 pub const DIGEST_SIZE: usize = 1;
-pub const RATE: usize = 14;
+pub const RATE: usize = 16;
 
 #[cfg(test)]
 mod tests {

--- a/recursion/core/src/stark/config.rs
+++ b/recursion/core/src/stark/config.rs
@@ -23,7 +23,7 @@ use super::poseidon2::bn254_poseidon2_rc3;
 pub type OuterVal = BabyBear;
 pub type OuterChallenge = BinomialExtensionField<OuterVal, 4>;
 pub type OuterPerm = Poseidon2<Bn254Fr, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBN254, 3, 5>;
-pub type OuterHash = MultiField32PaddingFreeSponge<OuterVal, Bn254Fr, OuterPerm, 3, 14, 1>;
+pub type OuterHash = MultiField32PaddingFreeSponge<OuterVal, Bn254Fr, OuterPerm, 3, 16, 1>;
 pub type OuterDigestHash = Hash<Bn254Fr, Bn254Fr, 1>;
 pub type OuterDigest = [Bn254Fr; 1];
 pub type OuterCompress = TruncatedPermutation<OuterPerm, 2, 1, 3>;


### PR DESCRIPTION
in the circuit, each babybear elemnet is log2(15*2^27+1)*8=247 bits which is less than Bn254, so we can actually absorb 8 elements, not 7 per Bn254. Should increase hashing efficiency at the leaves by ~15%.