### PR TITLE
fix: use correct value for blowup

### DIFF
--- a/recursion/program/src/fri/two_adic_pcs.rs
+++ b/recursion/program/src/fri/two_adic_pcs.rs
@@ -33,7 +33,7 @@ pub fn verify_two_adic_pcs<C: Config>(
     let g = builder.generator();
 
     let log_blowup = config.log_blowup;
-    let blowup = config.log_blowup;
+    let blowup = config.blowup;
     let alpha = challenger.sample_ext(builder);
 
     builder.cycle_tracker("stage-d-1-verify-shape-and-sample-challenges");


### PR DESCRIPTION
This change doesn’t seem to impact the logic as `blowup` is used solely to calculate matrix heights through the expression `mat.domain.size() * blowup`, and these computed heights are then only used in equality comparisons against each other. Any nonzero value for blowup should therefore "work". (But this does make me wonder why both `batch_heights_log2` and `batch_dims` are computed, since the former should also work for this kind of logic.)