### PR TITLE
Add benchmark workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -115,7 +115,54 @@ jobs:
         env:
           CARGO_INCREMENTAL: 1
 
-  examples:
+  examples-base:
+    name: Examples (baseline)
+    runs-on: runs-on,runner=8cpu-linux-x64
+    env:
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+            ref: igor/bench # TODO: change to main
+
+      - name: Setup CI
+        uses: ./.github/actions/setup
+
+      - name: Install SP1 toolchain
+        run: |
+          curl -L https://sp1.succinct.xyz | bash
+          ~/.sp1/bin/sp1up 
+          ~/.sp1/bin/cargo-prove prove --version
+
+      - name: Install SP1 CLI
+        run: |
+          cd cli
+          cargo install --force --locked --path .
+          ~/.sp1/bin/cargo-prove prove install-toolchain
+          cd ~
+
+      - name: Run cargo check
+        run: |
+          RUSTFLAGS="-Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0 -C target-cpu=native" \
+          cargo check --manifest-path examples/Cargo.toml --all-targets --all-features
+
+      - name: Run benchmark
+        run: cargo run --manifest-path examples/Cargo.toml --release --bin bench-fibonacci -- run benchmark_base.json
+        env:
+          RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0 -C target-cpu=native
+          RUST_BACKTRACE: 1
+          FRI_QUERIES: 1
+          SP1_DEV: 1
+
+      - name: Upload benchmark result
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark_base.json
+          path: benchmark_base.json
+          if-no-files-found: error
+
+  examples-head:
     name: Examples
     runs-on: runs-on,runner=8cpu-linux-x64
     env:
@@ -144,6 +191,66 @@ jobs:
         run: |
           RUSTFLAGS="-Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0 -C target-cpu=native" \
           cargo check --manifest-path examples/Cargo.toml --all-targets --all-features
+
+      - name: Run benchmark
+        run: cargo run --manifest-path examples/Cargo.toml --release --bin bench-fibonacci -- run benchmark_head.json
+        env:
+          RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0 -C target-cpu=native
+          RUST_BACKTRACE: 1
+          FRI_QUERIES: 1
+          SP1_DEV: 1
+
+      - name: Upload benchmark result
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark_head.json
+          path: benchmark_head.json
+          if-no-files-found: error
+
+  examples-benchmark:
+    name: Examples (benchmark)
+    needs: [examples-head, examples-base]
+    runs-on: runs-on,runner=8cpu-linux-x64
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Setup CI
+        uses: ./.github/actions/setup
+
+      - name: Install SP1 toolchain
+        run: |
+          curl -L https://sp1.succinct.xyz | bash
+          ~/.sp1/bin/sp1up 
+          ~/.sp1/bin/cargo-prove prove --version
+
+      - name: Install SP1 CLI
+        run: |
+          cd cli
+          cargo install --force --locked --path .
+          ~/.sp1/bin/cargo-prove prove install-toolchain
+          cd ~
+
+      - name: Download result examples
+        uses: actions/download-artifact@v4
+        with:
+          name: benchmark_head.json
+
+      - name: Download result examples-base
+        uses: actions/download-artifact@v4
+        with:
+          name: benchmark_base.json
+
+      - name: Run benchmark comparison
+        run: |
+          cargo run --manifest-path examples/Cargo.toml --release --bin bench-fibonacci -- compare benchmark_base.json benchmark_head.json | tee result.txt
+
+      - name: Comment PR
+        uses: mshick/add-pr-comment@v2
+        with:
+          message-path: result.txt
 
   cli:
     name: CLI

--- a/core/src/runtime/mod.rs
+++ b/core/src/runtime/mod.rs
@@ -617,6 +617,7 @@ impl<'a> Runtime<'a> {
                 .entry(instruction.opcode)
                 .and_modify(|c| *c += 1)
                 .or_insert(1);
+            self.report.total_cycles += 1;
         }
 
         match instruction.opcode {

--- a/core/src/runtime/report.rs
+++ b/core/src/runtime/report.rs
@@ -8,6 +8,7 @@ use super::*;
 
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct ExecutionReport {
+    pub total_cycles: u64,
     pub opcode_counts: HashMap<Opcode, u64>,
     pub syscall_counts: HashMap<SyscallCode, u64>,
 }

--- a/examples/fibonacci/script/Cargo.toml
+++ b/examples/fibonacci/script/Cargo.toml
@@ -8,7 +8,12 @@ publish = false
 [dependencies]
 itertools = "0.12.1"
 sp1-sdk = { path = "../../../sdk", version = "0.0.2-test" }
+sp1-core = { path = "../../../core", version = "0.0.2-test" }
 sha2 = "0.10.8"
+clap = { version = "4.5.8", features = ["derive"] }
+serde = { version = "1.0.204", features = ["derive"] }
+serde_json = "1.0.120"
+anyhow = "1.0.86"
 
 [build-dependencies]
 sp1-helper = { path = "../../../helper", version = "0.0.2-test" }
@@ -28,3 +33,7 @@ path = "bin/execute.rs"
 [[bin]]
 name = "fibonacci-script"
 path = "src/main.rs"
+
+[[bin]]
+name = "bench-fibonacci"
+path = "bin/bench.rs"

--- a/examples/fibonacci/script/bin/bench.rs
+++ b/examples/fibonacci/script/bin/bench.rs
@@ -1,0 +1,103 @@
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::time::Duration;
+use anyhow::Context;
+use clap::{Parser, Subcommand};
+use serde::{Deserialize, Serialize};
+use sp1_sdk::{utils, ProverClient, SP1Stdin};
+
+/// The ELF we want to execute inside the zkVM.
+const ELF: &[u8] = include_bytes!("../../program/elf/riscv32im-succinct-zkvm-elf");
+
+fn get_time() -> Duration {
+    std::time::SystemTime::now().duration_since(std::time::SystemTime::UNIX_EPOCH).expect("get millis error")
+}
+
+#[derive(Parser)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    #[command(subcommand)]
+    cmd: Commands
+}
+
+#[derive(Subcommand, Debug, Clone)]
+enum Commands {
+    Run {
+        output: String,
+    },
+    Compare {
+        base: String,
+        head: String,
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct BenchResult {
+    cycles_per_msec: f64,
+}
+
+fn main() {
+    let args = Args::parse();
+
+    match args.cmd {
+        Commands::Run{output} => run_bench(&output),
+        Commands::Compare{base, head} => run_comp(&base, &head)
+    }
+}
+
+fn read_result(path: &String) -> anyhow::Result<BenchResult> {
+    let file = File::open(path)?;
+    let result: BenchResult = serde_json::from_reader(&file)?;
+    Ok(result)
+}
+
+fn run_comp(base: &String, head: &String) {
+    let base_result = read_result(base).expect(&format!("failed to read {}", base));
+    let head_result = read_result(head).expect(&format!("failed to read {}", head));
+
+    println!("Performance benchmark results");
+    println!("base: {:?}", base_result);
+    println!("head: {:?}", head_result);
+
+    if head_result.cycles_per_msec > 1.05 * base_result.cycles_per_msec {
+        panic!("performance degradation")
+    }
+}
+
+fn run_bench(output: &String) {
+    // Setup logging.
+    utils::setup_logger();
+
+    // Create an input stream and write '500' to it.
+    let n = 1u32;
+
+    let mut stdin = SP1Stdin::new();
+    stdin.write(&n);
+
+    // Generate the proof for the given program and input.
+    let client = ProverClient::new();
+    let (pk, _vk) = client.setup(ELF);
+
+    let now = get_time();
+    let _proof = client.prove(&pk, stdin.clone()).run().unwrap();
+    let prove_millis = (get_time() - now).as_millis() * 2;
+    println!("prove millis: {}", prove_millis);
+
+    let exec_result = client.execute(&ELF, stdin.clone()).run().unwrap();
+    let exec_report = &exec_result.1;
+    let exec_cycles = exec_report.total_cycles;
+    println!("execute total_cycles: {}", exec_cycles);
+
+    let cycles_per_msec = exec_cycles as f64 / prove_millis as f64;
+    println!("cycles per msec: {:.2}", cycles_per_msec);
+
+    let result = BenchResult{cycles_per_msec};
+    let mut output_file = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .open(output)
+        .unwrap();
+
+    let serialized = serde_json::to_string(&result).unwrap();
+    output_file.write_all(serialized.as_bytes()).unwrap();
+}

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -59,7 +59,7 @@ use sp1_recursion_program::machine::{
 pub use sp1_recursion_program::machine::{
     SP1DeferredMemoryLayout, SP1RecursionMemoryLayout, SP1ReduceMemoryLayout, SP1RootMemoryLayout,
 };
-use tracing::{info_span, instrument};
+use tracing::instrument;
 pub use types::*;
 use utils::words_to_bytes;
 


### PR DESCRIPTION
This PR adds a performance benchmark to the GitHub Actions PR workflow. Changes include:
- The fibonacci-script package adds a new binary `bench-fibonacci` that measures proving latency and normalizes by cycles executed.
- The example job within the PR workflow is renamed to example-head and runs `bench-fibonacci` and uploads the results to GitHub as an artifact.
- The example job is duplicated into example-base to run benchmark on a fixed, hard-coded, ref tag such as main.
- A example-benchmark job is added that retrieves the results from the previous two jobs and displays them to the job output. This job fails if performance degrades more than 10%. This job also posts the results as a PR comment.