### PR TITLE
feat: Build `sp1-sdk` in `--release`

### DIFF
--- a/crates/sdk/build.rs
+++ b/crates/sdk/build.rs
@@ -1,3 +1,8 @@
 fn main() {
+    #[cfg(debug_assertions)]
+    compile_error!(
+        "sp1-sdk must be used in release mode. Please compile with the --release flag."
+    );
+
     vergen::EmitBuilder::builder().build_timestamp().git_sha(true).emit().unwrap();
 }

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -5,6 +5,9 @@
 //! Visit the [Getting Started](https://succinctlabs.github.io/sp1/getting-started.html) section
 //! in the official SP1 documentation for a quick start guide.
 
+#[cfg(debug_assertions)]
+compile_error!("sp1-sdk must be used in release mode. Please compile sp1-sdk with --release flag.");
+
 #[rustfmt::skip]
 pub mod proto {
     pub mod network;

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -5,9 +5,6 @@
 //! Visit the [Getting Started](https://succinctlabs.github.io/sp1/getting-started.html) section
 //! in the official SP1 documentation for a quick start guide.
 
-#[cfg(debug_assertions)]
-compile_error!("sp1-sdk must be used in release mode. Please compile sp1-sdk with --release flag.");
-
 #[rustfmt::skip]
 pub mod proto {
     pub mod network;


### PR DESCRIPTION
While `sp1-sdk` must be built in `--release` mode, we should throw a compile time error if a user attempts compiling in `debug` mode.