### PR TITLE
fix: gnark-ffi Dockerfile caching

### DIFF
--- a/Dockerfile.gnark-ffi
+++ b/Dockerfile.gnark-ffi
@@ -22,7 +22,8 @@ COPY . /sp1
 WORKDIR /sp1/crates/recursion/gnark-cli
 
 RUN \
-  --mount=type=cache,target=target \
+  --mount=type=cache,target=/usr/local/cargo/registry \
+  --mount=type=cache,target=/sp1/target \
   cargo build --release && cp ../../../target/release/sp1-recursion-gnark-cli /gnark-cli
 
 FROM rustlang/rust:nightly-bullseye-slim


### PR DESCRIPTION
The current cache mount in `Dockerfile.gnark-ffi` is broken:

1. It's mounting a cache dir at `/sp1/crates/recursion/gnark-cli/target` instead of `/sp1/target`, which is useless and as a result doesn't really cache anything. Any Docker build context changes would trigger a full rebuild.
2. It's not caching the Cargo registry. Even after fixing the issue above, any context change would still trigger a full dependency crate download. The correct solution is to also cache `/usr/local/cargo/registry`, which is the directory the build image uses for Cargo cache.