### PR TITLE
chore: wrap entrypoint with `target_os`=`zkvm`

### DIFF
--- a/crates/zkvm/entrypoint/src/lib.rs
+++ b/crates/zkvm/entrypoint/src/lib.rs
@@ -16,7 +16,6 @@ pub mod lib {
 #[cfg(all(target_os = "zkvm", feature = "libm"))]
 mod libm;
 
-#[cfg(target_os = "zkvm")]
 use cfg_if::cfg_if;
 
 /// The number of 32 bit words that the public values digest is composed of.

--- a/crates/zkvm/entrypoint/src/lib.rs
+++ b/crates/zkvm/entrypoint/src/lib.rs
@@ -96,18 +96,19 @@ mod zkvm {
 macro_rules! entrypoint {
     ($path:path) => {
         #[cfg(target_os = "zkvm")]
-        mod zkvm_impl {
-            use $crate::heap::SimpleAlloc;
+        use $crate::heap::SimpleAlloc;
 
-            pub const ZKVM_ENTRY: fn() = $path;
+        #[cfg(target_os = "zkvm")]
+        pub const ZKVM_ENTRY: fn() = $path;
 
-            #[global_allocator]
-            static HEAP: SimpleAlloc = SimpleAlloc;
+        #[cfg(target_os = "zkvm")]
+        #[global_allocator]
+        static HEAP: SimpleAlloc = SimpleAlloc;
 
-            #[no_mangle]
-            pub fn main() {
-                ZKVM_ENTRY()
-            }
+        #[cfg(target_os = "zkvm")]
+        #[no_mangle]
+        pub fn main() {
+            ZKVM_ENTRY()
         }
 
         #[cfg(not(target_os = "zkvm"))]


### PR DESCRIPTION
If you put the `program` and the `script` in the same workspace and build it will fail because the `entrypoint` macro is only intended to be built in the `zkvm` context.

Users should be able to put their `program` and `script` in the same workspace, so this macro should no-op outside of the `zkvm` context.