### PR TITLE
feat: execution record of program statistics

### DIFF
--- a/core/src/runtime/execution_report.rs
+++ b/core/src/runtime/execution_report.rs
@@ -1,0 +1,170 @@
+use super::Runtime;
+use std::{any::Any, collections::HashMap};
+
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+/// Errors which may occur when querying an execution report for
+/// instruction details.
+pub enum MetricRetrievalError {
+    #[error("category not found")]
+    CategoryNotFound,
+
+    #[error("opcode not found in category")]
+    OpcodeNotFound,
+
+    #[error("data type mismatch for the stored metric")]
+    DataTypeMismatch,
+}
+
+/// A report containing useful information about the execution of a program.
+/// It stores useful information about the resource footprint of a provable
+/// RISCV program, including number of cycles, instruction count, and syscall
+/// count.
+///
+/// ### Custom Metrics:
+/// An execution report contains a rich set of metrics and granular details
+/// that can be easily accessed. You can, for example, count the total
+/// number of ADD instructions that occurred during a program run:
+/// ```
+/// use sp1_core::runtime::{Instruction, Opcode, Program, Register, Runtime, SP1CoreOpts};
+///
+/// // Simple program to test the ADD instruction
+/// let instructions = vec![
+///     Instruction::new(Opcode::ADD, 29, 0, 5, false, true),
+///     Instruction::new(Opcode::ADD, 30, 0, 37, false, true),
+///     Instruction::new(Opcode::ADD, 31, 30, 29, false, false),
+/// ];
+///
+/// // Setup a program and a runtime
+/// let program = Program::new(instructions, 0, 0);
+/// let mut runtime = Runtime::new(program, SP1CoreOpts::default());
+/// // Runtime must execute to produce runtime statistics
+/// let mut res = runtime.run().unwrap();
+///
+/// // Retrieve the number of ADD operations
+/// let add_count = &res.get_metric("Arithmetic", "ADD").unwrap_or(0);
+/// assert_eq!(*add_count, 3);
+///
+/// // You can also get a count of all opcode occurences by category
+/// let memory_operations_count = res.get_total_for_category("Arithmetic").unwrap_or(0);
+/// assert_eq!(memory_operations_count, 3,);
+/// ```
+#[derive(Debug)]
+pub struct ExecutionReport {
+    /// Total number of cycles occurred during program execution
+    pub cycles: u32,
+    /// Total number of instructions occurred during program execution
+    pub total_instruction_count: usize,
+    /// Total number of syscalls occurred during program execution
+    pub syscall_count: usize,
+    /// Contains precise counts of each individual instruction,
+    /// as well as counts of instruction by category. See [ExecutionReport] Usage for
+    /// more details
+    pub custom_metrics: HashMap<String, Box<dyn Any>>,
+}
+
+impl ExecutionReport {
+    /// Accept a runtime from a program which has already executed
+    /// and extract some useful information from it.
+    pub fn new(runtime: &Runtime) -> Self {
+        let total_instruction_count = runtime
+            .instruction_log
+            .values()
+            .map(|counts| counts.values().sum::<u64>() as usize)
+            .sum();
+
+        let syscall_count = runtime
+            .instruction_log
+            .get("Syscalls")
+            .map_or(0, |counts| counts.values().sum::<u64>() as usize);
+
+        let mut custom_metrics = HashMap::new();
+        for (category, counts) in &runtime.instruction_log {
+            // Convert the inner HashMap to a format that can be boxed as `dyn Any`
+            let metrics: HashMap<_, _> = counts
+                .iter()
+                .map(|(opcode, count)| (format!("{:?}", opcode), *count))
+                .collect();
+            custom_metrics.insert(category.clone(), Box::new(metrics) as Box<dyn Any>);
+        }
+
+        Self {
+            cycles: runtime.state.clk,
+            total_instruction_count,
+            syscall_count,
+            custom_metrics,
+        }
+    }
+
+    /// Retrieve specific metric based on category and opcode.
+    pub fn get_metric(&self, category: &str, opcode: &str) -> Result<u64, MetricRetrievalError> {
+        let boxed_map = self
+            .custom_metrics
+            .get(category)
+            .ok_or(MetricRetrievalError::CategoryNotFound)?;
+
+        let map = boxed_map
+            .downcast_ref::<HashMap<String, u64>>()
+            .ok_or(MetricRetrievalError::DataTypeMismatch)?;
+
+        let count = map
+            .get(opcode)
+            .copied()
+            .ok_or(MetricRetrievalError::OpcodeNotFound)?;
+
+        Ok(count)
+    }
+
+    /// Retrieve the total count of all operations for a given category.
+    pub fn get_total_for_category(&self, category: &str) -> Result<u64, MetricRetrievalError> {
+        let boxed_map = self
+            .custom_metrics
+            .get(category)
+            .ok_or(MetricRetrievalError::CategoryNotFound)?;
+
+        let map = boxed_map
+            .downcast_ref::<HashMap<String, u64>>()
+            .ok_or(MetricRetrievalError::DataTypeMismatch)?;
+
+        Ok(map.values().sum())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        runtime::{Instruction, Opcode, Program, Register, Runtime},
+        utils::SP1CoreOpts,
+    };
+
+    #[test]
+    fn test_logging() {
+        // main:
+        //     addi x29, x0, 5
+        //     addi x30, x0, 37
+        //     add x31, x30, x29
+        let instructions = vec![
+            Instruction::new(Opcode::ADD, 29, 0, 5, false, true),
+            Instruction::new(Opcode::ADD, 30, 0, 37, false, true),
+            Instruction::new(Opcode::ADD, 31, 30, 29, false, false),
+        ];
+
+        // Setup a program and a runtime
+        let program = Program::new(instructions, 0, 0);
+        let mut runtime = Runtime::new(program, SP1CoreOpts::default());
+        // Runtime must execute to report runtime statistics
+        let res = runtime.dry_run().unwrap();
+        assert_eq!(runtime.register(Register::X31), 42);
+
+        // Retrieve the number of ADD operations
+        let add_count = &res.get_metric("Arithmetic", "ADD").unwrap_or(0);
+        assert_eq!(*add_count, 3);
+        assert_eq!(res.cycles, 12);
+        assert_eq!(res.total_instruction_count, 3);
+
+        // You can also get a count of all opcode occurences by category
+        let memory_operations_count = res.get_total_for_category("Arithmetic").unwrap_or(0);
+        assert_eq!(memory_operations_count, 3,);
+    }
+}

--- a/core/src/runtime/execution_report.rs
+++ b/core/src/runtime/execution_report.rs
@@ -47,8 +47,8 @@ pub enum MetricRetrievalError {
 /// assert_eq!(*add_count, 3);
 ///
 /// // You can also get a count of all opcode occurences by category
-/// let memory_operations_count = res.get_total_for_category("Arithmetic").unwrap_or(0);
-/// assert_eq!(memory_operations_count, 3,);
+/// let add_operations_count = res.get_total_for_category("Arithmetic").unwrap_or(0);
+/// assert_eq!(add_operations_count, 3,);
 /// ```
 #[derive(Debug)]
 pub struct ExecutionReport {
@@ -163,8 +163,8 @@ mod tests {
         assert_eq!(res.cycles, 12);
         assert_eq!(res.total_instruction_count, 3);
 
-        // You can also get a count of all opcode occurences by category
-        let memory_operations_count = res.get_total_for_category("Arithmetic").unwrap_or(0);
-        assert_eq!(memory_operations_count, 3,);
+        // You can also get a count of all instruction/opcode occurences by category
+        let add_operations_count = res.get_total_for_category("Arithmetic").unwrap_or(0);
+        assert_eq!(add_operations_count, 3,);
     }
 }

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -28,6 +28,7 @@ use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use rayon::prelude::*;
 use sp1_core::air::{PublicValues, Word};
 pub use sp1_core::io::{SP1PublicValues, SP1Stdin};
+use sp1_core::runtime::execution_report::ExecutionReport;
 use sp1_core::runtime::{ExecutionError, Runtime};
 use sp1_core::stark::{Challenge, StarkProvingKey};
 use sp1_core::stark::{Challenger, MachineVerificationError};
@@ -213,16 +214,23 @@ impl SP1Prover {
 
     /// Generate a proof of an SP1 program with the specified inputs.
     #[instrument(name = "execute", level = "info", skip_all)]
-    pub fn execute(elf: &[u8], stdin: &SP1Stdin) -> Result<SP1PublicValues, ExecutionError> {
+    pub fn execute(
+        elf: &[u8],
+        stdin: &SP1Stdin,
+    ) -> Result<(SP1PublicValues, ExecutionReport), ExecutionError> {
         let program = Program::from(elf);
         let opts = SP1CoreOpts::default();
         let mut runtime = Runtime::new(program, opts);
+        let report = ExecutionReport::new(&runtime);
         runtime.write_vecs(&stdin.buffer);
         for (proof, vkey) in stdin.proofs.iter() {
             runtime.write_proof(proof.clone(), vkey.clone());
         }
         runtime.run_untraced()?;
-        Ok(SP1PublicValues::from(&runtime.state.public_values_stream))
+        Ok((
+            SP1PublicValues::from(&runtime.state.public_values_stream),
+            report,
+        ))
     }
 
     /// Generate shard proofs which split up and prove the valid execution of a RISC-V program with

--- a/prover/src/utils.rs
+++ b/prover/src/utils.rs
@@ -31,7 +31,7 @@ pub fn get_cycles(elf: &[u8], stdin: &SP1Stdin) -> u64 {
     let program = Program::from(elf);
     let mut runtime = Runtime::new(program, SP1CoreOpts::default());
     runtime.write_vecs(&stdin.buffer);
-    runtime.dry_run();
+    let _ = runtime.dry_run();
     runtime.state.global_clk
 }
 

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -24,7 +24,10 @@ use std::{env, fmt::Debug, fs::File, path::Path};
 use anyhow::{Ok, Result};
 pub use provers::{LocalProver, MockProver, NetworkProver, Prover};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use sp1_core::stark::{MachineVerificationError, ShardProof};
+use sp1_core::{
+    runtime::execution_report::ExecutionReport,
+    stark::{MachineVerificationError, ShardProof},
+};
 pub use sp1_prover::{
     CoreSC, HashableKey, InnerSC, OuterSC, PlonkBn254Proof, SP1Prover, SP1ProvingKey,
     SP1PublicValues, SP1Stdin, SP1VerifyingKey,
@@ -169,8 +172,13 @@ impl ProverClient {
     /// // Execute the program on the inputs.
     /// let public_values = client.execute(elf, stdin).unwrap();
     /// ```
-    pub fn execute(&self, elf: &[u8], stdin: SP1Stdin) -> Result<SP1PublicValues> {
-        Ok(SP1Prover::execute(elf, &stdin)?)
+    pub fn execute(
+        &self,
+        elf: &[u8],
+        stdin: SP1Stdin,
+    ) -> Result<(SP1PublicValues, ExecutionReport)> {
+        let result = SP1Prover::execute(elf, &stdin)?;
+        Ok(result)
     }
 
     /// Setup a program to be proven and verified by the SP1 RISC-V zkVM by computing the proving

--- a/sdk/src/provers/mock.rs
+++ b/sdk/src/provers/mock.rs
@@ -36,7 +36,7 @@ impl Prover for MockProver {
     }
 
     fn prove(&self, pk: &SP1ProvingKey, stdin: SP1Stdin) -> Result<SP1Proof> {
-        let public_values = SP1Prover::execute(&pk.elf, &stdin)?;
+        let public_values = SP1Prover::execute(&pk.elf, &stdin)?.0;
         Ok(SP1ProofWithPublicValues {
             proof: vec![],
             stdin,
@@ -53,7 +53,7 @@ impl Prover for MockProver {
     }
 
     fn prove_plonk(&self, pk: &SP1ProvingKey, stdin: SP1Stdin) -> Result<SP1PlonkBn254Proof> {
-        let public_values = SP1Prover::execute(&pk.elf, &stdin)?;
+        let public_values = SP1Prover::execute(&pk.elf, &stdin)?.0;
         Ok(SP1PlonkBn254Proof {
             proof: PlonkBn254Proof {
                 public_inputs: [


### PR DESCRIPTION
Currently, when a RISCV program executes, we do not store detailed logs of the execution separate from the actual trace. When running a program within the provable setting, every cycle counts, and we want to be able to have a detailed view inside of our program that allows us to understand where compute resources are being used.

This PR introduces an execution record, which contains detailed information about the types of RISCV instructions and opcodes that are carried out during a programs run. It can be used in the following way:

```rust
use sp1_core::runtime::{Instruction, Opcode, Program, Register, Runtime, SP1CoreOpts};

let instructions = vec![
    Instruction::new(Opcode::ADD, 29, 0, 5, false, true),
    Instruction::new(Opcode::ADD, 30, 0, 37, false, true),
    Instruction::new(Opcode::ADD, 31, 30, 29, false, false),
];

// Setup a program and a runtime
let program = Program::new(instructions, 0, 0);
let mut runtime = Runtime::new(program, SP1CoreOpts::default());
// Runtime must execute before reporting statistics
let res = runtime.dry_run().unwrap();
assert_eq!(runtime.register(Register::X31), 42);

// Retrieve the number of ADD operations
let add_count = &res.get_metric("Arithmetic", "ADD").unwrap_or(0);
assert_eq!(*add_count, 3);
assert_eq!(res.cycles, 12);
assert_eq!(res.total_instruction_count, 3);

// You can also get a count of all instruction/opcode occurences by category
let add_operations_count = res.get_total_for_category("Arithmetic").unwrap_or(0);
assert_eq!(add_operations_count, 3,);
```

This will allow for cheap and easy program profiling to help understand the costs of running a program within the proof pipeline. These metrics can be retrieved from running formally and from executing a dry run