### PR TITLE
chore: export execution report

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4954,7 +4954,6 @@ dependencies = [
  "p3-symmetric",
  "p3-util",
  "rand",
- "rayon",
  "serde",
  "serde_with",
  "sp1-core",

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -59,7 +59,7 @@ use sp1_recursion_program::machine::{
 pub use sp1_recursion_program::machine::{
     SP1DeferredMemoryLayout, SP1RecursionMemoryLayout, SP1ReduceMemoryLayout, SP1RootMemoryLayout,
 };
-use tracing::{info_span, instrument};
+use tracing::instrument;
 pub use types::*;
 use utils::words_to_bytes;
 

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -31,7 +31,7 @@ use std::env;
 
 pub use provers::{LocalProver, MockProver, Prover};
 
-pub use sp1_core::runtime::{Hook, HookEnv, SP1Context, SP1ContextBuilder};
+pub use sp1_core::runtime::{ExecutionReport, Hook, HookEnv, SP1Context, SP1ContextBuilder};
 use sp1_core::SP1_CIRCUIT_VERSION;
 pub use sp1_prover::{
     CoreSC, HashableKey, InnerSC, OuterSC, PlonkBn254Proof, SP1Prover, SP1ProvingKey,


### PR DESCRIPTION
Export the ExecutionReport for external usage from the SDK.