### PR TITLE
perf: unify variable counters

### DIFF
--- a/crates/recursion/compiler/src/circuit/compiler.rs
+++ b/crates/recursion/compiler/src/circuit/compiler.rs
@@ -715,25 +715,25 @@ impl_reg_borrowed!(&mut T);
 impl_reg_borrowed!(Box<T>);
 
 macro_rules! impl_reg_vaddr {
-    ($a:ty, $offset:expr) => {
+    ($a:ty) => {
         impl<C: Config<F: PrimeField64>> Reg<C> for $a {
             fn read(&self, compiler: &mut AsmCompiler<C>) -> Address<C::F> {
-                compiler.read_vaddr(self.0 as usize * 3 + $offset)
+                compiler.read_vaddr(self.0 as usize)
             }
             fn read_ghost(&self, compiler: &mut AsmCompiler<C>) -> Address<C::F> {
-                compiler.read_ghost_vaddr(self.0 as usize * 3 + $offset)
+                compiler.read_ghost_vaddr(self.0 as usize)
             }
             fn write(&self, compiler: &mut AsmCompiler<C>) -> Address<C::F> {
-                compiler.write_fp(self.0 as usize * 3 + $offset)
+                compiler.write_fp(self.0 as usize)
             }
         }
     };
 }
 
 // These three types have `.fp()` but they don't share a trait.
-impl_reg_vaddr!(Var<C::F>, 1);
-impl_reg_vaddr!(Felt<C::F>, 2);
-impl_reg_vaddr!(Ext<C::F, C::EF>, 0);
+impl_reg_vaddr!(Var<C::F>);
+impl_reg_vaddr!(Felt<C::F>);
+impl_reg_vaddr!(Ext<C::F, C::EF>);
 
 impl<C: Config<F: PrimeField64>> Reg<C> for Imm<C::F, C::EF> {
     fn read(&self, compiler: &mut AsmCompiler<C>) -> Address<C::F> {

--- a/crates/recursion/compiler/src/ir/builder.rs
+++ b/crates/recursion/compiler/src/ir/builder.rs
@@ -81,9 +81,7 @@ impl<T> IntoIterator for TracedVec<T> {
 /// Can compile to both assembly and a set of constraints.
 #[derive(Debug, Clone)]
 pub struct Builder<C: Config> {
-    pub(crate) felt_count: u32,
-    pub(crate) ext_count: u32,
-    pub(crate) var_count: u32,
+    pub(crate) variable: u32,
     pub operations: TracedVec<DslIr<C>>,
     pub(crate) nb_public_values: Option<Var<C::N>>,
     pub(crate) witness_var_count: u32,
@@ -107,9 +105,7 @@ impl<C: Config> Builder<C> {
         let placeholder_p2_hash_num = Var::new(0);
 
         let mut new_builder = Self {
-            felt_count: 0,
-            ext_count: 0,
-            var_count: 0,
+            variable: 0,
             witness_var_count: 0,
             witness_felt_count: 0,
             witness_ext_count: 0,
@@ -127,18 +123,14 @@ impl<C: Config> Builder<C> {
 
     /// Creates a new builder with a given number of counts for each type.
     pub fn new_sub_builder(
-        var_count: u32,
-        felt_count: u32,
-        ext_count: u32,
+        all_count: u32,
         nb_public_values: Option<Var<C::N>>,
         p2_hash_num: Var<C::N>,
         debug: bool,
         program_type: RecursionProgramType,
     ) -> Self {
         Self {
-            felt_count,
-            ext_count,
-            var_count,
+            variable: all_count,
             // Witness counts are only used when the target is a gnark circuit.  And sub-builders
             // are not used when the target is a gnark circuit, so it's fine to set the
             // witness counts to 0.
@@ -514,9 +506,7 @@ impl<'a, C: Config> IfBuilder<'a, C> {
 
         // Execute the `then` block and collect the instructions.
         let mut f_builder = Builder::<C>::new_sub_builder(
-            self.builder.var_count,
-            self.builder.felt_count,
-            self.builder.ext_count,
+            self.builder.variable,
             self.builder.nb_public_values,
             self.builder.p2_hash_num,
             self.builder.debug,
@@ -566,9 +556,7 @@ impl<'a, C: Config> IfBuilder<'a, C> {
         // Get the condition reduced from the expressions for lhs and rhs.
         let condition = self.condition();
         let mut then_builder = Builder::<C>::new_sub_builder(
-            self.builder.var_count,
-            self.builder.felt_count,
-            self.builder.ext_count,
+            self.builder.variable,
             self.builder.nb_public_values,
             self.builder.p2_hash_num,
             self.builder.debug,
@@ -582,9 +570,7 @@ impl<'a, C: Config> IfBuilder<'a, C> {
         let then_instructions = then_builder.operations;
 
         let mut else_builder = Builder::<C>::new_sub_builder(
-            self.builder.var_count,
-            self.builder.felt_count,
-            self.builder.ext_count,
+            self.builder.variable,
             self.builder.nb_public_values,
             self.builder.p2_hash_num,
             self.builder.debug,
@@ -720,9 +706,7 @@ impl<'a, C: Config> RangeBuilder<'a, C> {
         let step_size = C::N::from_canonical_usize(self.step_size);
         let loop_variable: Var<C::N> = self.builder.uninit();
         let mut loop_body_builder = Builder::<C>::new_sub_builder(
-            self.builder.var_count,
-            self.builder.felt_count,
-            self.builder.ext_count,
+            self.builder.variable,
             self.builder.nb_public_values,
             self.builder.p2_hash_num,
             self.builder.debug,

--- a/crates/recursion/compiler/src/ir/builder.rs
+++ b/crates/recursion/compiler/src/ir/builder.rs
@@ -81,7 +81,7 @@ impl<T> IntoIterator for TracedVec<T> {
 /// Can compile to both assembly and a set of constraints.
 #[derive(Debug, Clone)]
 pub struct Builder<C: Config> {
-    pub(crate) variable: u32,
+    pub(crate) variable_count: u32,
     pub operations: TracedVec<DslIr<C>>,
     pub(crate) nb_public_values: Option<Var<C::N>>,
     pub(crate) witness_var_count: u32,
@@ -105,7 +105,7 @@ impl<C: Config> Builder<C> {
         let placeholder_p2_hash_num = Var::new(0);
 
         let mut new_builder = Self {
-            variable: 0,
+            variable_count: 0,
             witness_var_count: 0,
             witness_felt_count: 0,
             witness_ext_count: 0,
@@ -123,14 +123,14 @@ impl<C: Config> Builder<C> {
 
     /// Creates a new builder with a given number of counts for each type.
     pub fn new_sub_builder(
-        all_count: u32,
+        variable_count: u32,
         nb_public_values: Option<Var<C::N>>,
         p2_hash_num: Var<C::N>,
         debug: bool,
         program_type: RecursionProgramType,
     ) -> Self {
         Self {
-            variable: all_count,
+            variable_count,
             // Witness counts are only used when the target is a gnark circuit.  And sub-builders
             // are not used when the target is a gnark circuit, so it's fine to set the
             // witness counts to 0.
@@ -506,7 +506,7 @@ impl<'a, C: Config> IfBuilder<'a, C> {
 
         // Execute the `then` block and collect the instructions.
         let mut f_builder = Builder::<C>::new_sub_builder(
-            self.builder.variable,
+            self.builder.variable_count,
             self.builder.nb_public_values,
             self.builder.p2_hash_num,
             self.builder.debug,
@@ -556,7 +556,7 @@ impl<'a, C: Config> IfBuilder<'a, C> {
         // Get the condition reduced from the expressions for lhs and rhs.
         let condition = self.condition();
         let mut then_builder = Builder::<C>::new_sub_builder(
-            self.builder.variable,
+            self.builder.variable_count,
             self.builder.nb_public_values,
             self.builder.p2_hash_num,
             self.builder.debug,
@@ -570,7 +570,7 @@ impl<'a, C: Config> IfBuilder<'a, C> {
         let then_instructions = then_builder.operations;
 
         let mut else_builder = Builder::<C>::new_sub_builder(
-            self.builder.variable,
+            self.builder.variable_count,
             self.builder.nb_public_values,
             self.builder.p2_hash_num,
             self.builder.debug,
@@ -706,7 +706,7 @@ impl<'a, C: Config> RangeBuilder<'a, C> {
         let step_size = C::N::from_canonical_usize(self.step_size);
         let loop_variable: Var<C::N> = self.builder.uninit();
         let mut loop_body_builder = Builder::<C>::new_sub_builder(
-            self.builder.variable,
+            self.builder.variable_count,
             self.builder.nb_public_values,
             self.builder.p2_hash_num,
             self.builder.debug,

--- a/crates/recursion/compiler/src/ir/types.rs
+++ b/crates/recursion/compiler/src/ir/types.rs
@@ -396,8 +396,8 @@ impl<C: Config> Variable<C> for Var<C::N> {
     type Expression = SymbolicVar<C::N>;
 
     fn uninit(builder: &mut Builder<C>) -> Self {
-        let var = Var(builder.variable, PhantomData);
-        builder.variable += 1;
+        let var = Var(builder.variable_count, PhantomData);
+        builder.variable_count += 1;
         var
     }
 
@@ -735,8 +735,8 @@ impl<C: Config> Variable<C> for Felt<C::F> {
     type Expression = SymbolicFelt<C::F>;
 
     fn uninit(builder: &mut Builder<C>) -> Self {
-        let felt = Felt(builder.variable, PhantomData);
-        builder.variable += 1;
+        let felt = Felt(builder.variable_count, PhantomData);
+        builder.variable_count += 1;
         felt
     }
 
@@ -1119,8 +1119,8 @@ impl<C: Config> Variable<C> for Ext<C::F, C::EF> {
     type Expression = SymbolicExt<C::F, C::EF>;
 
     fn uninit(builder: &mut Builder<C>) -> Self {
-        let ext = Ext(builder.variable, PhantomData);
-        builder.variable += 1;
+        let ext = Ext(builder.variable_count, PhantomData);
+        builder.variable_count += 1;
         ext
     }
 

--- a/crates/recursion/compiler/src/ir/types.rs
+++ b/crates/recursion/compiler/src/ir/types.rs
@@ -396,8 +396,8 @@ impl<C: Config> Variable<C> for Var<C::N> {
     type Expression = SymbolicVar<C::N>;
 
     fn uninit(builder: &mut Builder<C>) -> Self {
-        let var = Var(builder.var_count, PhantomData);
-        builder.var_count += 1;
+        let var = Var(builder.variable, PhantomData);
+        builder.variable += 1;
         var
     }
 
@@ -735,8 +735,8 @@ impl<C: Config> Variable<C> for Felt<C::F> {
     type Expression = SymbolicFelt<C::F>;
 
     fn uninit(builder: &mut Builder<C>) -> Self {
-        let felt = Felt(builder.felt_count, PhantomData);
-        builder.felt_count += 1;
+        let felt = Felt(builder.variable, PhantomData);
+        builder.variable += 1;
         felt
     }
 
@@ -1119,8 +1119,8 @@ impl<C: Config> Variable<C> for Ext<C::F, C::EF> {
     type Expression = SymbolicExt<C::F, C::EF>;
 
     fn uninit(builder: &mut Builder<C>) -> Self {
-        let ext = Ext(builder.ext_count, PhantomData);
-        builder.ext_count += 1;
+        let ext = Ext(builder.variable, PhantomData);
+        builder.variable += 1;
         ext
     }
 


### PR DESCRIPTION
Enables a contiguous `VecMap` in the compiler.

Depends on #1371 and will need a rebase.