### PR TITLE
fix: bump workflow versions

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -20,7 +20,7 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up git private repo access
         run: |
@@ -41,7 +41,7 @@ jobs:
           ./eval.sh
 
       - name: Upload Benchmark as Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: benchmark-results-${{ matrix.arch }}
           path: benchmark.csv

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
           CARGO_NET_GIT_FETCH_WITH_CLI: "true"
         steps:
           - name: Checkout sources
-            uses: actions/checkout@v2
+            uses: actions/checkout@v4
     
           - name: Setup CI
             uses: ./.github/actions/setup

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,7 +28,7 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup CI
         uses: ./.github/actions/setup
@@ -59,7 +59,7 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup CI
         uses: ./.github/actions/setup
@@ -90,7 +90,7 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup CI
         uses: ./.github/actions/setup
@@ -118,7 +118,7 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup CI
         uses: ./.github/actions/setup
@@ -147,7 +147,7 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup CI
         uses: ./.github/actions/setup


### PR DESCRIPTION
This PR bumps multiple actions versions:
1. actions/checkout@v2 -> actions/checkout@v4
2. actions/upload-artifact@v2 -> actions/upload-artifact@v4
 > actions/upload-artifact@v3 is scheduled for deprecation on November 30, 2024. [Learn more.](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) Similarly, v1/v2 are scheduled for deprecation on June 30, 2024.
  > https://github.com/actions/upload-artifact

It's weird that seems all the `Evaluate Performance`  workflows are failing because there were no enabled runners online to process the request🤔, should we fix that problem or should we just delete that workflow?
![](https://github.com/succinctlabs/sp1/assets/170700811/63a92f74-fbf2-4a58-9b43-be9733ba64e9)
