### PR TITLE
feat: enforce only `dev` can merge into `main`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,3 +39,12 @@ jobs:
             env:
               RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0 -C target-cpu=native
               RUST_BACKTRACE: 1
+    check-branch:
+        name: Check branch
+        runs-on: ubuntu-latest
+        steps:
+          - name: Check branch
+            if: github.head_ref != 'dev'
+            run: |
+              echo "ERROR: You can only merge to main from dev."
+              exit 1


### PR DESCRIPTION
Enforce that only `dev` can merge into `main` in a GitHub workflow. This will prevent accidental merges into `main`.

TODO: I'll add this as a required check before merging into `main` once this is merged into `main`.

Example accidental merge: https://github.com/succinctlabs/sp1/pull/840

Source: https://stackoverflow.com/questions/71120146/allowing-only-certain-branches-to-pr-merge-to-mainmaster-branch