### PR TITLE
fix: `getrandom` version

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -175,4 +175,5 @@ jobs:
           cargo prove build
           cd ../script
           cargo add sp1-sdk --path $GITHUB_WORKSPACE/sdk
+          cargo add sp1-zkvm --path $GITHUB_WORKSPACE/zkvm
           SP1_DEV=1 RUST_LOG=info cargo run --release

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -172,7 +172,7 @@ jobs:
         run: |
           cd fibonacci
           cd program
-          cargo add sp1-zkvm --path $GITHUB_WORKSPACE/zkvm
+          cargo add sp1-zkvm --path $GITHUB_WORKSPACE/zkvm/entrypoint
           cargo prove build
           cd ../script
           cargo add sp1-sdk --path $GITHUB_WORKSPACE/sdk

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -172,8 +172,8 @@ jobs:
         run: |
           cd fibonacci
           cd program
+          cargo add sp1-zkvm --path $GITHUB_WORKSPACE/zkvm
           cargo prove build
           cd ../script
           cargo add sp1-sdk --path $GITHUB_WORKSPACE/sdk
-          cargo add sp1-zkvm --path $GITHUB_WORKSPACE/zkvm
           SP1_DEV=1 RUST_LOG=info cargo run --release

--- a/zkvm/entrypoint/Cargo.toml
+++ b/zkvm/entrypoint/Cargo.toml
@@ -10,7 +10,7 @@ p3-baby-bear = { workspace = true, optional = true }
 p3-field = { workspace = true, optional = true }
 bincode = "1.3.3"
 cfg-if = "1.0.0"
-getrandom = { version = "0.2.15", features = ["custom"] }
+getrandom = { version = "0.2.14", features = ["custom"] }
 k256 = { version = "0.13.3", features = ["ecdsa", "std", "bits"] }
 once_cell = "1.19.0"
 rand = "0.8.5"
@@ -21,4 +21,9 @@ sha2 = { version = "0.10.8" }
 [features]
 default = ["libm"]
 libm = ["dep:libm"]
-verify = ["dep:sp1-primitives", "dep:p3-baby-bear", "dep:p3-field", "sp1-precompiles/verify"]
+verify = [
+    "dep:sp1-primitives",
+    "dep:p3-baby-bear",
+    "dep:p3-field",
+    "sp1-precompiles/verify",
+]

--- a/zkvm/precompiles/Cargo.toml
+++ b/zkvm/precompiles/Cargo.toml
@@ -4,16 +4,18 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-amcl = { package = "snowbridge-amcl", version="1.0.2", default-features = false, features = ["bls381"]}
+amcl = { package = "snowbridge-amcl", version = "1.0.2", default-features = false, features = [
+    "bls381",
+] }
 anyhow = "1.0.83"
 bincode = "1.3.3"
 cfg-if = "1.0.0"
-getrandom = { version = "0.2.15", features = ["custom"] }
+getrandom = { version = "0.2.14", features = ["custom"] }
 hex = "0.4.3"
 k256 = { version = "0.13.3", features = ["ecdsa", "std", "bits"] }
 rand = "0.8.5"
 serde = { version = "1.0.201", features = ["derive"] }
-num = {version = "0.4.3"}
+num = { version = "0.4.3" }
 
 [features]
 verify = []


### PR DESCRIPTION
`cargo prove new` is currently broken due to https://github.com/rust-random/getrandom/issues/423. This PR downgrades the version of `getrandom` to `v0.2.14`.