### PR TITLE
fix: ci test examples

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,7 +113,7 @@ jobs:
 
       - name: Install SP1 CLI
         run: |
-          cd cli
+          cd crates/cli
           cargo install --force --locked --path .
           cd ~
 
@@ -153,7 +153,7 @@ jobs:
 
       - name: Install SP1 CLI
         run: |
-          cd cli
+          cd crates/cli
           cargo install --force --locked --path .
           cd ~
 


### PR DESCRIPTION
fixes this:
```
Run cd cli
/home/runner/_work/_temp/0f6d5fad-2519-476c-a6c3-519453a159f8.sh: line 1: cd: cli: No such file or directory
```