### PR TITLE
chore: Add `BuildArgs` re-export to `sp1-helper`

### DIFF
--- a/crates/helper/src/lib.rs
+++ b/crates/helper/src/lib.rs
@@ -1,5 +1,5 @@
 #[deprecated(
     since = "1.2.0",
-    note = "Please use `sp1_build::build_program` and `sp1_build::build_program_with_args` directly"
+    note = "Please use `sp1_build::build_program`, `sp1_build::build_program_with_args` and `sp1_build::BuildArgs` directly"
 )]
-pub use sp1_build::{build_program, build_program_with_args};
+pub use sp1_build::{build_program, build_program_with_args, BuildArgs};


### PR DESCRIPTION
For backwards compatibility, add `BuildArgs` to the exported structs from `sp1-helper` (which is now deprecated).