### PR TITLE
feat(cli): check for rust usage during installation

### DIFF
--- a/book/getting-started/install.md
+++ b/book/getting-started/install.md
@@ -5,6 +5,7 @@ build the toolchain and CLI from source.
 
 ## Requirements
 
+- [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 - [Rust (Nightly)](https://www.rust-lang.org/tools/install)
 - [Docker](https://docs.docker.com/get-docker/)
 - [Go >1.22.1 (Optional)](https://go.dev/doc/install)

--- a/cli/src/commands/install_toolchain.rs
+++ b/cli/src/commands/install_toolchain.rs
@@ -24,6 +24,19 @@ pub struct InstallToolchainCmd {}
 
 impl InstallToolchainCmd {
     pub fn run(&self) -> Result<()> {
+        // Check if rust is installed.
+        if Command::new("rustup")
+            .arg("--version")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .is_err()
+        {
+            return Err(anyhow::anyhow!(
+                "Rust is not installed. Please install Rust from https://rustup.rs/ and try again."
+            ));
+        }
+
         // Setup client.
         let client = Client::builder().user_agent("Mozilla/5.0").build()?;
 


### PR DESCRIPTION
Previous experience installing SP1 if rust not found:
```
Downloaded https://github.com/succinctlabs/rust/releases/download/succinct-v2024-02-24.1/rust-toolchain-aarch64-unknown-linux-gnu.tar.gz to File { fd: 12, path: "/root/.sp1/rust-toolchain-aarch64-unknown-linux-gnu.tar.gz", read: false, write: true }
  [00:00:15] [#################################################################] 372.11 MiB/372.11 MiB (23.97 MiB/s, 0s)Error: No such file or directory (os error 2)
sp1up: command failed: /root/.sp1/bin/cargo-prove prove install-toolchain
```

This PR makes it so immediately throws an error if rust isn't installed and prompts user to install it first.