### PR TITLE
feat: put hook results in front of the input stream

### DIFF
--- a/core/src/syscall/write.rs
+++ b/core/src/syscall/write.rs
@@ -74,7 +74,9 @@ impl Syscall for SyscallWrite {
             rt.state.input_stream.push(slice.to_vec());
         } else if let Some(mut hook) = rt.hook_registry.get(&fd) {
             let res = hook.invoke_hook(rt.hook_env(), slice);
-            rt.state.input_stream.extend(res);
+            // Add result vectors to the beginning of the stream.
+            let ptr = rt.state.input_stream_ptr;
+            rt.state.input_stream.splice(ptr..ptr, res);
         } else {
             log::warn!("tried to write to unknown file descriptor {fd}");
         }


### PR DESCRIPTION
Hook results must be accessed immediately after calling.

One no longer has to rely on the `input_stream` being empty when calling a hook and accessing its results.