### PR TITLE
chore: remove default compressed proofs from examples

### DIFF
--- a/examples/fibonacci/script/src/main.rs
+++ b/examples/fibonacci/script/src/main.rs
@@ -16,7 +16,7 @@ fn main() {
     // Generate the proof for the given program and input.
     let client = ProverClient::new();
     let (pk, vk) = client.setup(ELF);
-    let mut proof = client.prove_compressed(&pk, stdin).unwrap();
+    let mut proof = client.prove(&pk, stdin).unwrap();
 
     println!("generated proof");
 
@@ -29,9 +29,7 @@ fn main() {
     println!("b: {}", b);
 
     // Verify proof and public values
-    client
-        .verify_compressed(&proof, &vk)
-        .expect("verification failed");
+    client.verify(&proof, &vk).expect("verification failed");
 
     // Save the proof.
     proof

--- a/examples/ssz-withdrawals/script/src/main.rs
+++ b/examples/ssz-withdrawals/script/src/main.rs
@@ -10,12 +10,10 @@ fn main() {
     let stdin = SP1Stdin::new();
     let client = ProverClient::new();
     let (pk, vk) = client.setup(ELF);
-    let proof = client.prove_compressed(&pk, stdin).expect("proving failed");
+    let proof = client.prove(&pk, stdin).expect("proving failed");
 
     // Verify proof.
-    client
-        .verify_compressed(&proof, &vk)
-        .expect("verification failed");
+    client.verify(&proof, &vk).expect("verification failed");
 
     // Save proof.
     proof

--- a/examples/tendermint/script/src/main.rs
+++ b/examples/tendermint/script/src/main.rs
@@ -62,11 +62,11 @@ fn main() {
 
     let client = ProverClient::new();
     let (pk, vk) = client.setup(TENDERMINT_ELF);
-        let proof = client.prove_compressed(&pk, stdin).expect("proving failed");
+        let proof = client.prove(&pk, stdin).expect("proving failed");
 
     // Verify proof.
     client
-        .verify_compressed(&proof, &vk)
+        .verify(&proof, &vk)
         .expect("verification failed");
 
     // Verify the public values


### PR DESCRIPTION
to make devex more seamless