### PR TITLE
chore: add ignore rust version to build script

### DIFF
--- a/helper/src/lib.rs
+++ b/helper/src/lib.rs
@@ -64,7 +64,7 @@ fn execute_build_cmd(
 
     let mut cmd = Command::new("cargo");
     cmd.current_dir(program_dir)
-        .args(["prove", "build"])
+        .args(["prove", "build", "--ignore-rust-version"])
         .env_remove("RUSTC")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());


### PR DESCRIPTION
Add ignore rust version to `sp1-helper`. 

Certain packages (such as [alloy-rs](https://github.com/alloy-rs/alloy)), require Rust versions greater than the one specified in SP1's fork of https://github.com/succinctlabs/rust. Until we upgrade this Rust version, users will encounter errors similar to this:

```bash
  [sp1] error: package `alloy v0.1.2` cannot be built because it requires rustc 1.76 or newer, while the currently active rustc version is 1.75.0-nightly
  [sp1] Either upgrade to rustc 1.76 or newer, or use
  [sp1] cargo update alloy@0.1.2 --precise ver
  [sp1] where `ver` is the latest version of `alloy` supporting rustc 1.75.0-nightly
  thread 'main' panicked at /Users/ratankaliani/.cargo/git/checkouts/sp1-20c98843a1ffc860/b35be42/helper/src/lib.rs:47:9:
  Failed to build `blobstream-program`.
```

This PR ignores the Rust version in this build script by default.