### PR TITLE
chore(ci): disable spot for larger ci jobs

### DIFF
--- a/.github/workflows/docker-gnark.yml
+++ b/.github/workflows/docker-gnark.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   test-docker:
     name: Test
-    runs-on: runs-on,runner=64cpu-linux-arm64
+    runs-on: runs-on,runner=64cpu-linux-arm64,spot=false
     env:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   plonk:
     name: Plonk Native
-    runs-on: runs-on,cpu=64,ram=256,family=m7i+m7a,hdd=80,image=ubuntu22-full-x64
+    runs-on: runs-on,cpu=64,ram=256,family=m7i+m7a,hdd=80,image=ubuntu22-full-x64,spot=false
     env:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
@@ -41,7 +41,7 @@ jobs:
           RUST_BACKTRACE: 1
   plonk-docker:
     name: Plonk Docker
-    runs-on: runs-on,cpu=64,ram=256,family=m7i+m7a,hdd=80,image=ubuntu22-full-x64
+    runs-on: runs-on,cpu=64,ram=256,family=m7i+m7a,hdd=80,image=ubuntu22-full-x64,spot=false
     env:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   test-x86:
     name: Test (x86-64)
-    runs-on: runs-on,runner=64cpu-linux-x64
+    runs-on: runs-on,runner=64cpu-linux-x64,spot=false
     env:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
@@ -57,7 +57,7 @@ jobs:
 
   test-arm:
     name: Test (ARM)
-    runs-on: runs-on,runner=64cpu-linux-arm64
+    runs-on: runs-on,runner=64cpu-linux-arm64,spot=false
     env:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:


### PR DESCRIPTION
Disable usage of spot instances for `test-x86`, `test-arm` and Plonk native, which were flaky due to spot instance interruption.