### PR TITLE
ci: groth16 releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
         id: release_info
         run: |
           if [[ $IS_NIGHTLY ]]; then
-            echo "tag_name=nightly-${GITHUB_SHA}" >> $GITHUB_OUTPUT
+            echo "tag_name=nightly" >> $GITHUB_OUTPUT
             echo "release_name=Nightly ($(date '+%Y-%m-%d'))" >> $GITHUB_OUTPUT
           else
             echo "tag_name=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
@@ -64,7 +64,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   release:
-    name: ${{ matrix.target }} (${{ matrix.runner }})
+    name: Release ${{ matrix.target }} (${{ matrix.runner }})
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 240
     needs: prepare
@@ -156,6 +156,43 @@ jobs:
             ldd "$bin" || true
             $bin --version || true
           done
+
+      - name: Build groth16 and create tarball
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        run: |
+          # Enter the directory and build groth16
+          cd prover
+          RUST_LOG=info RUST_BACKTRACE=1 make groth16
+          cd build
+          pwd
+          ls -al
+
+          # Create the tarball
+          touch build.tar.gz
+          tar --exclude=build.tar.gz -czvf build.tar.gz .
+
+          # Prepare the final tarball name
+          VERSION_NAME="${{ (env.IS_NIGHTLY && 'nightly') || needs.prepare.outputs.tag_name }}"
+          TARGET_TARBALL="groth16.tar.gz"
+
+          # Move the tarball to the GitHub Actions environment directory
+          mv build.tar.gz "${GITHUB_WORKSPACE}/${TARGET_TARBALL}"
+          ls -al "${GITHUB_WORKSPACE}
+
+          # Output the tarball name for use in later steps
+          echo "::set-output name=build_tarball_name::${TARGET_TARBALL}""
+        id: build_artifact
+
+      - name: Upload build artifact to release
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        uses: softprops/action-gh-release@v1
+        with:
+          name: ${{ needs.prepare.outputs.release_name }}
+          tag_name: ${{ needs.prepare.outputs.tag_name }}
+          prerelease: ${{ env.IS_NIGHTLY }}
+          body: ${{ needs.prepare.outputs.changelog }}
+          files: |
+            ${{ steps.build_artifact.outputs.build_tarball_name }}
 
       - name: Archive binaries
         id: artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,7 +162,7 @@ jobs:
         run: |
           # Enter the directory and build groth16
           cd prover
-          RUST_LOG=info RUST_BACKTRACE=1 SP1_DEV_WRAPPER=false make groth16
+          RUST_LOG=info RUST_BACKTRACE=1 FRI_QUERIES=1 SP1_DEV_WRAPPER=false make groth16
           cd build
           pwd
           ls -al

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,7 +162,7 @@ jobs:
         run: |
           # Enter the directory and build groth16
           cd prover
-          RUST_LOG=info RUST_BACKTRACE=1 make groth16
+          RUST_LOG=info RUST_BACKTRACE=1 SP1_DEV_WRAPPER=false make groth16
           cd build
           pwd
           ls -al

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,10 +177,8 @@ jobs:
 
           # Move the tarball to the GitHub Actions environment directory
           mv build.tar.gz "${GITHUB_WORKSPACE}/${TARGET_TARBALL}"
-          ls -al "${GITHUB_WORKSPACE}
-
-          # Output the tarball name for use in later steps
-          echo "::set-output name=build_tarball_name::${TARGET_TARBALL}""
+          echo "::set-output name=build_tarball_name::${TARGET_TARBALL}"
+          ls -al "${GITHUB_WORKSPACE}"
         id: build_artifact
 
       - name: Upload build artifact to release

--- a/cli/src/commands/install_circuit.rs
+++ b/cli/src/commands/install_circuit.rs
@@ -21,7 +21,7 @@ impl From<ClapCircuitType> for WrapCircuitType {
 #[derive(Parser)]
 #[command(
     name = "install-circuit",
-    about = "Install prebuilt artifacts for the Groth16 or Plonk wrapper circuit."
+    about = "Install prebuilt artifacts for the Groth16 or PlonK wrapper circuit."
 )]
 pub struct InstallCircuitCmd {
     /// The type of circuit to build.
@@ -62,15 +62,16 @@ impl InstallCircuitCmd {
         }
 
         let version = match self.version.as_str() {
-            "latest" => None,
-            _ => Some(
-                self.version
-                    .parse::<u32>()
-                    .context("Failed to parse version number.")?,
-            ),
+            "latest" | "nightly" => None,
+            _ => Some(self.version.clone()),
         };
 
-        install_circuit_artifacts(self.circuit_type.into(), true, Some(build_dir), version)?;
+        install_circuit_artifacts(
+            self.circuit_type.into(),
+            true,
+            Some(build_dir),
+            version.as_deref(),
+        )?;
 
         Ok(())
     }


### PR DESCRIPTION
Creates a release nightly release like this: https://github.com/succinctlabs/sp1/releases/tag/nightly which includes `groth16.tar.gz`.

Then, nightly `groth16.tar.gz` is downloaded instead of the S3 tarball.