### PR TITLE
feat: load circuit artifacts in faster

### DIFF
--- a/.github/workflows/groth16.yml
+++ b/.github/workflows/groth16.yml
@@ -36,6 +36,3 @@ jobs:
           RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0 -Ctarget-cpu=native
           RUST_LOG: "info"
           RUST_BACKTRACE: "1"
-          MAX_RECURSION_PROGRAM_SIZE: "1"
-          FRI_QUERIES: "1"
-          VERBOSE: "true"

--- a/.github/workflows/groth16.yml
+++ b/.github/workflows/groth16.yml
@@ -36,3 +36,5 @@ jobs:
           RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0 -Ctarget-cpu=native
           RUST_LOG: "info"
           RUST_BACKTRACE: "1"
+          FRI_QUERIES: "1"
+          SP1_DEV_WRAPPER: "false"

--- a/.github/workflows/groth16.yml
+++ b/.github/workflows/groth16.yml
@@ -1,0 +1,41 @@
+name: Gnark Tests
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  groth16:
+    name: Groth16
+    runs-on: warp-ubuntu-latest-arm64-8x
+    env:
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Setup CI
+        uses: ./.github/actions/setup
+        with:
+          pull_token: ${{ secrets.PULL_TOKEN }}
+
+      - name: Install sp1 toolchain
+        run: |
+          curl -L https://sp1.succinct.xyz | bash
+          echo "/root/.sp1/bin" >> $GITHUB_PATH
+          /root/.sp1/bin/sp1up
+
+      - name: Run make groth16
+        run: make groth16
+        working-directory: prover
+        env:
+          RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0 -Ctarget-cpu=native
+          RUST_LOG: "info"
+          RUST_BACKTRACE: "1"
+          MAX_RECURSION_PROGRAM_SIZE: "1"
+          FRI_QUERIES: "1"
+          VERBOSE: "true"

--- a/recursion/gnark-ffi/src/groth16.rs
+++ b/recursion/gnark-ffi/src/groth16.rs
@@ -148,7 +148,11 @@ impl Groth16Prover {
                         log::debug!("Gnark server is healthy!");
                         return Ok(());
                     } else {
-                        log::debug!("Gnark server is not healthy: {:?}", response.status());
+                        log::debug!(
+                            "Gnark server is not healthy, code: {:?} message: {:?}",
+                            response.status(),
+                            response.text()
+                        );
                     }
                 }
                 Err(_) => {

--- a/recursion/gnark/main.go
+++ b/recursion/gnark/main.go
@@ -122,7 +122,7 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
-		pk.WriteTo(pkFile)
+		pk.WriteRawTo(pkFile)
 		pkFile.Close()
 
 		// Write the verifier key.

--- a/recursion/gnark/server/load.go
+++ b/recursion/gnark/server/load.go
@@ -1,13 +1,15 @@
 package server
 
 import (
-	"bytes"
+	"bufio"
 	"context"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/backend/groth16"
@@ -34,7 +36,7 @@ func LoadCircuit(ctx context.Context, dataDir, circuitType string) (constraint.C
 	if !filesExist {
 		return nil, nil, errors.New("circuit files not found")
 	} else {
-		fmt.Println("files found, loading circuit...")
+		fmt.Println("Files found, loading circuit...")
 	}
 
 	// Load the circuit artifacts into memory
@@ -42,51 +44,78 @@ func LoadCircuit(ctx context.Context, dataDir, circuitType string) (constraint.C
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "loading circuit artifacts")
 	}
+	fmt.Println("Circuit artifacts loaded successfully")
 
 	return r1cs, pk, nil
 }
 
 // LoadCircuitArtifacts loads the R1CS and Proving Key from the specified data directory into memory.
 func LoadCircuitArtifacts(dataDir, circuitType string) (constraint.ConstraintSystem, groth16.ProvingKey, error) {
-	r1csFilePath := filepath.Join(dataDir, "circuit_"+circuitType+".bin")
-	pkFilePath := filepath.Join(dataDir, "pk_"+circuitType+".bin")
+	var wg sync.WaitGroup
+	var r1cs constraint.ConstraintSystem
+	var pk groth16.ProvingKey
+	var errR1CS, errPK error
 
-	// Read the R1CS content
-	r1csFile, err := os.Open(r1csFilePath)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "opening R1CS file")
+	startTime := time.Now()
+	fmt.Printf("Loading artifacts start time %s\n", startTime.Format(time.RFC3339))
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+
+		r1csFilePath := filepath.Join(dataDir, "circuit_"+circuitType+".bin")
+		fmt.Println("Opening R1CS file at:", r1csFilePath)
+		r1csFile, err := os.Open(r1csFilePath)
+		if err != nil {
+			errR1CS = errors.Wrap(err, "opening R1CS file")
+			return
+		}
+		defer r1csFile.Close()
+
+		r1csReader := bufio.NewReader(r1csFile)
+		r1csStart := time.Now()
+		r1cs = groth16.NewCS(ecc.BN254)
+		fmt.Println("Reading R1CS file...")
+		if _, err = r1cs.ReadFrom(r1csReader); err != nil {
+			errR1CS = errors.Wrap(err, "reading R1CS content from file")
+		} else {
+			fmt.Printf("R1CS loaded in %s\n", time.Since(r1csStart))
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		pkFilePath := filepath.Join(dataDir, "pk_"+circuitType+".bin")
+		fmt.Println("Opening PK file at:", pkFilePath)
+		pkFile, err := os.Open(pkFilePath)
+		if err != nil {
+			errPK = errors.Wrap(err, "opening PK file")
+			return
+		}
+		defer pkFile.Close()
+
+		pkReader := bufio.NewReader(pkFile)
+		pkStart := time.Now()
+		pk = groth16.NewProvingKey(ecc.BN254)
+		fmt.Println("Reading PK file...")
+		if _, err = pk.UnsafeReadFrom(pkReader); err != nil {
+			errPK = errors.Wrap(err, "reading PK content from file")
+		} else {
+			fmt.Printf("PK loaded in %s\n", time.Since(pkStart))
+		}
+	}()
+
+	wg.Wait()
+
+	if errR1CS != nil {
+		return nil, nil, errors.Wrap(errR1CS, "processing R1CS")
+	}
+	if errPK != nil {
+		return nil, nil, errors.Wrap(errPK, "processing PK")
 	}
 
-	r1csFile.Seek(0, io.SeekStart)
-	r1csContent, err := io.ReadAll(r1csFile)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "reading R1CS content")
-	}
-
-	// Read the PK content
-	pkFile, err := os.Open(pkFilePath)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "opening PK file")
-	}
-
-	pkFile.Seek(0, io.SeekStart)
-	pkContent, err := io.ReadAll(pkFile)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "reading PK content")
-	}
-
-	// Load R1CS and Proving Key into memory
-	r1cs := groth16.NewCS(ecc.BN254)
-	_, err = r1cs.ReadFrom(bytes.NewReader(r1csContent))
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "error reading R1CS content")
-	}
-
-	pk := groth16.NewProvingKey(ecc.BN254)
-	_, err = pk.ReadFrom(bytes.NewReader(pkContent))
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "error reading PK content")
-	}
+	fmt.Printf("Circuit artifacts loaded successfully in %s\n", time.Since(startTime))
 
 	return r1cs, pk, nil
 }

--- a/recursion/gnark/server/server.go
+++ b/recursion/gnark/server/server.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math/big"
 	"net/http"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -29,7 +30,6 @@ func New(ctx context.Context, dataDir, circuitType string) (*Server, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "loading circuit")
 	}
-	fmt.Println("Loaded circuit")
 
 	s := &Server{
 		r1cs: r1cs,
@@ -69,20 +69,25 @@ func (s *Server) handleGroth16Prove(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Generate the witness.
+	fmt.Println("Generating witness...")
+	start := time.Now()
 	assignment := sp1.NewCircuitFromWitness(witnessInput)
 	witness, err := frontend.NewWitness(&assignment, ecc.BN254.ScalarField())
 	if err != nil {
 		ReturnErrorJSON(w, "generating witness", http.StatusInternalServerError)
 		return
 	}
+	fmt.Printf("Witness generated in %s\n", time.Since(start))
 
 	// Generate the proof.
 	fmt.Println("Generating proof...")
+	start = time.Now()
 	proof, err := groth16.Prove(s.r1cs, s.pk, witness)
 	if err != nil {
 		ReturnErrorJSON(w, "generating proof", http.StatusInternalServerError)
 		return
 	}
+	fmt.Printf("Proof generated in %s\n", time.Since(start))
 
 	// Serialize the proof to JSON.
 	const fpSize = 4 * 8


### PR DESCRIPTION
Adds:
* parallel loading of r1cs and pk
* pk using WriteRawTo and UnsafeReadFrom
* add more logging + timings for debugging
* CI: https://github.com/succinctlabs/sp1/actions/runs/8900694723/job/24442833596#step:6:659


Example output:
```
Running 'serve' with data=build, type=groth16, version=3
Files found, loading circuit...
Loading artifacts start time 2024-05-01T03:19:27Z
Opening PK file at: build/pk_groth16.bin
Reading PK file...
Opening R1CS file at: build/circuit_groth16.bin
Reading R1CS file...
PK loaded in 3m46.522924354s
R1CS loaded in 4m38.507870276s
Circuit artifacts loaded successfully in 2024-05-01 03:24:06.214061705 +0000 UTC m=+278.514784538
Circuit artifacts loaded successfully
Starting server on 8082
BatchProve 1 1
14:42:22 DBG prover done backend=groth16 curve=bn254 nbConstraints=66108688 took=564918.203292
Proof generated Duration: 11m24.584948292s
```

while curling:
```
http://localhost:8082/groth16/prove

{"a":["16601911996586084212369066040317151053233139433586035583210513600031969350324","20832125526734311964196063812338100795259534809509488864632435728830694217174"],"b":[["14860243812559083561722709848237158744153164190583109066524365899250727933249","6992923364395310474213672428968738972984700725133460331907996090593673499862"],["13570383590573337727220329636277336380460146539340928521677789087287694795488","19548564821200619766216755152094936996227187818141031428622932120291584869564"]],"c":["17328068244906888967619682505616938638516663165007925205669332830794271330076","7037317293145248676542069780093151371717553394662238201634449637818132042114"],"public_inputs":["0","0"]}
```

