### PR TITLE
chore(build): friendly error msg when Cargo.toml is not found

### DIFF
--- a/crates/build/src/build.rs
+++ b/crates/build/src/build.rs
@@ -35,8 +35,7 @@ pub fn execute_build_program(
     // Get the program metadata.
     let program_metadata_file = program_dir.join("Cargo.toml");
     let mut program_metadata_cmd = cargo_metadata::MetadataCommand::new();
-    let program_metadata =
-        program_metadata_cmd.manifest_path(program_metadata_file).exec().unwrap();
+    let program_metadata = program_metadata_cmd.manifest_path(program_metadata_file).exec()?;
 
     // Get the command corresponding to Docker or local build.
     let cmd = if args.docker {


### PR DESCRIPTION
Closes: https://github.com/succinctlabs/sp1/issues/733

Commit msg fully describe that small change.

New error msg looks as follows:
```shell
Error: `cargo metadata` exited with an error: error: manifest path `/path/to/current/dir/Cargo.toml` does not exist
```

Unsure if test needed, tag me if so.