### PR TITLE
ci: only post perfomance to slack on dev merge

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,7 +2,7 @@ name: PR
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
     branches:
       - "**"
@@ -158,7 +158,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: -p sp1-sdk --target wasm32-unknown-unknown --no-default-features 
+          args: -p sp1-sdk --target wasm32-unknown-unknown --no-default-features
 
   examples:
     name: Examples
@@ -252,8 +252,10 @@ jobs:
           cd crates/eval
           RUSTFLAGS='-C target-cpu=native' cargo run --release -- \
             --programs fibonacci,ssz-withdrawals,tendermint \
-            --slack-channel-id ${{ secrets.SLACK_CHANNEL_ID }} \
-            --slack-token ${{ secrets.SLACK_TOKEN }} \
+            --post-to-slack ${{ github.ref == 'refs/heads/dev' }} \
+            --slack-channel-id "${{ secrets.SLACK_CHANNEL_ID }}" \
+            --slack-token "${{ secrets.SLACK_TOKEN }}" \
+            --post-to-github ${{ github.event_name == 'pull_request' }} \
             --github-token "${{ secrets.GITHUB_TOKEN }}" \
             --repo-owner "${{ github.repository_owner }}" \
             --repo-name "${{ github.event.repository.name }}" \

--- a/crates/eval/src/lib.rs
+++ b/crates/eval/src/lib.rs
@@ -31,11 +31,11 @@ struct EvalArgs {
     #[arg(long)]
     pub post_to_slack: bool,
 
-    /// The Slack channel ID to post results to. Only used if post_to_slack is true.
+    /// The Slack channel ID to post results to, only used if post_to_slack is true.
     #[arg(long)]
     pub slack_channel_id: Option<String>,
 
-    /// The Slack bot token to post results to. Only used if post_to_slack is true.
+    /// The Slack bot token to post results to, only used if post_to_slack is true.
     #[arg(long)]
     pub slack_token: Option<String>,
 
@@ -43,21 +43,37 @@ struct EvalArgs {
     #[arg(long)]
     pub post_to_github: bool,
 
-    /// The GitHub token for authentication. Only used if post_to_github is true.
+    /// The GitHub token for authentication, only used if post_to_github is true.
     #[arg(long)]
     pub github_token: Option<String>,
 
-    /// The GitHub repository owner. Only used if post_to_github is true.
+    /// The GitHub repository owner.
     #[arg(long)]
     pub repo_owner: Option<String>,
 
-    /// The GitHub repository name. Only used if post_to_github is true.
+    /// The GitHub repository name.
     #[arg(long)]
     pub repo_name: Option<String>,
 
-    /// The GitHub PR number. Only used if post_to_github is true.
+    /// The GitHub PR number.
     #[arg(long)]
     pub pr_number: Option<String>,
+
+    /// The name of the pull request.
+    #[arg(long)]
+    pub pr_name: Option<String>,
+
+    /// The name of the branch.
+    #[arg(long)]
+    pub branch_name: Option<String>,
+
+    /// The commit hash.
+    #[arg(long)]
+    pub commit_hash: Option<String>,
+
+    /// The author of the commit.
+    #[arg(long)]
+    pub author: Option<String>,
 }
 
 pub async fn evaluate_performance<C: SP1ProverComponents>() -> Result<(), Box<dyn std::error::Error>>
@@ -376,16 +392,18 @@ mod tests {
         let args = EvalArgs {
             programs: vec!["fibonacci".to_string(), "super-program".to_string()],
             shard_size: None,
+            post_to_slack: false,
             slack_channel_id: None,
             slack_token: None,
+            post_to_github: true,
+            github_token: Some("abcdef1234567890".to_string()),
+            repo_owner: Some("succinctlabs".to_string()),
+            repo_name: Some("sp1".to_string()),
+            pr_number: Some("123456".to_string()),
             pr_name: Some("Test PR".to_string()),
             branch_name: Some("feature-branch".to_string()),
             commit_hash: Some("abcdef1234567890".to_string()),
             author: Some("John Doe".to_string()),
-            repo_owner: Some("succinctlabs".to_string()),
-            repo_name: Some("sp1".to_string()),
-            pr_number: Some("123456".to_string()),
-            github_token: Some("abcdef1234567890".to_string()),
         };
 
         let formatted_results = format_results(&args, &dummy_reports);

--- a/crates/eval/src/lib.rs
+++ b/crates/eval/src/lib.rs
@@ -120,9 +120,7 @@ pub async fn evaluate_performance<C: SP1ProverComponents>() -> Result<(), Box<dy
                     post_to_slack(token, channel, message).await?;
                 }
             }
-            _ => println!(
-                "Warning: post_to_slack is true, but slack_token or slack_channel_id is missing."
-            ),
+            _ => println!("Warning: post_to_slack is true, required Slack arguments are missing."),
         }
     }
 
@@ -133,7 +131,9 @@ pub async fn evaluate_performance<C: SP1ProverComponents>() -> Result<(), Box<dy
                 let message = format_github_message(&results_text);
                 post_to_github_pr(owner, repo, pr_number, token, &message).await?;
             }
-            _ => println!("Warning: post_to_github is true, but one or more required GitHub arguments are missing."),
+            _ => {
+                println!("Warning: post_to_github is true, required GitHub arguments are missing.")
+            }
         }
     }
 

--- a/crates/eval/src/lib.rs
+++ b/crates/eval/src/lib.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use clap::{command, Parser};
+use clap::{command, ArgAction, Parser};
 use reqwest::Client;
 use serde::Serialize;
 use serde_json::json;
@@ -28,7 +28,7 @@ struct EvalArgs {
     pub shard_size: Option<usize>,
 
     /// Whether to post results to Slack.
-    #[arg(long)]
+    #[arg(long, action = ArgAction::SetTrue)]
     pub post_to_slack: bool,
 
     /// The Slack channel ID to post results to, only used if post_to_slack is true.
@@ -40,7 +40,7 @@ struct EvalArgs {
     pub slack_token: Option<String>,
 
     /// Whether to post results to a GitHub PR.
-    #[arg(long)]
+    #[arg(long, action = ArgAction::SetTrue)]
     pub post_to_github: bool,
 
     /// The GitHub token for authentication, only used if post_to_github is true.

--- a/crates/eval/src/lib.rs
+++ b/crates/eval/src/lib.rs
@@ -28,8 +28,8 @@ struct EvalArgs {
     pub shard_size: Option<usize>,
 
     /// Whether to post results to Slack.
-    #[arg(long, action = ArgAction::SetTrue)]
-    pub post_to_slack: bool,
+    #[arg(long, default_missing_value="true", num_args=0..=1)]
+    pub post_to_slack: Option<bool>,
 
     /// The Slack channel ID to post results to, only used if post_to_slack is true.
     #[arg(long)]
@@ -39,9 +39,9 @@ struct EvalArgs {
     #[arg(long)]
     pub slack_token: Option<String>,
 
-    /// Whether to post results to a GitHub PR.
-    #[arg(long, action = ArgAction::SetTrue)]
-    pub post_to_github: bool,
+    /// Whether to post results to GitHub PR.
+    #[arg(long, default_missing_value="true", num_args=0..=1)]
+    pub post_to_github: Option<bool>,
 
     /// The GitHub token for authentication, only used if post_to_github is true.
     #[arg(long)]
@@ -113,7 +113,7 @@ pub async fn evaluate_performance<C: SP1ProverComponents>() -> Result<(), Box<dy
     println!("{}", results_text.join("\n"));
 
     // Post to Slack if applicable
-    if args.post_to_slack {
+    if args.post_to_slack.unwrap_or(false) {
         match (&args.slack_token, &args.slack_channel_id) {
             (Some(token), Some(channel)) => {
                 for message in &results_text {
@@ -127,7 +127,7 @@ pub async fn evaluate_performance<C: SP1ProverComponents>() -> Result<(), Box<dy
     }
 
     // Post to GitHub PR if applicable
-    if args.post_to_github {
+    if args.post_to_github.unwrap_or(false) {
         match (&args.repo_owner, &args.repo_name, &args.pr_number, &args.github_token) {
             (Some(owner), Some(repo), Some(pr_number), Some(token)) => {
                 let message = format_github_message(&results_text);
@@ -392,10 +392,10 @@ mod tests {
         let args = EvalArgs {
             programs: vec!["fibonacci".to_string(), "super-program".to_string()],
             shard_size: None,
-            post_to_slack: false,
+            post_to_slack: Some(false),
             slack_channel_id: None,
             slack_token: None,
-            post_to_github: true,
+            post_to_github: Some(true),
             github_token: Some("abcdef1234567890".to_string()),
             repo_owner: Some("succinctlabs".to_string()),
             repo_name: Some("sp1".to_string()),

--- a/crates/eval/src/lib.rs
+++ b/crates/eval/src/lib.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use clap::{command, ArgAction, Parser};
+use clap::{command, Parser};
 use reqwest::Client;
 use serde::Serialize;
 use serde_json::json;


### PR DESCRIPTION
Check `${{ github.ref == 'refs/heads/dev' }}` to determine if it's necessary to post to Slack. This reduces spam. 

Results are still updated every time on PRs.