### PR TITLE
feat: `cargo prove new` cloning message

### DIFF
--- a/cli/src/commands/new.rs
+++ b/cli/src/commands/new.rs
@@ -29,6 +29,12 @@ impl NewCmd {
             fs::create_dir(&self.name)?;
         }
 
+        println!(
+            "     \x1b[1m{}\x1b[0m {}",
+            Paint::green("Cloning"),
+            TEMPLATE_REPOSITORY_URL
+        );
+
         // Clone the repository with the specified version.
         let output = Command::new("git")
             .arg("clone")
@@ -65,7 +71,7 @@ impl NewCmd {
         }
 
         println!(
-            "    \x1b[1m{}\x1b[0m {} ({})",
+            " \x1b[1m{}\x1b[0m {} ({})",
             Paint::green("Initialized"),
             self.name,
             std::fs::canonicalize(root)


### PR DESCRIPTION
<img width="505" alt="image" src="https://github.com/user-attachments/assets/2633aeb3-f983-43ad-ac4a-3a7886565ff5">
