### PR TITLE
feat(sdk): send cpu cycles in network

### DIFF
--- a/crates/sdk/src/network/auth.rs
+++ b/crates/sdk/src/network/auth.rs
@@ -34,6 +34,12 @@ sol! {
         string description;
     }
 
+    struct ModifyCpuCycles {
+        uint64 nonce;
+        string proof_id;
+        uint64 cycles;
+    }
+
     struct FulfillProof {
         uint64 nonce;
         string proof_id;
@@ -113,6 +119,18 @@ impl NetworkAuth {
         description: String,
     ) -> Result<Vec<u8>> {
         let type_struct = UnclaimProof { nonce, proof_id, reason: reason as u8, description };
+        self.sign_message(type_struct).await
+    }
+
+    /// Signs a message to modify the CPU cycles for a proof. The proof must have been previously
+    /// claimed by the signer first.
+    pub async fn sign_modify_cpu_cycles_message(
+        &self,
+        nonce: u64,
+        proof_id: &str,
+        cycles: u64,
+    ) -> Result<Vec<u8>> {
+        let type_struct = ModifyCpuCycles { nonce, proof_id: proof_id.to_string(), cycles };
         self.sign_message(type_struct).await
     }
 

--- a/crates/sdk/src/network/client.rs
+++ b/crates/sdk/src/network/client.rs
@@ -2,7 +2,9 @@ use std::{env, time::Duration};
 
 use crate::{
     network::auth::NetworkAuth,
-    proto::network::{UnclaimProofRequest, UnclaimReason},
+    proto::network::{
+        ModifyCpuCyclesRequest, ModifyCpuCyclesResponse, UnclaimProofRequest, UnclaimReason,
+    },
 };
 use anyhow::{Context, Ok, Result};
 use futures::{future::join_all, Future};
@@ -219,9 +221,31 @@ impl NetworkClient {
         Ok(())
     }
 
+    /// Modifies the CPU cycles for a proof. May be called by the claimer after the proof has been
+    /// claimed. Returns an error if the proof is not in a PROOF_CLAIMED state or if the caller is
+    /// not the claimer.
+    pub async fn modify_cpu_cycles(
+        &self,
+        proof_id: &str,
+        cycles: u64,
+    ) -> Result<ModifyCpuCyclesResponse> {
+        let nonce = self.get_nonce().await?;
+        let signature = self.auth.sign_modify_cpu_cycles_message(nonce, proof_id, cycles).await?;
+        let res = self
+            .with_error_handling(self.rpc.modify_cpu_cycles(ModifyCpuCyclesRequest {
+                signature,
+                nonce,
+                proof_id: proof_id.to_string(),
+                cycles,
+            }))
+            .await?;
+
+        Ok(res)
+    }
+
     /// Fulfill a proof. Should only be called after the proof has been uploaded. Returns an error
     /// if the proof is not in a PROOF_CLAIMED state or if the caller is not the claimer.
-    pub async fn fulfill_proof(&self, proof_id: &str, cycles: u64) -> Result<FulfillProofResponse> {
+    pub async fn fulfill_proof(&self, proof_id: &str) -> Result<FulfillProofResponse> {
         let nonce = self.get_nonce().await?;
         let signature = self.auth.sign_fulfill_proof_message(nonce, proof_id).await?;
         let res = self
@@ -229,7 +253,6 @@ impl NetworkClient {
                 signature,
                 nonce,
                 proof_id: proof_id.to_string(),
-                cycles,
             }))
             .await?;
 

--- a/crates/sdk/src/network/client.rs
+++ b/crates/sdk/src/network/client.rs
@@ -221,7 +221,7 @@ impl NetworkClient {
 
     /// Fulfill a proof. Should only be called after the proof has been uploaded. Returns an error
     /// if the proof is not in a PROOF_CLAIMED state or if the caller is not the claimer.
-    pub async fn fulfill_proof(&self, proof_id: &str, cycles: u64) -> Result<()> {
+    pub async fn fulfill_proof(&self, proof_id: &str, cycles: u64) -> Result<FulfillProofResponse> {
         let nonce = self.get_nonce().await?;
         let signature = self.auth.sign_fulfill_proof_message(nonce, proof_id).await?;
         let res = self

--- a/crates/sdk/src/network/client.rs
+++ b/crates/sdk/src/network/client.rs
@@ -221,7 +221,7 @@ impl NetworkClient {
 
     /// Fulfill a proof. Should only be called after the proof has been uploaded. Returns an error
     /// if the proof is not in a PROOF_CLAIMED state or if the caller is not the claimer.
-    pub async fn fulfill_proof(&self, proof_id: &str) -> Result<FulfillProofResponse> {
+    pub async fn fulfill_proof(&self, proof_id: &str, cycles: u64) -> Result<()> {
         let nonce = self.get_nonce().await?;
         let signature = self.auth.sign_fulfill_proof_message(nonce, proof_id).await?;
         let res = self
@@ -229,6 +229,7 @@ impl NetworkClient {
                 signature,
                 nonce,
                 proof_id: proof_id.to_string(),
+                cycles,
             }))
             .await?;
 

--- a/crates/sdk/src/proto/network.rs
+++ b/crates/sdk/src/proto/network.rs
@@ -116,6 +116,29 @@ pub struct UnclaimProofRequest {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UnclaimProofResponse {}
+/// The request to update a proof's CPU cycle count.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ModifyCpuCyclesRequest {
+    /// The signature of the message.
+    #[prost(bytes = "vec", tag = "1")]
+    pub signature: ::prost::alloc::vec::Vec<u8>,
+    /// The nonce for the account.
+    #[prost(uint64, tag = "2")]
+    pub nonce: u64,
+    /// The proof identifier.
+    #[prost(string, tag = "3")]
+    pub proof_id: ::prost::alloc::string::String,
+    /// The number of CPU cycles for this proof.
+    #[prost(uint64, tag = "4")]
+    pub cycles: u64,
+}
+/// The response for updating a proof's CPU cycle count, empty on success.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ModifyCpuCyclesResponse {}
 /// The request to fulfill a proof. MUST be called after the proof has been uploaded and MUST be called
 /// when the proof is in a PROOF_CLAIMED state.
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -131,9 +154,6 @@ pub struct FulfillProofRequest {
     /// The proof identifier.
     #[prost(string, tag = "3")]
     pub proof_id: ::prost::alloc::string::String,
-    /// The number of cycles used.
-    #[prost(uint64, tag = "4")]
-    pub cycles: u64,
 }
 /// The response for fulfilling a proof, empty on success.
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -526,6 +546,11 @@ pub trait NetworkService {
         ctx: twirp::Context,
         req: UnclaimProofRequest,
     ) -> Result<UnclaimProofResponse, twirp::TwirpErrorResponse>;
+    async fn modify_cpu_cycles(
+        &self,
+        ctx: twirp::Context,
+        req: ModifyCpuCyclesRequest,
+    ) -> Result<ModifyCpuCyclesResponse, twirp::TwirpErrorResponse>;
     async fn fulfill_proof(
         &self,
         ctx: twirp::Context,
@@ -587,6 +612,12 @@ where
             },
         )
         .route(
+            "/ModifyCpuCycles",
+            |api: std::sync::Arc<T>, ctx: twirp::Context, req: ModifyCpuCyclesRequest| async move {
+                api.modify_cpu_cycles(ctx, req).await
+            },
+        )
+        .route(
             "/FulfillProof",
             |api: std::sync::Arc<T>, ctx: twirp::Context, req: FulfillProofRequest| async move {
                 api.fulfill_proof(ctx, req).await
@@ -642,6 +673,10 @@ pub trait NetworkServiceClient: Send + Sync + std::fmt::Debug {
         &self,
         req: UnclaimProofRequest,
     ) -> Result<UnclaimProofResponse, twirp::ClientError>;
+    async fn modify_cpu_cycles(
+        &self,
+        req: ModifyCpuCyclesRequest,
+    ) -> Result<ModifyCpuCyclesResponse, twirp::ClientError>;
     async fn fulfill_proof(
         &self,
         req: FulfillProofRequest,
@@ -693,6 +728,13 @@ impl NetworkServiceClient for twirp::client::Client {
         req: UnclaimProofRequest,
     ) -> Result<UnclaimProofResponse, twirp::ClientError> {
         let url = self.base_url.join("network.NetworkService/UnclaimProof")?;
+        self.request(url, req).await
+    }
+    async fn modify_cpu_cycles(
+        &self,
+        req: ModifyCpuCyclesRequest,
+    ) -> Result<ModifyCpuCyclesResponse, twirp::ClientError> {
+        let url = self.base_url.join("network.NetworkService/ModifyCpuCycles")?;
         self.request(url, req).await
     }
     async fn fulfill_proof(

--- a/crates/sdk/src/proto/network.rs
+++ b/crates/sdk/src/proto/network.rs
@@ -131,6 +131,9 @@ pub struct FulfillProofRequest {
     /// The proof identifier.
     #[prost(string, tag = "3")]
     pub proof_id: ::prost::alloc::string::String,
+    /// The number of cycles used.
+    #[prost(uint64, tag = "4")]
+    pub cycles: u64,
 }
 /// The response for fulfilling a proof, empty on success.
 #[derive(serde::Serialize, serde::Deserialize)]


### PR DESCRIPTION
New network route `modify_cpu_cycles` for a prover to update the cycle count while proving