### PR TITLE
fix: download Groth16 artifacts on `prove_groth16` invocation

### DIFF
--- a/sdk/src/provers/local.rs
+++ b/sdk/src/provers/local.rs
@@ -14,7 +14,6 @@ pub struct LocalProver {
 impl LocalProver {
     /// Creates a new [LocalProver].
     pub fn new() -> Self {
-        sp1_prover::build::get_groth16_artifacts_dir();
         let prover = SP1Prover::new();
         Self { prover }
     }
@@ -55,6 +54,8 @@ impl Prover for LocalProver {
     }
 
     fn prove_groth16(&self, pk: &SP1ProvingKey, stdin: SP1Stdin) -> Result<SP1Groth16Proof> {
+        sp1_prover::build::get_groth16_artifacts_dir();
+
         let proof = self.prover.prove_core(pk, &stdin);
         let deferred_proofs = stdin.proofs.iter().map(|p| p.0.clone()).collect();
         let public_values = proof.public_values.clone();


### PR DESCRIPTION
Download the Groth16 artifacts only when `prove_groth16` is called on the `LocalProver`.

Previously, when users initialize a ProverClient (which default to LocalProver) without any `.env` configuration, it will immediately download the Groth16 artifacts, which is bad UX. Users only need the Groth16 artifacts when they call `prove_groth16`, so we should only download the artifacts/check for the artifacts then.