### PR TITLE
fix: gnark-ffi linking on mac

### DIFF
--- a/recursion/gnark-ffi/build.rs
+++ b/recursion/gnark-ffi/build.rs
@@ -58,6 +58,12 @@ fn main() {
             // Link the Go library
             println!("cargo:rustc-link-search=native={}", dest_path.display());
             println!("cargo:rustc-link-lib=static={}", lib_name);
+
+            // Static linking doesn't really work on macos, so we need to link some system libs
+            if cfg!(target_os = "macos") {
+                println!("cargo:rustc-link-lib=framework=CoreFoundation");
+                println!("cargo:rustc-link-lib=framework=Security");
+            }
         }
     }
 }


### PR DESCRIPTION
* gnark-ffi building fails on certain mac versions due to missing macOS frameworks
* not sure exactly what combination of versions or dependencies causes it to happen as it worked before, but linking them fixes the issue
* see https://github.com/golang/go/issues/42459#issuecomment-896089738

fixes #841 