### PR TITLE
fix: proof request link

### DIFF
--- a/sdk/src/network/prover.rs
+++ b/sdk/src/network/prover.rs
@@ -70,7 +70,7 @@ impl NetworkProver {
 
         if NetworkClient::rpc_url() == DEFAULT_PROVER_NETWORK_RPC {
             log::info!(
-                "View in explorer: https://explorer.succinct.xyz/{}",
+                "View in explorer: https://explorer.succinct.xyz/proofrequest_{}",
                 proof_id
             );
         }


### PR DESCRIPTION
Proof request links outputted by the SDK don't have the `proof_request` prefix. Ex.
<img width="1009" alt="image" src="https://github.com/succinctlabs/sp1/assets/34041956/0354b13b-22e5-4d77-bd44-d32c91c4b33a">

This PR fixes the link.
