### PR TITLE
perf: various optimizations in v2 compiler/runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5189,6 +5189,7 @@ dependencies = [
  "p3-symmetric",
  "p3-util",
  "rand",
+ "rayon",
  "serde",
  "sp1-core",
  "sp1-primitives",

--- a/recursion/circuit-v2/src/utils.rs
+++ b/recursion/circuit-v2/src/utils.rs
@@ -69,9 +69,10 @@ pub(crate) mod tests {
         let config = SC::default();
 
         let run_span = tracing::debug_span!("run the recursive program").entered();
-        let mut runtime = Runtime::<F, EF, _>::new(&program, config.perm.clone());
+        let mut runtime = tracing::debug_span!("runtime new")
+            .in_scope(|| Runtime::<F, EF, _>::new(&program, config.perm.clone()));
         runtime.witness_stream.extend(witness_stream);
-        runtime.run().unwrap();
+        tracing::debug_span!("run").in_scope(|| runtime.run().unwrap());
         assert!(runtime.witness_stream.is_empty());
         run_span.exit();
 

--- a/recursion/circuit-v2/src/utils.rs
+++ b/recursion/circuit-v2/src/utils.rs
@@ -31,6 +31,8 @@ pub fn commit_recursion_public_values<C: Config>(
 
 #[cfg(any(test, feature = "export-tests"))]
 pub(crate) mod tests {
+    use std::sync::Arc;
+
     use sp1_core::stark::CpuProver;
     use sp1_core::stark::MachineProver;
     use sp1_core::utils::run_test_machine_with_prover;
@@ -63,14 +65,14 @@ pub(crate) mod tests {
 
         let compile_span = tracing::debug_span!("compile").entered();
         let mut compiler = AsmCompiler::<AsmConfig<F, EF>>::default();
-        let program = compiler.compile(operations);
+        let program = Arc::new(compiler.compile(operations));
         compile_span.exit();
 
         let config = SC::default();
 
         let run_span = tracing::debug_span!("run the recursive program").entered();
         let mut runtime = tracing::debug_span!("runtime new")
-            .in_scope(|| Runtime::<F, EF, _>::new(&program, config.perm.clone()));
+            .in_scope(|| Runtime::<F, EF, _>::new(program.clone(), config.perm.clone()));
         runtime.witness_stream.extend(witness_stream);
         tracing::debug_span!("run").in_scope(|| runtime.run().unwrap());
         assert!(runtime.witness_stream.is_empty());

--- a/recursion/compiler/Cargo.toml
+++ b/recursion/compiler/Cargo.toml
@@ -31,6 +31,7 @@ itertools = "0.13.0"
 serde = { version = "1.0.204", features = ["derive"] }
 backtrace = "0.3.71"
 tracing = "0.1.40"
+rayon = "1.10.0"
 
 [dev-dependencies]
 p3-challenger = { workspace = true }

--- a/recursion/compiler/src/circuit/compiler.rs
+++ b/recursion/compiler/src/circuit/compiler.rs
@@ -352,7 +352,7 @@ impl<C: Config> AsmCompiler<C> {
 
         let public_values_a: &RecursionPublicValues<Address<C::F>> = pv_addrs.as_slice().borrow();
         Instruction::CommitPublicValues(CommitPublicValuesInstr {
-            pv_addrs: *public_values_a,
+            pv_addrs: Box::new(*public_values_a),
         })
         .into()
     }

--- a/recursion/compiler/src/circuit/compiler.rs
+++ b/recursion/compiler/src/circuit/compiler.rs
@@ -811,7 +811,7 @@ impl<C: Config> Reg<C> for Address<C::F> {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::VecDeque, io::BufRead, iter::zip};
+    use std::{collections::VecDeque, io::BufRead, iter::zip, sync::Arc};
 
     use p3_baby_bear::DiffusionMatrixBabyBear;
     use p3_field::{Field, PrimeField32};
@@ -849,11 +849,11 @@ mod tests {
 
     fn test_operations_with_runner(
         operations: TracedVec<DslIr<AsmConfig<F, EF>>>,
-        run: impl FnOnce(&RecursionProgram<F>) -> ExecutionRecord<F>,
+        run: impl FnOnce(Arc<RecursionProgram<F>>) -> ExecutionRecord<F>,
     ) {
         let mut compiler = super::AsmCompiler::<AsmConfig<F, EF>>::default();
-        let program = compiler.compile(operations);
-        let record = run(&program);
+        let program = Arc::new(compiler.compile(operations));
+        let record = run(program.clone());
 
         // Run with the poseidon2 wide chip.
         let wide_machine = RecursionAir::<_, 3, 0>::machine_wide(BabyBearPoseidon2::default());

--- a/recursion/compiler/src/circuit/mod.rs
+++ b/recursion/compiler/src/circuit/mod.rs
@@ -6,6 +6,8 @@ pub use compiler::*;
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use p3_baby_bear::DiffusionMatrixBabyBear;
     use p3_field::{AbstractExtensionField, AbstractField};
     use rand::{rngs::StdRng, Rng, SeedableRng};
@@ -85,9 +87,9 @@ mod tests {
 
         let operations = builder.operations;
         let mut compiler = AsmCompiler::default();
-        let program = compiler.compile(operations);
+        let program = Arc::new(compiler.compile(operations));
         let mut runtime = Runtime::<F, EF, DiffusionMatrixBabyBear>::new(
-            &program,
+            program.clone(),
             BabyBearPoseidon2Inner::new().perm,
         );
         runtime.run().unwrap();
@@ -147,8 +149,9 @@ mod tests {
 
         let operations = builder.operations;
         let mut compiler = AsmCompiler::default();
-        let program = compiler.compile(operations);
-        let mut runtime = Runtime::<F, EF, DiffusionMatrixBabyBear>::new(&program, SC::new().perm);
+        let program = Arc::new(compiler.compile(operations));
+        let mut runtime =
+            Runtime::<F, EF, DiffusionMatrixBabyBear>::new(program.clone(), SC::new().perm);
         runtime.witness_stream = [
             vec![F::one().into(), F::one().into(), F::two().into()],
             vec![F::zero().into(), F::one().into(), F::two().into()],
@@ -184,8 +187,9 @@ mod tests {
 
         let operations = builder.operations;
         let mut compiler = AsmCompiler::default();
-        let program = compiler.compile(operations);
-        let mut runtime = Runtime::<F, EF, DiffusionMatrixBabyBear>::new(&program, SC::new().perm);
+        let program = Arc::new(compiler.compile(operations));
+        let mut runtime =
+            Runtime::<F, EF, DiffusionMatrixBabyBear>::new(program.clone(), SC::new().perm);
         runtime.witness_stream = [vec![F::one().into(), F::one().into(), F::two().into()]]
             .concat()
             .into();

--- a/recursion/core-v2/src/chips/mem/constant.rs
+++ b/recursion/core-v2/src/chips/mem/constant.rs
@@ -155,6 +155,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use machine::{tests::run_recursion_test_machines, RecursionAir};
     use p3_baby_bear::{BabyBear, DiffusionMatrixBabyBear};
     use p3_field::AbstractField;
@@ -177,8 +179,9 @@ mod tests {
     type A = RecursionAir<F, 3, 1>;
 
     pub fn prove_program(program: RecursionProgram<F>) {
+        let program = Arc::new(program);
         let mut runtime = Runtime::<F, EF, DiffusionMatrixBabyBear>::new(
-            &program,
+            program.clone(),
             BabyBearPoseidon2Inner::new().perm,
         );
         runtime.run().unwrap();

--- a/recursion/core-v2/src/chips/poseidon2_skinny/mod.rs
+++ b/recursion/core-v2/src/chips/poseidon2_skinny/mod.rs
@@ -82,6 +82,7 @@ pub(crate) fn internal_linear_layer<F: AbstractField>(state: &mut [F; WIDTH]) {
 pub(crate) mod tests {
 
     use std::iter::once;
+    use std::sync::Arc;
 
     use crate::machine::RecursionAir;
     use crate::{runtime::instruction as instr, MemAccessKind, RecursionProgram, Runtime};
@@ -141,12 +142,14 @@ pub(crate) mod tests {
                 }))
                 .collect::<Vec<_>>();
 
-        let program = RecursionProgram {
+        let program = Arc::new(RecursionProgram {
             instructions,
             traces: Default::default(),
-        };
-        let mut runtime =
-            Runtime::<F, EF, DiffusionMatrixBabyBear>::new(&program, BabyBearPoseidon2::new().perm);
+        });
+        let mut runtime = Runtime::<F, EF, DiffusionMatrixBabyBear>::new(
+            program.clone(),
+            BabyBearPoseidon2::new().perm,
+        );
         runtime.run().unwrap();
 
         let config = SC::new();

--- a/recursion/core-v2/src/chips/poseidon2_wide/mod.rs
+++ b/recursion/core-v2/src/chips/poseidon2_wide/mod.rs
@@ -113,6 +113,7 @@ pub(crate) fn internal_linear_layer<F: AbstractField>(state: &mut [F; WIDTH]) {
 pub(crate) mod tests {
 
     use std::iter::once;
+    use std::sync::Arc;
 
     use crate::machine::RecursionAir;
     use crate::{runtime::instruction as instr, MemAccessKind, RecursionProgram, Runtime};
@@ -173,12 +174,14 @@ pub(crate) mod tests {
                 }))
                 .collect::<Vec<_>>();
 
-        let program = RecursionProgram {
+        let program = Arc::new(RecursionProgram {
             instructions,
             traces: Default::default(),
-        };
-        let mut runtime =
-            Runtime::<F, EF, DiffusionMatrixBabyBear>::new(&program, BabyBearPoseidon2::new().perm);
+        });
+        let mut runtime = Runtime::<F, EF, DiffusionMatrixBabyBear>::new(
+            program.clone(),
+            BabyBearPoseidon2::new().perm,
+        );
         runtime.run().unwrap();
 
         let config = SC::new();

--- a/recursion/core-v2/src/lib.rs
+++ b/recursion/core-v2/src/lib.rs
@@ -189,7 +189,7 @@ pub struct FriFoldEvent<F> {
 /// it's digest.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CommitPublicValuesInstr<F> {
-    pub pv_addrs: RecursionPublicValues<Address<F>>,
+    pub pv_addrs: Box<RecursionPublicValues<Address<F>>>,
 }
 
 /// The event for committing to the public values.

--- a/recursion/core-v2/src/machine.rs
+++ b/recursion/core-v2/src/machine.rs
@@ -211,6 +211,8 @@ impl<F: PrimeField32 + BinomiallyExtendable<D>, const DEGREE: usize, const COL_P
 #[cfg(test)]
 pub mod tests {
 
+    use std::sync::Arc;
+
     use machine::RecursionAir;
     use p3_baby_bear::DiffusionMatrixBabyBear;
     use p3_field::{
@@ -234,7 +236,9 @@ pub mod tests {
 
     /// Runs the given program on machines that use the wide and skinny Poseidon2 chips.
     pub fn run_recursion_test_machines(program: RecursionProgram<F>) {
-        let mut runtime = Runtime::<F, EF, DiffusionMatrixBabyBear>::new(&program, SC::new().perm);
+        let program = Arc::new(program);
+        let mut runtime =
+            Runtime::<F, EF, DiffusionMatrixBabyBear>::new(program.clone(), SC::new().perm);
         runtime.run().unwrap();
 
         // Run with the poseidon2 wide chip.

--- a/recursion/core-v2/src/runtime/instruction.rs
+++ b/recursion/core-v2/src/runtime/instruction.rs
@@ -231,6 +231,6 @@ pub fn commit_public_values<F: AbstractField>(
     let pv_address: &RecursionPublicValues<Address<F>> = pv_a.as_slice().borrow();
 
     Instruction::CommitPublicValues(CommitPublicValuesInstr {
-        pv_addrs: pv_address.clone(),
+        pv_addrs: Box::new(pv_address.clone()),
     })
 }

--- a/recursion/core-v2/src/runtime/mod.rs
+++ b/recursion/core-v2/src/runtime/mod.rs
@@ -174,7 +174,7 @@ where
     >: CryptographicPermutation<[F; PERMUTATION_WIDTH]>,
 {
     pub fn new(
-        program: &RecursionProgram<F>,
+        program: Arc<RecursionProgram<F>>,
         perm: Poseidon2<
             F,
             Poseidon2ExternalMatrixGeneral,
@@ -183,9 +183,8 @@ where
             POSEIDON2_SBOX_DEGREE,
         >,
     ) -> Self {
-        let program = Arc::new(program.to_owned());
         let record = ExecutionRecord::<F> {
-            program: Arc::clone(&program),
+            program: program.clone(),
             ..Default::default()
         };
         Self {

--- a/recursion/core-v2/src/runtime/mod.rs
+++ b/recursion/core-v2/src/runtime/mod.rs
@@ -103,7 +103,7 @@ pub struct Runtime<'a, F: PrimeField32, EF: ExtensionField<F>, Diffusion> {
     pub pc: F,
 
     /// The program.
-    pub program: RecursionProgram<F>,
+    pub program: Arc<RecursionProgram<F>>,
 
     /// Memory. From canonical usize of an Address to a MemoryEntry.
     pub memory: Memory<F>,
@@ -184,8 +184,10 @@ where
             POSEIDON2_SBOX_DEGREE,
         >,
     ) -> Self {
+        // let program = Arc::clone(program);
+        let program = Arc::new(program.to_owned());
         let record = ExecutionRecord::<F> {
-            program: Arc::new(program.clone()),
+            program: Arc::clone(&program),
             ..Default::default()
         };
         Self {
@@ -202,7 +204,7 @@ where
             nb_print_f: 0,
             nb_print_e: 0,
             clk: F::zero(),
-            program: program.clone(),
+            program,
             pc: F::zero(),
             memory: Default::default(),
             record,


### PR DESCRIPTION
- Employ fusion (avoid building intermediate data structures) in the compiler.
- Clone the program one less time in `Runtime::new`.
- Shrink the `Instruction` enum by boxing the particularly large `CommitPublicValues` variant.
- Replace the `HashMap` used for runtime memory by a `Vec`.