### PR TITLE
feat(cli): vkey command to output program vkey hash

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sp1-cli"
-description = "SP1 is a performant, 100% open-source, contributor-friendly zkVM."
-readme = "../README.md"
+description = "The CLI is used for various tasks related to SP1, such as building the toolchain, compiling programs, and tracing programs."
+readme = "README.md"
 version = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -11,6 +11,7 @@ cargo run --bin cargo-prove -- --help
 ```
 
 To test a particular subcommand, you can pass in `prove` and the subcommand you want to test along with the arguments you want to pass to it. For example, to test the `trace` subcommand, you can run the following command:
+
 ```bash
 cargo run --bin cargo-prove -- prove trace --elf <...> --trace <...>
 ```

--- a/crates/cli/src/bin/cargo-prove.rs
+++ b/crates/cli/src/bin/cargo-prove.rs
@@ -4,6 +4,7 @@ use sp1_cli::{
     commands::{
         build::BuildCmd, build_toolchain::BuildToolchainCmd,
         install_toolchain::InstallToolchainCmd, new::NewCmd, prove::ProveCmd, trace::TraceCmd,
+        vkey::VkeyCmd,
     },
     SP1_VERSION_MESSAGE,
 };
@@ -32,6 +33,7 @@ pub enum ProveCliCommands {
     BuildToolchain(BuildToolchainCmd),
     InstallToolchain(InstallToolchainCmd),
     Trace(TraceCmd),
+    Vkey(VkeyCmd),
 }
 
 fn main() -> Result<()> {
@@ -44,5 +46,6 @@ fn main() -> Result<()> {
         ProveCliCommands::BuildToolchain(cmd) => cmd.run(),
         ProveCliCommands::InstallToolchain(cmd) => cmd.run(),
         ProveCliCommands::Trace(cmd) => cmd.run(),
+        ProveCliCommands::Vkey(cmd) => cmd.run(),
     }
 }

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -4,3 +4,4 @@ pub mod install_toolchain;
 pub mod new;
 pub mod prove;
 pub mod trace;
+pub mod vkey;

--- a/crates/cli/src/commands/vkey.rs
+++ b/crates/cli/src/commands/vkey.rs
@@ -1,0 +1,33 @@
+use std::fs::File;
+
+use anyhow::Result;
+use clap::Parser;
+use sp1_sdk::HashableKey;
+use sp1_sdk::ProverClient;
+use std::io::Read;
+
+#[derive(Parser)]
+#[command(name = "vkey", about = "View the verification key hash for a program.")]
+pub struct VkeyCmd {
+    /// Path to the ELF.
+    #[arg(long, required = true)]
+    elf: String,
+}
+
+impl VkeyCmd {
+    pub fn run(&self) -> Result<()> {
+        // Read the elf file contents
+        let mut file = File::open(self.elf.clone()).unwrap();
+        let mut elf = Vec::new();
+        file.read_to_end(&mut elf).unwrap();
+
+        // Get the verification key
+        let prover = ProverClient::new();
+        let (_, vk) = prover.setup(&elf);
+
+        // Print the verification key hash
+        println!("Verification Key Hash:\n{}", vk.vk.bytes32());
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
```sh
cargo prove vkey --elf examples/tendermint/program/elf/riscv32im-succinct-zkvm-elf

Verification Key Hash:
0x00c8cf1fbd86e856e8cb5b1dabfff9d42bf08b08ac18255db5170fe885cf3c37
```