### PR TITLE
feat(cli): allow template version and fix CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -169,7 +169,7 @@ jobs:
 
       - name: Run cargo prove new
         run: |
-          cargo prove new fibonacci
+          cargo prove new fibonacci --version dev
 
       - name: Build program and run script
         run: |

--- a/cli/src/commands/new.rs
+++ b/cli/src/commands/new.rs
@@ -12,6 +12,10 @@ pub struct NewCmd {
     /// Whether to create the project with template EVM contracts.
     #[arg(long, action)]
     evm: bool,
+
+    /// Version of sp1-project-template to use (branch or tag).
+    #[arg(long, default_value = "main")]
+    version: String,
 }
 
 const TEMPLATE_REPOSITORY_URL: &str = "https://github.com/succinctlabs/sp1-project-template";
@@ -25,9 +29,11 @@ impl NewCmd {
             fs::create_dir(&self.name)?;
         }
 
-        // Clone the repository.
+        // Clone the repository with the specified version (branch or tag).
         let output = Command::new("git")
             .arg("clone")
+            .arg("--branch")
+            .arg(&self.version)
             .arg(TEMPLATE_REPOSITORY_URL)
             .arg(root.as_os_str())
             .arg("--recurse-submodules")

--- a/cli/src/commands/new.rs
+++ b/cli/src/commands/new.rs
@@ -29,7 +29,7 @@ impl NewCmd {
             fs::create_dir(&self.name)?;
         }
 
-        // Clone the repository with the specified version (branch or tag).
+        // Clone the repository with the specified version.
         let output = Command::new("git")
             .arg("clone")
             .arg("--branch")


### PR DESCRIPTION
`cargo prove new --version <version>` will clone the specific version of the template, defaulting to `main` (which from this point forward, will be the latest release version, as we will follow the same release proceedure in the template as we do sp1).

We now have a `dev` branch in template that we can use for CI. If there were any breaking changes in the SDK, CI will fail and we should update the template to match the changes.