### PR TITLE
feat: encode proof solidity

### DIFF
--- a/recursion/gnark-ffi/go/sp1/prove.go
+++ b/recursion/gnark-ffi/go/sp1/prove.go
@@ -5,7 +5,7 @@ import (
 	"os"
 
 	"github.com/consensys/gnark-crypto/ecc"
-	"github.com/consensys/gnark/backend/plonk"
+	plonk "github.com/consensys/gnark/backend/plonk"
 	"github.com/consensys/gnark/frontend"
 )
 

--- a/recursion/gnark-ffi/go/sp1/prove.go
+++ b/recursion/gnark-ffi/go/sp1/prove.go
@@ -5,7 +5,7 @@ import (
 	"os"
 
 	"github.com/consensys/gnark-crypto/ecc"
-	plonk "github.com/consensys/gnark/backend/plonk"
+	"github.com/consensys/gnark/backend/plonk"
 	"github.com/consensys/gnark/frontend"
 )
 

--- a/recursion/gnark-ffi/go/sp1/utils.go
+++ b/recursion/gnark-ffi/go/sp1/utils.go
@@ -19,7 +19,7 @@ func NewSP1PlonkBn254Proof(proof *plonk.Proof, witnessInput WitnessInput) Proof 
 	publicInputs[0] = witnessInput.VkeyHash
 	publicInputs[1] = witnessInput.CommitedValuesDigest
 
-	// Cast plonk proof into plonk_bn254 proof.
+	// Cast plonk proof into plonk_bn254 proof so we can call MarshalSolidity.
 	p := (*proof).(*plonk_bn254.Proof)
 
 	encodedProof := p.MarshalSolidity()

--- a/recursion/gnark-ffi/go/sp1/utils.go
+++ b/recursion/gnark-ffi/go/sp1/utils.go
@@ -4,7 +4,8 @@ import (
 	"bytes"
 	"encoding/hex"
 
-	"github.com/consensys/gnark/backend/plonk"
+	plonk "github.com/consensys/gnark/backend/plonk"
+	plonk_bn254 "github.com/consensys/gnark/backend/plonk/bn254"
 	"github.com/consensys/gnark/frontend"
 	"github.com/succinctlabs/sp1-recursion-gnark/sp1/babybear"
 )
@@ -17,11 +18,15 @@ func NewSP1PlonkBn254Proof(proof *plonk.Proof, witnessInput WitnessInput) Proof 
 	var publicInputs [2]string
 	publicInputs[0] = witnessInput.VkeyHash
 	publicInputs[1] = witnessInput.CommitedValuesDigest
-	encodedProof := hex.EncodeToString(proofBytes)
+
+	// Cast plonk proof into plonk_bn254 proof.
+	p := (*proof).(*plonk_bn254.Proof)
+
+	encodedProof := p.MarshalSolidity()
 
 	return Proof{
 		PublicInputs: publicInputs,
-		EncodedProof: encodedProof,
+		EncodedProof: hex.EncodeToString(encodedProof),
 		RawProof:     hex.EncodeToString(proofBytes),
 	}
 }

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -426,19 +426,6 @@ mod tests {
     }
 
     #[test]
-    fn test_e2e_prove_local() {
-        utils::setup_logger();
-        let client = ProverClient::local();
-        let elf =
-            include_bytes!("../../examples/fibonacci/program/elf/riscv32im-succinct-zkvm-elf");
-        let (pk, vk) = client.setup(elf);
-        let mut stdin = SP1Stdin::new();
-        stdin.write(&10usize);
-        let proof = client.prove(&pk, stdin).unwrap();
-        client.verify(&proof, &vk).unwrap();
-    }
-
-    #[test]
     fn test_e2e_prove_plonk() {
         utils::setup_logger();
         let client = ProverClient::local();
@@ -449,19 +436,6 @@ mod tests {
         stdin.write(&10usize);
         let proof = client.prove_plonk(&pk, stdin).unwrap();
         client.verify_plonk(&proof, &vk).unwrap();
-    }
-
-    #[test]
-    fn test_e2e_prove_mock() {
-        utils::setup_logger();
-        let client = ProverClient::mock();
-        let elf =
-            include_bytes!("../../examples/fibonacci/program/elf/riscv32im-succinct-zkvm-elf");
-        let (pk, vk) = client.setup(elf);
-        let mut stdin = SP1Stdin::new();
-        stdin.write(&10usize);
-        let proof = client.prove(&pk, stdin).unwrap();
-        client.verify(&proof, &vk).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
Encode the proof into the expected Solidity verifier format using `MarshalSolidity`. Previously, when trying to use the `encoded_proof` from the `PlonkBn254Proof`, we would get the proof bytes were too large, as we were using the `raw_proof`.

Also, removes the `test_prove_e2e` tests as they're redundant given the `test_prove_e2e_plonk` tests.