### PR TITLE
feat(cli): use GH token during installation to avoid rate limiting

### DIFF
--- a/book/getting-started/install.md
+++ b/book/getting-started/install.md
@@ -42,7 +42,9 @@ If this works, go to the [next section](./quickstart.md) to compile and prove a 
 
 ### Troubleshooting
 
-If you have installed `cargo-prove` from source, it may conflict with sp1up's `cargo-prove` installation or vice versa. You can remove the `cargo-prove` that was installed from source with the following command:
+If you experience [rate-limiting](https://docs.github.com/en/rest/using-the-rest-api/getting-started-with-the-rest-api?apiVersion=2022-11-28#rate-limiting) when using the `sp1up` command, you can resolve this by using the `--token` flag and providing your GitHub token.
+
+If you have installed `cargo-prove` from source, it may conflict with `sp1up`'s `cargo-prove` installation or vice versa. You can remove the `cargo-prove` that was installed from source with the following command:
 
 ```bash
 rm ~/.cargo/bin/cargo-prove

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -69,7 +69,7 @@ pub async fn get_toolchain_download_url(client: &Client, target: String) -> Stri
         .json::<serde_json::Value>()
         .await
         .unwrap();
-    let tag = json["tag_name"].as_str().expect("Failed to download Succinct toolchain. Likely caused by GitHub rate limiting. Please try again.");
+    let tag = json["tag_name"].as_str().expect("Failed to download Succinct toolchain. Likely caused by GitHub rate limiting. Please try again using the --token flag.");
 
     let url = format!(
         "https://github.com/succinctlabs/rust/releases/download/{}/rust-toolchain-{}.tar.gz",

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -69,7 +69,7 @@ pub async fn get_toolchain_download_url(client: &Client, target: String) -> Stri
         .json::<serde_json::Value>()
         .await
         .unwrap();
-    let tag = json["tag_name"].as_str().expect("Failed to download Succinct toolchain. Likely caused by GitHub rate limiting. Please try again using the --token flag.");
+    let tag = json["tag_name"].as_str().expect("Failed to download Succinct toolchain. Likely caused by GitHub rate limiting. Please try again using the --token flag. Docs: https://docs.succinct.xyz/getting-started/install.html#troubleshooting");
 
     let url = format!(
         "https://github.com/succinctlabs/rust/releases/download/{}/rust-toolchain-{}.tar.gz",

--- a/sp1up/sp1up
+++ b/sp1up/sp1up
@@ -29,6 +29,7 @@ main() {
       -C|--commit)      shift; SP1UP_COMMIT=$1;;
       --arch)           shift; SP1UP_ARCH=$1;;
       --platform)       shift; SP1UP_PLATFORM=$1;;
+      -t|--token)       shift; GITHUB_TOKEN=$1;;
       -h|--help)
         usage
         exit 0


### PR DESCRIPTION
During `sp1up` installation, you can run into this:
```
Successfully cleaned up ~/.sp1 directory.
Successfully created ~/.sp1 directory.
thread 'main' panicked at cli/src/lib.rs:72:41:
Failed to download Succinct toolchain. Likely caused by GitHub rate limiting. Please try again.
```

Now you can use `sp1up --token $GITHUB_TOKEN` to avoid the rate-limiting.