### PR TITLE
fix: remove changelog-seen from config.toml

### DIFF
--- a/cli/src/commands/config-ci.toml
+++ b/cli/src/commands/config-ci.toml
@@ -1,5 +1,3 @@
-changelog-seen = 2
-
 [build]
 target = ["riscv32im-succinct-zkvm-elf"]
 extended = true

--- a/cli/src/commands/config.toml
+++ b/cli/src/commands/config.toml
@@ -1,5 +1,3 @@
-changelog-seen = 2
-
 [build]
 target = ["riscv32im-succinct-zkvm-elf"]
 extended = true


### PR DESCRIPTION
fixes this error: 

> Building bootstrap
> failed to parse TOML configuration 'config.toml': unknown field `changelog-seen`
