### PR TITLE
fix: docker build xz-utils

### DIFF
--- a/cli/docker/Dockerfile
+++ b/cli/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:24.04@sha256:e3f92abc0967a6c19d0dfa2d55838833e947b9d74edbcb0113e48535ad4be12a
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates clang curl libssl-dev pkg-config git dialog \
+    && apt-get install -y --no-install-recommends ca-certificates clang curl libssl-dev pkg-config git dialog xz-utils \
     && curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL 'https://sh.rustup.rs' | sh -s -- -y
 
 ENV PATH="/root/.cargo/bin:${PATH}"


### PR DESCRIPTION
need `xz-utils` to decompress the .tar.xz file containing the RISC-V toolchain