### PR TITLE
chore: fix duplicate fibonacci program

### DIFF
--- a/book/generating-proofs/basics.md
+++ b/book/generating-proofs/basics.md
@@ -43,4 +43,3 @@ If you run `RUST_LOG=info cargo run --release -vv`, you will see the following o
 [fibonacci-script 0.1.0] [sp1]     Finished release [optimized] target(s) in 0.15s
 warning: fibonacci-script@0.1.0: fibonacci-program built at 2024-03-02 22:01:26```
 ````
-

--- a/book/generating-proofs/basics.md
+++ b/book/generating-proofs/basics.md
@@ -43,3 +43,4 @@ If you run `RUST_LOG=info cargo run --release -vv`, you will see the following o
 [fibonacci-script 0.1.0] [sp1]     Finished release [optimized] target(s) in 0.15s
 warning: fibonacci-script@0.1.0: fibonacci-program built at 2024-03-02 22:01:26```
 ````
+

--- a/tests/fibonacci/Cargo.toml
+++ b/tests/fibonacci/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 [package]
 version = "0.1.0"
-name = "fibonacci-program"
+name = "fibonacci-program-tests"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Fixes the below by changing the name of the `fibonacci-program` crate in `tests`.
```
warning: skipping duplicate package `fibonacci-program`
```
