### PR TITLE
feat: Basic metrics client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2715,6 +2715,7 @@ checksum = "2145869435ace5ea6ea3d35f59be559317ec9a0d04e1812d5f185a87b6d36f1a"
 name = "metrics"
 version = "0.1.0"
 dependencies = [
+ "regex",
  "sp1-core",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2712,6 +2712,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2145869435ace5ea6ea3d35f59be559317ec9a0d04e1812d5f185a87b6d36f1a"
 
 [[package]]
+name = "metrics"
+version = "0.1.0"
+dependencies = [
+ "sp1-core",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1126,7 +1126,7 @@ version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
 dependencies = [
- "encode_unicode",
+ "encode_unicode 0.3.6",
  "lazy_static",
  "libc",
  "unicode-width",
@@ -1517,6 +1517,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1537,6 +1547,17 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -1621,6 +1642,12 @@ name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -2715,8 +2742,8 @@ checksum = "2145869435ace5ea6ea3d35f59be559317ec9a0d04e1812d5f185a87b6d36f1a"
 name = "metrics"
 version = "0.1.0"
 dependencies = [
+ "prettytable-rs",
  "regex",
- "sp1-core",
 ]
 
 [[package]]
@@ -3469,6 +3496,20 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "prettytable-rs"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eea25e07510aa6ab6547308ebe3c036016d162b8da920dbb079e3ba8acf3d95a"
+dependencies = [
+ "csv",
+ "encode_unicode 1.0.0",
+ "is-terminal",
+ "lazy_static",
+ "term",
+ "unicode-width",
+]
 
 [[package]]
 name = "primitive-types"
@@ -4959,6 +5000,17 @@ dependencies = [
  "fastrand",
  "rustix",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [
   "core",
   "derive",
   "eval",
-  "helper",
+  "helper", "metrics",
   "primitives",
   "prover",
   "recursion/circuit",

--- a/core/src/stark/machine.rs
+++ b/core/src/stark/machine.rs
@@ -667,18 +667,8 @@ pub mod tests {
     #[serial]
     // Can run Fibonacci test.
     // RUST_LOG=debug cargo test stark::machine::tests::test_fibonacci_prove --release -- --nocapture
+    // Make sure that `SP1_LOG_DIR` is set if we want to write to file
     fn test_fibonacci_prove() {
-        // let temp_directory = tempdir().expect("could not create a temporary directory");
-        // let temp_directory = temp_directory.path().to_path_buf();
-        // let path = temp_directory.join("sp1-core").with_extension("log");
-
-        let path_dir = PathBuf::from("/Users/maximvezenov/Documents/dev/succinctlabs/.sp1-logs");
-        let log_path = path_dir
-            .join("sp1-core")
-            .join("fibonacci")
-            .with_extension("log");
-        std::env::set_var("SP1_LOG_DIR", log_path.as_os_str());
-
         setup_logger();
         let program = fibonacci_program();
         run_test(program).unwrap();

--- a/core/src/stark/machine.rs
+++ b/core/src/stark/machine.rs
@@ -677,26 +677,17 @@ pub mod tests {
 
     // #[test]
     // #[serial]
-    // fn test_fibonacci_prove_batch() {
-    //     std::env::set_var("SHARD_BATCH_SIZE", "1");
-    //     std::env::set_var("SHARD_SIZE", "16384");
-    //     // Stuff to set up a temp dir
-    //     // let temp_directory = tempdir().expect("could not create a temporary directory");
-    //     // let temp_directory = temp_directory.path().to_path_buf();
-    //     // let path = temp_directory.join("sp1-core").with_extension("log");
-    //     let path_dir = PathBuf::from("/Users/maximvezenov/Documents/dev/succinctlabs/.sp1-logs");
-    //     let log_path = path_dir
-    //         .join("sp1-core")
-    //         .join("fibonacci-batch")
-    //         .with_extension("log");
-    //     std::env::set_var("SP1_LOG_DIR", log_path.as_os_str());
-    //     setup_logger();
-    //     let program = fibonacci_program();
-    //     let stdin = SP1Stdin::new();
-    //     run_and_prove(program, &stdin, BabyBearPoseidon2::new());
-    //     std::env::remove_var("SHARD_BATCH_SIZE");
-    //     std::env::remove_var("SHARD_SIZE");
-    // }
+    fn test_fibonacci_prove_batch() {
+        std::env::set_var("SHARD_BATCH_SIZE", "1");
+        std::env::set_var("SHARD_SIZE", "16384");
+
+        setup_logger();
+        let program = fibonacci_program();
+        let stdin = SP1Stdin::new();
+        run_and_prove(program, &stdin, BabyBearPoseidon2::new());
+        std::env::remove_var("SHARD_BATCH_SIZE");
+        std::env::remove_var("SHARD_SIZE");
+    }
 
     #[test]
     fn test_simple_memory_program_prove() {

--- a/core/src/stark/machine.rs
+++ b/core/src/stark/machine.rs
@@ -281,6 +281,7 @@ impl<SC: StarkGenericConfig, A: MachineAir<Val<SC>>> StarkMachine<SC, A> {
         let shards = tracing::info_span!("shard_record")
             .in_scope(|| self.shard(record, &<A::Record as MachineRecord>::Config::default()));
 
+        // We care about profiling this function, can pass in the client here.
         tracing::info_span!("prove_shards")
             .in_scope(|| P::prove_shards(self, pk, shards, challenger))
     }

--- a/core/src/stark/machine.rs
+++ b/core/src/stark/machine.rs
@@ -664,6 +664,8 @@ pub mod tests {
 
     #[test]
     #[serial]
+    // Can run Fibonacci test.
+    // RUST_LOG=debug cargo test stark::machine::tests::test_fibonacci_prove --release -- --nocapture
     fn test_fibonacci_prove() {
         setup_logger();
         let program = fibonacci_program();

--- a/core/src/stark/machine.rs
+++ b/core/src/stark/machine.rs
@@ -16,6 +16,7 @@ use std::cmp::Reverse;
 use std::collections::HashMap;
 use std::fmt::Debug;
 use tracing::instrument;
+use web_time::Instant;
 
 use super::debug_constraints;
 use super::Dom;

--- a/core/src/stark/prover.rs
+++ b/core/src/stark/prover.rs
@@ -364,7 +364,8 @@ where
                 .into_par_iter()
                 .enumerate()
                 .map(|(i, quotient_domain)| {
-                    tracing::debug_span!(parent: &parent_span, "compute quotient values for domain")
+                    let chip_name = chips[i].name();
+                    tracing::debug_span!(parent: &parent_span, "compute quotient values for domain", %chip_name)
                         .in_scope(|| {
                             let preprocessed_trace_on_quotient_domains = pk
                                 .chip_ordering
@@ -432,8 +433,9 @@ where
                 .sum::<usize>()
         );
 
-        let (quotient_commit, quotient_data) = tracing::debug_span!("commit to quotient traces")
-            .in_scope(|| pcs.commit(quotient_domains_and_chunks));
+        let (quotient_commit, quotient_data) =
+            tracing::debug_span!("pcs.commit to quotient traces")
+                .in_scope(|| pcs.commit(quotient_domains_and_chunks));
         challenger.observe(quotient_commit.clone());
 
         // Compute the quotient argument.

--- a/core/src/utils/prove.rs
+++ b/core/src/utils/prove.rs
@@ -45,6 +45,7 @@ pub fn run_test_io(
     Ok(public_values)
 }
 
+// Entrypoint for run_test
 pub fn run_test(
     program: Program,
 ) -> Result<
@@ -74,6 +75,7 @@ pub fn run_test_core(
     run_test_machine(record, machine, pk, vk)
 }
 
+// Calls run_test_machine which is the core of the core proof generation logic.
 #[allow(unused_variables)]
 pub fn run_test_machine<SC, A>(
     record: A::Record,
@@ -106,6 +108,7 @@ where
 
     let start = Instant::now();
     let mut challenger = machine.config().challenger();
+    // Instantiate some sort of client and pass it into this function.
     let proof = machine.prove::<LocalProver<SC, A>>(&pk, record, &mut challenger);
     let time = start.elapsed().as_millis();
     let nb_bytes = bincode::serialize(&proof).unwrap().len();

--- a/core/src/utils/prove.rs
+++ b/core/src/utils/prove.rs
@@ -103,7 +103,7 @@ where
         let record_clone = record.clone();
         machine.debug_constraints(&pk, record_clone, &mut challenger_clone);
     }
-    let stats = record.stats().clone();
+    let stats = record.stats();
     let cycles = stats.get("cpu_events").unwrap();
 
     let start = Instant::now();

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-sp1-core = { path = "../core" }
 regex = "1.10.4"
+prettytable-rs = "0.10.0"

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2021"
 
 [dependencies]
 sp1-core = { path = "../core" }
+regex = "1.10.4"

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "metrics"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+sp1-core = { path = "../core" }

--- a/metrics/src/main.rs
+++ b/metrics/src/main.rs
@@ -1,7 +1,5 @@
-use sp1_core::air::MachineAir;
-use sp1_core::stark::RiscvAir;
-use sp1_core::utils::BabyBearPoseidon2;
-use std::collections::BTreeMap;
+use prettytable::{row, table, Row};
+use std::{collections::BTreeMap, fmt::Display};
 
 use regex::Regex;
 
@@ -18,25 +16,76 @@ struct ChipTraceMetric {
     permutation: bool,
 }
 
+impl From<ChipTraceMetric> for Row {
+    fn from(chip_metric: ChipTraceMetric) -> Self {
+        row![
+            Fr->format!("{}", chip_metric.phase),
+            Fm->format!("{}", chip_metric.shard_index),
+            Fm->format!("{}", chip_metric.chip),
+            Fm->format!("{}", chip_metric.permutation),
+            Fg->format!("{}", chip_metric.time),
+        ]
+    }
+}
+
+#[derive(Debug, Clone)]
+struct QuotientValuesMetric {
+    chip: String,
+    shard_index: u32,
+    time: f64,
+}
+
 #[derive(Default, Debug, Clone)]
 struct PcsMetric {
     phase: Phase,
+    // States what kind of evaluation domain for which we are committing upon
+    evaluation: EvaluationType,
     time: f64,
-    // States whether we are committing to a permutation trace
-    permutation: bool,
 }
 
-// struct Metric {
-//     phase: Phase,
-//     metadata:
-// }
+#[derive(Default, Debug, Clone)]
+enum EvaluationType {
+    #[default]
+    Trace,
+    Permutation,
+    Quotient,
+}
+
+impl Display for EvaluationType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            EvaluationType::Trace => write!(f, "trace"),
+            EvaluationType::Permutation => write!(f, "permutation"),
+            EvaluationType::Quotient => write!(f, "quotient"),
+        }
+    }
+}
+
+impl From<PcsMetric> for Row {
+    fn from(value: PcsMetric) -> Self {
+        row![
+            Fr->format!("{}", value.phase),
+            Fm->format!("{}", value.evaluation),
+            Fg->format!("{}", value.time),
+        ]
+    }
+}
 
 // Phase of the prover from which a log trace comes
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, Copy)]
 enum Phase {
     #[default]
     Commit,
     Prove,
+}
+
+impl Display for Phase {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Phase::Commit => write!(f, "Commit"),
+            Phase::Prove => write!(f, "Prove Opening"),
+        }
+    }
 }
 
 fn main() {
@@ -46,159 +95,309 @@ fn main() {
 
     let logs = contents.split('\n').collect::<Vec<_>>();
 
-    // TOOD: these imports are done just to get the chip names
-    // Switch to just extracting the chip name directly so we don't have to check against these chip names
-    let config = BabyBearPoseidon2::new();
-    let machine = RiscvAir::machine(config);
-    let chips = machine.chips();
-    let chip_names = chips.iter().map(|chip| chip.name()).collect::<Vec<_>>();
-    dbg!(chip_names.len());
     let mut chip_trace_times = Vec::new();
+    let mut pcs_commit_metrics = Vec::new();
+    let mut chip_quotient_values_times = Vec::new();
 
-    let mut pcs_commit_metric = Vec::new();
+    // These are the following total time of the parallel
+    // chip executions
+    let mut total_generate_trace_time = 0f64;
+    let mut total_permutation_trace_time = 0f64;
+    let mut total_quotient_values_time = 0f64;
 
-    // TODO: consider better names for these?
-    let mut total_commit_time = 0f64;
+    // Total time to comptue the phase one commitment
+    let mut total_phase_one = 0f64;
+    // Total time to compute phase two
+    let mut total_phase_two = 0f64;
+    // This is the complete total time to generate a proof for all shards
     let mut total_prove_time = 0f64;
-    let mut total_commit_and_prove_time = 0f64;
     for log in logs {
-        // println!("{}", log);
+        println!("{}", log);
         // If no chips were found the ANSI encoding on the tracing logger may have been turned to true.
         // ANSI encoding should always be turned to false for parsing the logs
-        if log.contains("chip_name=") {
-            for chip_name in chip_names.iter() {
-                // Some chips also have the same substrings contained within them so
-                // we precede the match with an equal sign so that we do not match twice.
-                if log.contains(&format!("={}", chip_name)) {
-                    let shard_index = fetch_shard_index(log);
-                    let time = fetch_time_from_log(log);
-                    if log.contains("commit_shards") {
-                        chip_trace_times.push(ChipTraceMetric {
-                            phase: Phase::Commit,
-                            shard_index,
-                            chip: chip_name.clone(),
-                            time,
-                            permutation: false,
-                        });
-                    } else if log.contains("open_shards") {
-                        if log.contains("permuation trace for chip") {
-                            chip_trace_times.push(ChipTraceMetric {
-                                phase: Phase::Prove,
-                                shard_index,
-                                chip: chip_name.clone(),
-                                time,
-                                permutation: true,
-                            });
-                        } else {
-                            chip_trace_times.push(ChipTraceMetric {
-                                phase: Phase::Prove,
-                                shard_index,
-                                chip: chip_name.clone(),
-                                time,
-                                permutation: false,
-                            });
-                        }
-                    }
-                    // If we have found the chip name we do not need to keep going through the loop
-
-                    break;
-                }
-            }
-        } else if log.contains("pcs.commit to permutation traces: close") {
-            let time = fetch_time_from_log(log);
-            pcs_commit_metric.push(PcsMetric {
-                phase: Phase::Prove,
-                time,
-                permutation: true,
-            });
-        } else if log.contains("pcs.commit to traces: close") {
+        // TODO: switch these trace names to constants. Any project using these metrics should use these constants as well
+        if let Some(chip_name) = Regex::new(r"chip_name=[a-zA-Z]+").unwrap().find(log) {
+            let chip_name = &chip_name.as_str()[10..];
+            let shard_index = fetch_shard_index(log);
             let time = fetch_time_from_log(log);
             if log.contains("commit_shards") {
-                pcs_commit_metric.push(PcsMetric {
+                chip_trace_times.push(ChipTraceMetric {
                     phase: Phase::Commit,
+                    shard_index,
+                    chip: chip_name.to_owned(),
                     time,
                     permutation: false,
                 });
             } else if log.contains("open_shards") {
-                pcs_commit_metric.push(PcsMetric {
+                if log.contains("permuation trace for chip") {
+                    chip_trace_times.push(ChipTraceMetric {
+                        phase: Phase::Prove,
+                        shard_index,
+                        chip: chip_name.to_owned(),
+                        time,
+                        permutation: true,
+                    });
+                } else if log.contains("generate trace for chip") {
+                    chip_trace_times.push(ChipTraceMetric {
+                        phase: Phase::Prove,
+                        shard_index,
+                        chip: chip_name.to_owned(),
+                        time,
+                        permutation: false,
+                    });
+                } else if log.contains("compute quotient values for domain") {
+                    chip_quotient_values_times.push(QuotientValuesMetric {
+                        chip: chip_name.to_owned(),
+                        shard_index,
+                        time,
+                    })
+                }
+            }
+        } else if log.contains("pcs.commit to permutation traces: close") {
+            let time = fetch_time_from_log(log);
+            pcs_commit_metrics.push(PcsMetric {
+                phase: Phase::Prove,
+                time,
+                evaluation: EvaluationType::Permutation,
+            });
+        } else if log.contains("pcs.commit to traces: close") {
+            let time = fetch_time_from_log(log);
+            if log.contains("commit_shards") {
+                pcs_commit_metrics.push(PcsMetric {
+                    phase: Phase::Commit,
+                    time,
+                    evaluation: EvaluationType::Trace,
+                });
+            } else if log.contains("open_shards") {
+                pcs_commit_metrics.push(PcsMetric {
                     phase: Phase::Prove,
                     time,
-                    permutation: false,
+                    evaluation: EvaluationType::Trace,
                 });
             }
+        } else if log.contains("pcs.commit to quotient traces: close") {
+            let time = fetch_time_from_log(log);
+            pcs_commit_metrics.push(PcsMetric {
+                phase: Phase::Prove,
+                time,
+                evaluation: EvaluationType::Quotient,
+            });
         } else if log.contains("prove_shards:commit_shards: close") {
-            total_commit_time = fetch_time_from_log(log);
+            total_phase_one = fetch_time_from_log(log);
         } else if log.contains("prove_shards:open_shards: close") {
-            total_prove_time = fetch_time_from_log(log);
+            total_phase_two = fetch_time_from_log(log);
+        } else if log.contains("generate traces for shard: close") {
+            total_generate_trace_time = fetch_time_from_log(log);
+        } else if log.contains("generate permutation traces: close ") {
+            total_permutation_trace_time = fetch_time_from_log(log);
+        } else if log.contains("compute quotient values: close") {
+            total_quotient_values_time = fetch_time_from_log(log);
         } else if log.contains("prove_shards: close") {
-            total_commit_and_prove_time = fetch_time_from_log(log);
+            total_prove_time = fetch_time_from_log(log);
         }
     }
 
-    dbg!(total_commit_time);
-    dbg!(total_prove_time);
-    dbg!(total_commit_time + total_prove_time);
-    dbg!(total_commit_and_prove_time);
+    let mut total_trace_time = 0f64;
+    for chip_trace in chip_trace_times.iter() {
+        total_trace_time += chip_trace.time;
+    }
+    dbg!(total_trace_time);
 
-    // TODO: switch debug output to something actually readable
-    // dbg!(chip_trace_times.clone());
-    dbg!(chip_trace_times.len());
-    // dbg!(pcs_commit_metric.clone());
+    let mut total_pcs_commit_time = 0f64;
+    for pcs_commit_metric in pcs_commit_metrics.iter() {
+        total_pcs_commit_time += pcs_commit_metric.time;
+    }
+    dbg!(total_pcs_commit_time);
+
+    dbg!(total_trace_time + total_pcs_commit_time);
+
+    dbg!(total_generate_trace_time);
+    dbg!(total_permutation_trace_time);
+    dbg!(total_quotient_values_time);
+    dbg!(total_generate_trace_time + total_permutation_trace_time);
+    dbg!(
+        total_pcs_commit_time
+            + total_generate_trace_time
+            + total_permutation_trace_time
+            + total_quotient_values_time
+    );
+    dbg!(total_prove_time);
+
+    let mut chip_trace_table =
+        table!([Fc->"Phase", Fc->"Shard", Fc->"Chip", Fc->"Permutation Trace", Fc->"Time (mus)"]);
 
     // Let's get some basic metrics here in Rust
     // Probably will want to convert it into JSON to be ported for deeper data analysis in python or something
     // Using BTreeMaps for my own debugging purposes so things do not get re-ordered
-    let mut commit_phase_time_per_chip: BTreeMap<String, f64> = BTreeMap::new();
-    let mut prove_phase_time_per_chip: BTreeMap<String, f64> = BTreeMap::new();
+    // TODO: Also some of the computation inside of these loops are reported
+
+    let mut total_percent = 0f64;
+    let mut chip_commit_report_table = table!([Fc->"Chip", Fc->"Shard", Fc->"Percent of Generate Trace Time", Fc->"Percent of Phase One", Fc->"Percent of Total Time"]);
+    let mut chip_prove_report_table = table!([Fc->"Chip", Fc->"Shard", Fc->"Permutation Trace", Fc->"Percent of Generate Trace Time", Fc->"Percent of Phase Two", Fc->"Percent of Total Time"]);
+
     for chip_trace in chip_trace_times.into_iter() {
+        let chip_row: Row = chip_trace.clone().into();
+        chip_trace_table.add_row(chip_row);
+
         match chip_trace.phase {
-            // TOOD: DRY, both match statements do the same thing
             Phase::Commit => {
-                if let Some(accumulated_time) = commit_phase_time_per_chip.get_mut(&chip_trace.chip)
-                {
-                    *accumulated_time += chip_trace.time
-                } else {
-                    commit_phase_time_per_chip.insert(chip_trace.chip, chip_trace.time);
-                }
+                let commit_time = chip_trace.time;
+                let percent_of_generate_trace = commit_time / total_generate_trace_time * 100f64;
+                let percent_of_phase_one = commit_time / total_phase_one * 100f64;
+                let percent_of_total = commit_time / total_prove_time * 100f64;
+                total_percent += percent_of_total;
+
+                let commit_report = ChipCommitReport {
+                    chip: chip_trace.chip,
+                    shard: chip_trace.shard_index,
+                    percent_of_generate_trace,
+                    percent_of_phase_one,
+                    percent_of_total,
+                };
+                chip_commit_report_table.add_row(commit_report.into());
             }
             Phase::Prove => {
-                if let Some(accumulated_time) = prove_phase_time_per_chip.get_mut(&chip_trace.chip)
-                {
-                    *accumulated_time += chip_trace.time
-                } else {
-                    prove_phase_time_per_chip.insert(chip_trace.chip, chip_trace.time);
-                }
+                let prove_time = chip_trace.time;
+                let percent_of_perm_trace = prove_time / total_permutation_trace_time * 100f64;
+                let percent_of_phase_two = prove_time / total_phase_two * 100f64;
+                let percent_of_total = prove_time / total_prove_time * 100f64;
+
+                total_percent += percent_of_total;
+
+                let prove_report = ChipProveReport {
+                    chip: chip_trace.chip,
+                    shard: chip_trace.shard_index,
+                    permutation: chip_trace.permutation,
+                    percent_of_perm_trace,
+                    percent_of_phase_two,
+                    percent_of_total,
+                };
+                chip_prove_report_table.add_row(prove_report.into());
             }
         }
     }
-    dbg!(commit_phase_time_per_chip.clone());
-    dbg!(prove_phase_time_per_chip.clone());
 
-    println!("Some commit phase numbers: ");
-    for (commit_chip, commit_time) in commit_phase_time_per_chip.iter() {
-        let percent_of_commit = commit_time / total_commit_time;
-        let percent_of_total = commit_time / total_commit_and_prove_time;
+    println!("\x1B[1;31mAll Trace Generation Times\x1B[0m");
+    chip_trace_table.printstd();
+    println!("\x1B[1;31mCommit Shards (phase one) Trace Generation\x1B[0m");
+    chip_commit_report_table.printstd();
+    println!("\x1B[1;31mOpen Shards (phase two) Trace Generation\x1B[0m");
+    chip_prove_report_table.printstd();
 
-        println!("Chip: {}", commit_chip);
-        println!(
-            "percent_of_commit: {}, percent_of_total: {}",
-            percent_of_commit, percent_of_total
-        );
+    let mut quotient_values_report_table = table!([Fc->"Chip", Fc->"Shard", Fc->"Percent of Quotient Values Comp", Fc->"Percent of Phase Two", Fc->"Percent of Total Time"]);
+    for quotient_metric in chip_quotient_values_times.into_iter() {
+        let percent_of_quotient_comp = quotient_metric.time / total_quotient_values_time * 100f64;
+        let percent_of_phase_two = quotient_metric.time / total_phase_two * 100f64;
+        let percent_of_total = quotient_metric.time / total_prove_time * 100f64;
+
+        let quotient_report = QuotientValueReport {
+            quotient_metric,
+            percent_of_quotient_comp,
+            percent_of_phase_two,
+            percent_of_total,
+        };
+
+        quotient_values_report_table.add_row(quotient_report.into());
     }
+    println!("\x1B[1;31mQuotient Values Computation\x1B[0m");
+    quotient_values_report_table.printstd();
 
-    println!("Some prove phase numbers: ");
-    for (prove_chip, prove_time) in prove_phase_time_per_chip.iter() {
-        let percent_of_prove = prove_time / total_prove_time;
-        let percent_of_total = prove_time / total_commit_and_prove_time;
+    let mut pcs_metrics_table = table!([Fc->"Phase", Fc->"Evaluation Domain Type", Fc->"Time (mus)", Fc->"Percent of Total Time"]);
+    for pcs_metric in pcs_commit_metrics.into_iter() {
+        let percent_of_total = pcs_metric.time / total_prove_time * 100f64;
 
-        println!("Chip: {}", prove_chip);
-        println!(
-            "percent_of_prove: {}, percent_of_total: {}",
-            percent_of_prove, percent_of_total
-        );
+        let pcs_metric_report = PcsCommitReport {
+            pcs_metric,
+            percent_of_total,
+        };
+
+        let pcs_row: Row = pcs_metric_report.into();
+        pcs_metrics_table.add_row(pcs_row);
+    }
+    println!("\x1B[1;31mpcs.commit table\x1B[0m");
+    pcs_metrics_table.printstd();
+
+    dbg!(total_percent);
+}
+
+struct ChipCommitReport {
+    chip: String,
+    shard: u32,
+    percent_of_generate_trace: f64,
+    percent_of_phase_one: f64,
+    percent_of_total: f64,
+}
+
+impl From<ChipCommitReport> for Row {
+    fn from(value: ChipCommitReport) -> Self {
+        row![
+            Fr->format!("{}", value.chip),
+            Fm->format!("{}", value.shard),
+            Fg->format!("{:.3}", value.percent_of_generate_trace),
+            Fg->format!("{:.3}", value.percent_of_phase_one),
+            Fg->format!("{:.3}", value.percent_of_total),
+        ]
     }
 }
 
+struct ChipProveReport {
+    chip: String,
+    shard: u32,
+    permutation: bool,
+    percent_of_perm_trace: f64,
+    percent_of_phase_two: f64,
+    percent_of_total: f64,
+}
+
+impl From<ChipProveReport> for Row {
+    fn from(value: ChipProveReport) -> Self {
+        row![
+            Fr->format!("{}", value.chip),
+            Fm->format!("{}", value.shard),
+            Fm->format!("{}", value.permutation),
+            Fg->format!("{:.3}", value.percent_of_perm_trace),
+            Fg->format!("{:.3}", value.percent_of_phase_two),
+            Fg->format!("{:.3}", value.percent_of_total),
+        ]
+    }
+}
+
+struct QuotientValueReport {
+    quotient_metric: QuotientValuesMetric,
+    percent_of_quotient_comp: f64,
+    percent_of_phase_two: f64,
+    percent_of_total: f64,
+}
+
+impl From<QuotientValueReport> for Row {
+    fn from(value: QuotientValueReport) -> Self {
+        row![
+            Fr->format!("{}", value.quotient_metric.chip),
+            Fm->format!("{}", value.quotient_metric.shard_index),
+            Fg->format!("{:.3}", value.percent_of_quotient_comp),
+            Fg->format!("{:.3}", value.percent_of_phase_two),
+            Fg->format!("{:.3}", value.percent_of_total),
+        ]
+    }
+}
+
+struct PcsCommitReport {
+    pcs_metric: PcsMetric,
+    percent_of_total: f64,
+}
+
+impl From<PcsCommitReport> for Row {
+    fn from(value: PcsCommitReport) -> Self {
+        row![
+            Fr->format!("{}", value.pcs_metric.phase),
+            Fm->format!("{}", value.pcs_metric.evaluation),
+            Fg->format!("{}", value.pcs_metric.time),
+            Fg->format!("{:.3}", value.percent_of_total),
+        ]
+    }
+}
+
+// NOTE: This method will only work if `FmtSpan::CLOSE` is activated for the tracing subscriber
 fn fetch_time_from_log(log: &str) -> f64 {
     // We use `time.busy=` to find the start but do `+ 10` to start at the actual time amount
     // Reverse search in both cases as the time comes at the end of the log
@@ -225,16 +424,12 @@ fn fetch_time_from_log(log: &str) -> f64 {
 }
 
 fn fetch_shard_index(log: &str) -> u32 {
-    if log.contains("shard_index") {
-        let shard_index_str = Regex::new(r"shard_index=[0-9]+")
-            .unwrap()
-            .find(log)
-            .expect("Should have a shard index");
-        let shard_index = shard_index_str.as_str()[12..]
-            .parse::<u32>()
-            .expect("Failed to parse shard index");
-        shard_index
-    } else {
-        panic!("Misplaced fetch_shard_index method.\n{}", log);
-    }
+    let shard_index_str = Regex::new(r"shard_index=[0-9]+")
+        .unwrap()
+        .find(log)
+        .expect("Should have a shard index");
+    let shard_index = shard_index_str.as_str()[12..]
+        .parse::<u32>()
+        .expect("Failed to parse shard index");
+    shard_index
 }

--- a/metrics/src/main.rs
+++ b/metrics/src/main.rs
@@ -1,8 +1,7 @@
 use sp1_core::air::MachineAir;
 use sp1_core::stark::RiscvAir;
 use sp1_core::utils::BabyBearPoseidon2;
-use std::collections::{BTreeMap, HashMap};
-use std::path::PathBuf;
+use std::collections::BTreeMap;
 
 use regex::Regex;
 
@@ -225,7 +224,6 @@ fn fetch_time_from_log(log: &str) -> f64 {
 
 fn fetch_shard_index(log: &str) -> u32 {
     if log.contains("shard_index") {
-        let start = log.rfind("shard_index=").unwrap();
         let shard_index_str = Regex::new(r"shard_index=[0-9]+")
             .unwrap()
             .find(log)

--- a/metrics/src/main.rs
+++ b/metrics/src/main.rs
@@ -46,6 +46,8 @@ fn main() {
 
     let logs = contents.split('\n').collect::<Vec<_>>();
 
+    // TOOD: these imports are done just to get the chip names
+    // Switch to just extracting the chip name directly so we don't have to check against these chip names
     let config = BabyBearPoseidon2::new();
     let machine = RiscvAir::machine(config);
     let chips = machine.chips();

--- a/metrics/src/main.rs
+++ b/metrics/src/main.rs
@@ -1,0 +1,158 @@
+use sp1_core::air::MachineAir;
+use sp1_core::stark::RiscvAir;
+use sp1_core::utils::BabyBearPoseidon2;
+use std::path::PathBuf;
+
+// TODO: Need to add the shard index to the logs
+// Which shard are we proving for?
+// Need some sort of shard index to expand the chip metric
+// to a general metric
+#[derive(Debug, Clone)]
+struct ChipTraceMetric {
+    phase: Phase,
+    chip: String,
+    time: f64,
+    permutation: bool,
+}
+
+#[derive(Default, Debug, Clone)]
+struct PcsMetric {
+    phase: Phase,
+    time: f64,
+    // States whether we are committing to a permutation trace
+    permutation: bool,
+}
+
+// struct Metric {
+//     phase: Phase,
+//     metadata:
+// }
+
+// Phase of the prover for which we are tracking a log
+#[derive(Default, Debug, Clone)]
+enum Phase {
+    #[default]
+    Commit,
+    Prove,
+}
+
+fn main() {
+    // TODO: currently hardcoding the file but make this based off of env variables
+    let fibonacci_path = PathBuf::from(
+        "/Users/maximvezenov/Documents/dev/succinctlabs/.sp1-logs/sp1-core/fibonacci.log",
+    );
+
+    let contents =
+        std::fs::read_to_string(fibonacci_path).expect("Should have been able to read the file");
+
+    let logs = contents.split('\n').collect::<Vec<_>>();
+
+    let config = BabyBearPoseidon2::new();
+    let machine = RiscvAir::machine(config);
+    let chips = machine.chips();
+    let chip_names = chips.iter().map(|chip| chip.name()).collect::<Vec<_>>();
+
+    let mut phase_one_trace_times = Vec::new();
+    let mut phase_two_trace_times = Vec::new();
+
+    let mut phase_one_pcs_commit = Vec::new();
+    let mut phase_two_pcs_commit = Vec::new();
+    for log in logs {
+        println!("{}", log);
+        fetch_shard_index(log);
+        // If no chips were found the ANSI encoding on the tracing logger may have been turned to true.
+        // ANSI encoding should always be turned to false for parsing the logs
+        if log.contains("chip_name=") {
+            for chip_name in chip_names.iter() {
+                if log.contains(chip_name) {
+                    let time = fetch_time_from_log(log);
+                    if log.contains("commit_shards") {
+                        phase_one_trace_times.push(ChipTraceMetric {
+                            phase: Phase::Commit,
+                            chip: chip_name.clone(),
+                            time,
+                            permutation: false,
+                        });
+                    } else if log.contains("open_shards") {
+                        if log.contains("permuation trace for chip") {
+                            phase_two_trace_times.push(ChipTraceMetric {
+                                phase: Phase::Prove,
+                                chip: chip_name.clone(),
+                                time,
+                                permutation: true,
+                            });
+                        } else {
+                            phase_two_trace_times.push(ChipTraceMetric {
+                                phase: Phase::Prove,
+                                chip: chip_name.clone(),
+                                time,
+                                permutation: false,
+                            });
+                        }
+                    }
+                }
+            }
+        } else if log.contains("pcs.commit to permutation traces: close") {
+            let time = fetch_time_from_log(log);
+            phase_two_pcs_commit.push(PcsMetric {
+                phase: Phase::Prove,
+                time,
+                permutation: true,
+            });
+        } else if log.contains("pcs.commit to traces: close") {
+            let time = fetch_time_from_log(log);
+            if log.contains("commit_shards") {
+                phase_one_pcs_commit.push(PcsMetric {
+                    phase: Phase::Commit,
+                    time,
+                    permutation: false,
+                });
+            } else if log.contains("open_shards") {
+                phase_two_pcs_commit.push(PcsMetric {
+                    phase: Phase::Prove,
+                    time,
+                    permutation: false,
+                });
+            }
+        }
+    }
+
+    // TODO: switch debug output to something actually readable
+    dbg!(phase_one_trace_times.clone());
+    dbg!(phase_two_trace_times.clone());
+    dbg!(phase_one_trace_times.len());
+    dbg!(phase_two_trace_times.len());
+
+    dbg!(phase_one_pcs_commit);
+    dbg!(phase_two_pcs_commit);
+}
+
+fn fetch_time_from_log(log: &str) -> f64 {
+    // We use `time.busy=` to find the start but do `+ 10` to start at the actual time amount
+    // Reverse search in both cases as the time comes at the end of the log
+    let start = log.rfind("time.busy=").unwrap() + 10;
+    let end = log.rfind(" time.idle").unwrap();
+    let time_with_unit = &log[start..end];
+    // We transform everything into microseconds to have one unit of measurement
+    // TODO: Figure out how to get the tracing logs to always use one unit of time
+    let (end_offset, multiplier) = if time_with_unit.contains("µs") {
+        // `µ` is two characters so the offset for `µs` is 3
+        (3, 1f64)
+    } else if time_with_unit.contains("ms") {
+        (2, 1000f64)
+    } else {
+        // Panic if we do not otherwise have a second
+        assert!(time_with_unit.contains('s'));
+        (1, 1000000f64)
+    };
+    let time = &log[start..(end - end_offset)];
+    let time: f64 = time.parse::<f64>().expect("Failed to parse time");
+    // The final time in µs
+    time * multiplier
+}
+
+fn fetch_shard_index(log: &str) {
+    if log.contains("shard_index") {
+        dbg!("got shard index");
+    }
+}

--- a/metrics/src/main.rs
+++ b/metrics/src/main.rs
@@ -116,6 +116,9 @@ fn main() {
         // If no chips were found the ANSI encoding on the tracing logger may have been turned to true.
         // ANSI encoding should always be turned to false for parsing the logs
         // TODO: switch these trace names to constants. Any project using these metrics should use these constants as well
+        // TODO: Also consider a way to make these logs into a better nested structure
+        // If we could form some type of graph based upon the logs that would be ideal.
+        // We could then parse the graph for all the data we need (looking parallel vs. serial, time spent in different graph children, etc.)
         if let Some(chip_name) = Regex::new(r"chip_name=[a-zA-Z]+").unwrap().find(log) {
             let chip_name = &chip_name.as_str()[10..];
             let shard_index = fetch_shard_index(log);
@@ -203,24 +206,11 @@ fn main() {
     }
     dbg!(total_trace_time);
 
-    let mut total_pcs_commit_time = 0f64;
-    for pcs_commit_metric in pcs_commit_metrics.iter() {
-        total_pcs_commit_time += pcs_commit_metric.time;
-    }
-    dbg!(total_pcs_commit_time);
+    // let mut total_pcs_commit_time = 0f64;
+    // for pcs_commit_metric in pcs_commit_metrics.iter() {
+    //     total_pcs_commit_time += pcs_commit_metric.time;
+    // }
 
-    dbg!(total_trace_time + total_pcs_commit_time);
-
-    dbg!(total_generate_trace_time);
-    dbg!(total_permutation_trace_time);
-    dbg!(total_quotient_values_time);
-    dbg!(total_generate_trace_time + total_permutation_trace_time);
-    dbg!(
-        total_pcs_commit_time
-            + total_generate_trace_time
-            + total_permutation_trace_time
-            + total_quotient_values_time
-    );
     dbg!(total_prove_time);
 
     let mut chip_trace_table =

--- a/metrics/src/main.rs
+++ b/metrics/src/main.rs
@@ -3,6 +3,8 @@ use sp1_core::stark::RiscvAir;
 use sp1_core::utils::BabyBearPoseidon2;
 use std::path::PathBuf;
 
+use regex::Regex;
+
 // TODO: Need to add the shard index to the logs
 // Which shard are we proving for?
 // Need some sort of shard index to expand the chip metric
@@ -10,6 +12,7 @@ use std::path::PathBuf;
 #[derive(Debug, Clone)]
 struct ChipTraceMetric {
     phase: Phase,
+    shard_index: u32,
     chip: String,
     time: f64,
     permutation: bool,
@@ -28,7 +31,7 @@ struct PcsMetric {
 //     metadata:
 // }
 
-// Phase of the prover for which we are tracking a log
+// Phase of the prover from which a log trace comes
 #[derive(Default, Debug, Clone)]
 enum Phase {
     #[default]
@@ -37,13 +40,9 @@ enum Phase {
 }
 
 fn main() {
-    // TODO: currently hardcoding the file but make this based off of env variables
-    let fibonacci_path = PathBuf::from(
-        "/Users/maximvezenov/Documents/dev/succinctlabs/.sp1-logs/sp1-core/fibonacci.log",
-    );
-
+    let log_path = std::env::var("SP1_LOG_DIR").unwrap();
     let contents =
-        std::fs::read_to_string(fibonacci_path).expect("Should have been able to read the file");
+        std::fs::read_to_string(log_path).expect("Should have been able to read the file");
 
     let logs = contents.split('\n').collect::<Vec<_>>();
 
@@ -52,49 +51,54 @@ fn main() {
     let chips = machine.chips();
     let chip_names = chips.iter().map(|chip| chip.name()).collect::<Vec<_>>();
 
-    let mut phase_one_trace_times = Vec::new();
-    let mut phase_two_trace_times = Vec::new();
+    let mut chip_trace_times = Vec::new();
 
-    let mut phase_one_pcs_commit = Vec::new();
-    let mut phase_two_pcs_commit = Vec::new();
+    let mut pcs_commit_metric = Vec::new();
     for log in logs {
         println!("{}", log);
-        fetch_shard_index(log);
         // If no chips were found the ANSI encoding on the tracing logger may have been turned to true.
         // ANSI encoding should always be turned to false for parsing the logs
         if log.contains("chip_name=") {
             for chip_name in chip_names.iter() {
                 if log.contains(chip_name) {
+                    let shard_index = fetch_shard_index(log);
                     let time = fetch_time_from_log(log);
                     if log.contains("commit_shards") {
-                        phase_one_trace_times.push(ChipTraceMetric {
+                        chip_trace_times.push(ChipTraceMetric {
                             phase: Phase::Commit,
+                            shard_index,
                             chip: chip_name.clone(),
                             time,
                             permutation: false,
                         });
                     } else if log.contains("open_shards") {
                         if log.contains("permuation trace for chip") {
-                            phase_two_trace_times.push(ChipTraceMetric {
+                            chip_trace_times.push(ChipTraceMetric {
                                 phase: Phase::Prove,
+                                shard_index,
                                 chip: chip_name.clone(),
                                 time,
                                 permutation: true,
                             });
                         } else {
-                            phase_two_trace_times.push(ChipTraceMetric {
+                            chip_trace_times.push(ChipTraceMetric {
                                 phase: Phase::Prove,
+                                shard_index,
                                 chip: chip_name.clone(),
                                 time,
                                 permutation: false,
                             });
                         }
                     }
+                    // If we have found the chip name we do not need to keep going through the loop
+                    // Some chips also have the same substrings contained within them so we want to make sure
+                    // that we do not match twice
+                    break;
                 }
             }
         } else if log.contains("pcs.commit to permutation traces: close") {
             let time = fetch_time_from_log(log);
-            phase_two_pcs_commit.push(PcsMetric {
+            pcs_commit_metric.push(PcsMetric {
                 phase: Phase::Prove,
                 time,
                 permutation: true,
@@ -102,13 +106,13 @@ fn main() {
         } else if log.contains("pcs.commit to traces: close") {
             let time = fetch_time_from_log(log);
             if log.contains("commit_shards") {
-                phase_one_pcs_commit.push(PcsMetric {
+                pcs_commit_metric.push(PcsMetric {
                     phase: Phase::Commit,
                     time,
                     permutation: false,
                 });
             } else if log.contains("open_shards") {
-                phase_two_pcs_commit.push(PcsMetric {
+                pcs_commit_metric.push(PcsMetric {
                     phase: Phase::Prove,
                     time,
                     permutation: false,
@@ -118,18 +122,16 @@ fn main() {
     }
 
     // TODO: switch debug output to something actually readable
-    dbg!(phase_one_trace_times.clone());
-    dbg!(phase_two_trace_times.clone());
-    dbg!(phase_one_trace_times.len());
-    dbg!(phase_two_trace_times.len());
+    dbg!(chip_trace_times.clone());
+    dbg!(chip_trace_times.len());
 
-    dbg!(phase_one_pcs_commit);
-    dbg!(phase_two_pcs_commit);
+    dbg!(pcs_commit_metric.clone());
 }
 
 fn fetch_time_from_log(log: &str) -> f64 {
     // We use `time.busy=` to find the start but do `+ 10` to start at the actual time amount
     // Reverse search in both cases as the time comes at the end of the log
+    // TODO: this can probably be switched to use regex
     let start = log.rfind("time.busy=").unwrap() + 10;
     let end = log.rfind(" time.idle").unwrap();
     let time_with_unit = &log[start..end];
@@ -151,8 +153,19 @@ fn fetch_time_from_log(log: &str) -> f64 {
     time * multiplier
 }
 
-fn fetch_shard_index(log: &str) {
+fn fetch_shard_index(log: &str) -> u32 {
     if log.contains("shard_index") {
-        dbg!("got shard index");
+        let start = log.rfind("shard_index=").unwrap();
+        let shard_index = &log[start..];
+        let shard_index_str = Regex::new(r"shard_index=[0-9]+")
+            .unwrap()
+            .find(log)
+            .expect("Should have a shard index");
+        let shard_index = shard_index_str.as_str()[12..]
+            .parse::<u32>()
+            .expect("Failed to parse shard index");
+        shard_index
+    } else {
+        panic!("Misplaced fetch_shard_index method.\n{}", log);
     }
 }


### PR DESCRIPTION
To test set the `SP1_LOG_PATH` env var to a file for which the tracing crate will write logs. 

Run the following:
```
RUST_LOG=debug cargo test stark::machine::tests::test_fibonacci_prove --release -- --nocapture
```
And then inside of the new `metrics` crate simply run:
```
cargo run
```

Example output:
<img width="925" alt="Screenshot 2024-05-10 at 5 28 30 PM" src="https://github.com/succinctlabs/sp1/assets/169395015/b56afde5-afe5-4efb-bff4-3119ffa94d3c">

The `metrics` binary still does pretty primitive checks against the tracing span strings.  
Open work to b done:
1. It should be decided how to best set the spans so that if they are changed either in the client or the metrics crate that running the metrics crate does not break. We probably need some sort of constants inside of `core` that set tracing log spans. 
2. We could refactor the metrics crate to form a log graph. Right now the parent span is tracked individually and compared against to calculate percentages. Ideally we could build a graph as we parse the logs, process the graph in one step (calculating percentages/total times), and then display any charts based upon the processed graph.