### PR TITLE
fix: mutable static ref warning in halt syscall

### DIFF
--- a/zkvm/entrypoint/src/syscalls/halt.rs
+++ b/zkvm/entrypoint/src/syscalls/halt.rs
@@ -22,9 +22,10 @@ pub extern "C" fn syscall_halt(exit_code: u8) -> ! {
     unsafe {
         // When we halt, we retrieve the public values finalized digest.  This is the hash of all
         // the bytes written to the public values fd.
-        let pv_digest_bytes = core::mem::take(core::ptr::addr_of_mut!(zkvm::PUBLIC_VALUES_HASHER))
-            .unwrap()
-            .finalize();
+        let pv_digest_bytes =
+            core::mem::take(&mut *core::ptr::addr_of_mut!(zkvm::PUBLIC_VALUES_HASHER))
+                .unwrap()
+                .finalize();
 
         // For each digest word, call COMMIT ecall.  In the runtime, this will store the digest words
         // into the runtime's execution record's public values digest.  In the AIR, it will be used

--- a/zkvm/entrypoint/src/syscalls/halt.rs
+++ b/zkvm/entrypoint/src/syscalls/halt.rs
@@ -22,7 +22,7 @@ pub extern "C" fn syscall_halt(exit_code: u8) -> ! {
     unsafe {
         // When we halt, we retrieve the public values finalized digest.  This is the hash of all
         // the bytes written to the public values fd.
-        let pv_digest_bytes = core::mem::take(&mut zkvm::PUBLIC_VALUES_HASHER)
+        let pv_digest_bytes = core::mem::take(core::ptr::addr_of_mut!(zkvm::PUBLIC_VALUES_HASHER))
             .unwrap()
             .finalize();
 


### PR DESCRIPTION
context:
```
[sp1]  warning: creating a mutable reference to mutable static is discouraged
[sp1]    --> /Users/mattstam/go/src/github.com/succinctlabs/sp1/zkvm/entrypoint/src/syscalls/halt.rs:25:47
[sp1]     |
[sp1]  25 |         let pv_digest_bytes = core::mem::take(&mut zkvm::PUBLIC_VALUES_HASHER)
[sp1]     |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ mutable reference to mutable static
[sp1]     |
[sp1]     = note: for more information, see issue #114447 <https://github.com/rust-lang/rust/issues/114447>
[sp1]     = note: this will be a hard error in the 2024 edition
[sp1]     = note: this mutable reference has lifetime `'static`, but if the static gets accessed (read or written) by any other means, or any other reference is created, then any further use of this mutable reference is Undefined Behavior
[sp1]     = note: `#[warn(static_mut_refs)]` on by default
[sp1]  help: use `addr_of_mut!` instead to create a raw pointer
[sp1]     |
[sp1]  25 |         let pv_digest_bytes = core::mem::take(addr_of_mut!(zkvm::PUBLIC_VALUES_HASHER))
[sp1]     |                                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[sp1]  
[sp1]  warning: `sp1-zkvm` (lib) generated 1 warning
```