### PR TITLE
chore: replace `raw()` with `bytes()` in fibonacci example

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1850,6 +1850,7 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 name = "fibonacci-script"
 version = "1.1.0"
 dependencies = [
+ "hex",
  "itertools 0.12.1",
  "sha2 0.10.8",
  "sp1-build",

--- a/examples/fibonacci/script/Cargo.toml
+++ b/examples/fibonacci/script/Cargo.toml
@@ -6,6 +6,7 @@ default-run = "fibonacci-script"
 publish = false
 
 [dependencies]
+hex = "0.4.3"
 itertools = "0.12.1"
 sp1-sdk = { workspace = true }
 sha2 = "0.10.8"

--- a/examples/fibonacci/script/bin/groth16_bn254.rs
+++ b/examples/fibonacci/script/bin/groth16_bn254.rs
@@ -21,12 +21,12 @@ fn main() {
     println!("generated proof");
 
     // Get the public values as bytes.
-    let public_values = proof.public_values.raw();
-    println!("public values: {:?}", public_values);
+    let public_values = proof.public_values.as_slice();
+    println!("public values: 0x{}", hex::encode(public_values));
 
     // Get the proof as bytes.
-    let solidity_proof = proof.raw();
-    println!("proof: {:?}", solidity_proof);
+    let solidity_proof = proof.bytes();
+    println!("proof: 0x{}", hex::encode(solidity_proof));
 
     // Verify proof and public values
     client.verify(&proof, &vk).expect("verification failed");


### PR DESCRIPTION
Using methods that return vectors or slices is more idiomatic.