### PR TITLE
chore: upgrade Rust toolchain to 1.81.0

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -37,11 +37,11 @@ runs:
           ~/.cargo/git/db/
           target/
           ~/.rustup/
-        key: rust-1.79.0-${{ hashFiles('**/Cargo.toml') }}
-        restore-keys: rust-1.79.0-
+        key: rust-1.81.0-${{ hashFiles('**/Cargo.toml') }}
+        restore-keys: rust-1.81.0-
 
     - name: Setup toolchain
       id: rustc-toolchain
       shell: bash
       run: |
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.79.0 -y
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.81.0 -y

--- a/.github/workflows/docker-gnark.yml
+++ b/.github/workflows/docker-gnark.yml
@@ -41,5 +41,5 @@ jobs:
           SP1_GNARK_IMAGE: sp1-gnark
         with:
           command: test
-          toolchain: 1.79.0
+          toolchain: 1.81.0
           args: --release -p sp1-prover -- --exact tests::test_e2e

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          toolchain: 1.79.0
+          toolchain: 1.81.0
           args: --release -p sp1-sdk --features native-gnark -- test_e2e_prove_plonk --nocapture
         env:
           RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0 -C target-cpu=native
@@ -72,7 +72,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          toolchain: 1.79.0
+          toolchain: 1.81.0
           args: --release -p sp1-sdk -- test_e2e_prove_plonk --nocapture
         env:
           RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0 -C target-cpu=native
@@ -220,14 +220,14 @@ jobs:
             ~/.cargo/git/db/
             target/
             ~/.rustup/
-          key: rust-1.79.0-${{ hashFiles('**/Cargo.toml') }}
-          restore-keys: rust-1.79.0-
+          key: rust-1.81.0-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: rust-1.81.0-
 
       - name: Setup toolchain
         id: rustc-toolchain
         shell: bash
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.79.0 -y
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.81.0 -y
 
       - name: Run script
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,14 +34,14 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: check
-          toolchain: 1.79.0
+          toolchain: 1.81.0
           args: --all-targets --all-features
 
       - name: Run cargo test core-v2
         uses: actions-rs/cargo@v1
         with:
           command: test
-          toolchain: 1.79.0
+          toolchain: 1.81.0
           args: --release --package sp1-recursion-core-v2 --package sp1-recursion-circuit-v2 --features native-gnark
         env:
           RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0 -C target-cpu=native
@@ -71,14 +71,14 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: check
-          toolchain: 1.79.0
+          toolchain: 1.81.0
           args: --all-targets --all-features
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1
         with:
           command: test
-          toolchain: 1.79.0
+          toolchain: 1.81.0
           args: --release --features native-gnark
         env:
           RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0 -C target-cpu=native
@@ -108,14 +108,14 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: check
-          toolchain: 1.79.0
+          toolchain: 1.81.0
           args: --all-targets --all-features
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1
         with:
           command: test
-          toolchain: 1.79.0
+          toolchain: 1.81.0
           args: --release --features native-gnark
         env:
           RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0 -C target-cpu=native

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,7 @@ jobs:
         id: rustc-toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.79.0
+          toolchain: 1.81.0
           profile: minimal
           override: true
           targets: ${{ matrix.target }}

--- a/book/developers/usage-in-ci.md
+++ b/book/developers/usage-in-ci.md
@@ -9,7 +9,7 @@ You first need have Rust installed, and you can use
 - name: Install Rust Toolchain
   uses: actions-rs/toolchain@v1
   with:
-    toolchain: 1.79.0
+    toolchain: 1.81.0
     profile: default
     override: true
     default: true

--- a/crates/build/src/command/local.rs
+++ b/crates/build/src/command/local.rs
@@ -42,6 +42,6 @@ pub(crate) fn create_local_command(
         .env("CARGO_ENCODED_RUSTFLAGS", get_rust_compiler_flags())
         .env_remove("RUSTC")
         .env("CARGO_TARGET_DIR", program_metadata.target_directory.join(HELPER_TARGET_SUBDIR))
-        .args(&get_program_build_args(args));
+        .args(get_program_build_args(args));
     command
 }

--- a/crates/cli/src/commands/build_toolchain.rs
+++ b/crates/cli/src/commands/build_toolchain.rs
@@ -115,7 +115,7 @@ impl BuildToolchainCmd {
         for tool in tools_bin_dir.read_dir()? {
             let tool = tool?;
             let tool_name = tool.file_name();
-            std::fs::copy(&tool.path(), target_bin_dir.join(tool_name))?;
+            std::fs::copy(tool.path(), target_bin_dir.join(tool_name))?;
         }
 
         // Link the toolchain to rustup.

--- a/crates/core/executor/src/hook.rs
+++ b/crates/core/executor/src/hook.rs
@@ -108,7 +108,7 @@ pub struct HookEnv<'a, 'b: 'a> {
 /// * `env` - The environment in which the hook is invoked.
 /// * `buf` - The buffer containing the signature and message hash.
 ///     - The signature is 65 bytes, the first 64 bytes are the signature and the last byte is the
-/// recovery ID.
+///       recovery ID.
 ///     - The message hash is 32 bytes.
 ///
 /// The result is returned as a pair of bytes, where the first 32 bytes are the X coordinate

--- a/crates/recursion/core/src/range_check/mod.rs
+++ b/crates/recursion/core/src/range_check/mod.rs
@@ -31,10 +31,9 @@ impl<F: Field> RangeCheckChip<F> {
     /// Creates the preprocessed range check trace and event map.
     ///
     /// This function returns a pair `(trace, map)`, where:
-    ///  - `trace` is a matrix containing all possible range check values.
+    /// - `trace` is a matrix containing all possible range check values.
     /// - `map` is a map from a range check lookup to the value's corresponding row it appears in
-    ///   the table and
-    /// the index of the result in the array of multiplicities.
+    ///   the table and the index of the result in the array of multiplicities.
     pub fn trace_and_map() -> (RowMajorMatrix<F>, BTreeMap<RangeCheckEvent, (usize, usize)>) {
         // A map from a byte lookup to its corresponding row in the table and index in the array of
         // multiplicities.

--- a/crates/recursion/program/src/machine/deferred.rs
+++ b/crates/recursion/program/src/machine/deferred.rs
@@ -130,7 +130,7 @@ where
     /// verifier:
     /// - Asserts that each of these proofs is valid as a `compress` proof.
     /// - Asserts that each of these proofs is complete by checking the `is_complete` flag in the
-    ///  proof's public values.
+    ///   proof's public values.
     /// - Aggregates the proof information into the accumulated deferred digest.
     pub fn verify(
         builder: &mut Builder<C>,

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.79.0"
+channel = "1.81.0"
 components = ["llvm-tools", "rustc-dev"]


### PR DESCRIPTION
No good reason to stay on old Rust toolchain.

Also resolves new clippy lint warnings.