### PR TITLE
docs: execute example doesnt generate proof

### DIFF
--- a/examples/fibonacci/script/bin/execute.rs
+++ b/examples/fibonacci/script/bin/execute.rs
@@ -17,7 +17,7 @@ fn main() {
     let client = ProverClient::new();
     let (mut public_values, _) = client.execute(ELF, stdin).unwrap();
 
-    println!("generated proof");
+    println!("program executed");
 
     // Read and verify the output.
     let _ = public_values.read::<u32>();


### PR DESCRIPTION
This specific example was given for local development cycle where you usually do not want to spend time on generating proofs but just verify that your program is running without any runtime errors.