### PR TITLE
feat: sp1 circuit version

### DIFF
--- a/.github/workflows/docker-publish-gnark.yml
+++ b/.github/workflows/docker-publish-gnark.yml
@@ -5,6 +5,8 @@ on:
   push:
     tags:
       - "v*.*.*"
+    branches:
+      - chris/circuit-version
   schedule:
     - cron: "0 0 * * *"
   # Trigger without any parameters a proactive rebuild
@@ -65,16 +67,17 @@ jobs:
       - name: Finalize Docker Metadata
         id: docker_tagging
         run: |
-          if [[ "${{ github.event_name }}" == 'workflow_dispatch' ]]; then
-            echo "manual trigger from workflow_dispatch, assigning tag ${{ github.event.inputs.tags }}"
-            echo "docker_tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.inputs.tags }}" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.event_name }}" == 'schedule' ]]; then
-            echo "cron trigger, assigning nightly tag"
-            echo "docker_tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:nightly,${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:nightly-${GITHUB_SHA}" >> $GITHUB_OUTPUT
-          else
-            echo "Neither scheduled nor manual release from main branch. Just tagging as branch name"
-            echo "docker_tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
-          fi
+          echo "docker_tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:v1.0.7-testnet" >> $GITHUB_OUTPUT
+          # if [[ "${{ github.event_name }}" == 'workflow_dispatch' ]]; then
+          #   echo "manual trigger from workflow_dispatch, assigning tag ${{ github.event.inputs.tags }}"
+          #   echo "docker_tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.inputs.tags }}" >> $GITHUB_OUTPUT
+          # elif [[ "${{ github.event_name }}" == 'schedule' ]]; then
+          #   echo "cron trigger, assigning nightly tag"
+          #   echo "docker_tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:nightly,${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:nightly-${GITHUB_SHA}" >> $GITHUB_OUTPUT
+          # else
+          #   echo "Neither scheduled nor manual release from main branch. Just tagging as branch name"
+          #   echo "docker_tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
+          # fi
 
       # Log docker metadata to explicitly know what is being pushed
       - name: Inspect Docker Metadata

--- a/.github/workflows/docker-publish-gnark.yml
+++ b/.github/workflows/docker-publish-gnark.yml
@@ -5,8 +5,6 @@ on:
   push:
     tags:
       - "v*.*.*"
-    branches:
-      - chris/circuit-version
   schedule:
     - cron: "0 0 * * *"
   # Trigger without any parameters a proactive rebuild
@@ -67,17 +65,16 @@ jobs:
       - name: Finalize Docker Metadata
         id: docker_tagging
         run: |
-          echo "docker_tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:v1.0.7-testnet" >> $GITHUB_OUTPUT
-          # if [[ "${{ github.event_name }}" == 'workflow_dispatch' ]]; then
-          #   echo "manual trigger from workflow_dispatch, assigning tag ${{ github.event.inputs.tags }}"
-          #   echo "docker_tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.inputs.tags }}" >> $GITHUB_OUTPUT
-          # elif [[ "${{ github.event_name }}" == 'schedule' ]]; then
-          #   echo "cron trigger, assigning nightly tag"
-          #   echo "docker_tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:nightly,${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:nightly-${GITHUB_SHA}" >> $GITHUB_OUTPUT
-          # else
-          #   echo "Neither scheduled nor manual release from main branch. Just tagging as branch name"
-          #   echo "docker_tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
-          # fi
+          if [[ "${{ github.event_name }}" == 'workflow_dispatch' ]]; then
+            echo "manual trigger from workflow_dispatch, assigning tag ${{ github.event.inputs.tags }}"
+            echo "docker_tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.inputs.tags }}" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.event_name }}" == 'schedule' ]]; then
+            echo "cron trigger, assigning nightly tag"
+            echo "docker_tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:nightly,${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:nightly-${GITHUB_SHA}" >> $GITHUB_OUTPUT
+          else
+            echo "Neither scheduled nor manual release from main branch. Just tagging as branch name"
+            echo "docker_tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
+          fi
 
       # Log docker metadata to explicitly know what is being pushed
       - name: Inspect Docker Metadata

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -34,7 +34,9 @@ pub mod utils;
 use runtime::{Program, Runtime};
 use stark::StarkGenericConfig;
 
-/// The global version for all components of SP1. This string should be updated whenever any step in
-/// verifying an SP1 proof changes, including core, recursion, and plonk-bn254. This string is used
-/// to download SP1 artifacts and the gnark docker image.
+/// The global version for all components of SP1.
+///
+/// This string should be updated whenever any step in verifying an SP1 proof changes, including
+/// core, recursion, and plonk-bn254. This string is used to download SP1 artifacts and the gnark
+/// docker image.
 pub const SP1_CIRCUIT_VERSION: &str = "v1.0.7-testnet";

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -33,3 +33,8 @@ pub mod utils;
 #[allow(unused_imports)]
 use runtime::{Program, Runtime};
 use stark::StarkGenericConfig;
+
+/// The global version for all components of SP1. This string should be updated whenever any step in
+/// verifying an SP1 proof changes, including core, recursion, and plonk-bn254. This string is used
+/// to download SP1 artifacts and the gnark docker image.
+pub const SP1_CIRCUIT_VERSION: &str = "v1.0.7-testnet";

--- a/prover/Makefile
+++ b/prover/Makefile
@@ -10,7 +10,8 @@ build-plonk-bn254:
 	--build-dir=./build
 
 release-plonk-bn254:
-	bash release.sh
+	@read -p "Release version (ex. v1.0.0-testnet)? " version; \
+	bash release.sh $$version
 
 test-e2e:
 	RUSTFLAGS='-C target-cpu=native' \

--- a/prover/release.sh
+++ b/prover/release.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 set -e
 
+# Get the version from the command line.
+VERSION=$1
+
+# Sanity check the version matches v*.*.*
+if [[ $version != v* ]]; then
+    echo "Error: Version must be in the format v*"
+    exit 1
+fi
+
 # Specify the file to upload and the S3 bucket name
 FILE_TO_UPLOAD="./build"
 S3_BUCKET="sp1-circuits"
@@ -18,8 +27,11 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
+# Put the version in the build directory
+echo "$COMMIT_HASH $VERSION" > ./build/SP1_COMMIT
+
 # Create archive named after the commit hash
-ARCHIVE_NAME="${COMMIT_HASH}.tar.gz"
+ARCHIVE_NAME="${VERSION}.tar.gz"
 cd $FILE_TO_UPLOAD
 tar --exclude='srs.bin' --exclude='srs_lagrange.bin' -czvf "../$ARCHIVE_NAME" .
 cd -

--- a/prover/src/build.rs
+++ b/prover/src/build.rs
@@ -12,9 +12,9 @@ use sp1_recursion_core::air::RecursionPublicValues;
 pub use sp1_recursion_core::stark::utils::sp1_dev_mode;
 use sp1_recursion_gnark_ffi::PlonkBn254Prover;
 
-use crate::install::{install_plonk_bn254_artifacts, PLONK_BN254_ARTIFACTS_COMMIT};
+use crate::install::install_plonk_bn254_artifacts;
 use crate::utils::{babybear_bytes_to_bn254, babybears_to_bn254, words_to_bytes};
-use crate::{OuterSC, SP1Prover};
+use crate::{OuterSC, SP1Prover, SP1_CIRCUIT_VERSION};
 
 /// Tries to install the PLONK artifacts if they are not already installed.
 pub fn try_install_plonk_bn254_artifacts() -> PathBuf {
@@ -27,8 +27,8 @@ pub fn try_install_plonk_bn254_artifacts() -> PathBuf {
         );
     } else {
         println!(
-            "[sp1] plonk bn254 artifacts for commit {} do not exist at {}. downloading...",
-            PLONK_BN254_ARTIFACTS_COMMIT,
+            "[sp1] plonk bn254 artifacts for version {} do not exist at {}. downloading...",
+            SP1_CIRCUIT_VERSION,
             build_dir.display()
         );
         install_plonk_bn254_artifacts(build_dir.clone());
@@ -54,7 +54,7 @@ fn plonk_bn254_artifacts_dir() -> PathBuf {
         .join(".sp1")
         .join("circuits")
         .join("plonk_bn254")
-        .join(PLONK_BN254_ARTIFACTS_COMMIT)
+        .join(SP1_CIRCUIT_VERSION)
 }
 
 /// Gets the directory where the PLONK artifacts are installed in development mode.

--- a/prover/src/install.rs
+++ b/prover/src/install.rs
@@ -4,13 +4,10 @@ use futures::StreamExt;
 use indicatif::{ProgressBar, ProgressStyle};
 use reqwest::Client;
 
-use crate::utils::block_on;
+use crate::{utils::block_on, SP1_CIRCUIT_VERSION};
 
 /// The base URL for the S3 bucket containing the plonk bn254 artifacts.
 pub const PLONK_BN254_ARTIFACTS_URL_BASE: &str = "https://sp1-circuits.s3-us-east-2.amazonaws.com";
-
-/// The current version of the plonk bn254 artifacts.
-pub const PLONK_BN254_ARTIFACTS_COMMIT: &str = "4a525e9f";
 
 /// Install the latest plonk bn254 artifacts.
 ///
@@ -23,7 +20,7 @@ pub fn install_plonk_bn254_artifacts(build_dir: PathBuf) {
     // Download the artifacts.
     let download_url = format!(
         "{}/{}.tar.gz",
-        PLONK_BN254_ARTIFACTS_URL_BASE, PLONK_BN254_ARTIFACTS_COMMIT
+        PLONK_BN254_ARTIFACTS_URL_BASE, SP1_CIRCUIT_VERSION
     );
     let mut artifacts_tar_gz_file =
         tempfile::NamedTempFile::new().expect("failed to create tempfile");
@@ -63,7 +60,7 @@ pub fn install_plonk_bn254_artifacts_dir() -> PathBuf {
         .unwrap()
         .join(".sp1")
         .join("circuits")
-        .join(PLONK_BN254_ARTIFACTS_COMMIT)
+        .join(SP1_CIRCUIT_VERSION)
 }
 
 /// Download the file with a progress bar that indicates the progress.

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -60,6 +60,8 @@ use tracing::instrument;
 pub use types::*;
 use utils::words_to_bytes;
 
+pub const SP1_CIRCUIT_VERSION: &str = "v1.0.7-testnet";
+
 /// The configuration for the core prover.
 pub type CoreSC = BabyBearPoseidon2;
 

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -60,8 +60,7 @@ use tracing::instrument;
 pub use types::*;
 use utils::words_to_bytes;
 
-/// The global version for all components of SP1.
-pub const SP1_CIRCUIT_VERSION: &str = "v1.0.7-testnet";
+pub use sp1_core::SP1_CIRCUIT_VERSION;
 
 /// The configuration for the core prover.
 pub type CoreSC = BabyBearPoseidon2;

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -60,6 +60,7 @@ use tracing::instrument;
 pub use types::*;
 use utils::words_to_bytes;
 
+/// The global version for all components of SP1.
 pub const SP1_CIRCUIT_VERSION: &str = "v1.0.7-testnet";
 
 /// The configuration for the core prover.

--- a/recursion/gnark-ffi/src/ffi/docker.rs
+++ b/recursion/gnark-ffi/src/ffi/docker.rs
@@ -16,8 +16,9 @@ fn assert_docker() {
 }
 
 fn get_docker_image() -> String {
-    std::env::var("SP1_GNARK_IMAGE")
-        .unwrap_or_else(|_| "ghcr.io/succinctlabs/sp1-gnark:ffi-docker".to_string())
+    std::env::var("SP1_GNARK_IMAGE").unwrap_or_else(|_| {
+        format!("ghcr.io/succinctlabs/sp1-gnark:{}", SP1_CIRCUIT_VERSION)
+    })
 }
 
 /// Calls `docker run` with the given arguments and bind mounts.

--- a/recursion/gnark-ffi/src/ffi/docker.rs
+++ b/recursion/gnark-ffi/src/ffi/docker.rs
@@ -1,3 +1,5 @@
+use sp1_core::SP1_CIRCUIT_VERSION;
+
 use crate::PlonkBn254Proof;
 use std::io::Write;
 use std::process::Command;
@@ -16,9 +18,8 @@ fn assert_docker() {
 }
 
 fn get_docker_image() -> String {
-    std::env::var("SP1_GNARK_IMAGE").unwrap_or_else(|_| {
-        format!("ghcr.io/succinctlabs/sp1-gnark:{}", SP1_CIRCUIT_VERSION)
-    })
+    std::env::var("SP1_GNARK_IMAGE")
+        .unwrap_or_else(|_| format!("ghcr.io/succinctlabs/sp1-gnark:{}", SP1_CIRCUIT_VERSION))
 }
 
 /// Calls `docker run` with the given arguments and bind mounts.

--- a/sdk/src/network/prover.rs
+++ b/sdk/src/network/prover.rs
@@ -9,9 +9,8 @@ use crate::{
 use crate::{SP1CompressedProof, SP1PlonkBn254Proof, SP1Proof, SP1ProvingKey, SP1VerifyingKey};
 use anyhow::{Context, Result};
 use serde::de::DeserializeOwned;
-use sp1_prover::install::PLONK_BN254_ARTIFACTS_COMMIT;
 use sp1_prover::utils::block_on;
-use sp1_prover::{SP1Prover, SP1Stdin};
+use sp1_prover::{SP1Prover, SP1Stdin, SP1_CIRCUIT_VERSION};
 use tokio::{runtime, time::sleep};
 
 use crate::provers::{LocalProver, ProverType};
@@ -56,7 +55,7 @@ impl NetworkProver {
             log::info!("Skipping simulation");
         }
 
-        let version = PLONK_BN254_ARTIFACTS_COMMIT;
+        let version = SP1_CIRCUIT_VERSION;
         log::info!("Client version {}", version);
 
         let proof_id = client.create_proof(elf, &stdin, mode, version).await?;


### PR DESCRIPTION
* Have global circuit version string rather than plonk commit
  * This is easier to track than commit as it directly maps to an sp1-sdk release