### PR TITLE
feat: suggest prover network if high cycles

### DIFF
--- a/core/src/syscall/precompiles/keccak256/air.rs
+++ b/core/src/syscall/precompiles/keccak256/air.rs
@@ -190,7 +190,7 @@ mod test {
         let config = BabyBearPoseidon2::new();
 
         let program = Program::from(KECCAK256_ELF);
-        let (proof, public_values) =
+        let (proof, public_values, _) =
             prove(program, &stdin, config, SP1CoreOpts::default()).unwrap();
         let mut public_values = SP1PublicValues::from(&public_values);
 

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -255,8 +255,9 @@ impl SP1Prover {
             .get_or_insert_with(|| Arc::new(self));
         let config = CoreSC::default();
         let program = Program::from(&pk.elf);
-        let (proof, public_values_stream) =
+        let (proof, public_values_stream, cycles) =
             sp1_core::utils::prove_with_context(program, stdin, config, opts.core_opts, context)?;
+        Self::check_for_high_cycles(cycles);
         let public_values = SP1PublicValues::from(&public_values_stream);
         Ok(SP1CoreProof {
             proof: SP1CoreProofData(proof.shard_proofs),
@@ -677,6 +678,12 @@ impl SP1Prover {
             );
         }
         digest
+    }
+
+    fn check_for_high_cycles(cycles: u64) {
+        if cycles > 100_000_000 {
+            tracing::warn!("high cycle count, consider using the prover network for proof generation: https://docs.succinct.xyz/prover-network/setup.html");
+        }
     }
 }
 

--- a/recursion/program/src/constraints.rs
+++ b/recursion/program/src/constraints.rs
@@ -284,7 +284,7 @@ mod tests {
         let machine = A::machine(SC::default());
         let (_, vk) = machine.setup(&Program::from(elf));
         let mut challenger = machine.config().challenger();
-        let (proof, _) = sp1_core::utils::prove(
+        let (proof, _, _) = sp1_core::utils::prove(
             Program::from(elf),
             &SP1Stdin::new(),
             SC::default(),

--- a/recursion/program/src/machine/mod.rs
+++ b/recursion/program/src/machine/mod.rs
@@ -90,7 +90,7 @@ mod tests {
 
         let mut challenger = machine.config().challenger();
         let time = std::time::Instant::now();
-        let (proof, _) = sp1_core::utils::prove(
+        let (proof, _, _) = sp1_core::utils::prove(
             program,
             &SP1Stdin::new(),
             SC::default(),

--- a/recursion/program/src/stark.rs
+++ b/recursion/program/src/stark.rs
@@ -454,7 +454,7 @@ pub(crate) mod tests {
         let machine = A::machine(SC::default());
         let (_, vk) = machine.setup(&Program::from(elf));
         let mut challenger_val = machine.config().challenger();
-        let (proof, _) = sp1_core::utils::prove(
+        let (proof, _, _) = sp1_core::utils::prove(
             Program::from(elf),
             &SP1Stdin::new(),
             SC::default(),


### PR DESCRIPTION
Example output:
```
2024-07-02T21:15:10.518487Z  INFO prove_core: summary: cycles=11106, e2e=2.716364875, khz=4088.55, proofSize=1419784
2024-07-02T21:15:10.523268Z  WARN prove_core: high cycle count, consider using the prover network for proof generation: https://docs.succinct.xyz/prover-network/setup.html
2024-07-02T21:15:10.523282Z  INFO prove_core: close time.busy=2.72s time.idle=27.5µs
```