### PR TITLE
ci: enable merge-groups for PRs into `main`

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,6 +5,7 @@ on:
     types:
       - opened
       - edited
+  merge_group:
 
 permissions:
   pull-requests: read

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,7 @@ on:
       - "sdk/**"
       - "examples/fibonacci/**"
       - ".github/workflows/**"
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
This needs to be paired with a config change after it went in.