### PR TITLE
feat: make `AddressValue.value` a `Block`

### DIFF
--- a/recursion/core-v2/src/alu.rs
+++ b/recursion/core-v2/src/alu.rs
@@ -95,7 +95,6 @@ impl<F: PrimeField32> MachineAir<F> for FieldAluChip {
                     opcode,
                 } = event;
 
-                // Should we check (at some point) that the other array entries are zero?
                 let (v1, v2) = (in1.val.0[0], in2.val.0[0]);
 
                 let cols: &mut FieldAluCols<_> = row.as_mut_slice().borrow_mut();
@@ -160,6 +159,11 @@ where
         builder
             .when(local.is_real)
             .assert_one(local.is_add + local.is_sub + local.is_mul + local.is_div);
+
+        // Check the values read/written to memory are base elements.
+        builder.assert_is_base_element(local.in1.val.as_extension::<AB>());
+        builder.assert_is_base_element(local.in2.val.as_extension::<AB>());
+        builder.assert_is_base_element(local.out.val.as_extension::<AB>());
 
         let mut when_add = builder.when(local.is_add);
         when_add.assert_eq(local.out.val.0[0], local.sum);

--- a/recursion/core-v2/src/lib.rs
+++ b/recursion/core-v2/src/lib.rs
@@ -1,6 +1,6 @@
 use std::iter::once;
 
-use p3_field::PrimeField32;
+use p3_field::{AbstractField, PrimeField32};
 use sp1_core::{air::PublicValues, stark::MachineRecord};
 
 pub mod alu;
@@ -18,9 +18,9 @@ pub mod program;
 #[derive(Clone, Debug)]
 pub struct AluEvent<F> {
     pub opcode: Opcode,
-    pub out: AddressValue<F>,
-    pub in1: AddressValue<F>,
-    pub in2: AddressValue<F>,
+    pub out: AddressValueBase<F>,
+    pub in1: AddressValueBase<F>,
+    pub in2: AddressValueBase<F>,
     pub mult: F, // number of times we need this value in the future
 }
 
@@ -48,12 +48,41 @@ impl<F> AddressValue<F> {
         Self { addr, val }
     }
 
-    pub fn iter(&self) -> impl DoubleEndedIterator<Item = &F> {
+    pub fn iter(&self) -> std::iter::Chain<std::iter::Once<&F>, std::slice::Iter<F>> {
         once(&self.addr).chain(self.val.0.iter())
     }
 
-    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut F> {
+    pub fn iter_mut(
+        &mut self,
+    ) -> std::iter::Chain<std::iter::Once<&mut F>, std::slice::IterMut<F>> {
         once(&mut self.addr).chain(self.val.0.iter_mut())
+    }
+}
+
+/// Used for base field computations.
+/// Should not be read/written to memory directly. Instead, convert to `AddressValue`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct AddressValueBase<F> {
+    addr: F,
+    val: F,
+}
+
+impl<F> AddressValueBase<F> {
+    pub fn new(addr: F, val: F) -> Self {
+        Self { addr, val }
+    }
+}
+
+// TODO this is not what we want and doesn't work in `eval`
+impl<F: Default> From<AddressValueBase<F>> for AddressValue<F> {
+    fn from(other: AddressValueBase<F>) -> Self {
+        let AddressValueBase { addr, val } = other;
+        let mut padded_val = <[F; D]>::default();
+        padded_val[0] = val;
+        Self {
+            addr,
+            val: Block(padded_val),
+        }
     }
 }
 
@@ -121,7 +150,7 @@ impl<F: PrimeField32> MachineRecord for ExecutionRecord<F> {
 use p3_field::Field;
 use serde::{Deserialize, Serialize};
 use sp1_core::air::MachineProgram;
-use sp1_recursion_core::air::Block;
+use sp1_recursion_core::{air::Block, runtime::D};
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct RecursionProgram<F> {

--- a/recursion/core-v2/src/lib.rs
+++ b/recursion/core-v2/src/lib.rs
@@ -1,3 +1,5 @@
+use std::iter::once;
+
 use p3_field::PrimeField32;
 use sp1_core::{air::PublicValues, stark::MachineRecord};
 
@@ -38,12 +40,20 @@ pub enum MemAccessKind {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct AddressValue<F> {
     addr: F,
-    val: F,
+    val: Block<F>,
 }
 
 impl<F> AddressValue<F> {
-    pub fn new(addr: F, val: F) -> Self {
+    pub fn new(addr: F, val: Block<F>) -> Self {
         Self { addr, val }
+    }
+
+    pub fn iter(&self) -> impl DoubleEndedIterator<Item = &F> {
+        once(&self.addr).chain(self.val.0.iter())
+    }
+
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut F> {
+        once(&mut self.addr).chain(self.val.0.iter_mut())
     }
 }
 
@@ -111,6 +121,7 @@ impl<F: PrimeField32> MachineRecord for ExecutionRecord<F> {
 use p3_field::Field;
 use serde::{Deserialize, Serialize};
 use sp1_core::air::MachineProgram;
+use sp1_recursion_core::air::Block;
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct RecursionProgram<F> {

--- a/recursion/core-v2/src/machine.rs
+++ b/recursion/core-v2/src/machine.rs
@@ -113,8 +113,8 @@ mod tests {
     // use sp1_recursion_core::air::SP1RecursionAirBuilder;
 
     use crate::{
-        machine::RecursionAir, AddressValue, AluEvent, ExecutionRecord, MemAccessKind, MemEvent,
-        Opcode, RecursionProgram,
+        machine::RecursionAir, AddressValue, AddressValueBase, AluEvent, ExecutionRecord,
+        MemAccessKind, MemEvent, Opcode, RecursionProgram,
     };
 
     #[test]
@@ -134,9 +134,9 @@ mod tests {
         let record = ExecutionRecord {
             alu_events: vec![
                 AluEvent {
-                    out: AddressValue::new(embed(100), embed(2).into()),
-                    in1: AddressValue::new(embed(101), embed(1).into()),
-                    in2: AddressValue::new(embed(101), embed(1).into()),
+                    out: AddressValueBase::new(embed(100), embed(2)),
+                    in1: AddressValueBase::new(embed(101), embed(1)),
+                    in2: AddressValueBase::new(embed(101), embed(1)),
                     mult: embed(1),
                     opcode: Opcode::AddF,
                 },
@@ -194,15 +194,15 @@ mod tests {
 
         let mut record = ExecutionRecord::default();
 
-        let mut x = AddressValue::new(F::zero(), F::one().into());
+        let mut x = AddressValueBase::new(F::zero(), F::one());
         record.mem_events.push(MemEvent {
-            address_value: x,
+            address_value: x.into(),
             multiplicity: embed(3),
             kind: MemAccessKind::Write,
         });
         for _ in 0..100 {
-            let prod = AddressValue::new(x.addr + embed(1), (x.val.0[0] * x.val.0[0]).into());
-            let sum = AddressValue::new(x.addr + embed(2), (prod.val.0[0] + x.val.0[0]).into());
+            let prod = AddressValueBase::new(x.addr + embed(1), x.val * x.val);
+            let sum = AddressValueBase::new(x.addr + embed(2), prod.val + x.val);
             record.alu_events.push(AluEvent {
                 opcode: Opcode::MulF,
                 out: prod,
@@ -220,7 +220,7 @@ mod tests {
             x = sum;
         }
         record.mem_events.push(MemEvent {
-            address_value: x,
+            address_value: x.into(),
             multiplicity: embed(3),
             kind: MemAccessKind::Read,
         });
@@ -243,15 +243,15 @@ mod tests {
 
         let mut record = ExecutionRecord::default();
 
-        let mut x = AddressValue::new(F::zero(), F::one().into());
+        let mut x = AddressValueBase::new(F::zero(), F::one());
         record.mem_events.push(MemEvent {
-            address_value: x,
+            address_value: x.into(),
             multiplicity: embed(3),
             kind: MemAccessKind::Write,
         });
         for _ in 0..100 {
-            let prod = AddressValue::new(x.addr + embed(1), (x.val.0[0] * x.val.0[0]).into());
-            let sum = AddressValue::new(x.addr + embed(2), (prod.val.0[0] + x.val.0[0]).into());
+            let prod = AddressValueBase::new(x.addr + embed(1), x.val * x.val);
+            let sum = AddressValueBase::new(x.addr + embed(2), prod.val + x.val);
             record.alu_events.push(AluEvent {
                 opcode: Opcode::MulF,
                 out: prod,
@@ -269,7 +269,7 @@ mod tests {
             x = sum;
         }
         record.mem_events.push(MemEvent {
-            address_value: x,
+            address_value: x.into(),
             multiplicity: embed(3),
             kind: MemAccessKind::Read,
         });
@@ -292,20 +292,20 @@ mod tests {
 
         let mut record = ExecutionRecord::default();
 
-        let four = AddressValue::new(embed(0), embed(3).into());
+        let four = AddressValueBase::new(embed(0), embed(3));
         record.mem_events.push(MemEvent {
-            address_value: four,
+            address_value: four.into(),
             multiplicity: embed(4),
             kind: MemAccessKind::Write,
         });
-        let three = AddressValue::new(embed(1), embed(4).into());
+        let three = AddressValueBase::new(embed(1), embed(4));
         record.mem_events.push(MemEvent {
-            address_value: three,
+            address_value: three.into(),
             multiplicity: embed(4),
             kind: MemAccessKind::Write,
         });
 
-        let sum = AddressValue::new(embed(1), (four.val.0[0] + three.val.0[0]).into());
+        let sum = AddressValueBase::new(embed(1), four.val + three.val);
         record.alu_events.push(AluEvent {
             opcode: Opcode::AddF,
             out: sum,
@@ -314,7 +314,7 @@ mod tests {
             mult: embed(0),
         });
 
-        let diff = AddressValue::new(embed(1), (four.val.0[0] - three.val.0[0]).into());
+        let diff = AddressValueBase::new(embed(1), four.val - three.val);
         record.alu_events.push(AluEvent {
             opcode: Opcode::SubF,
             out: diff,
@@ -323,7 +323,7 @@ mod tests {
             mult: embed(0),
         });
 
-        let prod = AddressValue::new(embed(1), (four.val.0[0] * three.val.0[0]).into());
+        let prod = AddressValueBase::new(embed(1), four.val * three.val);
         record.alu_events.push(AluEvent {
             opcode: Opcode::MulF,
             out: prod,
@@ -332,7 +332,7 @@ mod tests {
             mult: embed(0),
         });
 
-        let quot = AddressValue::new(embed(1), (four.val.0[0] / three.val.0[0]).into());
+        let quot = AddressValueBase::new(embed(1), four.val / three.val);
         record.alu_events.push(AluEvent {
             opcode: Opcode::DivF,
             out: quot,

--- a/recursion/core-v2/src/machine.rs
+++ b/recursion/core-v2/src/machine.rs
@@ -134,9 +134,9 @@ mod tests {
         let record = ExecutionRecord {
             alu_events: vec![
                 AluEvent {
-                    out: AddressValue::new(embed(100), embed(2)),
-                    in1: AddressValue::new(embed(101), embed(1)),
-                    in2: AddressValue::new(embed(101), embed(1)),
+                    out: AddressValue::new(embed(100), embed(2).into()),
+                    in1: AddressValue::new(embed(101), embed(1).into()),
+                    in2: AddressValue::new(embed(101), embed(1).into()),
                     mult: embed(1),
                     opcode: Opcode::AddF,
                 },
@@ -144,27 +144,27 @@ mod tests {
             ],
             mem_events: vec![
                 MemEvent {
-                    address_value: AddressValue::new(embed(1), embed(2)),
+                    address_value: AddressValue::new(embed(1), embed(2).into()),
                     multiplicity: F::two(),
                     kind: MemAccessKind::Write,
                 },
                 MemEvent {
-                    address_value: AddressValue::new(embed(1), embed(2)),
+                    address_value: AddressValue::new(embed(1), embed(2).into()),
                     multiplicity: F::one(),
                     kind: MemAccessKind::Read,
                 },
                 MemEvent {
-                    address_value: AddressValue::new(embed(1), embed(2)),
+                    address_value: AddressValue::new(embed(1), embed(2).into()),
                     multiplicity: F::one(),
                     kind: MemAccessKind::Read,
                 },
                 MemEvent {
-                    address_value: AddressValue::new(embed(101), embed(1)),
+                    address_value: AddressValue::new(embed(101), embed(1).into()),
                     multiplicity: F::two(),
                     kind: MemAccessKind::Write,
                 },
                 MemEvent {
-                    address_value: AddressValue::new(embed(100), embed(2)),
+                    address_value: AddressValue::new(embed(100), embed(2).into()),
                     multiplicity: F::one(),
                     kind: MemAccessKind::Read,
                 },
@@ -194,15 +194,15 @@ mod tests {
 
         let mut record = ExecutionRecord::default();
 
-        let mut x = AddressValue::new(F::zero(), F::one());
+        let mut x = AddressValue::new(F::zero(), F::one().into());
         record.mem_events.push(MemEvent {
             address_value: x,
             multiplicity: embed(3),
             kind: MemAccessKind::Write,
         });
         for _ in 0..100 {
-            let prod = AddressValue::new(x.addr + embed(1), x.val * x.val);
-            let sum = AddressValue::new(x.addr + embed(2), prod.val + x.val);
+            let prod = AddressValue::new(x.addr + embed(1), (x.val.0[0] * x.val.0[0]).into());
+            let sum = AddressValue::new(x.addr + embed(2), (prod.val.0[0] + x.val.0[0]).into());
             record.alu_events.push(AluEvent {
                 opcode: Opcode::MulF,
                 out: prod,
@@ -243,15 +243,15 @@ mod tests {
 
         let mut record = ExecutionRecord::default();
 
-        let mut x = AddressValue::new(F::zero(), F::one());
+        let mut x = AddressValue::new(F::zero(), F::one().into());
         record.mem_events.push(MemEvent {
             address_value: x,
             multiplicity: embed(3),
             kind: MemAccessKind::Write,
         });
         for _ in 0..100 {
-            let prod = AddressValue::new(x.addr + embed(1), x.val * x.val);
-            let sum = AddressValue::new(x.addr + embed(2), prod.val + x.val);
+            let prod = AddressValue::new(x.addr + embed(1), (x.val.0[0] * x.val.0[0]).into());
+            let sum = AddressValue::new(x.addr + embed(2), (prod.val.0[0] + x.val.0[0]).into());
             record.alu_events.push(AluEvent {
                 opcode: Opcode::MulF,
                 out: prod,
@@ -292,20 +292,20 @@ mod tests {
 
         let mut record = ExecutionRecord::default();
 
-        let four = AddressValue::new(embed(0), embed(3));
+        let four = AddressValue::new(embed(0), embed(3).into());
         record.mem_events.push(MemEvent {
             address_value: four,
             multiplicity: embed(4),
             kind: MemAccessKind::Write,
         });
-        let three = AddressValue::new(embed(1), embed(4));
+        let three = AddressValue::new(embed(1), embed(4).into());
         record.mem_events.push(MemEvent {
             address_value: three,
             multiplicity: embed(4),
             kind: MemAccessKind::Write,
         });
 
-        let sum = AddressValue::new(embed(1), four.val + three.val);
+        let sum = AddressValue::new(embed(1), (four.val.0[0] + three.val.0[0]).into());
         record.alu_events.push(AluEvent {
             opcode: Opcode::AddF,
             out: sum,
@@ -314,7 +314,7 @@ mod tests {
             mult: embed(0),
         });
 
-        let diff = AddressValue::new(embed(1), four.val - three.val);
+        let diff = AddressValue::new(embed(1), (four.val.0[0] - three.val.0[0]).into());
         record.alu_events.push(AluEvent {
             opcode: Opcode::SubF,
             out: diff,
@@ -323,7 +323,7 @@ mod tests {
             mult: embed(0),
         });
 
-        let prod = AddressValue::new(embed(1), four.val * three.val);
+        let prod = AddressValue::new(embed(1), (four.val.0[0] * three.val.0[0]).into());
         record.alu_events.push(AluEvent {
             opcode: Opcode::MulF,
             out: prod,
@@ -332,7 +332,7 @@ mod tests {
             mult: embed(0),
         });
 
-        let quot = AddressValue::new(embed(1), four.val / three.val);
+        let quot = AddressValue::new(embed(1), (four.val.0[0] / three.val.0[0]).into());
         record.alu_events.push(AluEvent {
             opcode: Opcode::DivF,
             out: quot,

--- a/recursion/core-v2/src/mem.rs
+++ b/recursion/core-v2/src/mem.rs
@@ -107,10 +107,12 @@ where
         // At most one should be true.
         // builder.assert_zero(local.read_mult * local.write_mult);
 
-        let values = vec![
-            local.address_value.addr.into(),
-            local.address_value.val.into(),
-        ];
+        let values = local
+            .address_value
+            .iter()
+            .cloned()
+            .map(Into::into)
+            .collect::<Vec<_>>();
 
         builder.receive(AirInteraction::new(
             values.clone(),
@@ -161,12 +163,12 @@ mod tests {
         let shard = ExecutionRecord::<BabyBear> {
             mem_events: vec![
                 MemEvent {
-                    address_value: AddressValue::new(BabyBear::zero(), BabyBear::one()),
+                    address_value: AddressValue::new(BabyBear::zero(), BabyBear::one().into()),
                     multiplicity: BabyBear::one(),
                     kind: MemAccessKind::Write,
                 },
                 MemEvent {
-                    address_value: AddressValue::new(BabyBear::zero(), BabyBear::one()),
+                    address_value: AddressValue::new(BabyBear::zero(), BabyBear::one().into()),
                     multiplicity: BabyBear::one(),
                     kind: MemAccessKind::Read,
                 },
@@ -193,14 +195,14 @@ mod tests {
         input_exec
             .mem_events
             .extend(test_xs.clone().into_iter().map(|x| MemEvent {
-                address_value: AddressValue::new(x, x + BabyBear::one()),
+                address_value: AddressValue::new(x, (x + BabyBear::one()).into()),
                 multiplicity: BabyBear::one(),
                 kind: MemAccessKind::Write,
             }));
         input_exec
             .mem_events
             .extend(test_xs.clone().into_iter().map(|x| MemEvent {
-                address_value: AddressValue::new(x, x + BabyBear::one()),
+                address_value: AddressValue::new(x, (x + BabyBear::one()).into()),
                 multiplicity: BabyBear::one(),
                 kind: MemAccessKind::Read,
             }));


### PR DESCRIPTION
The base field ALU (currently the only ALU) uses `AddressValueBase` to avoid extra columns and checks. Some ugly abstractions remain and need to be fixed.