### PR TITLE
refactor: generic_const_expr in core

### DIFF
--- a/core/benches/main.rs
+++ b/core/benches/main.rs
@@ -1,6 +1,3 @@
-#![allow(incomplete_features)]
-#![feature(generic_const_exprs)]
-
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use sp1_core::io::SP1Stdin;
 use sp1_core::runtime::{Program, Runtime};

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -11,7 +11,6 @@
     deprecated,
     incomplete_features
 )]
-#![feature(generic_const_exprs)]
 #![warn(unused_extern_crates)]
 
 extern crate alloc;

--- a/core/src/runtime/syscall.rs
+++ b/core/src/runtime/syscall.rs
@@ -22,6 +22,13 @@ use crate::utils::ec::weierstrass::bls12_381::Bls12381;
 use crate::utils::ec::weierstrass::{bn254::Bn254, secp256k1::Secp256k1};
 use crate::{runtime::ExecutionRecord, runtime::MemoryReadRecord, runtime::MemoryWriteRecord};
 
+use crate::syscall::precompiles::weierstrass::{
+    NUM_WEIERSTRASS_ADD_ASSIGN_COLS_BLS12381, NUM_WEIERSTRASS_ADD_ASSIGN_COLS_BN254,
+    NUM_WEIERSTRASS_ADD_ASSIGN_COLS_SECP256K1, NUM_WEIERSTRASS_DECOMPRESS_COLS_BLS12381,
+    NUM_WEIERSTRASS_DECOMPRESS_COLS_SECP256K1, NUM_WEIERSTRASS_DOUBLE_COLS_BLS12381,
+    NUM_WEIERSTRASS_DOUBLE_COLS_BN254, NUM_WEIERSTRASS_DOUBLE_COLS_SECP256K1,
+};
+
 /// A system call is invoked by the the `ecall` instruction with a specific value in register t0.
 /// The syscall number is a 32-bit integer, with the following layout (in litte-endian format)
 /// - The first byte is the syscall id.
@@ -279,23 +286,38 @@ pub fn default_syscall_map() -> HashMap<SyscallCode, Arc<dyn Syscall>> {
     );
     syscall_map.insert(
         SyscallCode::SECP256K1_ADD,
-        Arc::new(WeierstrassAddAssignChip::<Secp256k1>::new()),
+        Arc::new(WeierstrassAddAssignChip::<
+            Secp256k1,
+            NUM_WEIERSTRASS_ADD_ASSIGN_COLS_SECP256K1,
+        >::new()),
     );
     syscall_map.insert(
         SyscallCode::SECP256K1_DOUBLE,
-        Arc::new(WeierstrassDoubleAssignChip::<Secp256k1>::new()),
+        Arc::new(WeierstrassDoubleAssignChip::<
+            Secp256k1,
+            NUM_WEIERSTRASS_DOUBLE_COLS_SECP256K1,
+        >::new()),
     );
     syscall_map.insert(
         SyscallCode::SECP256K1_DECOMPRESS,
-        Arc::new(WeierstrassDecompressChip::<Secp256k1>::new()),
+        Arc::new(WeierstrassDecompressChip::<
+            Secp256k1,
+            NUM_WEIERSTRASS_DECOMPRESS_COLS_SECP256K1,
+        >::new()),
     );
     syscall_map.insert(
         SyscallCode::BN254_ADD,
-        Arc::new(WeierstrassAddAssignChip::<Bn254>::new()),
+        Arc::new(WeierstrassAddAssignChip::<
+            Bn254,
+            NUM_WEIERSTRASS_ADD_ASSIGN_COLS_BN254,
+        >::new()),
     );
     syscall_map.insert(
         SyscallCode::BN254_DOUBLE,
-        Arc::new(WeierstrassDoubleAssignChip::<Bn254>::new()),
+        Arc::new(WeierstrassDoubleAssignChip::<
+            Bn254,
+            NUM_WEIERSTRASS_DOUBLE_COLS_BN254,
+        >::new()),
     );
     syscall_map.insert(
         SyscallCode::BLAKE3_COMPRESS_INNER,
@@ -303,11 +325,17 @@ pub fn default_syscall_map() -> HashMap<SyscallCode, Arc<dyn Syscall>> {
     );
     syscall_map.insert(
         SyscallCode::BLS12381_ADD,
-        Arc::new(WeierstrassAddAssignChip::<Bls12381>::new()),
+        Arc::new(WeierstrassAddAssignChip::<
+            Bls12381,
+            NUM_WEIERSTRASS_ADD_ASSIGN_COLS_BLS12381,
+        >::new()),
     );
     syscall_map.insert(
         SyscallCode::BLS12381_DOUBLE,
-        Arc::new(WeierstrassDoubleAssignChip::<Bls12381>::new()),
+        Arc::new(WeierstrassDoubleAssignChip::<
+            Bls12381,
+            NUM_WEIERSTRASS_DOUBLE_COLS_BLS12381,
+        >::new()),
     );
     syscall_map.insert(
         SyscallCode::BLAKE3_COMPRESS_INNER,
@@ -336,7 +364,10 @@ pub fn default_syscall_map() -> HashMap<SyscallCode, Arc<dyn Syscall>> {
     syscall_map.insert(SyscallCode::HINT_READ, Arc::new(SyscallHintRead::new()));
     syscall_map.insert(
         SyscallCode::BLS12381_DECOMPRESS,
-        Arc::new(WeierstrassDecompressChip::<Bls12381>::new()),
+        Arc::new(WeierstrassDecompressChip::<
+            Bls12381,
+            NUM_WEIERSTRASS_DECOMPRESS_COLS_BLS12381,
+        >::new()),
     );
     syscall_map.insert(SyscallCode::UINT256_MUL, Arc::new(Uint256MulChip::new()));
 

--- a/core/src/stark/air.rs
+++ b/core/src/stark/air.rs
@@ -3,6 +3,12 @@ pub use crate::air::SP1AirBuilder;
 use crate::air::{MachineAir, SP1_PROOF_NUM_PV_ELTS};
 use crate::memory::{MemoryChipType, MemoryProgramChip};
 use crate::stark::Chip;
+use crate::syscall::precompiles::weierstrass::{
+    NUM_WEIERSTRASS_ADD_ASSIGN_COLS_BLS12381, NUM_WEIERSTRASS_ADD_ASSIGN_COLS_BN254,
+    NUM_WEIERSTRASS_ADD_ASSIGN_COLS_SECP256K1, NUM_WEIERSTRASS_DECOMPRESS_COLS_BLS12381,
+    NUM_WEIERSTRASS_DECOMPRESS_COLS_SECP256K1, NUM_WEIERSTRASS_DOUBLE_COLS_BLS12381,
+    NUM_WEIERSTRASS_DOUBLE_COLS_BN254, NUM_WEIERSTRASS_DOUBLE_COLS_SECP256K1,
+};
 use crate::StarkGenericConfig;
 use p3_field::PrimeField32;
 pub use riscv_chips::*;
@@ -81,27 +87,61 @@ pub enum RiscvAir<F: PrimeField32> {
     /// A precompile for decompressing a point on the Edwards curve ed25519.
     Ed25519Decompress(EdDecompressChip<Ed25519Parameters>),
     /// A precompile for decompressing a point on the K256 curve.
-    K256Decompress(WeierstrassDecompressChip<SwCurve<Secp256k1Parameters>>),
+    K256Decompress(
+        WeierstrassDecompressChip<
+            SwCurve<Secp256k1Parameters>,
+            NUM_WEIERSTRASS_DECOMPRESS_COLS_SECP256K1,
+        >,
+    ),
     /// A precompile for addition on the Elliptic curve secp256k1.
-    Secp256k1Add(WeierstrassAddAssignChip<SwCurve<Secp256k1Parameters>>),
+    Secp256k1Add(
+        WeierstrassAddAssignChip<
+            SwCurve<Secp256k1Parameters>,
+            NUM_WEIERSTRASS_ADD_ASSIGN_COLS_SECP256K1,
+        >,
+    ),
     /// A precompile for doubling a point on the Elliptic curve secp256k1.
-    Secp256k1Double(WeierstrassDoubleAssignChip<SwCurve<Secp256k1Parameters>>),
+    Secp256k1Double(
+        WeierstrassDoubleAssignChip<
+            SwCurve<Secp256k1Parameters>,
+            NUM_WEIERSTRASS_DOUBLE_COLS_SECP256K1,
+        >,
+    ),
     /// A precompile for the Keccak permutation.
     KeccakP(KeccakPermuteChip),
     /// A precompile for the Blake3 compression function. (Disabled by default.)
     Blake3Compress(Blake3CompressInnerChip),
     /// A precompile for addition on the Elliptic curve bn254.
-    Bn254Add(WeierstrassAddAssignChip<SwCurve<Bn254Parameters>>),
+    Bn254Add(
+        WeierstrassAddAssignChip<SwCurve<Bn254Parameters>, NUM_WEIERSTRASS_ADD_ASSIGN_COLS_BN254>,
+    ),
     /// A precompile for doubling a point on the Elliptic curve bn254.
-    Bn254Double(WeierstrassDoubleAssignChip<SwCurve<Bn254Parameters>>),
+    Bn254Double(
+        WeierstrassDoubleAssignChip<SwCurve<Bn254Parameters>, NUM_WEIERSTRASS_DOUBLE_COLS_BN254>,
+    ),
     /// A precompile for addition on the Elliptic curve bls12_381.
-    Bls12381Add(WeierstrassAddAssignChip<SwCurve<Bls12381Parameters>>),
+    Bls12381Add(
+        WeierstrassAddAssignChip<
+            SwCurve<Bls12381Parameters>,
+            NUM_WEIERSTRASS_ADD_ASSIGN_COLS_BLS12381,
+        >,
+    ),
     /// A precompile for doubling a point on the Elliptic curve bls12_381.
-    Bls12381Double(WeierstrassDoubleAssignChip<SwCurve<Bls12381Parameters>>),
+    Bls12381Double(
+        WeierstrassDoubleAssignChip<
+            SwCurve<Bls12381Parameters>,
+            NUM_WEIERSTRASS_DOUBLE_COLS_BLS12381,
+        >,
+    ),
     /// A precompile for uint256 mul.
     Uint256Mul(Uint256MulChip),
     /// A precompile for decompressing a point on the BLS12-381 curve.
-    Bls12381Decompress(WeierstrassDecompressChip<SwCurve<Bls12381Parameters>>),
+    Bls12381Decompress(
+        WeierstrassDecompressChip<
+            SwCurve<Bls12381Parameters>,
+            NUM_WEIERSTRASS_DECOMPRESS_COLS_BLS12381,
+        >,
+    ),
 }
 
 impl<F: PrimeField32> RiscvAir<F> {
@@ -131,26 +171,49 @@ impl<F: PrimeField32> RiscvAir<F> {
         chips.push(RiscvAir::Ed25519Add(ed_add_assign));
         let ed_decompress = EdDecompressChip::<Ed25519Parameters>::default();
         chips.push(RiscvAir::Ed25519Decompress(ed_decompress));
-        let k256_decompress = WeierstrassDecompressChip::<SwCurve<Secp256k1Parameters>>::new();
+        let k256_decompress = WeierstrassDecompressChip::<
+            SwCurve<Secp256k1Parameters>,
+            NUM_WEIERSTRASS_DECOMPRESS_COLS_SECP256K1,
+        >::new();
         chips.push(RiscvAir::K256Decompress(k256_decompress));
-        let secp256k1_add_assign = WeierstrassAddAssignChip::<SwCurve<Secp256k1Parameters>>::new();
+        let secp256k1_add_assign = WeierstrassAddAssignChip::<
+            SwCurve<Secp256k1Parameters>,
+            NUM_WEIERSTRASS_ADD_ASSIGN_COLS_SECP256K1,
+        >::new();
         chips.push(RiscvAir::Secp256k1Add(secp256k1_add_assign));
-        let secp256k1_double_assign =
-            WeierstrassDoubleAssignChip::<SwCurve<Secp256k1Parameters>>::new();
+        let secp256k1_double_assign = WeierstrassDoubleAssignChip::<
+            SwCurve<Secp256k1Parameters>,
+            NUM_WEIERSTRASS_DOUBLE_COLS_SECP256K1,
+        >::new();
         chips.push(RiscvAir::Secp256k1Double(secp256k1_double_assign));
         let keccak_permute = KeccakPermuteChip::new();
         chips.push(RiscvAir::KeccakP(keccak_permute));
-        let bn254_add_assign = WeierstrassAddAssignChip::<SwCurve<Bn254Parameters>>::new();
+        let bn254_add_assign = WeierstrassAddAssignChip::<
+            SwCurve<Bn254Parameters>,
+            NUM_WEIERSTRASS_ADD_ASSIGN_COLS_BN254,
+        >::new();
         chips.push(RiscvAir::Bn254Add(bn254_add_assign));
-        let bn254_double_assign = WeierstrassDoubleAssignChip::<SwCurve<Bn254Parameters>>::new();
+        let bn254_double_assign = WeierstrassDoubleAssignChip::<
+            SwCurve<Bn254Parameters>,
+            NUM_WEIERSTRASS_DOUBLE_COLS_BN254,
+        >::new();
         chips.push(RiscvAir::Bn254Double(bn254_double_assign));
-        let bls12381_add = WeierstrassAddAssignChip::<SwCurve<Bls12381Parameters>>::new();
+        let bls12381_add = WeierstrassAddAssignChip::<
+            SwCurve<Bls12381Parameters>,
+            NUM_WEIERSTRASS_ADD_ASSIGN_COLS_BLS12381,
+        >::new();
         chips.push(RiscvAir::Bls12381Add(bls12381_add));
-        let bls12381_double = WeierstrassDoubleAssignChip::<SwCurve<Bls12381Parameters>>::new();
+        let bls12381_double = WeierstrassDoubleAssignChip::<
+            SwCurve<Bls12381Parameters>,
+            NUM_WEIERSTRASS_DOUBLE_COLS_BLS12381,
+        >::new();
         chips.push(RiscvAir::Bls12381Double(bls12381_double));
         let uint256_mul = Uint256MulChip::default();
         chips.push(RiscvAir::Uint256Mul(uint256_mul));
-        let bls12381_decompress = WeierstrassDecompressChip::<SwCurve<Bls12381Parameters>>::new();
+        let bls12381_decompress = WeierstrassDecompressChip::<
+            SwCurve<Bls12381Parameters>,
+            NUM_WEIERSTRASS_DECOMPRESS_COLS_BLS12381,
+        >::new();
         chips.push(RiscvAir::Bls12381Decompress(bls12381_decompress));
         let add = AddSubChip::default();
         chips.push(RiscvAir::Add(add));

--- a/eval/src/main.rs
+++ b/eval/src/main.rs
@@ -1,5 +1,4 @@
-#![feature(generic_const_exprs)]
-#![allow(incomplete_features)]
+
 
 use clap::{command, Parser};
 use csv::WriterBuilder;

--- a/eval/src/main.rs
+++ b/eval/src/main.rs
@@ -1,5 +1,3 @@
-
-
 use clap::{command, Parser};
 use csv::WriterBuilder;
 use serde::Serialize;

--- a/prover/scripts/build_plonk_bn254.rs
+++ b/prover/scripts/build_plonk_bn254.rs
@@ -1,6 +1,3 @@
-#![feature(generic_const_exprs)]
-#![allow(incomplete_features)]
-
 use std::path::PathBuf;
 
 use clap::Parser;

--- a/prover/scripts/e2e.rs
+++ b/prover/scripts/e2e.rs
@@ -1,5 +1,3 @@
-
-
 use std::borrow::Borrow;
 use std::path::PathBuf;
 

--- a/prover/scripts/e2e.rs
+++ b/prover/scripts/e2e.rs
@@ -1,5 +1,4 @@
-#![feature(generic_const_exprs)]
-#![allow(incomplete_features)]
+
 
 use std::borrow::Borrow;
 use std::path::PathBuf;

--- a/prover/scripts/fibonacci_groth16.rs
+++ b/prover/scripts/fibonacci_groth16.rs
@@ -1,7 +1,5 @@
 //! Tests end-to-end performance of wrapping a recursion proof to PLONK.
 
-
-
 use std::time::Instant;
 
 use itertools::iproduct;

--- a/prover/scripts/fibonacci_groth16.rs
+++ b/prover/scripts/fibonacci_groth16.rs
@@ -1,7 +1,6 @@
 //! Tests end-to-end performance of wrapping a recursion proof to PLONK.
 
-#![feature(generic_const_exprs)]
-#![allow(incomplete_features)]
+
 
 use std::time::Instant;
 

--- a/prover/scripts/fibonacci_sweep.rs
+++ b/prover/scripts/fibonacci_sweep.rs
@@ -1,7 +1,6 @@
 //! Sweeps end-to-end prover performance across a wide range of parameters for Fibonacci.
 
-#![feature(generic_const_exprs)]
-#![allow(incomplete_features)]
+
 
 use std::{fs::File, io::BufWriter, io::Write, time::Instant};
 

--- a/prover/scripts/fibonacci_sweep.rs
+++ b/prover/scripts/fibonacci_sweep.rs
@@ -1,7 +1,5 @@
 //! Sweeps end-to-end prover performance across a wide range of parameters for Fibonacci.
 
-
-
 use std::{fs::File, io::BufWriter, io::Write, time::Instant};
 
 use itertools::iproduct;

--- a/prover/scripts/tendermint_sweep.rs
+++ b/prover/scripts/tendermint_sweep.rs
@@ -1,7 +1,5 @@
 //! Sweeps end-to-end prover performance across a wide range of parameters for Tendermint.
 
-
-
 use std::{fs::File, io::BufWriter, io::Write, time::Instant};
 
 use itertools::iproduct;

--- a/prover/scripts/tendermint_sweep.rs
+++ b/prover/scripts/tendermint_sweep.rs
@@ -1,7 +1,6 @@
 //! Sweeps end-to-end prover performance across a wide range of parameters for Tendermint.
 
-#![feature(generic_const_exprs)]
-#![allow(incomplete_features)]
+
 
 use std::{fs::File, io::BufWriter, io::Write, time::Instant};
 

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -7,8 +7,7 @@
 //! 3. Wrap the shard proof into a SNARK-friendly field.
 //! 4. Wrap the last shard proof, proven over the SNARK-friendly field, into a PLONK proof.
 
-#![allow(incomplete_features)]
-#![feature(generic_const_exprs)]
+
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::new_without_default)]
 

--- a/recursion/program/src/lib.rs
+++ b/recursion/program/src/lib.rs
@@ -1,5 +1,4 @@
-#![feature(generic_const_exprs)]
-#![allow(incomplete_features)]
+
 #![allow(type_alias_bounds)]
 #![allow(clippy::type_complexity)]
 #![allow(clippy::too_many_arguments)]

--- a/recursion/program/src/lib.rs
+++ b/recursion/program/src/lib.rs
@@ -1,4 +1,3 @@
-
 #![allow(type_alias_bounds)]
 #![allow(clippy::type_complexity)]
 #![allow(clippy::too_many_arguments)]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2024-04-17"
+channel = "1.79"
 components = ["llvm-tools", "rustc-dev"]

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -5,9 +5,6 @@
 //! Visit the [Getting Started](https://succinctlabs.github.io/sp1/getting-started.html) section
 //! in the official SP1 documentation for a quick start guide.
 
-#![allow(incomplete_features)]
-#![feature(generic_const_exprs)]
-
 #[rustfmt::skip]
 pub mod proto {
     pub mod network;


### PR DESCRIPTION
Remove `generic_const_exprs` in `core` so that `core` compiles on a stable release channel.
