### PR TITLE
fix(sdk): lock axum to 0.7.4

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
     schedule:
       interval: "weekly"
     target-branch: "dev"
+    ignore:
+      - dependency-name: "axum"
+        versions: ["> 0.7.4"]
   - package-ecosystem: "docker"
     directory: "/cli/docker"
     schedule:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,9 +438,9 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "axum"
-version = "0.7.5"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
+checksum = "1236b4b292f6c4d6dc34604bb5120d85c3fe1d1aa596bd5cc52ca054d13e7b9e"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -462,7 +462,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper 1.0.1",
+ "sync_wrapper 0.1.2",
  "tokio",
  "tower",
  "tower-layer",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -30,7 +30,7 @@ indicatif = "0.17.8"
 tracing = "0.1.40"
 hex = "0.4.3"
 log = "0.4.22"
-axum = "=0.7.5"
+axum = "=0.7.4"
 alloy-sol-types = { version = "0.7.6", optional = true }
 sha2 = "0.10.8"
 dirs = "5.0.1"


### PR DESCRIPTION
Twirp requires axum `0.7.4`
```
error: failed to select a version for `axum`.
    ... required by package `twirp v0.3.0 (https://github.com/github/twirp-rs.git?rev=c85f31f9c54957374e7dcb3534fc52cff0aa2dc5#c85f31f9)`
    ... which satisfies git dependency `twirp` of package `sp1-sdk v0.1.0 (https://github.com/succinctlabs/sp1.git?tag=v1.0.4-testnet#2ce75c6e)`
    ... which satisfies git dependency `sp1-sdk` of package `zkdna-script v0.1.0 (/Users/zachobront/code/zkdna/script)`
versions that meet the requirements `^0.7` (locked to 0.7.4) are: 0.7.4

all possible versions conflict with previously selected packages.

  previously selected package `axum v0.7.5`
    ... which satisfies dependency `axum = "=0.7.5"` of package `sp1-sdk v0.1.0 (https://github.com/succinctlabs/sp1.git?tag=v1.0.4-testnet#2ce75c6e)`
    ... which satisfies git dependency `sp1-sdk` of package `zkdna-script v0.1.0 (/Users/zachobront/code/zkdna/script)`
```