### PR TITLE
fix: updated install documentation in book

### DIFF
--- a/book/getting-started/install.md
+++ b/book/getting-started/install.md
@@ -63,24 +63,19 @@ cd sp1
 cd cli
 cargo install --locked --path .
 cd ~
-cargo prove build-toolchain
+cargo prove install-toolchain
 ```
 in cases where your pc isnt setup for ssh properly, the above would give an error
 instead use this https setup instead : 
 ```bash
-git clone [git@github.com:succinctlabs/sp1.git](https://github.com/succinctlabs/sp1.git)
+git clone https://github.com/succinctlabs/sp1.git
 cd sp1
 cd cli
 cargo install --locked --path .
 cd ~
-cargo prove build-toolchain
-```
-
-Building the toolchain can take a while, ranging from 30 mins to an hour depending on your machine. If you're on a machine that we have prebuilt binaries for (ARM Mac or x86 or ARM Linux), you can use the following to download a prebuilt version.
-
-```bash
 cargo prove install-toolchain
 ```
+
 
 To verify the installation of the tooolchain, run and make sure you see `succinct`:
 

--- a/book/getting-started/install.md
+++ b/book/getting-started/install.md
@@ -65,6 +65,16 @@ cargo install --locked --path .
 cd ~
 cargo prove build-toolchain
 ```
+in cases where your pc isnt setup for ssh properly, the above would give an error
+instead use this https setup instead : 
+```bash
+git clone [git@github.com:succinctlabs/sp1.git](https://github.com/succinctlabs/sp1.git)
+cd sp1
+cd cli
+cargo install --locked --path .
+cd ~
+cargo prove build-toolchain
+```
 
 Building the toolchain can take a while, ranging from 30 mins to an hour depending on your machine. If you're on a machine that we have prebuilt binaries for (ARM Mac or x86 or ARM Linux), you can use the following to download a prebuilt version.
 


### PR DESCRIPTION
The original documentation on installing sp1 and building toolchain keeps failing for new developers for the following reasons :

1. use of ssh for cloning repo when building from source but ssh for cloning from github is almost obsolete and would always give developers hurdle to setup.
2. the build-toolchain command tries cloning a private repo which would always fail unless access is given to every devloper 

solutions added :

1. i provided an alternative using https for cloning sp1 
2. i also changed the buid-toolchain to download the already built toolchain

thanks