### PR TITLE
fix(core): Fix benches warning for unstable features

### DIFF
--- a/core/benches/main.rs
+++ b/core/benches/main.rs
@@ -1,3 +1,6 @@
+#![allow(incomplete_features)]
+#![feature(generic_const_exprs)]
+
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use sp1_core::io::SP1Stdin;
 use sp1_core::runtime::{Program, Runtime};


### PR DESCRIPTION
Compiling with `cargo build --release --all-targets` would otherwise fail with the following: `error: failed to evaluate generic const expression`