### PR TITLE
fix: replace `jal` with `call` in entrypoint

### DIFF
--- a/zkvm/entrypoint/src/lib.rs
+++ b/zkvm/entrypoint/src/lib.rs
@@ -90,7 +90,7 @@ mod zkvm {
         .option pop;
         la sp, {0}
         lw sp, 0(sp)
-        jal ra, __start;
+        call __start;
     "#,
         sym STACK_TOP
     );


### PR DESCRIPTION
The use of the `jal` instruction fails in the entrypoint when the jump is greater than `2^20` (1MB). 

Solution: One line change to the program to use `call` instead of `jal`, which LLVM can use appropriately.

> `jal` is an RISC-V raw instruction that jumps to `__start`, where __start is represented by a signed 20-bit offset from the pc. This means that it can jump either backward up to 1MB or forward up to 1MB.

Compilation time error when running `cargo prove build` inside of `sovereign-sdk` for a large program:
>   = note: rust-lld: error: /Users/ratankaliani/sovereign/sovereign-sdk-wip/examples/demo-rollup/provers/sp1/guest-mock/target/riscv32im-succinct-zkvm-elf/release/deps/sov_demo_prover_guest_mock_sp1-43efdbec6e025eb5.sov_demo_prover_guest_mock_sp1.e995a60d3b6bb61f-cgu.05.rcgu.o:(.text._start+0x14): relocation R_RISCV_JAL out of range: 1485996 is not in [-1048576, 1048575]; references '__start'
          >>> referenced by musl_memcpy.c
          >>> defined in /Users/ratankaliani/sovereign/sovereign-sdk-wip/examples/demo-rollup/provers/sp1/guest-mock/target/riscv32im-succinct-zkvm-elf/release/deps/sov_demo_prover_guest_mock_sp1-43efdbec6e025eb5.sov_demo_prover_guest_mock_sp1.e995a60d3b6bb61f-cgu.05.rcgu.o
          
Definition for call is exactly:
```
auipc ra, TOP 20 bits
jalr ra, ra, LOWER 12 bits
```