### PR TITLE
chore: `verify_sp1_proof` naming

### DIFF
--- a/zkvm/lib/src/lib.rs
+++ b/zkvm/lib/src/lib.rs
@@ -69,7 +69,7 @@ extern "C" {
     pub fn syscall_exit_unconstrained();
 
     /// Defers the verification of a valid SP1 zkVM proof.
-    pub fn syscall_verify_sp1_proof(vkey: &[u32; 8], pv_digest: &[u8; 32]);
+    pub fn syscall_verify_sp1_proof(vk_digest: &[u32; 8], pv_digest: &[u8; 32]);
 
     /// Returns the length of the next element in the hint stream.
     pub fn syscall_hint_len() -> usize;

--- a/zkvm/lib/src/verify.rs
+++ b/zkvm/lib/src/verify.rs
@@ -3,7 +3,7 @@ use crate::syscall_verify_sp1_proof;
 /// Verifies the next proof in the proof input stream given a verification key digest and public
 /// values digest. If the proof is invalid, the function will panic.
 ///
-/// Enable this function in `sp1-lib` with the `verify` feature.
+/// Enable this function by adding the `verify` feature to both the `sp1-lib` AND `sp1-zkvm` crates.
 pub fn verify_sp1_proof(vk_digest: &[u32; 8], pv_digest: &[u8; 32]) {
     unsafe {
         syscall_verify_sp1_proof(vk_digest, pv_digest);

--- a/zkvm/lib/src/verify.rs
+++ b/zkvm/lib/src/verify.rs
@@ -1,10 +1,11 @@
 use crate::syscall_verify_sp1_proof;
 
-/// Verifies the next proof in the proof input stream given a pkey digest and public values digest.
+/// Verifies the next proof in the proof input stream given a verification key digest and public
+/// values digest. If the proof is invalid, the function will panic.
 ///
-/// Note: sp1_zkvm must also have feature `verify` enabled for this function to work.
-pub fn verify_sp1_proof(pkey_digest: &[u32; 8], pv_digest: &[u8; 32]) {
+/// Enable this function in `sp1-lib` with the `verify` feature.
+pub fn verify_sp1_proof(vk_digest: &[u32; 8], pv_digest: &[u8; 32]) {
     unsafe {
-        syscall_verify_sp1_proof(pkey_digest, pv_digest);
+        syscall_verify_sp1_proof(vk_digest, pv_digest);
     }
 }


### PR DESCRIPTION
Correct the naming for the inputs to `verify_sp1_proof` and make them consistent.