### PR TITLE
fix(core): Remove dummy constraint

### DIFF
--- a/core/src/alu/sr/mod.rs
+++ b/core/src/alu/sr/mod.rs
@@ -461,10 +461,6 @@ where
             }
         }
 
-        builder.assert_zero(
-            local.a[0] * local.b[0] * local.c[0] - local.a[0] * local.b[0] * local.c[0],
-        );
-
         // Check that the operation flags are boolean.
         builder.assert_bool(local.is_srl);
         builder.assert_bool(local.is_sra);

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,5 +1,4 @@
 #![allow(
-    clippy::eq_op,
     clippy::new_without_default,
     clippy::field_reassign_with_default,
     clippy::unnecessary_cast,


### PR DESCRIPTION
Removes a constraint that asserts nothing in the evaluation of `ShiftRightChip`.
Note that I haven't reviewed the whole associated constraint set, hence do not know if this is a miswritten constraint leading to an under-constrained system or simply a leftover.