### PR TITLE
fix: typo in docs

### DIFF
--- a/book/generating-proofs/proof-types.md
+++ b/book/generating-proofs/proof-types.md
@@ -36,7 +36,7 @@ WARNING: Groth16 proofs are currently only verifiable on testnets & are not prod
 WARNING: The Groth16 prover requires around 64GB of RAM and are only guaranteed to work on official releases of SP1. We recommend using the prover network to generate these proofs.
 </div>
 
-The Groth16 prover mode generate a SNARK proof with extremely small proof size and low verification cost.
+The Groth16 prover mode generates a SNARK proof with extremely small proof size and low verification cost.
 This mode generates proofs that can be verified onchain for around ~270k gas.
 
 ```rust,noplayground
@@ -50,7 +50,7 @@ client.prove(&pk, stdin).groth16().run().unwrap();
 WARNING: The PLONK prover requires around 64GB of RAM and are only guaranteed to work on official releases of SP1. We recommend using the prover network to generate these proofs.
 </div>
 
-The Groth16 and PLONK prover modes generate a SNARK proof with extremely small proof size and low verification cost.
+The PLONK prover mode generates a SNARK proof with extremely small proof size and low verification cost.
 This mode generates proofs that can be verified onchain for around ~300k gas.
 
 ```rust,noplayground

--- a/book/writing-programs/inputs-and-outputs.md
+++ b/book/writing-programs/inputs-and-outputs.md
@@ -34,7 +34,7 @@ sp1_zkvm::io::commit::<u64>(&b);
 sp1_zkvm::io::commit::<String>(&c);
 ```
 
-Note that `T` must implement the `Serialize` and `Deserialize` trait. If you want to write bytes directly, you can also use `sp1_zkvm::io::write_slice` method:
+Note that `T` must implement the `Serialize` and `Deserialize` trait. If you want to write bytes directly, you can also use `sp1_zkvm::io::commit_slice` method:
 
 ```rust,noplayground
 let mut my_slice = [0_u8; 32];
@@ -46,7 +46,7 @@ sp1_zkvm::io::commit_slice(&my_slice);
 Typically, you can implement the `Serialize` and `Deserialize` traits using a simple derive macro on a struct.
 
 ```rust,noplayground
-use serde::{Serialize, de::Deserialize};
+use serde::{Serialize, Deserialize};
 
 #[derive(Serialize, Deserialize)]
 struct MyStruct {


### PR DESCRIPTION
fix some typos i spotted in https://docs.succinct.xyz/