### PR TITLE
Use 24-element Poseidon2 for leaf hashing

### DIFF
--- a/core/src/stark/types.rs
+++ b/core/src/stark/types.rs
@@ -124,7 +124,9 @@ pub struct ShardOpenedValues<T: Serialize> {
 /// The maximum number of elements that can be stored in the public values vec.  Both SP1 and recursive
 /// proofs need to pad their public_values vec to this length.  This is required since the recursion
 /// verification program expects the public values vec to be fixed length.
-pub const PROOF_MAX_NUM_PVS: usize = 232;
+///
+/// nhuck@ : I had to increase this to match 24-wide Poseidon2 states.
+pub const PROOF_MAX_NUM_PVS: usize = 232 + 72;
 
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(bound = "")]

--- a/core/src/utils/config.rs
+++ b/core/src/utils/config.rs
@@ -23,11 +23,11 @@ pub const DIGEST_SIZE: usize = 8;
 pub type InnerVal = BabyBear;
 pub type InnerChallenge = BinomialExtensionField<InnerVal, 4>;
 pub type InnerPerm =
-    Poseidon2<InnerVal, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabyBear, 16, 7>;
-pub type InnerHash = PaddingFreeSponge<InnerPerm, 16, 8, 8>;
+    Poseidon2<InnerVal, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabyBear, 24, 7>;
+pub type InnerHash = PaddingFreeSponge<InnerPerm, 24, 16, 8>;
 pub type InnerDigestHash = Hash<InnerVal, InnerVal, DIGEST_SIZE>;
 pub type InnerDigest = [InnerVal; DIGEST_SIZE];
-pub type InnerCompress = TruncatedPermutation<InnerPerm, 2, 8, 16>;
+pub type InnerCompress = TruncatedPermutation<InnerPerm, 2, 8, 24>;
 pub type InnerValMmcs = FieldMerkleTreeMmcs<
     <InnerVal as Field>::Packing,
     <InnerVal as Field>::Packing,
@@ -36,7 +36,7 @@ pub type InnerValMmcs = FieldMerkleTreeMmcs<
     8,
 >;
 pub type InnerChallengeMmcs = ExtensionMmcs<InnerVal, InnerChallenge, InnerValMmcs>;
-pub type InnerChallenger = DuplexChallenger<InnerVal, InnerPerm, 16>;
+pub type InnerChallenger = DuplexChallenger<InnerVal, InnerPerm, 24>;
 pub type InnerDft = Radix2DitParallel;
 pub type InnerPcs = TwoAdicFriPcs<InnerVal, InnerDft, InnerValMmcs, InnerChallengeMmcs>;
 pub type InnerQueryProof = QueryProof<InnerChallenge, InnerChallengeMmcs>;

--- a/core/src/utils/prove.rs
+++ b/core/src/utils/prove.rs
@@ -403,16 +403,16 @@ pub mod baby_bear_poseidon2 {
     use p3_poseidon2::Poseidon2ExternalMatrixGeneral;
     use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
     use serde::{Deserialize, Serialize};
-    use sp1_primitives::RC_16_30;
+    use sp1_primitives::RC_24_29;
 
     use crate::stark::StarkGenericConfig;
 
     pub type Val = BabyBear;
     pub type Challenge = BinomialExtensionField<Val, 4>;
 
-    pub type Perm = Poseidon2<Val, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabyBear, 16, 7>;
-    pub type MyHash = PaddingFreeSponge<Perm, 16, 8, 8>;
-    pub type MyCompress = TruncatedPermutation<Perm, 2, 8, 16>;
+    pub type Perm = Poseidon2<Val, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabyBear, 24, 7>;
+    pub type MyHash = PaddingFreeSponge<Perm, 24, 16, 8>;
+    pub type MyCompress = TruncatedPermutation<Perm, 2, 8, 24>;
     pub type ValMmcs = FieldMerkleTreeMmcs<
         <Val as Field>::Packing,
         <Val as Field>::Packing,
@@ -422,13 +422,13 @@ pub mod baby_bear_poseidon2 {
     >;
     pub type ChallengeMmcs = ExtensionMmcs<Val, Challenge, ValMmcs>;
     pub type Dft = Radix2DitParallel;
-    pub type Challenger = DuplexChallenger<Val, Perm, 16>;
+    pub type Challenger = DuplexChallenger<Val, Perm, 24>;
     type Pcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
 
     pub fn my_perm() -> Perm {
         const ROUNDS_F: usize = 8;
-        const ROUNDS_P: usize = 13;
-        let mut round_constants = RC_16_30.to_vec();
+        const ROUNDS_P: usize = 21;
+        let mut round_constants = RC_24_29.to_vec();
         let internal_start = ROUNDS_F / 2;
         let internal_end = (ROUNDS_F / 2) + ROUNDS_P;
         let internal_round_constants = round_constants

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -12,3 +12,5 @@ p3-baby-bear = { workspace = true }
 p3-poseidon2 = { workspace = true }
 p3-symmetric = { workspace = true }
 itertools = "0.12.1"
+rand_xoshiro = "0.6.0"
+rand = "0.8.5"

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -1137,7 +1137,29 @@ lazy_static! {
     };
 }
 
-pub fn poseidon2_init(
+pub fn poseidon2_16_init(
+) -> Poseidon2<BabyBear, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabyBear, 16, 7> {
+    const ROUNDS_F: usize = 8;
+    const ROUNDS_P: usize = 13;
+    let mut round_constants = RC_16_30.to_vec();
+    let internal_start = ROUNDS_F / 2;
+    let internal_end = (ROUNDS_F / 2) + ROUNDS_P;
+    let internal_round_constants = round_constants
+        .drain(internal_start..internal_end)
+        .map(|vec| vec[0])
+        .collect::<Vec<_>>();
+    let external_round_constants = round_constants;
+    Poseidon2::new(
+        ROUNDS_F,
+        external_round_constants,
+        Poseidon2ExternalMatrixGeneral,
+        ROUNDS_P,
+        internal_round_constants,
+        DiffusionMatrixBabyBear,
+    )
+}
+
+pub fn poseidon2_24_init(
 ) -> Poseidon2<BabyBear, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabyBear, 24, 7> {
     const ROUNDS_F: usize = 8;
     const ROUNDS_P: usize = 21;
@@ -1166,7 +1188,7 @@ mod tests {
 
     #[test]
     fn test_24_permutation() {
-        let h1 = poseidon2_init();
+        let h1 = poseidon2_24_init();
 
         type Perm = Poseidon2<BabyBear, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabyBear, 24, 7>;
         let h2 = Perm::new_from_rng_128(
@@ -1209,7 +1231,7 @@ pub fn poseidon2_hasher() -> PaddingFreeSponge<
     16,
     8,
 > {
-    let hasher = poseidon2_init();
+    let hasher = poseidon2_24_init();
     PaddingFreeSponge::<
         Poseidon2<BabyBear, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabyBear, 24, 7>,
         24,

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -1104,7 +1104,7 @@ lazy_static! {
 }
 
 lazy_static! {
-    pub static ref RC_24_29: [[BabyBear; 24]; 29] = {
+    pub static ref RC_24_29: [[BabyBear; 24]; 30] = {
         let mut rng = &mut Xoroshiro128Plus::seed_from_u64(1);
         let mut external_constants: Vec<[BabyBear; 24]> = rng
             .sample_iter(Standard)
@@ -1115,7 +1115,7 @@ lazy_static! {
             .take(21)
             .collect();
 
-        let mut array: [[BabyBear; 24]; 29] = Default::default(); // Initializes with default values
+        let mut array: [[BabyBear; 24]; 30] = Default::default(); // Initializes with default values
 
         for (i, value) in external_constants.iter().take(4).enumerate() {
             array[i] = *value;
@@ -1130,7 +1130,7 @@ lazy_static! {
         array
     };
 
-    pub static ref RC_24_29_U32: [[u32; 24]; 29] = {
+    pub static ref RC_24_29_U32: [[u32; 24]; 30] = {
         RC_24_29.map(|sub_arr| {
             sub_arr.map(|x| x.as_canonical_u32())
         })

--- a/recursion/core/src/air/public_values.rs
+++ b/recursion/core/src/air/public_values.rs
@@ -15,7 +15,7 @@ use std::mem::size_of;
 
 pub const PV_DIGEST_NUM_WORDS: usize = 8;
 
-pub const CHALLENGER_STATE_NUM_ELTS: usize = 50;
+pub const CHALLENGER_STATE_NUM_ELTS: usize = PERMUTATION_WIDTH * 3 + 2;
 
 pub const RECURSIVE_PROOF_NUM_PV_ELTS: usize = size_of::<RecursionPublicValues<u8>>();
 

--- a/recursion/core/src/poseidon2/columns.rs
+++ b/recursion/core/src/poseidon2/columns.rs
@@ -10,7 +10,7 @@ pub struct Poseidon2Cols<T: Copy> {
     pub dst_input: T,
     pub left_input: T,
     pub right_input: T,
-    pub rounds: [T; 24], // 1 round for memory input; 1 round for initialize; 8 rounds for external; 13 rounds for internal; 1 round for memory output
+    pub rounds: [T; 32], // 1 round for memory input; 1 round for initialize; 8 rounds for external; 21 rounds for internal; 1 round for memory output
     pub round_specific_cols: RoundSpecificCols<T>,
 }
 

--- a/recursion/core/src/poseidon2/external.rs
+++ b/recursion/core/src/poseidon2/external.rs
@@ -5,8 +5,8 @@ use p3_air::{Air, BaseAir};
 use p3_field::AbstractField;
 use p3_matrix::Matrix;
 use sp1_core::air::{BaseAirBuilder, ExtensionAirBuilder, SP1AirBuilder};
-use sp1_primitives::RC_16_30_U32;
 use std::ops::Add;
+use sp1_primitives::RC_24_29_U32;
 
 use crate::air::{RecursionInteractionAirBuilder, RecursionMemoryAirBuilder};
 use crate::memory::MemoryCols;
@@ -19,7 +19,7 @@ use super::columns::Poseidon2Cols;
 pub const NUM_POSEIDON2_COLS: usize = size_of::<Poseidon2Cols<u8>>();
 
 /// The width of the permutation.
-pub const WIDTH: usize = 16;
+pub const WIDTH: usize = 24;
 
 /// A chip that implements addition for the opcode ADD.
 #[derive(Default)]
@@ -43,7 +43,7 @@ impl Poseidon2Chip {
         memory_access: AB::Expr,
     ) {
         let rounds_f = 8;
-        let rounds_p = 13;
+        let rounds_p = 21;
         let rounds_p_beginning = 2 + rounds_f / 2;
         let rounds_p_end = rounds_p_beginning + rounds_p;
 
@@ -158,7 +158,7 @@ impl Poseidon2Chip {
         let computation_cols = local.round_specific_cols.computation();
 
         // Convert the u32 round constants to field elements.
-        let constants: [[AB::F; WIDTH]; 30] = RC_16_30_U32
+        let constants: [[AB::F; WIDTH]; 30] = RC_24_29_U32
             .iter()
             .map(|round| round.map(AB::F::from_wrapped_u32))
             .collect::<Vec<_>>()
@@ -386,7 +386,7 @@ mod tests {
             BabyBear,
             Poseidon2ExternalMatrixGeneral,
             DiffusionMatrixBabyBear,
-            16,
+            24,
             7,
         > = inner_perm();
 
@@ -431,7 +431,7 @@ mod tests {
             BabyBear,
             Poseidon2ExternalMatrixGeneral,
             DiffusionMatrixBabyBear,
-            16,
+            24,
             7,
         > = inner_perm();
 
@@ -461,8 +461,8 @@ mod tests {
 
         let mut challenger: p3_challenger::DuplexChallenger<
             BabyBear,
-            Poseidon2<BabyBear, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabyBear, 16, 7>,
-            16,
+            Poseidon2<BabyBear, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabyBear, 24, 7>,
+            24,
         > = config.challenger();
         let start = Instant::now();
         uni_stark_verify(&config, &chip, &mut challenger, &proof)

--- a/recursion/core/src/poseidon2/trace.rs
+++ b/recursion/core/src/poseidon2/trace.rs
@@ -3,7 +3,7 @@ use std::borrow::BorrowMut;
 use p3_field::PrimeField32;
 use p3_matrix::dense::RowMajorMatrix;
 use sp1_core::{air::MachineAir, utils::pad_rows_fixed};
-use sp1_primitives::RC_16_30_U32;
+use sp1_primitives::RC_24_29_U32;
 use tracing::instrument;
 
 use crate::{
@@ -115,7 +115,7 @@ impl<F: PrimeField32> MachineAir<F> for Poseidon2Chip {
                         // Apply the round constants.
                         for j in 0..WIDTH {
                             computation_cols.add_rc[j] = computation_cols.input[j]
-                                + F::from_wrapped_u32(RC_16_30_U32[r - 2][j]);
+                                + F::from_wrapped_u32(RC_24_29_U32[r - 2][j]);
                         }
                     } else {
                         // Apply the round constants only on the first element.
@@ -123,7 +123,7 @@ impl<F: PrimeField32> MachineAir<F> for Poseidon2Chip {
                             .add_rc
                             .copy_from_slice(&computation_cols.input);
                         computation_cols.add_rc[0] =
-                            computation_cols.input[0] + F::from_wrapped_u32(RC_16_30_U32[r - 2][0]);
+                            computation_cols.input[0] + F::from_wrapped_u32(RC_24_29_U32[r - 2][0]);
                     };
 
                     // Apply the sbox.

--- a/recursion/core/src/poseidon2_wide/mod.rs
+++ b/recursion/core/src/poseidon2_wide/mod.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::needless_range_loop)]
 
 use crate::poseidon2_wide::external::WIDTH;
-use p3_baby_bear::{MONTY_INVERSE, POSEIDON2_INTERNAL_MATRIX_DIAG_16_BABYBEAR_MONTY};
+use p3_baby_bear::{MONTY_INVERSE, POSEIDON2_INTERNAL_MATRIX_DIAG_24_BABYBEAR_MONTY};
 use p3_field::AbstractField;
 use p3_field::PrimeField32;
 
@@ -51,7 +51,7 @@ pub(crate) fn external_linear_layer<AF: AbstractField>(state: &mut [AF; WIDTH]) 
 
 pub(crate) fn internal_linear_layer<F: AbstractField>(state: &mut [F; WIDTH]) {
     let matmul_constants: [<F as AbstractField>::F; WIDTH] =
-        POSEIDON2_INTERNAL_MATRIX_DIAG_16_BABYBEAR_MONTY
+        POSEIDON2_INTERNAL_MATRIX_DIAG_24_BABYBEAR_MONTY
             .iter()
             .map(|x| <F as AbstractField>::F::from_wrapped_u32(x.as_canonical_u32()))
             .collect::<Vec<_>>()

--- a/recursion/core/src/runtime/mod.rs
+++ b/recursion/core/src/runtime/mod.rs
@@ -32,7 +32,7 @@ pub const STACK_SIZE: usize = 1 << 24;
 pub const MEMORY_SIZE: usize = 1 << 28;
 
 /// The width of the Poseidon2 permutation.
-pub const PERMUTATION_WIDTH: usize = 16;
+pub const PERMUTATION_WIDTH: usize = 24;
 pub const POSEIDON2_SBOX_DEGREE: u64 = 7;
 pub const HASH_RATE: usize = 8;
 

--- a/recursion/program/src/fri/two_adic_pcs.rs
+++ b/recursion/program/src/fri/two_adic_pcs.rs
@@ -282,6 +282,7 @@ pub mod tests {
     use rand::rngs::OsRng;
     use sp1_core::utils::baby_bear_poseidon2::compressed_fri_config;
     use sp1_core::utils::inner_perm;
+    use sp1_core::utils::inner_perm16;
     use sp1_core::utils::InnerChallenge;
     use sp1_core::utils::InnerChallenger;
     use sp1_core::utils::InnerCompress;
@@ -307,9 +308,10 @@ pub mod tests {
         let mut rng = &mut OsRng;
         let log_degrees = &[nb_log2_rows];
         let perm = inner_perm();
+        let perm16 = inner_perm16();
         let fri_config = compressed_fri_config();
         let hash = InnerHash::new(perm.clone());
-        let compress = InnerCompress::new(perm.clone());
+        let compress = InnerCompress::new(perm16.clone());
         let val_mmcs = InnerValMmcs::new(hash, compress);
         let dft = InnerDft {};
         let pcs_val: InnerPcs = InnerPcs::new(

--- a/recursion/program/src/hints.rs
+++ b/recursion/program/src/hints.rs
@@ -386,7 +386,7 @@ impl Hintable<C> for ShardCommitment<InnerDigestHash> {
     }
 }
 
-impl Hintable<C> for DuplexChallenger<InnerVal, InnerPerm, 16> {
+impl Hintable<C> for DuplexChallenger<InnerVal, InnerPerm, 24> {
     type HintVariable = DuplexChallengerVariable<C>;
 
     fn read(builder: &mut Builder<C>) -> Self::HintVariable {

--- a/recursion/program/src/hints.rs
+++ b/recursion/program/src/hints.rs
@@ -513,9 +513,9 @@ impl<'a, A: MachineAir<BabyBear>> Hintable<C>
     fn read(builder: &mut Builder<C>) -> Self::HintVariable {
         let vk = VerifyingKeyHint::<'a, BabyBearPoseidon2, A>::read(builder);
         let shard_proofs = Vec::<ShardProofHint<'a, BabyBearPoseidon2, A>>::read(builder);
-        let leaf_challenger = DuplexChallenger::<InnerVal, InnerPerm, 16>::read(builder);
+        let leaf_challenger = DuplexChallenger::<InnerVal, InnerPerm, 24>::read(builder);
         let initial_reconstruct_challenger =
-            DuplexChallenger::<InnerVal, InnerPerm, 16>::read(builder);
+            DuplexChallenger::<InnerVal, InnerPerm, 24>::read(builder);
         let is_complete = builder.hint_var();
 
         SP1RecursionMemoryLayoutVariable {
@@ -626,7 +626,7 @@ impl<'a, A: MachineAir<BabyBear>> Hintable<C>
         let sp1_vk = VerifyingKeyHint::<'a, BabyBearPoseidon2, RiscvAir<_>>::read(builder);
         let committed_value_digest = Vec::<Vec<InnerVal>>::read(builder);
         let deferred_proofs_digest = Vec::<InnerVal>::read(builder);
-        let leaf_challenger = DuplexChallenger::<InnerVal, InnerPerm, 16>::read(builder);
+        let leaf_challenger = DuplexChallenger::<InnerVal, InnerPerm, 24>::read(builder);
         let end_pc = InnerVal::read(builder);
         let end_shard = InnerVal::read(builder);
 

--- a/recursion/program/src/utils.rs
+++ b/recursion/program/src/utils.rs
@@ -26,9 +26,9 @@ type EF = <SC as StarkGenericConfig>::Challenge;
 type C = AsmConfig<F, EF>;
 type Val = BabyBear;
 type Challenge = BinomialExtensionField<Val, 4>;
-type Perm = Poseidon2<Val, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabyBear, 16, 7>;
-type Hash = PaddingFreeSponge<Perm, 16, 8, 8>;
-type Compress = TruncatedPermutation<Perm, 2, 8, 16>;
+type Perm = Poseidon2<Val, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabyBear, 24, 7>;
+type Hash = PaddingFreeSponge<Perm, 24, 16, 8>;
+type Compress = TruncatedPermutation<Perm, 2, 8, 24>;
 type ValMmcs =
     FieldMerkleTreeMmcs<<Val as Field>::Packing, <Val as Field>::Packing, Hash, Compress, 8>;
 type ChallengeMmcs = ExtensionMmcs<Val, Challenge, ValMmcs>;

--- a/recursion/program/src/utils.rs
+++ b/recursion/program/src/utils.rs
@@ -27,8 +27,9 @@ type C = AsmConfig<F, EF>;
 type Val = BabyBear;
 type Challenge = BinomialExtensionField<Val, 4>;
 type Perm = Poseidon2<Val, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabyBear, 24, 7>;
+type Perm16 = Poseidon2<Val, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabyBear, 16, 7>;
 type Hash = PaddingFreeSponge<Perm, 24, 16, 8>;
-type Compress = TruncatedPermutation<Perm, 2, 8, 24>;
+type Compress = TruncatedPermutation<Perm16, 2, 8, 16>;
 type ValMmcs =
     FieldMerkleTreeMmcs<<Val as Field>::Packing, <Val as Field>::Packing, Hash, Compress, 8>;
 type ChallengeMmcs = ExtensionMmcs<Val, Challenge, ValMmcs>;


### PR DESCRIPTION
Use 24-element Poseidon2 for leaf hashing. This yields a 10-second speedup in overall proof time on my machine.