### PR TITLE
chore(curves): memoize EC constants, fix curve tests

### DIFF
--- a/crates/curves/Cargo.toml
+++ b/crates/curves/Cargo.toml
@@ -30,3 +30,4 @@ itertools = "0.13.0"
 
 [dev-dependencies]
 rand = "0.8.5"
+num = { version = "0.4.3", features = ["rand"] }

--- a/crates/curves/src/edwards/ed25519.rs
+++ b/crates/curves/src/edwards/ed25519.rs
@@ -1,8 +1,6 @@
-use std::str::FromStr;
-
 use curve25519_dalek::edwards::CompressedEdwardsY;
 use generic_array::GenericArray;
-use num::{BigUint, Num, One};
+use num::{BigUint, One};
 use serde::{Deserialize, Serialize};
 use typenum::{U32, U62};
 
@@ -54,17 +52,14 @@ impl EdwardsParameters for Ed25519Parameters {
     }
 
     fn generator() -> (BigUint, BigUint) {
-        let x = BigUint::from_str_radix(
-            "15112221349535400772501151409588531511454012693041857206046113283949847762202",
-            10,
-        )
-        .unwrap();
-        let y = BigUint::from_str_radix(
-            "46316835694926478169428394003475163141307993866256225615783033603165251855960",
-            10,
-        )
-        .unwrap();
-        (x, y)
+        let x = crate::utils::memo_big_uint_str!(
+            "15112221349535400772501151409588531511454012693041857206046113283949847762202"
+        );
+        let y = crate::utils::memo_big_uint_str!(
+            "46316835694926478169428394003475163141307993866256225615783033603165251855960"
+        );
+
+        (x.clone(), y.clone())
     }
 }
 
@@ -80,10 +75,9 @@ pub fn ed25519_sqrt(a: &BigUint) -> BigUint {
     let modulus = Ed25519BaseField::modulus();
     // The exponent is (modulus+3)/8;
     let mut beta = a.modpow(
-        &BigUint::from_str(
-            "7237005577332262213973186563042994240829374041602535252466099000494570602494",
-        )
-        .unwrap(),
+        crate::utils::memo_big_uint_str!(
+            "7237005577332262213973186563042994240829374041602535252466099000494570602494"
+        ),
         &modulus,
     );
 
@@ -92,16 +86,15 @@ pub fn ed25519_sqrt(a: &BigUint) -> BigUint {
     // ssh://git@github.com/succinctlabs/curve25519-dalek/blob/
     // e2d1bd10d6d772af07cac5c8161cd7655016af6d/curve25519-dalek/src/backend/serial/u64/constants.
     // rs#L89
-    let sqrt_m1 = BigUint::from_str(
-        "19681161376707505956807079304988542015446066515923890162744021073123829784752",
-    )
-    .unwrap();
+    let sqrt_m1 = crate::utils::memo_big_uint_str!(
+        "19681161376707505956807079304988542015446066515923890162744021073123829784752"
+    );
 
     let beta_squared = &beta * &beta % &modulus;
     let neg_a = &modulus - a;
 
     if beta_squared == neg_a {
-        beta = (&beta * &sqrt_m1) % &modulus;
+        beta = (&beta * sqrt_m1) % &modulus;
     }
 
     let correct_sign_sqrt = &beta_squared == a;

--- a/crates/curves/src/params.rs
+++ b/crates/curves/src/params.rs
@@ -14,8 +14,6 @@ use sp1_stark::air::Polynomial;
 
 use p3_field::Field;
 
-use crate::utils::biguint_from_limbs;
-
 pub const NB_BITS_PER_LIMB: usize = 8;
 
 /// An array representing N limbs of T.
@@ -38,7 +36,7 @@ pub trait FieldParameters:
     const MODULUS: &'static [u8];
 
     fn modulus() -> BigUint {
-        biguint_from_limbs(Self::MODULUS)
+        crate::utils::memo_big_uint_limbs!(Self::MODULUS).clone()
     }
 
     fn nb_bits() -> usize {

--- a/crates/curves/src/utils.rs
+++ b/crates/curves/src/utils.rs
@@ -26,3 +26,38 @@ pub fn biguint_to_limbs<const N: usize>(integer: &BigUint) -> [u8; N] {
 pub fn biguint_from_limbs(limbs: &[u8]) -> BigUint {
     BigUint::from_bytes_le(limbs)
 }
+
+/// Memoize a BigUint from a slice of limbs.
+///
+/// See: [biguint_from_limbs]
+macro_rules! memo_big_uint_limbs {
+    ($limbs:expr) => {{
+        static _MEMO_TEMP: std::sync::OnceLock<::num::BigUint> = std::sync::OnceLock::new();
+
+        _MEMO_TEMP.get_or_init(|| $crate::utils::biguint_from_limbs($limbs))
+    }};
+}
+
+/// Memoize a BigUint from a const string, you can optionally pass a radix.
+///
+/// ```ignore
+///     let t = memo_big_uint_str!("1234567890");
+///     let t = memo_big_uint_str!("1234567890", 16);
+/// ```
+macro_rules! memo_big_uint_str {
+    ($uint:expr, $radix:expr) => {{
+        static _MEMO_TEMP: std::sync::OnceLock<::num::BigUint> = std::sync::OnceLock::new();
+
+        _MEMO_TEMP.get_or_init(|| ::num::BigUint::from_str_radix($uint, $radix).unwrap())
+    }};
+    ($uint:expr) => {{
+        use std::str::FromStr;
+
+        static _MEMO_TEMP: std::sync::OnceLock<::num::BigUint> = std::sync::OnceLock::new();
+
+        _MEMO_TEMP.get_or_init(|| ::num::BigUint::from_str($uint).unwrap())
+    }};
+}
+
+pub(crate) use memo_big_uint_limbs;
+pub(crate) use memo_big_uint_str;

--- a/crates/curves/src/weierstrass/bls12_381.rs
+++ b/crates/curves/src/weierstrass/bls12_381.rs
@@ -43,11 +43,10 @@ impl FieldParameters for Bls12381BaseField {
     const WITNESS_OFFSET: usize = 1usize << 15;
 
     fn modulus() -> BigUint {
-        BigUint::from_str_radix(
-            "4002409555221667393417789825735904156556882819939007885332058136124031650490837864442687629129015664037894272559787",
-            10,
+        crate::utils::memo_big_uint_str!(
+            "4002409555221667393417789825735904156556882819939007885332058136124031650490837864442687629129015664037894272559787"
         )
-        .unwrap()
+        .clone()
     }
 }
 
@@ -79,27 +78,23 @@ impl WeierstrassParameters for Bls12381Parameters {
     ]);
 
     fn generator() -> (BigUint, BigUint) {
-        let x = BigUint::from_str_radix(
-            "3685416753713387016781088315183077757961620795782546409894578378688607592378376318836054947676345821548104185464507",
-            10,
-        )
-        .unwrap();
-        let y = BigUint::from_str_radix(
-            "1339506544944476473020471379941921221584933875938349620426543736416511423956333506472724655353366534992391756441569",
-            10,
-        )
-        .unwrap();
-        (x, y)
+        let x = crate::utils::memo_big_uint_str!(
+            "3685416753713387016781088315183077757961620795782546409894578378688607592378376318836054947676345821548104185464507"
+        );
+        let y = crate::utils::memo_big_uint_str!(
+            "1339506544944476473020471379941921221584933875938349620426543736416511423956333506472724655353366534992391756441569"
+        );
+
+        (x.clone(), y.clone())
     }
 
     // The prime group order has been taken from py_ecc python library by Ethereum Foundation.
     // https://github.com/ethereum/py_ecc/blob/7b9e1b3/py_ecc/bls12_381/bls12_381_curve.py#L21-L23
     fn prime_group_order() -> num::BigUint {
-        BigUint::from_str_radix(
-            "52435875175126190479447740508185965837690552500527637822603658699938581184513",
-            10,
+        crate::utils::memo_big_uint_str!(
+            "52435875175126190479447740508185965837690552500527637822603658699938581184513"
         )
-        .unwrap()
+        .clone()
     }
 
     fn a_int() -> BigUint {

--- a/crates/curves/src/weierstrass/bn254.rs
+++ b/crates/curves/src/weierstrass/bn254.rs
@@ -1,5 +1,5 @@
 use generic_array::GenericArray;
-use num::{BigUint, Num, Zero};
+use num::{BigUint, Zero};
 use serde::{Deserialize, Serialize};
 use typenum::{U32, U62};
 
@@ -31,11 +31,10 @@ impl FieldParameters for Bn254BaseField {
     // The modulus has been taken from py_ecc python library by Ethereum Foundation.
     // https://github.com/ethereum/py_pairing/blob/5f609da/py_ecc/bn128/bn128_field_elements.py#L10-L11
     fn modulus() -> BigUint {
-        BigUint::from_str_radix(
-            "21888242871839275222246405745257275088696311157297823662689037894645226208583",
-            10,
+        crate::utils::memo_big_uint_str!(
+            "21888242871839275222246405745257275088696311157297823662689037894645226208583"
         )
-        .unwrap()
+        .clone()
     }
 }
 
@@ -73,11 +72,10 @@ impl WeierstrassParameters for Bn254Parameters {
     }
 
     fn prime_group_order() -> num::BigUint {
-        BigUint::from_str_radix(
-            "21888242871839275222246405745257275088548364400416034343698204186575808495617",
-            10,
+        crate::utils::memo_big_uint_str!(
+            "21888242871839275222246405745257275088548364400416034343698204186575808495617"
         )
-        .unwrap()
+        .clone()
     }
 
     fn a_int() -> BigUint {

--- a/crates/curves/src/weierstrass/secp256k1.rs
+++ b/crates/curves/src/weierstrass/secp256k1.rs
@@ -1,8 +1,6 @@
 //! Modulo defining the Secp256k1 curve and its base field. The constants are all taken from
 //! https://en.bitcoin.it/wiki/Secp256k1.
 
-use std::str::FromStr;
-
 use elliptic_curve::{sec1::ToEncodedPoint, subtle::Choice};
 use generic_array::GenericArray;
 use k256::{elliptic_curve::point::DecompressPoint, FieldElement};
@@ -40,7 +38,7 @@ impl FieldParameters for Secp256k1BaseField {
     const WITNESS_OFFSET: usize = 1usize << 14;
 
     fn modulus() -> BigUint {
-        BigUint::from_bytes_le(Self::MODULUS)
+        crate::utils::memo_big_uint_limbs!(Self::MODULUS).clone()
     }
 }
 
@@ -64,16 +62,16 @@ impl WeierstrassParameters for Secp256k1Parameters {
         7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0,
     ]);
+
     fn generator() -> (BigUint, BigUint) {
-        let x = BigUint::from_str(
-            "55066263022277343669578718895168534326250603453777594175500187360389116729240",
-        )
-        .unwrap();
-        let y = BigUint::from_str(
-            "32670510020758816978083085130507043184471273380659243275938904335757337482424",
-        )
-        .unwrap();
-        (x, y)
+        let x = crate::utils::memo_big_uint_str!(
+            "55066263022277343669578718895168534326250603453777594175500187360389116729240"
+        );
+        let y = crate::utils::memo_big_uint_str!(
+            "32670510020758816978083085130507043184471273380659243275938904335757337482424"
+        );
+
+        (x.clone(), y.clone())
     }
 
     fn prime_group_order() -> num::BigUint {


### PR DESCRIPTION
Added memoization to some curve parameters to avoid string parsing more than once during runtime

The tests in `crates/curves` also werent working so I enabled the needed feature in dev-deps