### PR TITLE
fix: UB from `OpcodeSpecificCols` union

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4760,6 +4760,7 @@ dependencies = [
  "sp1-derive",
  "sp1-primitives",
  "sp1-zkvm",
+ "static_assertions",
  "strum",
  "strum_macros",
  "tempfile",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -65,6 +65,7 @@ num-bigint = { version = "0.4.6", default-features = false }
 rand = "0.8.5"
 bytemuck = "1.16.0"
 hashbrown = { version = "0.14.5", features = ["serde", "inline-more"] }
+static_assertions = "1.1.0"
 
 [dev-dependencies]
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }

--- a/core/src/cpu/columns/opcode_specific.rs
+++ b/core/src/cpu/columns/opcode_specific.rs
@@ -2,6 +2,8 @@ use crate::cpu::columns::{AuipcCols, BranchCols, JumpCols, MemoryColumns};
 use std::fmt::{Debug, Formatter};
 use std::mem::{size_of, transmute};
 
+use static_assertions::const_assert;
+
 use super::ecall::EcallCols;
 
 pub const NUM_OPCODE_SPECIFIC_COLS: usize = size_of::<OpcodeSpecificCols<u8>>();
@@ -19,6 +21,9 @@ pub union OpcodeSpecificCols<T: Copy> {
 
 impl<T: Copy + Default> Default for OpcodeSpecificCols<T> {
     fn default() -> Self {
+        // We must use the largest field to avoid uninitialized padding bytes.
+        const_assert!(size_of::<MemoryColumns<u8>>() == size_of::<OpcodeSpecificCols<u8>>());
+
         OpcodeSpecificCols {
             memory: MemoryColumns::default(),
         }

--- a/recursion/core/src/cpu/columns/opcode_specific.rs
+++ b/recursion/core/src/cpu/columns/opcode_specific.rs
@@ -1,6 +1,8 @@
 use std::fmt::{Debug, Formatter};
 use std::mem::{size_of, transmute};
 
+use static_assertions::const_assert;
+
 use super::branch::BranchCols;
 use super::heap_expand::HeapExpandCols;
 use super::memory::MemoryCols;
@@ -20,8 +22,11 @@ pub union OpcodeSpecificCols<T: Copy> {
 
 impl<T: Copy + Default> Default for OpcodeSpecificCols<T> {
     fn default() -> Self {
+        // We must use the largest field to avoid uninitialized padding bytes.
+        const_assert!(size_of::<MemoryCols<u8>>() == size_of::<OpcodeSpecificCols<u8>>());
+
         OpcodeSpecificCols {
-            branch: BranchCols::<T>::default(),
+            memory: MemoryCols::<T>::default(),
         }
     }
 }


### PR DESCRIPTION
The following test previously caused undefined behavior in `sp1-recursion-core`, as can be seen by running with [Miri](https://github.com/rust-lang/miri).
```rust
#[cfg(test)]
mod tests {
    use crate::cpu::columns::opcode_specific::OpcodeSpecificCols;

    #[test]
    fn test_ub() {
        let cols: OpcodeSpecificCols<usize> = Default::default();
        dbg!(cols);
    }
}
```
```
cargo miri test -p sp1-recursion-core cpu::columns::opcode_specific::tests::test_ub
```
The problem is that the `Default` implementation previously relied on the `Default` implementation of a field smaller than the union itself. Rust pads any such field to match the size of the union, causing UB when these uninitialized padding bytes are transmuted to an array.

I added the `static_assertions` dependency to `sp1-core` to match `sp1-recursion-core`, but that could easily be replaced with a runtime assert or a hackier const assertion. 