### PR TITLE
fix: `sp1-recursion-gnark-ffi` rebuilds unnecessarily

### DIFF
--- a/crates/recursion/gnark-ffi/build.rs
+++ b/crates/recursion/gnark-ffi/build.rs
@@ -45,7 +45,9 @@ fn main() {
             let header_path = dest_path.join(format!("lib{}.h", lib_name));
             let bindings = bindgen::Builder::default()
                 .header(header_path.to_str().unwrap())
-                .parse_callbacks(Box::new(CargoCallbacks::new()))
+                // `rerun_on_header_files` needs to be turned off as `libsp1gnark.h` is regenerated
+                // on each run.
+                .parse_callbacks(Box::new(CargoCallbacks::new().rerun_on_header_files(false)))
                 .generate()
                 .expect("Unable to generate bindings");
 


### PR DESCRIPTION
The `sp1-recursion-gnark-ffi` crate's build script reruns when there are no changes. This is caused by the input header files from the Go compilation step above generating fresh header files each time. This PR solves the issue by turning the `rerun_on_header_files` option off.