### PR TITLE
chore: refactor derive, serialize bounds

### DIFF
--- a/core/src/io.rs
+++ b/core/src/io.rs
@@ -20,7 +20,7 @@ pub struct SP1Stdin {
 }
 
 /// Public values for the prover.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct SP1PublicValues {
     buffer: Buffer,
 }

--- a/core/src/io.rs
+++ b/core/src/io.rs
@@ -114,6 +114,7 @@ impl SP1PublicValues {
     pub fn read<T: Serialize + DeserializeOwned>(&mut self) -> T {
         self.buffer.read()
     }
+
     /// Read a slice of bytes from the buffer.
     pub fn read_slice(&mut self, slice: &mut [u8]) {
         self.buffer.read_slice(slice);

--- a/core/src/io.rs
+++ b/core/src/io.rs
@@ -45,7 +45,7 @@ impl SP1Stdin {
     }
 
     /// Read a value from the buffer.
-    pub fn read<T: Serialize + DeserializeOwned>(&mut self) -> T {
+    pub fn read<T: DeserializeOwned>(&mut self) -> T {
         let result: T =
             bincode::deserialize(&self.buffer[self.ptr]).expect("failed to deserialize");
         self.ptr += 1;

--- a/core/src/io.rs
+++ b/core/src/io.rs
@@ -114,7 +114,6 @@ impl SP1PublicValues {
     pub fn read<T: Serialize + DeserializeOwned>(&mut self) -> T {
         self.buffer.read()
     }
-
     /// Read a slice of bytes from the buffer.
     pub fn read_slice(&mut self, slice: &mut [u8]) {
         self.buffer.read_slice(slice);

--- a/core/src/io.rs
+++ b/core/src/io.rs
@@ -121,7 +121,7 @@ impl SP1PublicValues {
     }
 
     /// Write a value to the buffer.
-    pub fn write<T: Serialize + DeserializeOwned>(&mut self, data: &T) {
+    pub fn write<T: Serialize>(&mut self, data: &T) {
         self.buffer.write(data);
     }
 

--- a/core/src/io.rs
+++ b/core/src/io.rs
@@ -7,7 +7,7 @@ use num_bigint::BigUint;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 /// Standard input for the prover.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct SP1Stdin {
     /// Input stored as a vec of vec of bytes. It's stored this way because the read syscall reads
     /// a vec of bytes at a time.


### PR DESCRIPTION
Derive `Default` on `SP1Stdin` and `SP1PublicValues` for external use and remove unnecessary bounds from read/write on SP1Stdin and SP1PublicValues.