### PR TITLE
refactor: ProverClient::remote -> ProverClient::network

### DIFF
--- a/book/generating-proofs/network.md
+++ b/book/generating-proofs/network.md
@@ -12,7 +12,7 @@ To use the prover network to generate a proof, you can run your program as you w
 SP1_PROVER=network SP1_PRIVATE_KEY=... cargo run --release
 ```
 
-- `SP1_PROVER` can be set to `network` or `local`, and defaults to local.
+- `SP1_PROVER` should be set to `network` when using the prover network.
 
 - `SP1_PRIVATE_KEY` is your secp256k1 private key for signing messages on the network. The balance of
   the address corresponding to this private key will be used to pay for the proof request.

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -63,7 +63,7 @@ impl ProverClient {
     /// Setting the `SP1_PROVER` enviroment variable can change the prover used under the hood.
     /// - `local` (default): Uses [LocalProver]. Recommended for proving end-to-end locally.
     /// - `mock`: Uses [MockProver]. Recommended for testing and development.
-    /// - `remote`: Uses [NetworkProver]. Recommended for outsourcing proof generation to an RPC.
+    /// - `network`: Uses [NetworkProver]. Recommended for outsourcing proof generation to an RPC.
     ///
     /// ### Examples
     ///
@@ -89,7 +89,7 @@ impl ProverClient {
                 prover: Box::new(NetworkProver::new()),
             },
             _ => panic!(
-                "invalid value for SP1_PROVER enviroment variable: expected 'local', 'mock', or 'remote'"
+                "invalid value for SP1_PROVER enviroment variable: expected 'local', 'mock', or 'network'"
             ),
         }
     }
@@ -133,6 +133,7 @@ impl ProverClient {
     /// Creates a new [ProverClient] with the network prover.
     ///
     /// Recommended for outsourcing proof generation to an RPC. You can also use [ProverClient::new]
+    /// to set the prover to `network` with the `SP1_PROVER` enviroment variable.
     ///
     /// ### Examples
     ///

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -139,9 +139,9 @@ impl ProverClient {
     /// ```no_run
     /// use sp1_sdk::ProverClient;
     ///
-    /// let client = ProverClient::remote();
+    /// let client = ProverClient::network();
     /// ```
-    pub fn remote() -> Self {
+    pub fn network() -> Self {
         Self {
             prover: Box::new(NetworkProver::new()),
         }


### PR DESCRIPTION
Change `ProverClient::remote()` to `ProverClient::network()`. Change usage of `remote` in docs to `network`.