### PR TITLE
feat: add `prover_type`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4921,6 +4921,8 @@ dependencies = [
  "sha2",
  "sp1-core",
  "sp1-prover",
+ "strum",
+ "strum_macros",
  "tempfile",
  "tokio",
  "tracing",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -37,6 +37,8 @@ tempfile = "3.10.1"
 num-bigint = "0.4.5"
 cfg-if = "1.0"
 ethers = { version = "2", default-features = false }
+strum_macros = "0.26.2"
+strum = "0.26.2"
 
 [features]
 neon = ["sp1-core/neon"]

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -43,6 +43,7 @@ pub struct ProverClient {
     pub prover: Box<dyn Prover>,
 }
 
+/// The type of prover used by the [ProverClient].
 #[derive(Debug, PartialEq, EnumString)]
 pub enum ProverType {
     Local,
@@ -161,6 +162,17 @@ impl ProverClient {
         }
     }
 
+    /// Returns the type of prover used by the [ProverClient].
+    ///
+    /// ### Examples
+    ///
+    /// ```no_run
+    /// use sp1_sdk::ProverClient;
+    ///
+    /// let client = ProverClient::local();
+    /// let prover_type = client.prover_type();
+    /// assert_eq!(prover_type, ProverType::Local);
+    /// ```
     pub fn prover_type(&self) -> ProverType {
         let prover_type_id = (*self.prover).type_id();
         if prover_type_id == TypeId::of::<LocalProver>() {

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -41,6 +41,7 @@ use strum_macros::EnumString;
 pub struct ProverClient {
     /// The underlying prover implementation.
     pub prover: Box<dyn Prover>,
+    pub prover_type: ProverType,
 }
 
 /// The type of prover used by the [ProverClient].
@@ -96,12 +97,15 @@ impl ProverClient {
         {
             "mock" => Self {
                 prover: Box::new(MockProver::new()),
+                prover_type: ProverType::Mock,
             },
             "local" => Self {
                 prover: Box::new(LocalProver::new()),
+                prover_type: ProverType::Local,
             },
             "network" => Self {
                 prover: Box::new(NetworkProver::new()),
+                prover_type: ProverType::Network,
             },
             _ => panic!(
                 "invalid value for SP1_PROVER enviroment variable: expected 'local', 'mock', or 'remote'"
@@ -124,6 +128,7 @@ impl ProverClient {
     pub fn mock() -> Self {
         Self {
             prover: Box::new(MockProver::new()),
+            prover_type: ProverType::Mock,
         }
     }
 
@@ -142,6 +147,7 @@ impl ProverClient {
     pub fn local() -> Self {
         Self {
             prover: Box::new(LocalProver::new()),
+            prover_type: ProverType::Local,
         }
     }
 
@@ -159,30 +165,7 @@ impl ProverClient {
     pub fn remote() -> Self {
         Self {
             prover: Box::new(NetworkProver::new()),
-        }
-    }
-
-    /// Returns the type of prover used by the [ProverClient].
-    ///
-    /// ### Examples
-    ///
-    /// ```no_run
-    /// use sp1_sdk::ProverClient;
-    ///
-    /// let client = ProverClient::local();
-    /// let prover_type = client.prover_type();
-    /// assert_eq!(prover_type, ProverType::Local);
-    /// ```
-    pub fn prover_type(&self) -> ProverType {
-        let prover_type_id = (*self.prover).type_id();
-        if prover_type_id == TypeId::of::<LocalProver>() {
-            ProverType::Local
-        } else if prover_type_id == TypeId::of::<MockProver>() {
-            ProverType::Mock
-        } else if prover_type_id == TypeId::of::<NetworkProver>() {
-            ProverType::Network
-        } else {
-            panic!("invalid prover type")
+            prover_type: ProverType::Network,
         }
     }
 

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -154,9 +154,9 @@ impl ProverClient {
     /// ```no_run
     /// use sp1_sdk::ProverClient;
     ///
-    /// let client = ProverClient::remote();
+    /// let client = ProverClient::network();
     /// ```
-    pub fn remote() -> Self {
+    pub fn network() -> Self {
         Self {
             prover: Box::new(NetworkProver::new()),
             prover_type: ProverType::Network,

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -29,21 +29,11 @@ pub use sp1_prover::{
     CoreSC, HashableKey, InnerSC, OuterSC, PlonkBn254Proof, SP1Prover, SP1ProvingKey,
     SP1PublicValues, SP1Stdin, SP1VerifyingKey,
 };
-use strum_macros::EnumString;
 
 /// A client for interacting with SP1.
 pub struct ProverClient {
     /// The underlying prover implementation.
     pub prover: Box<dyn Prover>,
-    pub prover_type: ProverType,
-}
-
-/// The type of prover used by the [ProverClient].
-#[derive(Debug, PartialEq, EnumString)]
-pub enum ProverType {
-    Local,
-    Mock,
-    Network,
 }
 
 /// A proof generated with SP1.
@@ -91,15 +81,12 @@ impl ProverClient {
         {
             "mock" => Self {
                 prover: Box::new(MockProver::new()),
-                prover_type: ProverType::Mock,
             },
             "local" => Self {
                 prover: Box::new(LocalProver::new()),
-                prover_type: ProverType::Local,
             },
             "network" => Self {
                 prover: Box::new(NetworkProver::new()),
-                prover_type: ProverType::Network,
             },
             _ => panic!(
                 "invalid value for SP1_PROVER enviroment variable: expected 'local', 'mock', or 'remote'"
@@ -122,7 +109,6 @@ impl ProverClient {
     pub fn mock() -> Self {
         Self {
             prover: Box::new(MockProver::new()),
-            prover_type: ProverType::Mock,
         }
     }
 
@@ -141,7 +127,6 @@ impl ProverClient {
     pub fn local() -> Self {
         Self {
             prover: Box::new(LocalProver::new()),
-            prover_type: ProverType::Local,
         }
     }
 
@@ -159,7 +144,6 @@ impl ProverClient {
     pub fn remote() -> Self {
         Self {
             prover: Box::new(NetworkProver::new()),
-            prover_type: ProverType::Network,
         }
     }
 

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -19,13 +19,7 @@ pub mod utils {
     pub use sp1_core::utils::setup_logger;
 }
 
-use std::{
-    any::{Any, TypeId},
-    env,
-    fmt::Debug,
-    fs::File,
-    path::Path,
-};
+use std::{env, fmt::Debug, fs::File, path::Path};
 
 use anyhow::{Ok, Result};
 pub use provers::{LocalProver, MockProver, NetworkProver, Prover};

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -154,9 +154,9 @@ impl ProverClient {
     /// ```no_run
     /// use sp1_sdk::ProverClient;
     ///
-    /// let client = ProverClient::network();
+    /// let client = ProverClient::remote();
     /// ```
-    pub fn network() -> Self {
+    pub fn remote() -> Self {
         Self {
             prover: Box::new(NetworkProver::new()),
             prover_type: ProverType::Network,

--- a/sdk/src/provers/local.rs
+++ b/sdk/src/provers/local.rs
@@ -7,6 +7,8 @@ use crate::{
     SP1ProvingKey, SP1VerifyingKey,
 };
 
+use super::ProverType;
+
 /// An implementation of [crate::ProverClient] that can generate end-to-end proofs locally.
 pub struct LocalProver {
     prover: SP1Prover,
@@ -21,8 +23,8 @@ impl LocalProver {
 }
 
 impl Prover for LocalProver {
-    fn id(&self) -> String {
-        "local".to_string()
+    fn id(&self) -> ProverType {
+        ProverType::Local
     }
 
     fn setup(&self, elf: &[u8]) -> (SP1ProvingKey, SP1VerifyingKey) {

--- a/sdk/src/provers/mock.rs
+++ b/sdk/src/provers/mock.rs
@@ -9,6 +9,8 @@ use sp1_prover::{
     verify::verify_plonk_bn254_public_inputs, HashableKey, PlonkBn254Proof, SP1Prover, SP1Stdin,
 };
 
+use super::ProverType;
+
 /// An implementation of [crate::ProverClient] that can generate mock proofs.
 pub struct MockProver {
     pub(crate) prover: SP1Prover,
@@ -23,8 +25,8 @@ impl MockProver {
 }
 
 impl Prover for MockProver {
-    fn id(&self) -> String {
-        "mock".to_string()
+    fn id(&self) -> ProverType {
+        ProverType::Mock
     }
 
     fn setup(&self, elf: &[u8]) -> (SP1ProvingKey, SP1VerifyingKey) {

--- a/sdk/src/provers/mod.rs
+++ b/sdk/src/provers/mod.rs
@@ -13,10 +13,19 @@ use sp1_prover::SP1CoreProofData;
 use sp1_prover::SP1Prover;
 use sp1_prover::SP1ReduceProof;
 use sp1_prover::{SP1ProvingKey, SP1Stdin, SP1VerifyingKey};
+use strum_macros::EnumString;
+
+/// The type of prover.
+#[derive(Debug, PartialEq, EnumString)]
+pub enum ProverType {
+    Local,
+    Mock,
+    Network,
+}
 
 /// An implementation of [crate::ProverClient].
 pub trait Prover: Send + Sync {
-    fn id(&self) -> String;
+    fn id(&self) -> ProverType;
 
     fn sp1_prover(&self) -> &SP1Prover;
 

--- a/sdk/src/provers/network.rs
+++ b/sdk/src/provers/network.rs
@@ -15,7 +15,7 @@ use sp1_prover::utils::block_on;
 use sp1_prover::{SP1Prover, SP1Stdin};
 use tokio::{runtime, time::sleep};
 
-use super::LocalProver;
+use super::{LocalProver, ProverType};
 
 /// An implementation of [crate::ProverClient] that can generate proofs on a remote RPC server.
 pub struct NetworkProver {
@@ -151,8 +151,8 @@ impl NetworkProver {
 }
 
 impl Prover for NetworkProver {
-    fn id(&self) -> String {
-        "remote".to_string()
+    fn id(&self) -> ProverType {
+        ProverType::Network
     }
 
     fn setup(&self, elf: &[u8]) -> (SP1ProvingKey, SP1VerifyingKey) {


### PR DESCRIPTION
Change `id` field of the Prover to output `prover_type`.

Uses `strum` to automatically format the `ProverType` enum for formatting.