### PR TITLE
feat: Implement `verify_groth16` & `prove_groth16` on `MockProver`

### DIFF
--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -525,4 +525,17 @@ mod tests {
         let proof = client.prove(&pk, stdin).unwrap();
         client.verify(&proof, &vk).unwrap();
     }
+
+    #[test]
+    fn test_e2e_prove_groth16_mock() {
+        utils::setup_logger();
+        let client = ProverClient::mock();
+        let elf =
+            include_bytes!("../../examples/fibonacci/program/elf/riscv32im-succinct-zkvm-elf");
+        let (pk, vk) = client.setup(elf);
+        let mut stdin = SP1Stdin::new();
+        stdin.write(&10usize);
+        let proof = client.prove_groth16(&pk, stdin).unwrap();
+        client.verify_groth16(&proof, &vk).unwrap();
+    }
 }

--- a/sdk/src/provers/mock.rs
+++ b/sdk/src/provers/mock.rs
@@ -58,8 +58,8 @@ impl Prover for MockProver {
         Ok(SP1Groth16Proof {
             proof: Groth16Proof {
                 public_inputs: [
-                    public_values.hash().to_string(),
                     pk.vk.hash_bn254().as_canonical_biguint().to_string(),
+                    public_values.hash().to_string(),
                 ],
                 encoded_proof: "".to_string(),
                 raw_proof: "".to_string(),

--- a/sdk/src/provers/mock.rs
+++ b/sdk/src/provers/mock.rs
@@ -4,7 +4,8 @@ use crate::{
     SP1ProofVerificationError, SP1ProofWithPublicValues, SP1ProvingKey, SP1VerifyingKey,
 };
 use anyhow::Result;
-use sp1_prover::{SP1Prover, SP1Stdin};
+use p3_field::PrimeField;
+use sp1_prover::{Groth16Proof, HashableKey, SP1Prover, SP1Stdin};
 
 /// An implementation of [crate::ProverClient] that can generate mock proofs.
 pub struct MockProver {
@@ -50,7 +51,19 @@ impl Prover for MockProver {
     }
 
     fn prove_groth16(&self, pk: &SP1ProvingKey, stdin: SP1Stdin) -> Result<SP1Groth16Proof> {
-        todo!()
+        let public_values = SP1Prover::execute(&pk.elf, &stdin)?;
+        Ok(SP1Groth16Proof {
+            proof: Groth16Proof {
+                public_inputs: [
+                    public_values.hash().to_string(),
+                    pk.vk.hash_bn254().as_canonical_biguint().to_string(),
+                ],
+                encoded_proof: "".to_string(),
+                raw_proof: "".to_string(),
+            },
+            stdin,
+            public_values,
+        })
     }
 
     fn prove_plonk(&self, pk: &SP1ProvingKey, stdin: SP1Stdin) -> Result<SP1PlonkProof> {


### PR DESCRIPTION
Add implementations for `verify_groth16` and `prove_groth16` to the MockProver.

These implementations simply check that the `public_values` and `vkey_hash` are correct.

This ensures that the following user flow is correct:
1. User generates a proof in mock mode and saves it locally.
2. User loads in the proof and calls `verify_groth16` on it in mock mode. If they are using the correct `vkey` (i.e. their program hasn't changed), then the proof will verify.