### PR TITLE
fix(log): add instrument for prover::compress

### DIFF
--- a/crates/prover/src/lib.rs
+++ b/crates/prover/src/lib.rs
@@ -364,6 +364,7 @@ impl<C: SP1ProverComponents> SP1Prover<C> {
     }
 
     /// Reduce shards proofs to a single shard proof using the recursion prover.
+    #[instrument(name = "compress", level = "info", skip_all)]
     pub fn compress(
         &self,
         vk: &SP1VerifyingKey,


### PR DESCRIPTION
this instrument line existed long ago, but got lost during some refactor.

Add it back here.