### PR TITLE
feat: improve network prover error output

### DIFF
--- a/sdk/src/network/auth.rs
+++ b/sdk/src/network/auth.rs
@@ -39,15 +39,6 @@ sol! {
         uint64 nonce;
         string proof_id;
     }
-
-    struct RelayProof {
-        uint64 nonce;
-        string proof_id;
-        uint32 chain_id;
-        address verifier;
-        address callback;
-        bytes callback_data;
-    }
 }
 
 /// Handles authentication for the Succinct prover network. All interactions that could potentially
@@ -147,28 +138,6 @@ impl NetworkAuth {
         let type_struct = FulfillProof {
             nonce,
             proof_id: proof_id.to_string(),
-        };
-        self.sign_message(type_struct).await
-    }
-
-    /// Signs a message to remote relay a proof to a specific chain with the verifier and callback
-    /// specified.
-    pub async fn sign_relay_proof_message(
-        &self,
-        nonce: u64,
-        proof_id: &str,
-        chain_id: u32,
-        verifier: [u8; 20],
-        callback: [u8; 20],
-        callback_data: &[u8],
-    ) -> Result<Vec<u8>> {
-        let type_struct = RelayProof {
-            nonce,
-            proof_id: proof_id.to_string(),
-            chain_id,
-            verifier: verifier.into(),
-            callback: callback.into(),
-            callback_data: callback_data.to_vec().into(),
         };
         self.sign_message(type_struct).await
     }

--- a/sdk/src/network/client.rs
+++ b/sdk/src/network/client.rs
@@ -12,7 +12,7 @@ use serde::de::DeserializeOwned;
 use sp1_prover::SP1Stdin;
 use std::result::Result::Ok as StdOk;
 use std::time::{SystemTime, UNIX_EPOCH};
-use twirp::Client as TwirpClient;
+use twirp::{Client as TwirpClient, ClientError};
 
 use crate::proto::network::{
     ClaimProofRequest, ClaimProofResponse, CreateProofRequest, FulfillProofRequest,
@@ -347,7 +347,7 @@ impl NetworkClient {
         match result {
             StdOk(response) => StdOk(response),
             Err(ClientError::TwirpError(err)) => {
-                let display_err = format!("error: {:?} message: {:?}", err.code, err.msg);
+                let display_err = format!("error: \"{:?}\" message: {:?}", err.code, err.msg);
                 Err(anyhow::anyhow!(display_err))
             }
             Err(err) => Err(err.into()),

--- a/sdk/src/network/client.rs
+++ b/sdk/src/network/client.rs
@@ -35,11 +35,12 @@ pub struct NetworkClient {
 }
 
 impl NetworkClient {
+    /// Returns the currently configured RPC endpoint for the Succinct prover network.
     pub fn rpc_url() -> String {
         env::var("PROVER_NETWORK_RPC").unwrap_or_else(|_| DEFAULT_PROVER_NETWORK_RPC.to_string())
     }
 
-    // Create a new NetworkClient with the given private key for authentication.
+    /// Create a new NetworkClient with the given private key for authentication.
     pub fn new(private_key: &str) -> Self {
         let auth = NetworkAuth::new(private_key);
 
@@ -76,13 +77,13 @@ impl NetworkClient {
         Ok(res.nonce)
     }
 
-    // Upload a file to the specified url.
+    /// Upload a file to the specified url.
     async fn upload_file(&self, url: &str, data: Vec<u8>) -> Result<()> {
         self.http.put(url).body(data).send().await?;
         Ok(())
     }
 
-    // Get the status of a given proof. If the status is ProofFulfilled, the proof is also returned.
+    /// Get the status of a given proof. If the status is ProofFulfilled, the proof is also returned.
     pub async fn get_proof_status<P: DeserializeOwned>(
         &self,
         proof_id: &str,
@@ -115,7 +116,7 @@ impl NetworkClient {
         Ok((res, proof))
     }
 
-    // Relay a proof. Returns an error if the proof is not in a PROOF_FULFILLED state.
+    /// Relay a proof. Returns an error if the proof is not in a PROOF_FULFILLED state.
     pub async fn get_proof_requests(
         &self,
         status: ProofStatus,
@@ -126,7 +127,7 @@ impl NetworkClient {
         .await
     }
 
-    // Get the status of a relay transaction request.
+    /// Get the status of a relay transaction request.
     pub async fn get_relay_status(
         &self,
         tx_id: &str,
@@ -205,8 +206,8 @@ impl NetworkClient {
         Ok(res.proof_id)
     }
 
-    // Claim a proof that was requested. This commits to generating a proof and fulfilling it.
-    // Returns an error if the proof is not in a PROOF_REQUESTED state.
+    /// Claim a proof that was requested. This commits to generating a proof and fulfilling it.
+    /// Returns an error if the proof is not in a PROOF_REQUESTED state.
     pub async fn claim_proof(&self, proof_id: &str) -> Result<ClaimProofResponse> {
         let nonce = self.get_nonce().await?;
         let signature = self.auth.sign_claim_proof_message(nonce, proof_id).await?;
@@ -219,9 +220,9 @@ impl NetworkClient {
         .await
     }
 
-    // Unclaim a proof that was claimed. This should only be called if the proof has not been
-    // fulfilled yet. Returns an error if the proof is not in a PROOF_CLAIMED state or if the caller
-    // is not the claimer.
+    /// Unclaim a proof that was claimed. This should only be called if the proof has not been
+    /// fulfilled yet. Returns an error if the proof is not in a PROOF_CLAIMED state or if the caller
+    /// is not the claimer.
     pub async fn unclaim_proof(
         &self,
         proof_id: String,
@@ -246,8 +247,8 @@ impl NetworkClient {
         Ok(())
     }
 
-    // Fulfill a proof. Should only be called after the proof has been uploaded. Returns an error
-    // if the proof is not in a PROOF_CLAIMED state or if the caller is not the claimer.
+    /// Fulfill a proof. Should only be called after the proof has been uploaded. Returns an error
+    /// if the proof is not in a PROOF_CLAIMED state or if the caller is not the claimer.
     pub async fn fulfill_proof(&self, proof_id: &str) -> Result<FulfillProofResponse> {
         let nonce = self.get_nonce().await?;
         let signature = self
@@ -265,7 +266,7 @@ impl NetworkClient {
         Ok(res)
     }
 
-    /// Relays a proof to a verifier on a specific blockchain.
+    /// Relay a proof. Returns an error if the proof is not in a PROOF_FULFILLED state.
     pub async fn relay_proof(
         &self,
         proof_id: &str,
@@ -293,7 +294,7 @@ impl NetworkClient {
         Ok(res.tx_id)
     }
 
-    /// Awaits the future, then handles prover network errors.
+    /// Awaits the future, then handles Succinct prover network errors.
     async fn with_error_handling<T, F>(&self, future: F) -> Result<T>
     where
         F: Future<Output = std::result::Result<T, ClientError>>,

--- a/sdk/src/network/client.rs
+++ b/sdk/src/network/client.rs
@@ -115,7 +115,7 @@ impl NetworkClient {
         Ok((res, proof))
     }
 
-    // Get all the proof requests for a given status.
+    // Relay a proof. Returns an error if the proof is not in a PROOF_FULFILLED state.
     pub async fn get_proof_requests(
         &self,
         status: ProofStatus,


### PR DESCRIPTION
Removes Twirp references:

Previous: 

> called `Result::unwrap()` on an `Err` value: twirp error: TwirpErrorResponse { code: InvalidArgument, msg: "version is invalid, only 'e48c01ec' is supported - use sp1 commit 'e48c01ec' and try again", meta: {"argument": "version"} }

After change:

> called `Result::unwrap()` on an `Err` value: error: "InvalidArgument" message: "version is invalid, only 'e48c01ec' is supported - use sp1 commit 'e48c01ec' and try again"

also removing relay usage.