### PR TITLE
refactor: "exp reverse bits" -> "exp bits" in v2 recursion

### DIFF
--- a/crates/recursion/circuit-v2/src/fri.rs
+++ b/crates/recursion/circuit-v2/src/fri.rs
@@ -113,14 +113,13 @@ pub fn verify_two_adic_pcs<C: CircuitConfig<F = SC::Val>, SC: BabyBearFriConfigV
                     let log_height = log2_strict_usize(mat_domain.size()) + config.log_blowup;
 
                     let bits_reduced = log_global_max_height - log_height;
-                    let reduced_index_bits_trunc =
-                        index_bits[bits_reduced..(bits_reduced + log_height)].to_vec();
+                    let reduced_index_bits_trunc = &index_bits[bits_reduced..log_global_max_height];
 
                     let g = builder.generator();
                     let two_adic_generator: Felt<_> =
                         builder.eval(C::F::two_adic_generator(log_height));
                     let two_adic_generator_exp =
-                        C::exp_bits(builder, two_adic_generator, reduced_index_bits_trunc);
+                        C::exp_reverse_bits(builder, two_adic_generator, reduced_index_bits_trunc);
                     let x: Felt<_> = builder.eval(g * two_adic_generator_exp);
 
                     for (z, ps_at_z) in izip!(mat_points, mat_values) {
@@ -193,7 +192,7 @@ pub fn verify_query<C: CircuitConfig<F = SC::Val>, SC: BabyBearFriConfigVariable
     let mut folded_eval: Ext<_, _> = builder.constant(C::EF::zero());
     let two_adic_generator: Felt<_> = builder.constant(C::F::two_adic_generator(log_max_height));
 
-    let x_felt = C::exp_bits(builder, two_adic_generator, index_bits[..log_max_height].to_vec());
+    let x_felt = C::exp_reverse_bits(builder, two_adic_generator, &index_bits[..log_max_height]);
     let mut x: Ext<_, _> = builder.eval(SymbolicExt::one() * SymbolicFelt::from(x_felt));
 
     for (offset, log_folded_height, commit, step, beta) in izip!(

--- a/crates/recursion/circuit-v2/src/fri.rs
+++ b/crates/recursion/circuit-v2/src/fri.rs
@@ -120,7 +120,7 @@ pub fn verify_two_adic_pcs<C: CircuitConfig<F = SC::Val>, SC: BabyBearFriConfigV
                     let two_adic_generator: Felt<_> =
                         builder.eval(C::F::two_adic_generator(log_height));
                     let two_adic_generator_exp =
-                        C::exp_reverse_bits(builder, two_adic_generator, reduced_index_bits_trunc);
+                        C::exp_bits(builder, two_adic_generator, reduced_index_bits_trunc);
                     let x: Felt<_> = builder.eval(g * two_adic_generator_exp);
 
                     for (z, ps_at_z) in izip!(mat_points, mat_values) {
@@ -193,8 +193,7 @@ pub fn verify_query<C: CircuitConfig<F = SC::Val>, SC: BabyBearFriConfigVariable
     let mut folded_eval: Ext<_, _> = builder.constant(C::EF::zero());
     let two_adic_generator: Felt<_> = builder.constant(C::F::two_adic_generator(log_max_height));
 
-    let x_felt =
-        C::exp_reverse_bits(builder, two_adic_generator, index_bits[..log_max_height].to_vec());
+    let x_felt = C::exp_bits(builder, two_adic_generator, index_bits[..log_max_height].to_vec());
     let mut x: Ext<_, _> = builder.eval(SymbolicExt::one() * SymbolicFelt::from(x_felt));
 
     for (offset, log_folded_height, commit, step, beta) in izip!(

--- a/crates/recursion/circuit-v2/src/lib.rs
+++ b/crates/recursion/circuit-v2/src/lib.rs
@@ -113,7 +113,7 @@ pub trait CircuitConfig: Config {
         ext: Ext<<Self as Config>::F, <Self as Config>::EF>,
     ) -> [Felt<<Self as Config>::F>; D];
 
-    fn exp_reverse_bits(
+    fn exp_bits(
         builder: &mut Builder<Self>,
         input: Felt<<Self as Config>::F>,
         power_bits: Vec<Self::Bit>,
@@ -161,12 +161,12 @@ impl CircuitConfig for InnerConfig {
         builder.ext2felt_v2(ext)
     }
 
-    fn exp_reverse_bits(
+    fn exp_bits(
         builder: &mut Builder<Self>,
         input: Felt<<Self as Config>::F>,
         power_bits: Vec<Felt<<Self as Config>::F>>,
     ) -> Felt<<Self as Config>::F> {
-        builder.exp_reverse_bits_v2(input, power_bits)
+        builder.exp_bits_v2(input, power_bits)
     }
 
     fn num2bits(
@@ -225,7 +225,7 @@ impl CircuitConfig for OuterConfig {
         felts
     }
 
-    fn exp_reverse_bits(
+    fn exp_bits(
         builder: &mut Builder<Self>,
         input: Felt<<Self as Config>::F>,
         power_bits: Vec<Var<<Self as Config>::N>>,

--- a/crates/recursion/compiler/src/circuit/builder.rs
+++ b/crates/recursion/compiler/src/circuit/builder.rs
@@ -14,8 +14,7 @@ pub trait CircuitV2Builder<C: Config> {
         bits: impl IntoIterator<Item = Felt<<C as Config>::F>>,
     ) -> Felt<C::F>;
     fn num2bits_v2_f(&mut self, num: Felt<C::F>, num_bits: usize) -> Vec<Felt<C::F>>;
-    fn exp_reverse_bits_v2(&mut self, input: Felt<C::F>, power_bits: Vec<Felt<C::F>>)
-        -> Felt<C::F>;
+    fn exp_bits_v2(&mut self, input: Felt<C::F>, power_bits: Vec<Felt<C::F>>) -> Felt<C::F>;
     fn poseidon2_permute_v2(&mut self, state: [Felt<C::F>; WIDTH]) -> [Felt<C::F>; WIDTH];
     fn poseidon2_hash_v2(&mut self, array: &[Felt<C::F>]) -> [Felt<C::F>; DIGEST_SIZE];
     fn poseidon2_compress_v2(
@@ -66,13 +65,9 @@ impl<C: Config> CircuitV2Builder<C> for Builder<C> {
     }
 
     /// A version of `exp_reverse_bits_len` that uses the ExpReverseBitsLen precompile.
-    fn exp_reverse_bits_v2(
-        &mut self,
-        input: Felt<C::F>,
-        power_bits: Vec<Felt<C::F>>,
-    ) -> Felt<C::F> {
+    fn exp_bits_v2(&mut self, input: Felt<C::F>, power_bits: Vec<Felt<C::F>>) -> Felt<C::F> {
         let output: Felt<_> = self.uninit();
-        self.operations.push(DslIr::CircuitV2ExpReverseBits(output, input, power_bits));
+        self.operations.push(DslIr::CircuitV2ExpBits(output, input, power_bits));
         output
     }
 

--- a/crates/recursion/compiler/src/circuit/compiler.rs
+++ b/crates/recursion/compiler/src/circuit/compiler.rs
@@ -253,7 +253,7 @@ where
         }))
     }
 
-    fn exp_reverse_bits(
+    fn exp_bits(
         &mut self,
         dst: impl Reg<C>,
         base: impl Reg<C>,
@@ -447,9 +447,7 @@ where
             DslIr::CircuitV2Poseidon2PermuteBabyBear(data) => {
                 f(self.poseidon2_permute(data.0, data.1))
             }
-            DslIr::CircuitV2ExpReverseBits(dst, base, exp) => {
-                f(self.exp_reverse_bits(dst, base, exp))
-            }
+            DslIr::CircuitV2ExpBits(dst, base, exp) => f(self.exp_bits(dst, base, exp)),
             DslIr::CircuitV2HintBitsF(output, value) => {
                 f(self.hint_bit_decomposition(value, output))
             }
@@ -632,7 +630,7 @@ const fn instr_name<F>(instr: &Instruction<F>) -> &'static str {
         Instruction::ExtAlu(_) => "ExtAlu",
         Instruction::Mem(_) => "Mem",
         Instruction::Poseidon2(_) => "Poseidon2",
-        Instruction::ExpBits(_) => "ExpReverseBitsLen",
+        Instruction::ExpBits(_) => "ExpBitsLen",
         Instruction::HintBits(_) => "HintBits",
         Instruction::FriFold(_) => "FriFold",
         Instruction::Print(_) => "Print",
@@ -912,7 +910,7 @@ mod tests {
 
             let base = rng.next().unwrap();
             let base_felt = builder.eval(base);
-            let result_felt = builder.exp_reverse_bits_v2(base_felt, power_bits_felt);
+            let result_felt = builder.exp_bits_v2(base_felt, power_bits_felt);
 
             let expected = power_bits
                 .into_iter()

--- a/crates/recursion/compiler/src/circuit/compiler.rs
+++ b/crates/recursion/compiler/src/circuit/compiler.rs
@@ -259,8 +259,8 @@ where
         base: impl Reg<C>,
         exp: impl IntoIterator<Item = impl Reg<C>>,
     ) -> Instruction<C::F> {
-        Instruction::ExpReverseBitsLen(ExpReverseBitsInstr {
-            addrs: ExpReverseBitsIo {
+        Instruction::ExpBits(ExpBitsInstr {
+            addrs: ExpBitsIo {
                 result: dst.write(self),
                 base: base.read(self),
                 exp: exp.into_iter().map(|r| r.read(self)).collect(),
@@ -560,8 +560,8 @@ where
                         } = instr.as_mut();
                         mults.iter_mut().zip(addrs).for_each(&mut backfill);
                     }
-                    Instruction::ExpReverseBitsLen(ExpReverseBitsInstr {
-                        addrs: ExpReverseBitsIo { result: ref addr, .. },
+                    Instruction::ExpBits(ExpBitsInstr {
+                        addrs: ExpBitsIo { result: ref addr, .. },
                         mult,
                     }) => backfill((mult, addr)),
                     Instruction::HintBits(HintBitsInstr { output_addrs_mults, .. })
@@ -632,7 +632,7 @@ const fn instr_name<F>(instr: &Instruction<F>) -> &'static str {
         Instruction::ExtAlu(_) => "ExtAlu",
         Instruction::Mem(_) => "Mem",
         Instruction::Poseidon2(_) => "Poseidon2",
-        Instruction::ExpReverseBitsLen(_) => "ExpReverseBitsLen",
+        Instruction::ExpBits(_) => "ExpReverseBitsLen",
         Instruction::HintBits(_) => "HintBits",
         Instruction::FriFold(_) => "FriFold",
         Instruction::Print(_) => "Print",

--- a/crates/recursion/compiler/src/circuit/mod.rs
+++ b/crates/recursion/compiler/src/circuit/mod.rs
@@ -106,7 +106,7 @@ mod tests {
                 fixed_log2_rows: Some(((POSEIDON_OPERATIONS - 1).ilog2() + 1) as usize),
                 pad: true,
             }),
-            A::ExpReverseBitsLen(ExpBitsChip::<DEGREE> {
+            A::ExpBits(ExpBitsChip::<DEGREE> {
                 fixed_log2_rows: Some(((EXP_REVERSE_BITS_LEN_OPERATIONS - 1).ilog2() + 1) as usize),
                 pad: true,
             }),

--- a/crates/recursion/compiler/src/circuit/mod.rs
+++ b/crates/recursion/compiler/src/circuit/mod.rs
@@ -17,7 +17,7 @@ mod tests {
         chips::{
             alu_base::BaseAluChip,
             alu_ext::ExtAluChip,
-            exp_reverse_bits::ExpReverseBitsLenChip,
+            exp_bits::ExpBitsChip,
             fri_fold::FriFoldChip,
             mem::{MemoryConstChip, MemoryVarChip},
             poseidon2_wide::Poseidon2WideChip,
@@ -106,7 +106,7 @@ mod tests {
                 fixed_log2_rows: Some(((POSEIDON_OPERATIONS - 1).ilog2() + 1) as usize),
                 pad: true,
             }),
-            A::ExpReverseBitsLen(ExpReverseBitsLenChip::<DEGREE> {
+            A::ExpReverseBitsLen(ExpBitsChip::<DEGREE> {
                 fixed_log2_rows: Some(((EXP_REVERSE_BITS_LEN_OPERATIONS - 1).ilog2() + 1) as usize),
                 pad: true,
             }),

--- a/crates/recursion/compiler/src/ir/instructions.rs
+++ b/crates/recursion/compiler/src/ir/instructions.rs
@@ -306,5 +306,5 @@ pub enum DslIr<C: Config> {
     // Reverse bits exponentiation.
     ExpReverseBitsLen(Ptr<C::N>, Var<C::N>, Var<C::N>),
     /// Reverse bits exponentiation. Output, base, exponent bits.
-    CircuitV2ExpReverseBits(Felt<C::F>, Felt<C::F>, Vec<Felt<C::F>>),
+    CircuitV2ExpBits(Felt<C::F>, Felt<C::F>, Vec<Felt<C::F>>),
 }

--- a/crates/recursion/core-v2/src/chips/exp_bits.rs
+++ b/crates/recursion/core-v2/src/chips/exp_bits.rs
@@ -140,7 +140,7 @@ impl<F: PrimeField32, const DEGREE: usize> MachineAir<F> for ExpBitsChip<DEGREE>
         Some(trace)
     }
 
-    #[instrument(name = "generate exp reverse bits len trace", level = "debug", skip_all, fields(rows = input.exp_bits_events.len()))]
+    #[instrument(name = "generate exp bits trace", level = "debug", skip_all, fields(rows = input.exp_bits_events.len()))]
     fn generate_trace(
         &self,
         input: &ExecutionRecord<F>,
@@ -190,11 +190,7 @@ impl<F: PrimeField32, const DEGREE: usize> MachineAir<F> for ExpBitsChip<DEGREE>
             RowMajorMatrix::new(overall_rows.into_iter().flatten().collect(), NUM_EXP_BITS_COLS);
 
         #[cfg(debug_assertions)]
-        println!(
-            "exp reverse bits len trace dims is width: {:?}, height: {:?}",
-            trace.width(),
-            trace.height()
-        );
+        println!("exp bits trace dims is width: {:?}, height: {:?}", trace.width(), trace.height());
 
         trace
     }
@@ -318,7 +314,7 @@ mod tests {
         chips::exp_bits::ExpBitsChip,
         machine::tests::run_recursion_test_machines,
         runtime::{instruction as instr, ExecutionRecord},
-        ExpReverseBitsEvent, Instruction, MemAccessKind, RecursionProgram,
+        ExpBitsEvent, Instruction, MemAccessKind, RecursionProgram,
     };
 
     #[test]
@@ -382,7 +378,7 @@ mod tests {
         type F = BabyBear;
 
         let shard = ExecutionRecord {
-            exp_bits_events: vec![ExpReverseBitsEvent {
+            exp_bits_events: vec![ExpBitsEvent {
                 base: F::two(),
                 exp: vec![F::zero(), F::one(), F::one()],
                 result: F::two().exp_u64(0b110),

--- a/crates/recursion/core-v2/src/chips/mod.rs
+++ b/crates/recursion/core-v2/src/chips/mod.rs
@@ -1,7 +1,7 @@
 pub mod alu_base;
 pub mod alu_ext;
 pub mod dummy;
-pub mod exp_reverse_bits;
+pub mod exp_bits;
 pub mod fri_fold;
 pub mod mem;
 pub mod poseidon2_skinny;

--- a/crates/recursion/core-v2/src/lib.rs
+++ b/crates/recursion/core-v2/src/lib.rs
@@ -117,7 +117,7 @@ pub type Poseidon2Event<F> = Poseidon2Io<F>;
 
 /// The inputs and outputs to an exp-reverse-bits operation.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ExpReverseBitsIo<V> {
+pub struct ExpBitsIo<V> {
     pub base: V,
     // The bits of the exponent in little-endian order in a vec.
     pub exp: Vec<V>,
@@ -129,8 +129,8 @@ pub type Poseidon2Instr<F> = Poseidon2SkinnyInstr<F>;
 
 /// An instruction invoking the exp-reverse-bits operation.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct ExpReverseBitsInstr<F> {
-    pub addrs: ExpReverseBitsIo<Address<F>>,
+pub struct ExpBitsInstr<F> {
+    pub addrs: ExpBitsIo<Address<F>>,
     pub mult: F,
 }
 

--- a/crates/recursion/core-v2/src/lib.rs
+++ b/crates/recursion/core-v2/src/lib.rs
@@ -137,7 +137,7 @@ pub struct ExpBitsInstr<F> {
 /// The event encoding the inputs and outputs of an exp-reverse-bits operation. The `len` operand is
 /// now stored as the length of the `exp` field.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ExpReverseBitsEvent<F> {
+pub struct ExpBitsEvent<F> {
     pub base: F,
     pub exp: Vec<F>,
     pub result: F,

--- a/crates/recursion/core-v2/src/machine.rs
+++ b/crates/recursion/core-v2/src/machine.rs
@@ -37,7 +37,7 @@ pub enum RecursionAir<
     FriFold(FriFoldChip<DEGREE>),
     // RangeCheck(RangeCheckChip<F>),
     // Multi(MultiChip<DEGREE>),
-    ExpReverseBitsLen(ExpBitsChip<DEGREE>),
+    ExpBits(ExpBitsChip<DEGREE>),
     PublicValues(PublicValuesChip),
     DummyWide(DummyChip<COL_PADDING>),
 }
@@ -104,7 +104,7 @@ impl<F: PrimeField32 + BinomiallyExtendable<D>, const DEGREE: usize, const COL_P
             RecursionAir::ExtAlu(ExtAluChip::default()),
             RecursionAir::Poseidon2Skinny(Poseidon2SkinnyChip::<DEGREE>::default()),
             // RecursionAir::Poseidon2Wide(Poseidon2WideChip::<DEGREE>::default()),
-            RecursionAir::ExpReverseBitsLen(ExpBitsChip::<DEGREE>::default()),
+            RecursionAir::ExpBits(ExpBitsChip::<DEGREE>::default()),
             RecursionAir::FriFold(FriFoldChip::<DEGREE>::default()),
             RecursionAir::PublicValues(PublicValuesChip::default()),
         ]
@@ -119,7 +119,7 @@ impl<F: PrimeField32 + BinomiallyExtendable<D>, const DEGREE: usize, const COL_P
             RecursionAir::ExtAlu(ExtAluChip::default()),
             // RecursionAir::Poseidon2Skinny(Poseidon2SkinnyChip::<DEGREE>::default()),
             RecursionAir::Poseidon2Wide(Poseidon2WideChip::<DEGREE>::default()),
-            RecursionAir::ExpReverseBitsLen(ExpBitsChip::<DEGREE>::default()),
+            RecursionAir::ExpBits(ExpBitsChip::<DEGREE>::default()),
             RecursionAir::FriFold(FriFoldChip::<DEGREE>::default()),
             RecursionAir::PublicValues(PublicValuesChip::default()),
         ]
@@ -141,7 +141,7 @@ impl<F: PrimeField32 + BinomiallyExtendable<D>, const DEGREE: usize, const COL_P
                 fixed_log2_rows: Some(poseidon2_padding),
                 pad: true,
             }),
-            RecursionAir::ExpReverseBitsLen(ExpBitsChip::<DEGREE> {
+            RecursionAir::ExpBits(ExpBitsChip::<DEGREE> {
                 fixed_log2_rows: Some(erbl_padding),
                 pad: true,
             }),
@@ -166,7 +166,7 @@ impl<F: PrimeField32 + BinomiallyExtendable<D>, const DEGREE: usize, const COL_P
     //             fixed_log2_rows: None,
     //         })))
     //         .chain(once(RecursionAir::RangeCheck(RangeCheckChip::default())))
-    //         .chain(once(RecursionAir::ExpReverseBitsLen(
+    //         .chain(once(RecursionAir::ExpBits(
     //             ExpBitsChip::<DEGREE> {
     //                 fixed_log2_rows: None,
     //                 pad: true,
@@ -188,7 +188,7 @@ impl<F: PrimeField32 + BinomiallyExtendable<D>, const DEGREE: usize, const COL_P
     //             fixed_log2_rows: Some(17),
     //         })))
     //         .chain(once(RecursionAir::RangeCheck(RangeCheckChip::default())))
-    //         .chain(once(RecursionAir::ExpReverseBitsLen(
+    //         .chain(once(RecursionAir::ExpBits(
     //             ExpBitsChip::<DEGREE> {
     //                 fixed_log2_rows: None,
     //                 pad: true,

--- a/crates/recursion/core-v2/src/machine.rs
+++ b/crates/recursion/core-v2/src/machine.rs
@@ -6,7 +6,7 @@ use crate::chips::{
     alu_base::BaseAluChip,
     alu_ext::ExtAluChip,
     dummy::DummyChip,
-    exp_reverse_bits::ExpReverseBitsLenChip,
+    exp_bits::ExpBitsChip,
     fri_fold::FriFoldChip,
     mem::{MemoryConstChip, MemoryVarChip},
     poseidon2_skinny::Poseidon2SkinnyChip,
@@ -37,7 +37,7 @@ pub enum RecursionAir<
     FriFold(FriFoldChip<DEGREE>),
     // RangeCheck(RangeCheckChip<F>),
     // Multi(MultiChip<DEGREE>),
-    ExpReverseBitsLen(ExpReverseBitsLenChip<DEGREE>),
+    ExpReverseBitsLen(ExpBitsChip<DEGREE>),
     PublicValues(PublicValuesChip),
     DummyWide(DummyChip<COL_PADDING>),
 }
@@ -104,7 +104,7 @@ impl<F: PrimeField32 + BinomiallyExtendable<D>, const DEGREE: usize, const COL_P
             RecursionAir::ExtAlu(ExtAluChip::default()),
             RecursionAir::Poseidon2Skinny(Poseidon2SkinnyChip::<DEGREE>::default()),
             // RecursionAir::Poseidon2Wide(Poseidon2WideChip::<DEGREE>::default()),
-            RecursionAir::ExpReverseBitsLen(ExpReverseBitsLenChip::<DEGREE>::default()),
+            RecursionAir::ExpReverseBitsLen(ExpBitsChip::<DEGREE>::default()),
             RecursionAir::FriFold(FriFoldChip::<DEGREE>::default()),
             RecursionAir::PublicValues(PublicValuesChip::default()),
         ]
@@ -119,7 +119,7 @@ impl<F: PrimeField32 + BinomiallyExtendable<D>, const DEGREE: usize, const COL_P
             RecursionAir::ExtAlu(ExtAluChip::default()),
             // RecursionAir::Poseidon2Skinny(Poseidon2SkinnyChip::<DEGREE>::default()),
             RecursionAir::Poseidon2Wide(Poseidon2WideChip::<DEGREE>::default()),
-            RecursionAir::ExpReverseBitsLen(ExpReverseBitsLenChip::<DEGREE>::default()),
+            RecursionAir::ExpReverseBitsLen(ExpBitsChip::<DEGREE>::default()),
             RecursionAir::FriFold(FriFoldChip::<DEGREE>::default()),
             RecursionAir::PublicValues(PublicValuesChip::default()),
         ]
@@ -141,7 +141,7 @@ impl<F: PrimeField32 + BinomiallyExtendable<D>, const DEGREE: usize, const COL_P
                 fixed_log2_rows: Some(poseidon2_padding),
                 pad: true,
             }),
-            RecursionAir::ExpReverseBitsLen(ExpReverseBitsLenChip::<DEGREE> {
+            RecursionAir::ExpReverseBitsLen(ExpBitsChip::<DEGREE> {
                 fixed_log2_rows: Some(erbl_padding),
                 pad: true,
             }),
@@ -167,7 +167,7 @@ impl<F: PrimeField32 + BinomiallyExtendable<D>, const DEGREE: usize, const COL_P
     //         })))
     //         .chain(once(RecursionAir::RangeCheck(RangeCheckChip::default())))
     //         .chain(once(RecursionAir::ExpReverseBitsLen(
-    //             ExpReverseBitsLenChip::<DEGREE> {
+    //             ExpBitsChip::<DEGREE> {
     //                 fixed_log2_rows: None,
     //                 pad: true,
     //             },
@@ -189,7 +189,7 @@ impl<F: PrimeField32 + BinomiallyExtendable<D>, const DEGREE: usize, const COL_P
     //         })))
     //         .chain(once(RecursionAir::RangeCheck(RangeCheckChip::default())))
     //         .chain(once(RecursionAir::ExpReverseBitsLen(
-    //             ExpReverseBitsLenChip::<DEGREE> {
+    //             ExpBitsChip::<DEGREE> {
     //                 fixed_log2_rows: None,
     //                 pad: true,
     //             },

--- a/crates/recursion/core-v2/src/runtime/instruction.rs
+++ b/crates/recursion/core-v2/src/runtime/instruction.rs
@@ -11,7 +11,7 @@ pub enum Instruction<F> {
     ExtAlu(ExtAluInstr<F>),
     Mem(MemInstr<F>),
     Poseidon2(Box<Poseidon2Instr<F>>),
-    ExpReverseBitsLen(ExpReverseBitsInstr<F>),
+    ExpBits(ExpBitsInstr<F>),
     HintBits(HintBitsInstr<F>),
     FriFold(Box<FriFoldInstr<F>>),
     Print(PrintInstr<F>),
@@ -145,15 +145,10 @@ pub fn poseidon2<F: AbstractField>(
     }))
 }
 
-pub fn exp_reverse_bits_len<F: AbstractField>(
-    mult: u32,
-    base: F,
-    exp: Vec<F>,
-    result: F,
-) -> Instruction<F> {
-    Instruction::ExpReverseBitsLen(ExpReverseBitsInstr {
+pub fn exp_bits<F: AbstractField>(mult: u32, base: F, exp: Vec<F>, result: F) -> Instruction<F> {
+    Instruction::ExpBits(ExpBitsInstr {
         mult: F::from_canonical_u32(mult),
-        addrs: ExpReverseBitsIo {
+        addrs: ExpBitsIo {
             base: Address(base),
             exp: exp.into_iter().map(Address).collect(),
             result: Address(result),

--- a/crates/recursion/core-v2/src/runtime/mod.rs
+++ b/crates/recursion/core-v2/src/runtime/mod.rs
@@ -350,8 +350,8 @@ where
                         .poseidon2_events
                         .push(Poseidon2Event { input: in_vals, output: perm_output });
                 }
-                Instruction::ExpReverseBitsLen(ExpReverseBitsInstr {
-                    addrs: ExpReverseBitsIo { base, exp, result },
+                Instruction::ExpBits(ExpBitsInstr {
+                    addrs: ExpBitsIo { base, exp, result },
                     mult,
                 }) => {
                     self.nb_exp_reverse_bits += 1;
@@ -365,7 +365,7 @@ where
                     let out =
                         base_val.exp_u64(reverse_bits_len(exp_val as usize, exp_bits.len()) as u64);
                     self.memory.mw(result, Block::from(out), mult);
-                    self.record.exp_reverse_bits_len_events.push(ExpReverseBitsEvent {
+                    self.record.exp_bits_events.push(ExpReverseBitsEvent {
                         result: out,
                         base: base_val,
                         exp: exp_bits,

--- a/crates/recursion/core-v2/src/runtime/mod.rs
+++ b/crates/recursion/core-v2/src/runtime/mod.rs
@@ -361,9 +361,9 @@ where
                     let exp_val = exp_bits
                         .iter()
                         .enumerate()
-                        .fold(0, |acc, (i, &val)| acc + val.as_canonical_u32() * (1 << i));
-                    let out =
-                        base_val.exp_u64(reverse_bits_len(exp_val as usize, exp_bits.len()) as u64);
+                        .map(|(i, &val)| val.as_canonical_u32() * (1 << i))
+                        .sum::<u32>();
+                    let out = base_val.exp_u64(exp_val as u64);
                     self.memory.mw(result, Block::from(out), mult);
                     self.record.exp_bits_events.push(ExpReverseBitsEvent {
                         result: out,

--- a/crates/recursion/core-v2/src/runtime/mod.rs
+++ b/crates/recursion/core-v2/src/runtime/mod.rs
@@ -84,7 +84,7 @@ pub struct Runtime<'a, F: PrimeField32, EF: ExtensionField<F>, Diffusion> {
 
     pub nb_branch_ops: usize,
 
-    pub nb_exp_reverse_bits: usize,
+    pub nb_exp_bits: usize,
 
     pub nb_fri_fold: usize,
 
@@ -187,7 +187,7 @@ where
             nb_poseidons: 0,
             nb_wide_poseidons: 0,
             nb_bit_decompositions: 0,
-            nb_exp_reverse_bits: 0,
+            nb_exp_bits: 0,
             nb_ext_ops: 0,
             nb_base_ops: 0,
             nb_memory_ops: 0,
@@ -213,7 +213,7 @@ where
         tracing::debug!("Total Cycles: {}", self.timestamp);
         tracing::debug!("Poseidon Skinny Operations: {}", self.nb_poseidons);
         tracing::debug!("Poseidon Wide Operations: {}", self.nb_wide_poseidons);
-        tracing::debug!("Exp Reverse Bits Operations: {}", self.nb_exp_reverse_bits);
+        tracing::debug!("Exp Reverse Bits Operations: {}", self.nb_exp_bits);
         tracing::debug!("FriFold Operations: {}", self.nb_fri_fold);
         tracing::debug!("Field Operations: {}", self.nb_base_ops);
         tracing::debug!("Extension Operations: {}", self.nb_ext_ops);
@@ -354,7 +354,7 @@ where
                     addrs: ExpBitsIo { base, exp, result },
                     mult,
                 }) => {
-                    self.nb_exp_reverse_bits += 1;
+                    self.nb_exp_bits += 1;
                     let base_val = self.memory.mr(base).val[0];
                     let exp_bits: Vec<_> =
                         exp.iter().map(|bit| self.memory.mr(*bit).val[0]).collect();

--- a/crates/recursion/core-v2/src/runtime/mod.rs
+++ b/crates/recursion/core-v2/src/runtime/mod.rs
@@ -29,7 +29,6 @@ use itertools::Itertools;
 use p3_field::{AbstractField, ExtensionField, PrimeField32};
 use p3_poseidon2::{Poseidon2, Poseidon2ExternalMatrixGeneral};
 use p3_symmetric::{CryptographicPermutation, Permutation};
-use p3_util::reverse_bits_len;
 use thiserror::Error;
 
 use sp1_recursion_core::air::{Block, RECURSIVE_PROOF_NUM_PV_ELTS};
@@ -213,7 +212,7 @@ where
         tracing::debug!("Total Cycles: {}", self.timestamp);
         tracing::debug!("Poseidon Skinny Operations: {}", self.nb_poseidons);
         tracing::debug!("Poseidon Wide Operations: {}", self.nb_wide_poseidons);
-        tracing::debug!("Exp Reverse Bits Operations: {}", self.nb_exp_bits);
+        tracing::debug!("Exp Bits Operations: {}", self.nb_exp_bits);
         tracing::debug!("FriFold Operations: {}", self.nb_fri_fold);
         tracing::debug!("Field Operations: {}", self.nb_base_ops);
         tracing::debug!("Extension Operations: {}", self.nb_ext_ops);
@@ -365,7 +364,7 @@ where
                         .sum::<u32>();
                     let out = base_val.exp_u64(exp_val as u64);
                     self.memory.mw(result, Block::from(out), mult);
-                    self.record.exp_bits_events.push(ExpReverseBitsEvent {
+                    self.record.exp_bits_events.push(ExpBitsEvent {
                         result: out,
                         base: base_val,
                         exp: exp_bits,

--- a/crates/recursion/core-v2/src/runtime/record.rs
+++ b/crates/recursion/core-v2/src/runtime/record.rs
@@ -21,7 +21,7 @@ pub struct ExecutionRecord<F> {
     pub public_values: RecursionPublicValues<F>,
 
     pub poseidon2_events: Vec<Poseidon2Event<F>>,
-    pub exp_reverse_bits_len_events: Vec<ExpReverseBitsEvent<F>>,
+    pub exp_bits_events: Vec<ExpReverseBitsEvent<F>>,
     pub fri_fold_events: Vec<FriFoldEvent<F>>,
     pub commit_pv_hash_events: Vec<CommitPublicValuesEvent<F>>,
 }
@@ -44,7 +44,7 @@ impl<F: PrimeField32> MachineRecord for ExecutionRecord<F> {
             mem_var_events,
             public_values: _,
             poseidon2_events,
-            exp_reverse_bits_len_events,
+            exp_bits_events: exp_reverse_bits_len_events,
             fri_fold_events,
             commit_pv_hash_events,
         } = self;
@@ -53,7 +53,7 @@ impl<F: PrimeField32> MachineRecord for ExecutionRecord<F> {
         *mem_const_count += other.mem_const_count;
         mem_var_events.append(&mut other.mem_var_events);
         poseidon2_events.append(&mut other.poseidon2_events);
-        exp_reverse_bits_len_events.append(&mut other.exp_reverse_bits_len_events);
+        exp_reverse_bits_len_events.append(&mut other.exp_bits_events);
         fri_fold_events.append(&mut other.fri_fold_events);
         commit_pv_hash_events.append(&mut other.commit_pv_hash_events);
     }

--- a/crates/recursion/core-v2/src/runtime/record.rs
+++ b/crates/recursion/core-v2/src/runtime/record.rs
@@ -21,7 +21,7 @@ pub struct ExecutionRecord<F> {
     pub public_values: RecursionPublicValues<F>,
 
     pub poseidon2_events: Vec<Poseidon2Event<F>>,
-    pub exp_bits_events: Vec<ExpReverseBitsEvent<F>>,
+    pub exp_bits_events: Vec<ExpBitsEvent<F>>,
     pub fri_fold_events: Vec<FriFoldEvent<F>>,
     pub commit_pv_hash_events: Vec<CommitPublicValuesEvent<F>>,
 }

--- a/crates/recursion/core-v2/src/runtime/record.rs
+++ b/crates/recursion/core-v2/src/runtime/record.rs
@@ -44,7 +44,7 @@ impl<F: PrimeField32> MachineRecord for ExecutionRecord<F> {
             mem_var_events,
             public_values: _,
             poseidon2_events,
-            exp_bits_events: exp_reverse_bits_len_events,
+            exp_bits_events,
             fri_fold_events,
             commit_pv_hash_events,
         } = self;
@@ -53,7 +53,7 @@ impl<F: PrimeField32> MachineRecord for ExecutionRecord<F> {
         *mem_const_count += other.mem_const_count;
         mem_var_events.append(&mut other.mem_var_events);
         poseidon2_events.append(&mut other.poseidon2_events);
-        exp_reverse_bits_len_events.append(&mut other.exp_bits_events);
+        exp_bits_events.append(&mut other.exp_bits_events);
         fri_fold_events.append(&mut other.fri_fold_events);
         commit_pv_hash_events.append(&mut other.commit_pv_hash_events);
     }


### PR DESCRIPTION
The reversal is done inside the `CircuitConfig` implementations --- when the circuit is built, instead of during the runtime. I have not checked the change's effects on performance because I expect them to be negligible.