### PR TITLE
chore: remove non-existent feature

### DIFF
--- a/crates/zkvm/entrypoint/src/lib.rs
+++ b/crates/zkvm/entrypoint/src/lib.rs
@@ -38,7 +38,6 @@ mod zkvm {
 
     pub static mut PUBLIC_VALUES_HASHER: Option<Sha256> = None;
 
-    #[cfg(not(feature = "interface"))]
     #[no_mangle]
     unsafe extern "C" fn __start() {
         {


### PR DESCRIPTION
The `interface` feature has been removed way back in https://github.com/succinctlabs/sp1/commit/e128143e9716d6457e67a06ba47646da439e1a10, but `sp1-zkvm` still uses it for a `cfg` section.