### PR TITLE
fix: cycle tracking logs

### DIFF
--- a/core/src/syscall/write.rs
+++ b/core/src/syscall/write.rs
@@ -36,7 +36,7 @@ impl Syscall for SyscallWrite {
                 rt.cycle_tracker
                     .insert(fn_name.to_string(), (rt.state.global_clk, depth));
                 let padding = (0..depth).map(|_| "│ ").collect::<String>();
-                log::debug!("{}┌╴{}", padding, fn_name);
+                log::info!("{}┌╴{}", padding, fn_name);
             } else if s.contains("cycle-tracker-end:") {
                 let fn_name = s
                     .split("cycle-tracker-end:")


### PR DESCRIPTION
In a previous PR (https://github.com/succinctlabs/sp1/pull/707), forgot to emit the function name `info` instead of `debug`, resulting in behavior which did not match the specified behavior: https://docs.succinct.xyz/writing-programs/cycle-tracking.html. 

In the future, we should use a specific module target so that users aren't seeing generic RUST_LOG statements from underlying libraries when using SP1.