### PR TITLE
fix: sys_bigint duplicate symbol

### DIFF
--- a/zkvm/entrypoint/src/syscalls/bigint.rs
+++ b/zkvm/entrypoint/src/syscalls/bigint.rs
@@ -1,6 +1,6 @@
-use crate::syscall_uint256_mulmod;
+use sp1_precompiles::BIGINT_WIDTH_WORDS;
 
-const BIGINT_WIDTH_WORDS: usize = 8;
+use super::syscall_uint256_mulmod;
 
 /// Sets result to be (x op y) % modulus. Currently only multiplication is supported. If modulus is
 /// zero, the modulus applied is 2^256.

--- a/zkvm/entrypoint/src/syscalls/mod.rs
+++ b/zkvm/entrypoint/src/syscalls/mod.rs
@@ -1,3 +1,4 @@
+mod bigint;
 mod blake3_compress;
 mod bls12381;
 mod bn254;

--- a/zkvm/precompiles/src/lib.rs
+++ b/zkvm/precompiles/src/lib.rs
@@ -1,4 +1,10 @@
-pub mod bigint_mulmod;
+//! Precompiles for SP1 zkVM.
+//!
+//! Specifically, this crate contains user-friendly functions that call SP1 syscalls. Syscalls are
+//! also declared here for convenience. In order to avoid duplicate symbol errors, the syscall
+//! function impls must live in sp1-zkvm, which is only imported into the end user program crate.
+//! In contrast, sp1-precompiles can be imported into any crate in the dependency tree.
+
 pub mod bls12381;
 pub mod bn254;
 pub mod io;
@@ -8,6 +14,8 @@ pub mod unconstrained;
 pub mod utils;
 #[cfg(feature = "verify")]
 pub mod verify;
+
+pub const BIGINT_WIDTH_WORDS: usize = 8;
 
 extern "C" {
     pub fn syscall_halt(exit_code: u8) -> !;
@@ -34,4 +42,11 @@ extern "C" {
     pub fn syscall_hint_read(ptr: *mut u8, len: usize);
     pub fn sys_alloc_aligned(bytes: usize, align: usize) -> *mut u8;
     pub fn syscall_bls12381_decompress(point: &mut [u8; 96], is_odd: bool);
+    pub fn sys_bigint(
+        result: *mut [u32; BIGINT_WIDTH_WORDS],
+        op: u32,
+        x: *const [u32; BIGINT_WIDTH_WORDS],
+        y: *const [u32; BIGINT_WIDTH_WORDS],
+        modulus: *const [u32; BIGINT_WIDTH_WORDS],
+    );
 }

--- a/zkvm/precompiles/src/uint256_div.rs
+++ b/zkvm/precompiles/src/uint256_div.rs
@@ -1,6 +1,6 @@
 #![allow(unused_imports)]
-use crate::bigint_mulmod::sys_bigint;
 use crate::io;
+use crate::sys_bigint;
 use crate::syscall_uint256_mulmod;
 use crate::unconstrained;
 use num::{BigUint, Integer};

--- a/zkvm/precompiles/src/uint256_div.rs
+++ b/zkvm/precompiles/src/uint256_div.rs
@@ -40,13 +40,15 @@ pub fn uint256_div(x: &mut [u8; 32], y: &[u8; 32]) -> [u8; 32] {
 
             let mut quotient_times_y = [0u8; 32];
             let zero = [0u32; 8];
-            sys_bigint(
-                quotient_times_y.as_mut_ptr() as *mut [u32; 8],
-                0,
-                quotient_bytes.as_ptr() as *const [u32; 8],
-                y.as_ptr() as *const [u32; 8],
-                zero.as_ptr() as *const [u32; 8]
-            );
+            unsafe {
+                sys_bigint(
+                    quotient_times_y.as_mut_ptr() as *mut [u32; 8],
+                    0,
+                    quotient_bytes.as_ptr() as *const [u32; 8],
+                    y.as_ptr() as *const [u32; 8],
+                    zero.as_ptr() as *const [u32; 8]
+                );
+            }
 
             let quotient_times_divisor = BigUint::from_bytes_le(&quotient_times_y);
             assert_eq!(quotient_times_divisor, dividend - remainder);


### PR DESCRIPTION
sys_bigint impl should be in sp1-zkvm, not sp1-precompiles. This should fix "duplicate symbol" error when sp1-precompiles is in multiple places in dependency tree