### PR TITLE
fix: install toolchain

### DIFF
--- a/cli/src/commands/install_toolchain.rs
+++ b/cli/src/commands/install_toolchain.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use clap::Parser;
 use dirs::home_dir;
+use rand::{distributions::Alphanumeric, Rng};
 use reqwest::Client;
 use sp1_sdk::artifacts::download_file;
 use std::fs::{self};
@@ -76,7 +77,7 @@ impl InstallToolchainCmd {
         }
 
         // Download the toolchain.
-        let mut file = fs::File::create(toolchain_archive_path)?;
+        let mut file = fs::File::create(&toolchain_archive_path)?;
         rt.block_on(download_file(
             &client,
             toolchain_download_url.as_str(),
@@ -107,36 +108,42 @@ impl InstallToolchainCmd {
         fs::create_dir_all(toolchain_dir.clone())?;
         Command::new("tar")
             .current_dir(&root_dir)
-            .args(["-xzf", &toolchain_asset_name, "-C", &target])
-            .run()?;
-
-        // Mkdir .sp1/toolchains if it doesn't exist.
-        fs::create_dir_all(root_dir.join("toolchains"))?;
-
-        // Move to the toolchain directory.
-        let mv_dir = root_dir.join("toolchains").join(&target);
-        Command::new("mv")
-            .current_dir(&root_dir)
             .args([
-                root_dir.join(&target).to_str().unwrap(),
-                mv_dir.to_str().unwrap(),
+                "-xzf",
+                &toolchain_asset_name,
+                "-C",
+                &toolchain_dir.to_string_lossy(),
             ])
             .status()?;
 
-        // Link the toolchain to rustup.
+        // Move the toolchain to a randomly named directory in the 'toolchains' folder
+        let toolchains_dir = root_dir.join("toolchains");
+        fs::create_dir_all(&toolchains_dir)?;
+        let random_string: String = rand::thread_rng()
+            .sample_iter(&Alphanumeric)
+            .take(10)
+            .map(char::from)
+            .collect();
+        let new_toolchain_dir = toolchains_dir.join(&random_string);
+        fs::rename(&toolchain_dir, &new_toolchain_dir)?;
+
+        // Link the new toolchain directory to rustup
         Command::new("rustup")
             .current_dir(&root_dir)
-            .args(["toolchain", "link", RUSTUP_TOOLCHAIN_NAME])
-            .arg(&toolchain_dir)
-            .run()?;
-        println!("Successfully linked toolchain to rustup.");
+            .args([
+                "toolchain",
+                "link",
+                RUSTUP_TOOLCHAIN_NAME,
+                &new_toolchain_dir.to_string_lossy(),
+            ])
+            .status()?;
 
-        // Ensure permissions.
-        let bin_dir = toolchain_dir.join("bin");
-        let rustlib_bin_dir = toolchain_dir.join(format!("lib/rustlib/{target}/bin"));
-        for wrapped_entry in fs::read_dir(bin_dir)?.chain(fs::read_dir(rustlib_bin_dir)?) {
-            let entry = wrapped_entry?;
-            if entry.file_type()?.is_file() {
+        // Set the executable permissions for binaries
+        let bin_dir = new_toolchain_dir.join("bin");
+        let rustlib_bin_dir = new_toolchain_dir.join(format!("lib/rustlib/{}/bin", target));
+        for entry in fs::read_dir(bin_dir)?.chain(fs::read_dir(rustlib_bin_dir)?) {
+            let entry = entry?;
+            if entry.path().is_file() {
                 let mut perms = entry.metadata()?.permissions();
                 perms.set_mode(0o755);
                 fs::set_permissions(entry.path(), perms)?;

--- a/sp1up/sp1up
+++ b/sp1up/sp1up
@@ -4,7 +4,7 @@
 
 set -eo pipefail
 
-BASE_DIR=${HOME}
+BASE_DIR=${XDG_CONFIG_HOME:-$HOME}
 SP1_DIR=${SP1_DIR:-"$BASE_DIR/.sp1"}
 SP1_BIN_DIR="$SP1_DIR/bin"
 mkdir -p $SP1_BIN_DIR


### PR DESCRIPTION
```
No existing ~/.sp1 directory to remove.
Successfully cleaned up ~/.sp1 directory.
Successfully created ~/.sp1 directory.
Downloading https://github.com/succinctlabs/rust/releases/download/succinct-v2024-02-24.1/rust-toolchain-aarch64-apple-darwin.tar.gz
Downloaded https://github.com/succinctlabs/rust/releases/download/succinct-v2024-02-24.1/rust-toolchain-aarch64-apple-darwin.tar.gz to File { fd: 12, path: "/Users/mattstam/.sp1/rust-toolchain-aarch64-apple-darwin.tar.gz", read: false, write: true }
  [00:00:19] [############################################################################] 308.96 MiB/308.96 MiB (15.55 MiB/s, 0s)info: uninstalling toolchain 'succinct'
info: toolchain 'succinct' uninstalled
Successfully removed existing toolchain.
Successfully linked toolchain to rustup.
```