### PR TITLE
feat: add `hash_public_values`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4305,6 +4305,7 @@ dependencies = [
  "log",
  "nohash-hasher",
  "num",
+ "num-bigint 0.4.5",
  "num_cpus",
  "p3-air",
  "p3-baby-bear",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -59,6 +59,7 @@ web-time = "1.1.0"
 rayon-scan = "0.1.1"
 serial_test = "3.1.1"
 thiserror = "1.0.60"
+num-bigint = "0.4.5"
 
 [dev-dependencies]
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -59,7 +59,7 @@ web-time = "1.1.0"
 rayon-scan = "0.1.1"
 serial_test = "3.1.1"
 thiserror = "1.0.60"
-num-bigint = "0.4.5"
+num-bigint = { version = "0.4.3", default-features = false }
 
 [dev-dependencies]
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }

--- a/core/src/io.rs
+++ b/core/src/io.rs
@@ -137,15 +137,16 @@ impl SP1PublicValues {
     /// return sha256(publicValues) & bytes32(uint256((1 << 253) - 1));
     /// ```
     pub fn hash_public_values(&self) -> BigUint {
+        // Hash the public values.
         let mut hasher = Sha256::new();
         hasher.update(self.buffer.data.as_slice());
         let hash_result = hasher.finalize();
-
         let mut hash = hash_result.to_vec();
 
         // Mask the top 3 bits.
         hash[0] &= 0b00011111;
 
+        // Return the masked hash as a BigUint.
         BigUint::from_bytes_be(&hash)
     }
 }

--- a/core/src/io.rs
+++ b/core/src/io.rs
@@ -146,6 +146,8 @@ impl SP1PublicValues {
         // Mask the top 3 bits.
         hash[0] &= 0b00011111;
 
+        println!("{:?}", hex::encode(&hash));
+
         BigUint::from_bytes_be(&hash)
     }
 }
@@ -191,5 +193,25 @@ pub mod proof_serde {
         } else {
             MachineProof::<SC>::deserialize(deserializer)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hash_public_values() {
+        let random_hex = "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
+        let random_bytes = hex::decode(random_hex).unwrap();
+
+        let expected_hash = "1ce987d0a7fcc2636fe87e69295ba12b1cc46c256b369ae7401c51b805ee91bd";
+        let expected_hash_biguint = BigUint::from_bytes_be(&hex::decode(expected_hash).unwrap());
+
+        let mut public_values = SP1PublicValues::new();
+        public_values.write_slice(&random_bytes);
+        let hash = public_values.hash_public_values();
+
+        assert_eq!(hash, expected_hash_biguint);
     }
 }

--- a/core/src/io.rs
+++ b/core/src/io.rs
@@ -146,8 +146,6 @@ impl SP1PublicValues {
         // Mask the top 3 bits.
         hash[0] &= 0b00011111;
 
-        println!("{:?}", hex::encode(&hash));
-
         BigUint::from_bytes_be(&hash)
     }
 }

--- a/core/src/io.rs
+++ b/core/src/io.rs
@@ -131,10 +131,10 @@ impl SP1PublicValues {
     }
 
     /// Hash the public values, mask the top 3 bits and return a BigUint.
-    /// Matches the implementation of hashPublicValues in the Solidity verifier.
+    /// Matches the implementation of `hashPublicValues` in the Solidity verifier.
     ///
-    /// ```
-    /// return sha256(publicValues) & bytes32(uint256((1 << 253) - 1));
+    /// ```solidity
+    /// sha256(publicValues) & bytes32(uint256((1 << 253) - 1));
     /// ```
     pub fn hash_public_values(&self) -> BigUint {
         // Hash the public values.

--- a/core/src/io.rs
+++ b/core/src/io.rs
@@ -130,8 +130,8 @@ impl SP1PublicValues {
         self.buffer.write_slice(slice);
     }
 
-    /// Hash the public values, mask the top 3 bits and return a BigUint.
-    /// Matches the implementation of `hashPublicValues` in the Solidity verifier.
+    /// Hash the public values, mask the top 3 bits and return a BigUint. Matches the implementation
+    /// of `hashPublicValues` in the Solidity verifier.
     ///
     /// ```solidity
     /// sha256(publicValues) & bytes32(uint256((1 << 253) - 1));

--- a/core/src/io.rs
+++ b/core/src/io.rs
@@ -201,15 +201,15 @@ mod tests {
 
     #[test]
     fn test_hash_public_values() {
-        let random_hex = "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
-        let random_bytes = hex::decode(random_hex).unwrap();
+        let test_hex = "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
+        let test_bytes = hex::decode(test_hex).unwrap();
+
+        let mut public_values = SP1PublicValues::new();
+        public_values.write_slice(&test_bytes);
+        let hash = public_values.hash_public_values();
 
         let expected_hash = "1ce987d0a7fcc2636fe87e69295ba12b1cc46c256b369ae7401c51b805ee91bd";
         let expected_hash_biguint = BigUint::from_bytes_be(&hex::decode(expected_hash).unwrap());
-
-        let mut public_values = SP1PublicValues::new();
-        public_values.write_slice(&random_bytes);
-        let hash = public_values.hash_public_values();
 
         assert_eq!(hash, expected_hash_biguint);
     }


### PR DESCRIPTION
Add `hash_public_values` to `core` to mirror the implementation of `hashPublicValues` in the Solidity verifier. This will be useful in https://github.com/succinctlabs/sp1/pull/729, where we'll add proof verification.