### PR TITLE
chore: disable nightly release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,13 +6,10 @@ on:
   push:
     tags:
       - "v*.*.*"
-  schedule:
-    - cron: "0 0 * * *"
   workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
-  IS_NIGHTLY: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
 
 jobs:
   prepare:


### PR DESCRIPTION
makes it so latest tagged release is always pinned on homepage of repo. our releases will always have working groth16 artifacts