### PR TITLE
perf: use crate `vec_map`, box large `Instruction` variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5350,6 +5350,7 @@ dependencies = [
  "sp1-recursion-derive",
  "sp1-stark",
  "tracing",
+ "vec_map",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5425,6 +5425,7 @@ dependencies = [
  "static_assertions",
  "thiserror",
  "tracing",
+ "vec_map",
  "zkhash",
 ]
 
@@ -6303,6 +6304,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vergen"

--- a/crates/core/machine/src/utils/mod.rs
+++ b/crates/core/machine/src/utils/mod.rs
@@ -199,10 +199,10 @@ where
     );
 }
 
-/// Returns whether the `SP1_DEV` environment variable is enabled or disabled.
+/// Returns whether the `SP1_DEBUG` environment variable is enabled or disabled.
 ///
-/// This variable controls whether a smaller version of the circuit will be used for generating the
-/// PLONK proofs. This is useful for development and testing purposes.
+/// This variable controls whether backtraces are attached to compiled circuit programs, as well
+/// as whether cycle tracking is performed for circuit programs.
 ///
 /// By default, the variable is disabled.
 pub fn sp1_debug_mode() -> bool {

--- a/crates/recursion/circuit-v2/src/build_wrap_v2.rs
+++ b/crates/recursion/circuit-v2/src/build_wrap_v2.rs
@@ -180,7 +180,7 @@
 //     let machine = machine_maker();
 //     let program = RecursionProgram {
 //         instructions,
-//         traces: Default::default(),
+//         ..Default::default()
 //     };
 //     let mut runtime = Runtime::<
 //         BabyBear,

--- a/crates/recursion/compiler/Cargo.toml
+++ b/crates/recursion/compiler/Cargo.toml
@@ -33,6 +33,7 @@ serde = { version = "1.0.204", features = ["derive"] }
 backtrace = "0.3.71"
 tracing = "0.1.40"
 rayon = "1.10.0"
+vec_map = "0.8.2"
 
 [dev-dependencies]
 p3-challenger = { workspace = true }

--- a/crates/recursion/compiler/src/circuit/compiler.rs
+++ b/crates/recursion/compiler/src/circuit/compiler.rs
@@ -1,7 +1,9 @@
 use chips::poseidon2_skinny::WIDTH;
 use core::fmt::Debug;
 use instruction::{FieldEltType, HintBitsInstr, HintExt2FeltsInstr, HintInstr, PrintInstr};
-use p3_field::{AbstractExtensionField, AbstractField, Field, PrimeField, TwoAdicField};
+use p3_field::{
+    AbstractExtensionField, AbstractField, Field, PrimeField, PrimeField64, TwoAdicField,
+};
 use sp1_core_machine::utils::{sp1_debug_mode, SpanBuilder};
 use sp1_recursion_core::air::{Block, RecursionPublicValues, RECURSIVE_PROOF_NUM_PV_ELTS};
 use sp1_recursion_core_v2::{BaseAluInstr, BaseAluOpcode};
@@ -11,6 +13,7 @@ use std::{
     iter::repeat,
     mem::transmute,
 };
+use vec_map::VecMap;
 
 use sp1_recursion_core_v2::*;
 
@@ -21,14 +24,17 @@ use crate::prelude::*;
 pub struct AsmCompiler<C: Config> {
     pub next_addr: C::F,
     /// Map the frame pointers of the variables to the "physical" addresses.
-    pub fp_to_addr: HashMap<i32, Address<C::F>>,
+    pub virtual_to_physical: VecMap<Address<C::F>>,
     /// Map base or extension field constants to "physical" addresses and mults.
     pub consts: HashMap<Imm<C::F, C::EF>, (Address<C::F>, C::F)>,
     /// Map each "physical" address to its read count.
-    pub addr_to_mult: HashMap<Address<C::F>, C::F>,
+    pub addr_to_mult: VecMap<C::F>,
 }
 
-impl<C: Config> AsmCompiler<C> {
+impl<C: Config> AsmCompiler<C>
+where
+    C::F: PrimeField64,
+{
     /// Allocate a fresh address. Checks that the address space is not full.
     pub fn alloc(next_addr: &mut C::F) -> Address<C::F> {
         let id = Address(*next_addr);
@@ -42,26 +48,27 @@ impl<C: Config> AsmCompiler<C> {
     /// Map `fp` to its existing address without changing its mult.
     ///
     /// Ensures that `fp` has already been assigned an address.
-    pub fn read_ghost_fp(&mut self, fp: i32) -> Address<C::F> {
-        self.read_fp_internal(fp, false)
+    pub fn read_ghost_vaddr(&mut self, vaddr: usize) -> Address<C::F> {
+        self.read_vaddr_internal(vaddr, false)
     }
 
     /// Map `fp` to its existing address and increment its mult.
     ///
     /// Ensures that `fp` has already been assigned an address.
-    pub fn read_fp(&mut self, fp: i32) -> Address<C::F> {
-        self.read_fp_internal(fp, true)
+    pub fn read_vaddr(&mut self, vaddr: usize) -> Address<C::F> {
+        self.read_vaddr_internal(vaddr, true)
     }
 
-    pub fn read_fp_internal(&mut self, fp: i32, increment_mult: bool) -> Address<C::F> {
-        match self.fp_to_addr.entry(fp) {
-            Entry::Vacant(entry) => panic!("expected entry in fp_to_addr: {entry:?}"),
+    pub fn read_vaddr_internal(&mut self, vaddr: usize, increment_mult: bool) -> Address<C::F> {
+        use vec_map::Entry;
+        match self.virtual_to_physical.entry(vaddr) {
+            Entry::Vacant(_) => panic!("expected entry: virtual_physical[{:?}]", vaddr),
             Entry::Occupied(entry) => {
                 if increment_mult {
                     // This is a read, so we increment the mult.
-                    match self.addr_to_mult.get_mut(entry.get()) {
+                    match self.addr_to_mult.get_mut(entry.get().as_usize()) {
                         Some(mult) => *mult += C::F::one(),
-                        None => panic!("expected entry in addr_mult: {entry:?}"),
+                        None => panic!("expected entry: virtual_physical[{:?}]", vaddr),
                     }
                 }
                 *entry.into_mut()
@@ -72,17 +79,20 @@ impl<C: Config> AsmCompiler<C> {
     /// Map `fp` to a fresh address and initialize the mult to 0.
     ///
     /// Ensures that `fp` has not already been written to.
-    pub fn write_fp(&mut self, fp: i32) -> Address<C::F> {
-        match self.fp_to_addr.entry(fp) {
+    pub fn write_fp(&mut self, vaddr: usize) -> Address<C::F> {
+        use vec_map::Entry;
+        match self.virtual_to_physical.entry(vaddr) {
             Entry::Vacant(entry) => {
                 let addr = Self::alloc(&mut self.next_addr);
                 // This is a write, so we set the mult to zero.
-                if let Some(x) = self.addr_to_mult.insert(addr, C::F::zero()) {
+                if let Some(x) = self.addr_to_mult.insert(addr.as_usize(), C::F::zero()) {
                     panic!("unexpected entry in addr_to_mult: {x:?}");
                 }
                 *entry.insert(addr)
             }
-            Entry::Occupied(entry) => panic!("unexpected entry in fp_to_addr: {entry:?}"),
+            Entry::Occupied(entry) => {
+                panic!("unexpected entry: virtual_to_physical[{:?}] = {:?}", vaddr, entry.get())
+            }
         }
     }
 
@@ -101,8 +111,9 @@ impl<C: Config> AsmCompiler<C> {
     }
 
     fn read_addr_internal(&mut self, addr: Address<C::F>, increment_mult: bool) -> &mut C::F {
-        match self.addr_to_mult.entry(addr) {
-            Entry::Vacant(entry) => panic!("expected entry in addr_to_mult: {entry:?}"),
+        use vec_map::Entry;
+        match self.addr_to_mult.entry(addr.as_usize()) {
+            Entry::Vacant(_) => panic!("expected entry: addr_to_mult[{:?}]", addr.as_usize()),
             Entry::Occupied(entry) => {
                 // This is a read, so we increment the mult.
                 let mult = entry.into_mut();
@@ -118,9 +129,12 @@ impl<C: Config> AsmCompiler<C> {
     ///
     /// Ensures that `addr` has not already been written to.
     pub fn write_addr(&mut self, addr: Address<C::F>) -> &mut C::F {
-        match self.addr_to_mult.entry(addr) {
+        use vec_map::Entry;
+        match self.addr_to_mult.entry(addr.as_usize()) {
             Entry::Vacant(entry) => entry.insert(C::F::zero()),
-            Entry::Occupied(entry) => panic!("unexpected entry in addr_to_mult: {entry:?}"),
+            Entry::Occupied(entry) => {
+                panic!("unexpected entry: addr_to_mult[{:?}] = {:?}", addr.as_usize(), entry.get())
+            }
         }
     }
 
@@ -529,8 +543,9 @@ impl<C: Config> AsmCompiler<C> {
         // Replace the mults using the address count data gathered in this previous.
         // Exhaustive match for refactoring purposes.
         let total_memory = self.addr_to_mult.len() + self.consts.len();
-        let mut backfill =
-            |(mult, addr): (&mut F, &Address<F>)| *mult = self.addr_to_mult.remove(addr).unwrap();
+        let mut backfill = |(mult, addr): (&mut F, &Address<F>)| {
+            *mult = self.addr_to_mult.remove(addr.as_usize()).unwrap()
+        };
         tracing::debug_span!("backfill mult").in_scope(|| {
             for asm_instr in instrs.iter_mut() {
                 match asm_instr {
@@ -607,7 +622,7 @@ impl<C: Config> AsmCompiler<C> {
         tracing::debug!("number of consts to initialize: {}", instrs_consts.len());
         // Reset the other fields.
         self.next_addr = Default::default();
-        self.fp_to_addr.clear();
+        self.virtual_to_physical.clear();
         // Place constant-initializing instructions at the top.
         let (instructions, traces) = tracing::debug_span!("construct program").in_scope(|| {
             if debug_mode {
@@ -718,28 +733,28 @@ impl_reg_borrowed!(&T);
 impl_reg_borrowed!(&mut T);
 impl_reg_borrowed!(Box<T>);
 
-macro_rules! impl_reg_fp {
-    ($a:ty) => {
-        impl<C: Config> Reg<C> for $a {
+macro_rules! impl_reg_vaddr {
+    ($a:ty, $offset:expr) => {
+        impl<C: Config<F: PrimeField64>> Reg<C> for $a {
             fn read(&self, compiler: &mut AsmCompiler<C>) -> Address<C::F> {
-                compiler.read_fp(self.fp())
+                compiler.read_vaddr(self.0 as usize * 3 + $offset)
             }
             fn read_ghost(&self, compiler: &mut AsmCompiler<C>) -> Address<C::F> {
-                compiler.read_ghost_fp(self.fp())
+                compiler.read_ghost_vaddr(self.0 as usize * 3 + $offset)
             }
             fn write(&self, compiler: &mut AsmCompiler<C>) -> Address<C::F> {
-                compiler.write_fp(self.fp())
+                compiler.write_fp(self.0 as usize * 3 + $offset)
             }
         }
     };
 }
 
 // These three types have `.fp()` but they don't share a trait.
-impl_reg_fp!(Var<C::F>);
-impl_reg_fp!(Felt<C::F>);
-impl_reg_fp!(Ext<C::F, C::EF>);
+impl_reg_vaddr!(Var<C::F>, 1);
+impl_reg_vaddr!(Felt<C::F>, 2);
+impl_reg_vaddr!(Ext<C::F, C::EF>, 0);
 
-impl<C: Config> Reg<C> for Imm<C::F, C::EF> {
+impl<C: Config<F: PrimeField64>> Reg<C> for Imm<C::F, C::EF> {
     fn read(&self, compiler: &mut AsmCompiler<C>) -> Address<C::F> {
         compiler.read_const(*self)
     }
@@ -753,7 +768,7 @@ impl<C: Config> Reg<C> for Imm<C::F, C::EF> {
     }
 }
 
-impl<C: Config> Reg<C> for Address<C::F> {
+impl<C: Config<F: PrimeField64>> Reg<C> for Address<C::F> {
     fn read(&self, compiler: &mut AsmCompiler<C>) -> Address<C::F> {
         compiler.read_addr(*self);
         *self

--- a/crates/recursion/compiler/src/circuit/compiler.rs
+++ b/crates/recursion/compiler/src/circuit/compiler.rs
@@ -528,6 +528,7 @@ impl<C: Config> AsmCompiler<C> {
 
         // Replace the mults using the address count data gathered in this previous.
         // Exhaustive match for refactoring purposes.
+        let total_memory = self.addr_to_mult.len() + self.consts.len();
         let mut backfill =
             |(mult, addr): (&mut F, &Address<F>)| *mult = self.addr_to_mult.remove(addr).unwrap();
         tracing::debug_span!("backfill mult").in_scope(|| {
@@ -614,7 +615,7 @@ impl<C: Config> AsmCompiler<C> {
                 (instrs_consts.chain(instrs).collect(), traces)
             }
         });
-        RecursionProgram { instructions, traces }
+        RecursionProgram { instructions, total_memory, traces }
     }
 }
 

--- a/crates/recursion/compiler/src/circuit/compiler.rs
+++ b/crates/recursion/compiler/src/circuit/compiler.rs
@@ -7,12 +7,7 @@ use p3_field::{
 use sp1_core_machine::utils::{sp1_debug_mode, SpanBuilder};
 use sp1_recursion_core::air::{Block, RecursionPublicValues, RECURSIVE_PROOF_NUM_PV_ELTS};
 use sp1_recursion_core_v2::{BaseAluInstr, BaseAluOpcode};
-use std::{
-    borrow::Borrow,
-    collections::{hash_map::Entry, HashMap},
-    iter::repeat,
-    mem::transmute,
-};
+use std::{borrow::Borrow, collections::HashMap, iter::repeat, mem::transmute};
 use vec_map::VecMap;
 
 use sp1_recursion_core_v2::*;

--- a/crates/recursion/core-v2/Cargo.toml
+++ b/crates/recursion/core-v2/Cargo.toml
@@ -42,6 +42,7 @@ arrayref = "0.3.7"
 static_assertions = "1.1.0"
 num_cpus = "1.16.0"
 thiserror = "1.0.60"
+vec_map = "0.8.2"
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/crates/recursion/core-v2/src/chips/alu_base.rs
+++ b/crates/recursion/core-v2/src/chips/alu_base.rs
@@ -245,7 +245,7 @@ mod tests {
             })
             .collect::<Vec<Instruction<F>>>();
 
-        let program = RecursionProgram { instructions, traces: Default::default() };
+        let program = RecursionProgram { instructions, ..Default::default() };
 
         run_recursion_test_machines(program);
     }

--- a/crates/recursion/core-v2/src/chips/alu_ext.rs
+++ b/crates/recursion/core-v2/src/chips/alu_ext.rs
@@ -228,7 +228,7 @@ mod tests {
             })
             .collect::<Vec<Instruction<F>>>();
 
-        let program = RecursionProgram { instructions, traces: Default::default() };
+        let program = RecursionProgram { instructions, ..Default::default() };
 
         run_recursion_test_machines(program);
     }

--- a/crates/recursion/core-v2/src/chips/exp_reverse_bits.rs
+++ b/crates/recursion/core-v2/src/chips/exp_reverse_bits.rs
@@ -378,7 +378,7 @@ mod tests {
             })
             .collect::<Vec<Instruction<F>>>();
 
-        let program = RecursionProgram { instructions, traces: Default::default() };
+        let program = RecursionProgram { instructions, ..Default::default() };
 
         run_recursion_test_machines(program);
     }

--- a/crates/recursion/core-v2/src/chips/fri_fold.rs
+++ b/crates/recursion/core-v2/src/chips/fri_fold.rs
@@ -119,7 +119,7 @@ impl<F: PrimeField32, const DEGREE: usize> MachineAir<F> for FriFoldChip<DEGREE>
                     ext_vec_addrs,
                     alpha_pow_mults,
                     ro_mults,
-                } = instruction;
+                } = instruction.as_ref();
                 let mut row_add =
                     vec![[F::zero(); NUM_FRI_FOLD_PREPROCESSED_COLS]; ext_vec_addrs.ps_at_z.len()];
 

--- a/crates/recursion/core-v2/src/chips/fri_fold.rs
+++ b/crates/recursion/core-v2/src/chips/fri_fold.rs
@@ -507,7 +507,7 @@ mod tests {
             })
             .collect::<Vec<Instruction<F>>>();
 
-        let program = RecursionProgram { instructions, traces: Default::default() };
+        let program = RecursionProgram { instructions, ..Default::default() };
 
         run_recursion_test_machines(program);
     }

--- a/crates/recursion/core-v2/src/chips/mem/constant.rs
+++ b/crates/recursion/core-v2/src/chips/mem/constant.rs
@@ -199,7 +199,7 @@ mod tests {
                 instr::mem(MemAccessKind::Write, 1, 1, 2),
                 instr::mem(MemAccessKind::Read, 1, 1, 2),
             ],
-            traces: Default::default(),
+            ..Default::default()
         });
     }
 
@@ -211,7 +211,7 @@ mod tests {
                 instr::mem(MemAccessKind::Write, 1, 1, 2),
                 instr::mem(MemAccessKind::Read, 999, 1, 2),
             ],
-            traces: Default::default(),
+            ..Default::default()
         });
     }
 
@@ -223,7 +223,7 @@ mod tests {
                 instr::mem(MemAccessKind::Write, 1, 1, 2),
                 instr::mem(MemAccessKind::Read, 1, 999, 2),
             ],
-            traces: Default::default(),
+            ..Default::default()
         });
     }
 
@@ -235,7 +235,7 @@ mod tests {
                 instr::mem(MemAccessKind::Write, 1, 1, 2),
                 instr::mem(MemAccessKind::Read, 1, 1, 999),
             ],
-            traces: Default::default(),
+            ..Default::default()
         });
     }
 }

--- a/crates/recursion/core-v2/src/chips/mem/variable.rs
+++ b/crates/recursion/core-v2/src/chips/mem/variable.rs
@@ -187,7 +187,7 @@ mod tests {
                 instr::mem(MemAccessKind::Write, 1, 1, 2),
                 instr::mem(MemAccessKind::Read, 1, 1, 2),
             ],
-            traces: Default::default(),
+            ..Default::default()
         };
 
         run_recursion_test_machines(program);
@@ -201,7 +201,7 @@ mod tests {
                 instr::mem(MemAccessKind::Write, 1, 1, 2),
                 instr::mem(MemAccessKind::Read, 999, 1, 2),
             ],
-            traces: Default::default(),
+            ..Default::default()
         };
 
         run_recursion_test_machines(program);
@@ -215,7 +215,7 @@ mod tests {
                 instr::mem(MemAccessKind::Write, 1, 1, 2),
                 instr::mem(MemAccessKind::Read, 1, 999, 2),
             ],
-            traces: Default::default(),
+            ..Default::default()
         };
 
         run_recursion_test_machines(program);
@@ -229,7 +229,7 @@ mod tests {
                 instr::mem(MemAccessKind::Write, 1, 1, 2),
                 instr::mem(MemAccessKind::Read, 1, 1, 999),
             ],
-            traces: Default::default(),
+            ..Default::default()
         };
 
         run_recursion_test_machines(program);

--- a/crates/recursion/core-v2/src/chips/poseidon2_skinny/mod.rs
+++ b/crates/recursion/core-v2/src/chips/poseidon2_skinny/mod.rs
@@ -133,7 +133,7 @@ pub(crate) mod tests {
                 }))
                 .collect::<Vec<_>>();
 
-        let program = Arc::new(RecursionProgram { instructions, traces: Default::default() });
+        let program = Arc::new(RecursionProgram { instructions, ..Default::default() });
         let mut runtime = Runtime::<F, EF, DiffusionMatrixBabyBear>::new(
             program.clone(),
             BabyBearPoseidon2::new().perm,

--- a/crates/recursion/core-v2/src/chips/poseidon2_wide/mod.rs
+++ b/crates/recursion/core-v2/src/chips/poseidon2_wide/mod.rs
@@ -164,7 +164,7 @@ pub(crate) mod tests {
                 }))
                 .collect::<Vec<_>>();
 
-        let program = Arc::new(RecursionProgram { instructions, traces: Default::default() });
+        let program = Arc::new(RecursionProgram { instructions, ..Default::default() });
         let mut runtime = Runtime::<F, EF, DiffusionMatrixBabyBear>::new(
             program.clone(),
             BabyBearPoseidon2::new().perm,

--- a/crates/recursion/core-v2/src/chips/public_values.rs
+++ b/crates/recursion/core-v2/src/chips/public_values.rs
@@ -215,7 +215,7 @@ mod tests {
         let public_values_a: &RecursionPublicValues<u32> = public_values_a.as_slice().borrow();
         instructions.push(instr::commit_public_values(public_values_a));
 
-        let program = RecursionProgram { instructions, traces: Default::default() };
+        let program = RecursionProgram { instructions, ..Default::default() };
 
         run_recursion_test_machines(program);
     }

--- a/crates/recursion/core-v2/src/lib.rs
+++ b/crates/recursion/core-v2/src/lib.rs
@@ -189,7 +189,7 @@ pub struct FriFoldEvent<F> {
 /// it's digest.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CommitPublicValuesInstr<F> {
-    pub pv_addrs: Box<RecursionPublicValues<Address<F>>>,
+    pub pv_addrs: RecursionPublicValues<Address<F>>,
 }
 
 /// The event for committing to the public values.

--- a/crates/recursion/core-v2/src/lib.rs
+++ b/crates/recursion/core-v2/src/lib.rs
@@ -1,5 +1,6 @@
 use std::iter::once;
 
+use p3_field::PrimeField64;
 use serde::{Deserialize, Serialize};
 use sp1_derive::AlignedBorrow;
 use sp1_recursion_core::air::{Block, RecursionPublicValues};
@@ -22,6 +23,12 @@ use crate::chips::poseidon2_skinny::WIDTH;
 )]
 #[repr(C)]
 pub struct Address<F>(pub F);
+
+impl<F: PrimeField64> Address<F> {
+    pub fn as_usize(&self) -> usize {
+        self.0.as_canonical_u64() as usize
+    }
+}
 
 // -------------------------------------------------------------------------------------------------
 

--- a/crates/recursion/core-v2/src/lib.rs
+++ b/crates/recursion/core-v2/src/lib.rs
@@ -25,6 +25,7 @@ use crate::chips::poseidon2_skinny::WIDTH;
 pub struct Address<F>(pub F);
 
 impl<F: PrimeField64> Address<F> {
+    #[inline]
     pub fn as_usize(&self) -> usize {
         self.0.as_canonical_u64() as usize
     }

--- a/crates/recursion/core-v2/src/machine.rs
+++ b/crates/recursion/core-v2/src/machine.rs
@@ -247,7 +247,7 @@ pub mod tests {
     }
 
     fn test_instructions(instructions: Vec<Instruction<F>>) {
-        let program = RecursionProgram { instructions, traces: Default::default() };
+        let program = RecursionProgram { instructions, ..Default::default() };
         run_recursion_test_machines(program);
     }
 

--- a/crates/recursion/core-v2/src/runtime/instruction.rs
+++ b/crates/recursion/core-v2/src/runtime/instruction.rs
@@ -10,13 +10,13 @@ pub enum Instruction<F> {
     BaseAlu(BaseAluInstr<F>),
     ExtAlu(ExtAluInstr<F>),
     Mem(MemInstr<F>),
-    Poseidon2(Poseidon2Instr<F>),
+    Poseidon2(Box<Poseidon2Instr<F>>),
     ExpReverseBitsLen(ExpReverseBitsInstr<F>),
     HintBits(HintBitsInstr<F>),
-    FriFold(FriFoldInstr<F>),
+    FriFold(Box<FriFoldInstr<F>>),
     Print(PrintInstr<F>),
     HintExt2Felts(HintExt2FeltsInstr<F>),
-    CommitPublicValues(CommitPublicValuesInstr<F>),
+    CommitPublicValues(Box<CommitPublicValuesInstr<F>>),
     Hint(HintInstr<F>),
 }
 
@@ -136,13 +136,13 @@ pub fn poseidon2<F: AbstractField>(
     output: [u32; WIDTH],
     input: [u32; WIDTH],
 ) -> Instruction<F> {
-    Instruction::Poseidon2(Poseidon2Instr {
+    Instruction::Poseidon2(Box::new(Poseidon2Instr {
         mults: mults.map(F::from_canonical_u32),
         addrs: Poseidon2Io {
             output: output.map(F::from_canonical_u32).map(Address),
             input: input.map(F::from_canonical_u32).map(Address),
         },
-    })
+    }))
 }
 
 pub fn exp_reverse_bits_len<F: AbstractField>(
@@ -175,7 +175,7 @@ pub fn fri_fold<F: AbstractField>(
     alpha_mults: Vec<u32>,
     ro_mults: Vec<u32>,
 ) -> Instruction<F> {
-    Instruction::FriFold(FriFoldInstr {
+    Instruction::FriFold(Box::new(FriFoldInstr {
         base_single_addrs: FriFoldBaseIo { x: Address(F::from_canonical_u32(x)) },
         ext_single_addrs: FriFoldExtSingleIo {
             z: Address(F::from_canonical_u32(z)),
@@ -200,7 +200,7 @@ pub fn fri_fold<F: AbstractField>(
         },
         alpha_pow_mults: alpha_mults.iter().map(|mult| F::from_canonical_u32(*mult)).collect(),
         ro_mults: ro_mults.iter().map(|mult| F::from_canonical_u32(*mult)).collect(),
-    })
+    }))
 }
 
 pub fn commit_public_values<F: AbstractField>(
@@ -209,7 +209,7 @@ pub fn commit_public_values<F: AbstractField>(
     let pv_a = public_values_a.to_vec().map(|pv| Address(F::from_canonical_u32(pv)));
     let pv_address: &RecursionPublicValues<Address<F>> = pv_a.as_slice().borrow();
 
-    Instruction::CommitPublicValues(CommitPublicValuesInstr {
-        pv_addrs: Box::new(pv_address.clone()),
-    })
+    Instruction::CommitPublicValues(Box::new(CommitPublicValuesInstr {
+        pv_addrs: pv_address.clone(),
+    }))
 }

--- a/crates/recursion/core-v2/src/runtime/memory.rs
+++ b/crates/recursion/core-v2/src/runtime/memory.rs
@@ -1,0 +1,108 @@
+use std::iter::repeat;
+
+use p3_field::PrimeField64;
+use sp1_recursion_core::air::Block;
+use vec_map::{Entry, VecMap};
+
+use crate::Address;
+
+#[derive(Debug, Clone, Default)]
+pub struct MemoryEntry<F> {
+    pub val: Block<F>,
+    pub mult: F,
+}
+
+pub trait Memory<F> {
+    /// Allocates memory with at least the given capacity.
+    fn with_capacity(capacity: usize) -> Self;
+
+    /// Read from a memory address. Decrements the memory entry's mult count.
+    ///
+    /// # Panics
+    /// Panics if the address is unassigned.
+    fn mr(&mut self, addr: Address<F>) -> &mut MemoryEntry<F>;
+
+    /// Read from a memory address. Reduces the memory entry's mult count by the given amount.
+    ///
+    /// # Panics
+    /// Panics if the address is unassigned.
+    fn mr_mult(&mut self, addr: Address<F>, mult: F) -> &mut MemoryEntry<F>;
+
+    /// Write to a memory address, setting the given value and mult.
+    ///
+    /// # Panics
+    /// Panics if the address is already assigned.
+    fn mw(&mut self, addr: Address<F>, val: Block<F>, mult: F) -> &mut MemoryEntry<F>;
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct MemVecMap<F>(pub VecMap<MemoryEntry<F>>);
+
+impl<F: PrimeField64> Memory<F> for MemVecMap<F> {
+    fn with_capacity(capacity: usize) -> Self {
+        Self(VecMap::with_capacity(capacity))
+    }
+
+    fn mr(&mut self, addr: Address<F>) -> &mut MemoryEntry<F> {
+        self.mr_mult(addr, F::one())
+    }
+
+    fn mr_mult(&mut self, addr: Address<F>, mult: F) -> &mut MemoryEntry<F> {
+        match self.0.entry(addr.as_usize()) {
+            Entry::Occupied(mut entry) => {
+                let entry_mult = &mut entry.get_mut().mult;
+                *entry_mult -= mult;
+                entry.into_mut()
+            }
+            Entry::Vacant(_) => panic!("tried to read from unassigned address: {addr:?}",),
+        }
+    }
+
+    fn mw(&mut self, addr: Address<F>, val: Block<F>, mult: F) -> &mut MemoryEntry<F> {
+        let index = addr.as_usize();
+        match self.0.entry(index) {
+            Entry::Occupied(entry) => {
+                panic!("tried to write to assigned address {}: {:?}", index, entry.get())
+            }
+            Entry::Vacant(entry) => entry.insert(MemoryEntry { val, mult }),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct MemVec<F>(pub Vec<Option<MemoryEntry<F>>>);
+
+impl<F: PrimeField64> Memory<F> for MemVec<F> {
+    fn with_capacity(capacity: usize) -> Self {
+        Self(Vec::with_capacity(capacity))
+    }
+
+    fn mr(&mut self, addr: Address<F>) -> &mut MemoryEntry<F> {
+        self.mr_mult(addr, F::one())
+    }
+
+    fn mr_mult(&mut self, addr: Address<F>, mult: F) -> &mut MemoryEntry<F> {
+        match self.0.get_mut(addr.as_usize()) {
+            Some(Some(entry)) => {
+                entry.mult -= mult;
+                entry
+            }
+            _ => panic!(
+                "tried to read from unassigned address: {addr:?}\nbacktrace: {:?}",
+                backtrace::Backtrace::new()
+            ),
+        }
+    }
+
+    fn mw(&mut self, addr: Address<F>, val: Block<F>, mult: F) -> &mut MemoryEntry<F> {
+        let addr_usize = addr.as_usize();
+        self.0.extend(repeat(None).take((addr_usize + 1).saturating_sub(self.0.len())));
+        match &mut self.0[addr_usize] {
+            Some(entry) => panic!(
+                "tried to write to assigned address: {entry:?}\nbacktrace: {:?}",
+                backtrace::Backtrace::new()
+            ),
+            entry @ None => entry.insert(MemoryEntry { val, mult }),
+        }
+    }
+}

--- a/crates/recursion/core-v2/src/runtime/mod.rs
+++ b/crates/recursion/core-v2/src/runtime/mod.rs
@@ -341,10 +341,11 @@ where
                     }
                     self.record.mem_const_count += 1;
                 }
-                Instruction::Poseidon2(Poseidon2Instr {
-                    addrs: Poseidon2Io { input, output },
-                    mults,
-                }) => {
+                Instruction::Poseidon2(instr) => {
+                    let Poseidon2Instr {
+                        addrs: Poseidon2Io { input, output },
+                        mults,
+                    } = *instr;
                     self.nb_poseidons += 1;
                     let in_vals = std::array::from_fn(|i| self.memory.mr(input[i]).val[0]);
                     let perm_output = self.perm.as_ref().unwrap().permute(in_vals);
@@ -391,13 +392,14 @@ where
                     }
                 }
 
-                Instruction::FriFold(FriFoldInstr {
-                    base_single_addrs,
-                    ext_single_addrs,
-                    ext_vec_addrs,
-                    alpha_pow_mults,
-                    ro_mults,
-                }) => {
+                Instruction::FriFold(instr) => {
+                    let FriFoldInstr {
+                        base_single_addrs,
+                        ext_single_addrs,
+                        ext_vec_addrs,
+                        alpha_pow_mults,
+                        ro_mults,
+                    } = *instr;
                     self.nb_fri_fold += 1;
                     let x = self.memory.mr(base_single_addrs.x).val[0];
                     let z = self.memory.mr(ext_single_addrs.z).val;
@@ -465,10 +467,8 @@ where
                     }
                 }
 
-                Instruction::CommitPublicValues(CommitPublicValuesInstr {
-                    pv_addrs: public_values_addrs,
-                }) => {
-                    let pv_addrs = public_values_addrs.to_vec();
+                Instruction::CommitPublicValues(instr) => {
+                    let pv_addrs = instr.pv_addrs.to_vec();
                     let pv_values: [F; RECURSIVE_PROOF_NUM_PV_ELTS] =
                         array::from_fn(|i| self.memory.mr(pv_addrs[i]).val[0]);
                     self.record.public_values = *pv_values.as_slice().borrow();

--- a/crates/recursion/core-v2/src/runtime/mod.rs
+++ b/crates/recursion/core-v2/src/runtime/mod.rs
@@ -185,6 +185,7 @@ where
         >,
     ) -> Self {
         let record = ExecutionRecord::<F> { program: program.clone(), ..Default::default() };
+        let memory = Memory { inner: Vec::with_capacity(program.total_memory) };
         Self {
             timestamp: 0,
             nb_poseidons: 0,
@@ -201,7 +202,7 @@ where
             clk: F::zero(),
             program,
             pc: F::zero(),
-            memory: Default::default(),
+            memory,
             record,
             witness_stream: VecDeque::new(),
             cycle_tracker: HashMap::new(),

--- a/crates/recursion/core-v2/src/runtime/mod.rs
+++ b/crates/recursion/core-v2/src/runtime/mod.rs
@@ -1,4 +1,5 @@
 pub mod instruction;
+mod memory;
 mod opcode;
 mod program;
 mod record;
@@ -7,6 +8,7 @@ mod record;
 use backtrace::Backtrace as Trace;
 pub use instruction::Instruction;
 use instruction::{FieldEltType, HintBitsInstr, HintExt2FeltsInstr, HintInstr, PrintInstr};
+use memory::*;
 pub use opcode::*;
 pub use program::*;
 pub use record::*;
@@ -17,20 +19,18 @@ use std::{
     collections::VecDeque,
     fmt::Debug,
     io::{stdout, Write},
-    iter::{repeat, zip},
+    iter::zip,
     marker::PhantomData,
     sync::Arc,
 };
 
 use hashbrown::HashMap;
 use itertools::Itertools;
-use p3_field::{AbstractField, ExtensionField, PrimeField32, PrimeField64};
+use p3_field::{AbstractField, ExtensionField, PrimeField32};
 use p3_poseidon2::{Poseidon2, Poseidon2ExternalMatrixGeneral};
 use p3_symmetric::{CryptographicPermutation, Permutation};
 use p3_util::reverse_bits_len;
 use thiserror::Error;
-
-use vec_map::{Entry, VecMap};
 
 use sp1_recursion_core::air::{Block, RECURSIVE_PROOF_NUM_PV_ELTS};
 
@@ -56,12 +56,6 @@ pub const DIGEST_SIZE: usize = 8;
 pub const NUM_BITS: usize = 31;
 
 pub const D: usize = 4;
-
-#[derive(Debug, Clone, Default)]
-pub struct MemoryEntry<F> {
-    pub val: Block<F>,
-    pub mult: F,
-}
 
 #[derive(Debug, Clone, Default)]
 pub struct CycleTrackerEntry {
@@ -525,111 +519,5 @@ where
             }
         }
         Ok(())
-    }
-}
-
-pub trait Memory<F> {
-    /// Creates an empty memory space.
-    fn new() -> Self;
-
-    /// Allocates memory with at least the given capacity.
-    fn with_capacity(capacity: usize) -> Self;
-
-    /// Read from a memory address. Decrements the memory entry's mult count.
-    ///
-    /// # Panics
-    /// Panics if the address is unassigned.
-    fn mr(&mut self, addr: Address<F>) -> &mut MemoryEntry<F>;
-
-    /// Read from a memory address. Reduces the memory entry's mult count by the given amount.
-    ///
-    /// # Panics
-    /// Panics if the address is unassigned.
-    fn mr_mult(&mut self, addr: Address<F>, mult: F) -> &mut MemoryEntry<F>;
-
-    /// Write to a memory address, setting the given value and mult.
-    ///
-    /// # Panics
-    /// Panics if the address is already assigned.
-    fn mw(&mut self, addr: Address<F>, val: Block<F>, mult: F) -> &mut MemoryEntry<F>;
-}
-
-#[derive(Clone, Debug, Default)]
-pub struct MemVecMap<F>(pub VecMap<MemoryEntry<F>>);
-
-impl<F: PrimeField64> Memory<F> for MemVecMap<F> {
-    fn new() -> Self {
-        Default::default()
-    }
-
-    fn with_capacity(capacity: usize) -> Self {
-        Self(VecMap::with_capacity(capacity))
-    }
-
-    fn mr(&mut self, addr: Address<F>) -> &mut MemoryEntry<F> {
-        self.mr_mult(addr, F::one())
-    }
-
-    fn mr_mult(&mut self, addr: Address<F>, mult: F) -> &mut MemoryEntry<F> {
-        match self.0.entry(addr.as_usize()) {
-            Entry::Occupied(mut entry) => {
-                let entry_mult = &mut entry.get_mut().mult;
-                *entry_mult -= mult;
-                entry.into_mut()
-            }
-            Entry::Vacant(_) => panic!("tried to read from unassigned address: {addr:?}",),
-        }
-    }
-
-    fn mw(&mut self, addr: Address<F>, val: Block<F>, mult: F) -> &mut MemoryEntry<F> {
-        let index = addr.as_usize();
-        match self.0.entry(index) {
-            Entry::Occupied(entry) => {
-                panic!("tried to write to assigned address {}: {:?}", index, entry.get())
-            }
-            Entry::Vacant(entry) => entry.insert(MemoryEntry { val, mult }),
-        }
-    }
-}
-
-#[derive(Clone, Debug, Default)]
-pub struct MemVec<F>(pub Vec<Option<MemoryEntry<F>>>);
-
-impl<F: PrimeField32> Memory<F> for MemVec<F> {
-    fn new() -> Self {
-        Default::default()
-    }
-
-    fn with_capacity(capacity: usize) -> Self {
-        Self(Vec::with_capacity(capacity))
-    }
-
-    fn mr(&mut self, addr: Address<F>) -> &mut MemoryEntry<F> {
-        self.mr_mult(addr, F::one())
-    }
-
-    fn mr_mult(&mut self, addr: Address<F>, mult: F) -> &mut MemoryEntry<F> {
-        match self.0.get_mut(addr.as_usize()) {
-            Some(Some(entry)) => {
-                entry.mult -= mult;
-                entry
-            }
-            _ => panic!(
-                "tried to read from unassigned address: {addr:?}\nbacktrace: {:?}",
-                backtrace::Backtrace::new()
-            ),
-        }
-    }
-
-    fn mw(&mut self, addr: Address<F>, val: Block<F>, mult: F) -> &mut MemoryEntry<F> {
-        let addr_usize = addr.as_usize();
-        self.0.extend(repeat(None).take((addr_usize + 1).saturating_sub(self.0.len())));
-        match &mut self.0[addr_usize] {
-            Some(entry) => panic!(
-                "tried to write to assigned address: {entry:?}\nbacktrace: {:?}",
-                backtrace::Backtrace::new()
-            ),
-            entry @ None => entry.insert(MemoryEntry { val, mult }),
-        }
     }
 }

--- a/crates/recursion/core-v2/src/runtime/program.rs
+++ b/crates/recursion/core-v2/src/runtime/program.rs
@@ -8,6 +8,7 @@ use crate::*;
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct RecursionProgram<F> {
     pub instructions: Vec<Instruction<F>>,
+    pub total_memory: usize,
     #[serde(skip)]
     pub traces: Vec<Option<Backtrace>>,
 }


### PR DESCRIPTION
Additionally:
- Correct documentation for `sp1_debug_mode`.
- Calculate total memory used at compile time and reserve the memory in the runtime.
- Create a trait for Runtime's memory and two implementations, backed by `VecMap` and `Vec`. There is a `HashMap` implementation in the PR history, too. Currently, only the `VecMap` implementation is used.

Potential future improvements:
- Avoid converting between `Address<C::F>` and `usize` all the time in the compiler. This is probably really cheap, though.
- Avoid striping `Var`, `Felt`, and `Ext`. Currently they have different counters and are thus each assigned a residue class mod 3 to use for "virtual addresses."