### PR TITLE
ci: test toolchain installation

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -319,3 +319,72 @@ jobs:
           cd examples/cycle-tracking/script
           cargo add sp1-sdk --path $GITHUB_WORKSPACE/crates/sdk
           SP1_DEV=1 RUST_LOG=info cargo run --release
+
+  toolchain-test:
+    name: "Test toolchain installation (${{ matrix.name }})"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: "Ubuntu 24.04 (x86_64)"
+            runner: "ubuntu-24.04"
+          - name: "Ubuntu 22.04 (x86_64)"
+            runner: "ubuntu-22.04"
+          - name: "Ubuntu 20.04 (x86_64)"
+            runner: "ubuntu-20.04"
+          - name: "macOS Monterey (x86_64)"
+            runner: "macos-12"
+          - name: "macOS Ventura (x86_64)"
+            runner: "macos-13"
+          - name: "macOS Sonoma (ARM64)"
+            runner: "macos-14"
+
+    runs-on: "${{ matrix.runner }}"
+    steps:
+      - name: "Checkout source code"
+        uses: "actions/checkout@v4"
+
+      - name: "Install cargo-prove"
+        run: |
+          cargo install --locked --path ./crates/cli
+
+      - name: "Install SP1 toolchain"
+        run: |
+          cargo prove install-toolchain --token ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Create SP1 project from template"
+        run: |
+          cargo prove new hello
+
+      - name: "Build SP1 project"
+        run: |
+          cd ./hello/program
+          cargo prove build
+
+  toolchain-test-ec2:
+    name: "Test toolchain installation (${{ matrix.name }})"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # AMI from `us-east-1`
+          - name: "Debian 12 (x86_64)"
+            ec2-instance: "c5.2xlarge"
+            ami: "ami-064519b8c76274859"
+            volume: "/dev/xvda"
+          - name: "Debian 12 (ARM64)"
+            ec2-instance: "c6g.2xlarge"
+            ami: "ami-0789039e34e739d67"
+            volume: "/dev/xvda"
+    uses: "./.github/workflows/toolchain-ec2.yml"
+    with:
+      image-id: "${{ matrix.ami }}"
+      instance-type: "${{ matrix.ec2-instance }}"
+      root-volume: "${{ matrix.volume }}"
+    secrets:
+      AWS_REGION: "${{ secrets.AWS_REGION }}"
+      AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
+      AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
+      AWS_SUBNET_ID: "${{ secrets.AWS_SUBNET_ID }}"
+      AWS_SG_ID: "${{ secrets.AWS_SG_ID }}"
+      GH_PAT: "${{ secrets.GH_PAT }}"

--- a/.github/workflows/toolchain-ec2.yml
+++ b/.github/workflows/toolchain-ec2.yml
@@ -1,0 +1,127 @@
+name: "Toolchain installation test with EC2"
+
+on:
+  workflow_call:
+    inputs:
+      image-id:
+        required: true
+        type: "string"
+      instance-type:
+        required: true
+        type: "string"
+      root-volume:
+        required: false
+        type: "string"
+        default: "/dev/sda1"
+    secrets:
+      AWS_REGION:
+        required: true
+      AWS_ACCESS_KEY_ID:
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        required: true
+      AWS_SUBNET_ID:
+        required: true
+      AWS_SG_ID:
+        required: true
+      GH_PAT:
+        required: true
+
+jobs:
+  start-runner:
+    name: "Start self-hosted EC2 runner"
+    runs-on: "ubuntu-latest"
+    outputs:
+      label: "${{ steps.start-ec2-runner.outputs.label }}"
+      ec2-instance-id: "${{ steps.start-ec2-runner.outputs.ec2-instance-id }}"
+
+    steps:
+      # Use an access key for an IAM user with these permissions:
+      # - ec2:RunInstances
+      # - ec2:TerminateInstances
+      # - ec2:DescribeInstances
+      # - ec2:DescribeInstanceStatus
+      - name: "Configure AWS credentials"
+        uses: "aws-actions/configure-aws-credentials@v1"
+        with:
+          aws-access-key-id: "${{ secrets.AWS_ACCESS_KEY_ID }}"
+          aws-secret-access-key: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
+          aws-region: "${{ secrets.AWS_REGION }}"
+
+      - name: "Start EC2 runner"
+        id: "start-ec2-runner"
+        uses: "xJonathanLEI/ec2-github-runner@main"
+        with:
+          mode: "start"
+          # Must use personal access token here as `GITHUB_TOKEN` does not have access to runners.
+          # Use a fine-grained token with these permissions to at least this repository:
+          # - Administration: Read and write
+          # - Contents: Read and write
+          # - Metadata: Read-only
+          # - Workflows: Read and write
+          github-token: "${{ secrets.GH_PAT }}"
+          ec2-image-id: "${{ inputs.image-id }}"
+          ec2-instance-type: "${{ inputs.instance-type }}"
+          subnet-id: "${{ secrets.AWS_SUBNET_ID }}"
+          security-group-id: "${{ secrets.AWS_SG_ID }}"
+          storage-size: 1024
+          storage-device: "${{ inputs.root-volume }}"
+
+  toolchain-test:
+    name: "Run toolchain test"
+    runs-on: "${{ needs.start-runner.outputs.label }}"
+    needs:
+      - "start-runner"
+
+    steps:
+      # Workaround for EC2 runner missing $HOME
+      - name: "Set HOME env var"
+        run: |
+          if [ -z "$HOME" ]; then
+            echo "HOME=/home/ubuntu" >> $GITHUB_ENV
+          fi
+
+      - name: "Checkout"
+        uses: "actions/checkout@v4"
+
+      - name: "Install Rust"
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s - -y
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+      - name: "Install build dependencies"
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential pkg-config libssl-dev
+
+      - name: "Install cargo-prove"
+        run: |
+          cargo install --locked --path ./crates/cli
+
+      - name: "Install SP1 toolchain"
+        run: |
+          cargo prove install-toolchain --token ${{ secrets.GH_PAT }}
+
+  stop-runner:
+    name: "Stop self-hosted EC2 runner"
+    runs-on: "ubuntu-latest"
+    needs:
+      - "start-runner"
+      - "toolchain-test"
+    if: ${{ always() }}
+
+    steps:
+      - name: "Configure AWS credentials"
+        uses: "aws-actions/configure-aws-credentials@v1"
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: "Stop EC2 runner"
+        uses: "xJonathanLEI/ec2-github-runner@main"
+        with:
+          mode: "stop"
+          github-token: ${{ secrets.GH_PAT }}
+          label: "${{ needs.start-runner.outputs.label }}"
+          ec2-instance-id: "${{ needs.start-runner.outputs.ec2-instance-id }}"


### PR DESCRIPTION
Adds a CI job that checks installation toolchain with `cargo prove install-toolchain` and creating and compiling a new project.

Runs on all GitHub Actions runners that SP1 supports; also runs on Debian 12 using AWS EC2. More systems can be easily added by adding AMIs.