### PR TITLE
docs: fix broken link to setup

### DIFF
--- a/book/what-is-a-zkvm.md
+++ b/book/what-is-a-zkvm.md
@@ -4,11 +4,11 @@ A zero-knowledge virtual machine (zkVM) is zero-knowledge proof system that allo
 
 Conceptually, you can think of the SP1 zkVM as proving the evaluation of a function `f(x) = y` by following the steps below:
 
-- Define `f` using normal Rust code and compile it to an ELF (covered in the [writing programs](../writing-programs/setup.md) section).
-- Setup a proving key (`pk`) and verifying key (`vk`) for the program given the ELF. 
+- Define `f` using normal Rust code and compile it to an ELF (covered in the [writing programs](./writing-programs/setup.md) section).
+- Setup a proving key (`pk`) and verifying key (`vk`) for the program given the ELF.
 - Generate a proof `π` using the SP1 zkVM that `f(x) = y` with `prove(pk, x)`.
 - Verify the proof `π` using `verify(vk, x, y, π)`.
 
 As a practical example, `f` could be a simple Fibonacci [program](https://github.com/succinctlabs/sp1/blob/main/examples/fibonacci/program/src/main.rs). The process of generating a proof and verifying it can be seen [here](https://github.com/succinctlabs/sp1/blob/main/examples/fibonacci/script/src/main.rs).
 
-For blockchain applications, the verification usually happens inside of a [smart contract](https://github.com/succinctlabs/sp1-project-template/blob/main/contracts/src/Fibonacci.sol). 
+For blockchain applications, the verification usually happens inside of a [smart contract](https://github.com/succinctlabs/sp1-project-template/blob/main/contracts/src/Fibonacci.sol).

--- a/book/writing-programs/patched-crates.md
+++ b/book/writing-programs/patched-crates.md
@@ -51,7 +51,7 @@ Next to the package name, it should have a link to the Github repository that yo
 
 To check if a precompile is used by your program, you can observe SP1's log output. Make sure to setup the logger with `sp1_sdk::utils::setup_logger()` and run your program with `RUST_LOG=info`.
 
-In the example below, note how the `sha256_extend` precompile was repoted as being used eight times.
+In the example below, note how the `sha256_extend` precompile was reported as being used eight times.
 
 ```bash
 2024-07-03T04:46:33.753527Z  INFO prove_core: execution report (syscall counts):
@@ -72,7 +72,7 @@ cargo update -p ed25519-consensus
 
 If you encounter issues relating to cargo / git, you can try setting `CARGO_NET_GIT_FETCH_WITH_CLI`:
 
-```
+```bash
 CARGO_NET_GIT_FETCH_WITH_CLI=true cargo update -p ed25519-consensus
 ```
 
@@ -82,4 +82,3 @@ You can permanently set this value in `~/.cargo/config`:
 [net]
 git-fetch-with-cli = true
 ```
-

--- a/book/writing-programs/setup.md
+++ b/book/writing-programs/setup.md
@@ -19,7 +19,7 @@ cd program
 
 To build the program while in development, simply run:
 
-```
+```bash
 cargo prove build
 ```
 
@@ -29,13 +29,13 @@ This will compile the ELF that can be executed in the zkVM and put the executabl
 
 For production builds of programs, you can build your program inside a Docker container which will generate a **reproducible ELF** on all platforms. To do so, just use the `--docker` flag and the `--tag` flag with the release version you want to use. For example:
 
-```
+```bash
 cargo prove build --docker --tag v1.0.5-testnet
 ```
 
 To verify that your build is reproducible, you can compute the SHA-512 hash of the ELF on different platforms and systems with:
 
-```
+```bash
 $ shasum -a 512 elf/riscv32im-succinct-zkvm-elf
 f9afb8caaef10de9a8aad484c4dd3bfa54ba7218f3fc245a20e8a03ed40b38c617e175328515968aecbd3c38c47b2ca034a99e6dbc928512894f20105b03a203
 ```


### PR DESCRIPTION
`[writing programs](../writing-programs/setup.md)` doesn't lead anywhere