### PR TITLE
fix: reduce minimum Solidity version for SP1 contracts

### DIFF
--- a/book/verifying-proofs/solidity-and-evm.md
+++ b/book/verifying-proofs/solidity-and-evm.md
@@ -54,7 +54,7 @@ Add `@sp1-contracts/=lib/sp1-contracts/contracts/src/` in `remappings.txt.`
 Once installed, you can use the contracts in the library by importing them:
 
 ```solidity
-pragma solidity ^0.8.25;
+pragma solidity ^0.8.19;
 
 import {SP1Verifier} from "@sp1-contracts/SP1Verifier.sol";
 

--- a/recursion/gnark-ffi/assets/ISP1Verifier.txt
+++ b/recursion/gnark-ffi/assets/ISP1Verifier.txt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.25;
+pragma solidity ^0.8.19;
 
 /// @title SP1 Verifier Interface
 /// @author Succinct Labs

--- a/recursion/gnark-ffi/assets/SP1MockVerifier.txt
+++ b/recursion/gnark-ffi/assets/SP1MockVerifier.txt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.25;
+pragma solidity ^0.8.19;
 
 import {ISP1Verifier} from "./ISP1Verifier.sol";
 

--- a/recursion/gnark-ffi/assets/SP1Verifier.txt
+++ b/recursion/gnark-ffi/assets/SP1Verifier.txt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.25;
+pragma solidity ^0.8.19;
 
 import {ISP1Verifier} from "./ISP1Verifier.sol";
 import {PlonkVerifier} from "./PlonkVerifier.sol";


### PR DESCRIPTION
Reduce the Solidity version required by the SP1 Ethereum contracts to `0.8.19` to match the auto-generated gnark PLONK verifier. This way, users can choose any version >= `0.8.19` to compile with, as the previous verison of `0.8.25` could be too restrictive.

The contracts associated with the next release will automatically update to this version.