### PR TITLE
feat: new `include_elf!` macro for importing ELF

### DIFF
--- a/crates/build/src/build.rs
+++ b/crates/build/src/build.rs
@@ -6,7 +6,7 @@ use cargo_metadata::camino::Utf8PathBuf;
 use crate::{
     command::{docker::create_docker_command, local::create_local_command, utils::execute_command},
     utils::{cargo_rerun_if_changed, copy_elf_to_output_dir, current_datetime},
-    BuildArgs,
+    BuildArgs, BUILD_TARGET, HELPER_TARGET_SUBDIR,
 };
 
 /// Build a program with the specified [`BuildArgs`]. The `program_dir` is specified as an argument
@@ -20,12 +20,12 @@ use crate::{
 ///
 /// # Returns
 ///
-/// * `Result<Utf8PathBuf>` - The path to the built program as a `Utf8PathBuf` on success, or an
-///   error on failure.
+/// * `Result<Vec<(String, Utf8PathBuf)>>` - A list of mapping from bin target names to the paths to
+///   the built program as a `Utf8PathBuf` on success, or an error on failure.
 pub fn execute_build_program(
     args: &BuildArgs,
     program_dir: Option<PathBuf>,
-) -> Result<Utf8PathBuf> {
+) -> Result<Vec<(String, Utf8PathBuf)>> {
     // If the program directory is not specified, use the current directory.
     let program_dir = program_dir
         .unwrap_or_else(|| std::env::current_dir().expect("Failed to get current directory."));
@@ -46,7 +46,15 @@ pub fn execute_build_program(
 
     execute_command(cmd, args.docker)?;
 
-    copy_elf_to_output_dir(args, &program_metadata)
+    let target_elf_paths = generate_elf_paths(&program_metadata, Some(args))?;
+
+    // Temporary backward compatibility with the deprecated behavior of copying the ELF file.
+    // TODO: add option to turn off this behavior
+    if target_elf_paths.len() == 1 {
+        copy_elf_to_output_dir(args, &program_metadata)?;
+    }
+
+    Ok(target_elf_paths)
 }
 
 /// Internal helper function to build the program with or without arguments.
@@ -64,6 +72,9 @@ pub(crate) fn build_program_internal(path: &str, args: Option<BuildArgs>) {
         .map(|v| v.eq_ignore_ascii_case("true"))
         .unwrap_or(false);
     if skip_program_build {
+        // Still need to set ELF env vars even if build is skipped.
+        generate_elf_paths(&metadata, args.as_ref()).expect("failed to collect target ELF paths");
+
         println!(
             "cargo:warning=Build skipped for {} at {} due to SP1_SKIP_PROGRAM_BUILD flag",
             root_package_name,
@@ -82,6 +93,9 @@ pub(crate) fn build_program_internal(path: &str, args: Option<BuildArgs>) {
         .map(|val| val.contains("clippy-driver"))
         .unwrap_or(false);
     if is_clippy_driver {
+        // Still need to set ELF env vars even if build is skipped.
+        generate_elf_paths(&metadata, args.as_ref()).expect("failed to collect target ELF paths");
+
         println!("cargo:warning=Skipping build due to clippy invocation.");
         return;
     }
@@ -97,4 +111,47 @@ pub(crate) fn build_program_internal(path: &str, args: Option<BuildArgs>) {
     }
 
     println!("cargo:warning={} built at {}", root_package_name, current_datetime());
+}
+
+/// Collects the list of targets that would be built and their output ELF file paths. Also prints
+/// cargo directives setting relevant `SP1_ELF_` environment variables.
+fn generate_elf_paths(
+    metadata: &cargo_metadata::Metadata,
+    args: Option<&BuildArgs>,
+) -> Result<Vec<(String, Utf8PathBuf)>> {
+    let mut target_elf_paths = vec![];
+
+    for program_crate in metadata.workspace_default_members.iter() {
+        let program = metadata
+            .packages
+            .iter()
+            .find(|p| &p.id == program_crate)
+            .ok_or_else(|| anyhow::anyhow!("cannot find package for {}", program_crate))?;
+
+        for bin_target in program.targets.iter().filter(|t| {
+            t.kind.contains(&"bin".to_owned()) && t.crate_types.contains(&"bin".to_owned())
+        }) {
+            // Filter out irrelevant targets if `--bin` is used.
+            if let Some(args) = args {
+                if !args.binary.is_empty() && bin_target.name != args.binary {
+                    continue;
+                }
+            }
+
+            let elf_path = metadata.target_directory.join(HELPER_TARGET_SUBDIR);
+            let elf_path = match args {
+                Some(args) if args.docker => elf_path.join("docker"),
+                _ => elf_path,
+            };
+            let elf_path = elf_path.join(BUILD_TARGET).join("release").join(&bin_target.name);
+
+            target_elf_paths.push((bin_target.name.to_owned(), elf_path));
+        }
+    }
+
+    for (target_name, elf_path) in target_elf_paths.iter() {
+        println!("cargo:rustc-env=SP1_ELF_{}={}", target_name, elf_path);
+    }
+
+    Ok(target_elf_paths)
 }

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -289,6 +289,22 @@ pub fn block_on<T>(fut: impl Future<Output = T>) -> T {
     }
 }
 
+/// Returns the raw ELF bytes by the zkVM program target name.
+///
+/// Note that this only works when using `sp1_build::build_program` or
+/// `sp1_build::build_program_with_args` in a build script.
+///
+/// By default, the program target name is the same as the program crate name. However, this might
+/// not be the case for non-standard project structures. For example, placing the entrypoint source
+/// file at `src/bin/my_entry.rs` would result in the program target being named `my_entry`, in
+/// which case the invocation should be `include_elf!("my_entry")` instead.
+#[macro_export]
+macro_rules! include_elf {
+    ($arg:tt) => {{
+        include_bytes!(env!(concat!("SP1_ELF_", $arg)))
+    }};
+}
+
 #[cfg(test)]
 mod tests {
 

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -376,7 +376,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tower 0.5.1",
+ "tower",
  "tracing",
  "url",
 ]
@@ -581,7 +581,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
- "tower 0.5.1",
+ "tower",
  "tracing",
  "url",
 ]
@@ -596,7 +596,7 @@ dependencies = [
  "alloy-transport",
  "reqwest 0.12.8",
  "serde_json",
- "tower 0.5.1",
+ "tower",
  "tracing",
  "url",
 ]
@@ -943,7 +943,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper 1.0.1",
  "tokio",
- "tower 0.5.1",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -4869,7 +4869,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.12.6",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b0487d90e047de87f984913713b85c601c05609aad5b0df4b4573fbf69aa13f"
+dependencies = [
+ "bytes",
+ "prost-derive 0.13.3",
 ]
 
 [[package]]
@@ -4886,12 +4896,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
+dependencies = [
+ "anyhow",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
 dependencies = [
- "prost",
+ "prost 0.12.6",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4759aa0d3a6232fb8dbdb97b61de2c20047c68aca932c7ed76da9d788508d670"
+dependencies = [
+ "prost 0.13.3",
 ]
 
 [[package]]
@@ -6859,8 +6891,8 @@ version = "2.0.0"
 dependencies = [
  "bincode",
  "ctrlc",
- "prost",
- "prost-types",
+ "prost 0.13.3",
+ "prost-types 0.13.3",
  "serde",
  "serde_json",
  "sp1-core-machine",
@@ -7208,7 +7240,7 @@ dependencies = [
  "p3-field",
  "p3-fri",
  "p3-matrix",
- "prost",
+ "prost 0.13.3",
  "reqwest 0.12.8",
  "reqwest-middleware",
  "serde",
@@ -7637,8 +7669,8 @@ dependencies = [
  "futures",
  "num-traits",
  "once_cell",
- "prost",
- "prost-types",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -7686,8 +7718,8 @@ dependencies = [
  "flex-error",
  "num-derive",
  "num-traits",
- "prost",
- "prost-types",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
  "serde",
  "serde_bytes",
  "subtle-encoding",
@@ -7951,16 +7983,6 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f"
@@ -8080,24 +8102,23 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "twirp-rs"
-version = "0.3.0"
+version = "0.13.0-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfa3161d8eee0abcad4e762f4215381a430cc1281870d575b0f1e4fbfc74b8ce"
+checksum = "27dfcc06b8d9262bc2d4b8d1847c56af9971a52dd8a0076876de9db763227d0d"
 dependencies = [
  "async-trait",
  "axum",
- "bytes",
  "futures",
  "http 1.1.0",
  "http-body-util",
  "hyper 1.4.1",
- "prost",
+ "prost 0.13.3",
  "reqwest 0.12.8",
  "serde",
  "serde_json",
  "thiserror",
  "tokio",
- "tower 0.4.13",
+ "tower",
  "url",
 ]
 

--- a/examples/aggregation/script/build.rs
+++ b/examples/aggregation/script/build.rs
@@ -1,12 +1,4 @@
-use sp1_build::{build_program_with_args, BuildArgs};
-
 fn main() {
-    build_program_with_args(
-        "../program",
-        BuildArgs { output_directory: "aggregation/program/elf".into(), ..Default::default() },
-    );
-    build_program_with_args(
-        "../../fibonacci/program",
-        BuildArgs { output_directory: "fibonacci/program/elf".into(), ..Default::default() },
-    );
+    sp1_build::build_program("../program");
+    sp1_build::build_program("../../fibonacci/program");
 }

--- a/examples/aggregation/script/src/main.rs
+++ b/examples/aggregation/script/src/main.rs
@@ -1,15 +1,15 @@
 //! A simple example showing how to aggregate proofs of multiple programs with SP1.
 
 use sp1_sdk::{
-    HashableKey, ProverClient, SP1Proof, SP1ProofWithPublicValues, SP1Stdin, SP1VerifyingKey,
+    include_elf, HashableKey, ProverClient, SP1Proof, SP1ProofWithPublicValues, SP1Stdin,
+    SP1VerifyingKey,
 };
 
 /// A program that aggregates the proofs of the simple program.
-const AGGREGATION_ELF: &[u8] = include_bytes!("../../program/elf/riscv32im-succinct-zkvm-elf");
+const AGGREGATION_ELF: &[u8] = include_elf!("aggregation-program");
 
 /// A program that just runs a simple computation.
-const FIBONACCI_ELF: &[u8] =
-    include_bytes!("../../../fibonacci/program/elf/riscv32im-succinct-zkvm-elf");
+const FIBONACCI_ELF: &[u8] = include_elf!("fibonacci-program");
 
 /// An input to the aggregation program.
 ///

--- a/examples/bls12381/script/build.rs
+++ b/examples/bls12381/script/build.rs
@@ -1,8 +1,3 @@
-use sp1_build::{build_program_with_args, BuildArgs};
-
 fn main() {
-    build_program_with_args(
-        "../program",
-        BuildArgs { output_directory: "bls12381/program/elf".into(), ..Default::default() },
-    );
+    sp1_build::build_program("../program");
 }

--- a/examples/bls12381/script/src/main.rs
+++ b/examples/bls12381/script/src/main.rs
@@ -1,5 +1,5 @@
-use sp1_sdk::{utils, ProverClient, SP1Stdin};
-pub const ELF: &[u8] = include_bytes!("../../program/elf/riscv32im-succinct-zkvm-elf");
+use sp1_sdk::{include_elf, utils, ProverClient, SP1Stdin};
+pub const ELF: &[u8] = include_elf!("bls12381-program");
 
 fn main() {
     utils::setup_logger();

--- a/examples/bn254/script/build.rs
+++ b/examples/bn254/script/build.rs
@@ -1,8 +1,3 @@
-use sp1_build::{build_program_with_args, BuildArgs};
-
 fn main() {
-    build_program_with_args(
-        "../program",
-        BuildArgs { output_directory: "bn254/program/elf".into(), ..Default::default() },
-    );
+    sp1_build::build_program("../program");
 }

--- a/examples/bn254/script/src/main.rs
+++ b/examples/bn254/script/src/main.rs
@@ -1,5 +1,5 @@
-use sp1_sdk::{utils, ProverClient, SP1Stdin};
-pub const ELF: &[u8] = include_bytes!("../../program/elf/riscv32im-succinct-zkvm-elf");
+use sp1_sdk::{include_elf, utils, ProverClient, SP1Stdin};
+pub const ELF: &[u8] = include_elf!("bn254-program");
 
 fn main() {
     utils::setup_logger();

--- a/examples/chess/script/build.rs
+++ b/examples/chess/script/build.rs
@@ -1,8 +1,3 @@
-use sp1_build::{build_program_with_args, BuildArgs};
-
 fn main() {
-    build_program_with_args(
-        "../program",
-        BuildArgs { output_directory: "chess/program/elf".into(), ..Default::default() },
-    );
+    sp1_build::build_program("../program");
 }

--- a/examples/chess/script/src/main.rs
+++ b/examples/chess/script/src/main.rs
@@ -1,6 +1,6 @@
-use sp1_sdk::{ProverClient, SP1ProofWithPublicValues, SP1Stdin};
+use sp1_sdk::{include_elf, ProverClient, SP1ProofWithPublicValues, SP1Stdin};
 
-const ELF: &[u8] = include_bytes!("../../program/elf/riscv32im-succinct-zkvm-elf");
+const ELF: &[u8] = include_elf!("chess-program");
 
 fn main() {
     let mut stdin = SP1Stdin::new();

--- a/examples/cycle-tracking/script/build.rs
+++ b/examples/cycle-tracking/script/build.rs
@@ -1,20 +1,3 @@
-use sp1_build::{build_program_with_args, BuildArgs};
-
 fn main() {
-    build_program_with_args(
-        "../program",
-        BuildArgs {
-            binary: "normal".to_string(),
-            output_directory: "cycle-tracking/program/elf".into(),
-            ..Default::default()
-        },
-    );
-    build_program_with_args(
-        "../program",
-        BuildArgs {
-            binary: "report".to_string(),
-            output_directory: "cycle-tracking/program/elf".into(),
-            ..Default::default()
-        },
-    );
+    sp1_build::build_program("../program");
 }

--- a/examples/cycle-tracking/script/src/main.rs
+++ b/examples/cycle-tracking/script/src/main.rs
@@ -1,8 +1,8 @@
-use sp1_sdk::{utils, ProverClient, SP1Stdin};
+use sp1_sdk::{include_elf, utils, ProverClient, SP1Stdin};
 
 /// The ELF we want to execute inside the zkVM.
-const REPORT_ELF: &[u8] = include_bytes!("../../program/elf/report");
-const NORMAL_ELF: &[u8] = include_bytes!("../../program/elf/normal");
+const REPORT_ELF: &[u8] = include_elf!("report");
+const NORMAL_ELF: &[u8] = include_elf!("normal");
 
 fn main() {
     // Setup a tracer for logging.

--- a/examples/fibonacci/script/build.rs
+++ b/examples/fibonacci/script/build.rs
@@ -1,8 +1,3 @@
-use sp1_build::{build_program_with_args, BuildArgs};
-
 fn main() {
-    build_program_with_args(
-        "../program",
-        BuildArgs { output_directory: "fibonacci/program/elf".into(), ..Default::default() },
-    );
+    sp1_build::build_program("../program");
 }

--- a/examples/fibonacci/script/src/main.rs
+++ b/examples/fibonacci/script/src/main.rs
@@ -1,7 +1,7 @@
-use sp1_sdk::{utils, ProverClient, SP1ProofWithPublicValues, SP1Stdin};
+use sp1_sdk::{include_elf, utils, ProverClient, SP1ProofWithPublicValues, SP1Stdin};
 
 /// The ELF we want to execute inside the zkVM.
-const ELF: &[u8] = include_bytes!("../../program/elf/riscv32im-succinct-zkvm-elf");
+const ELF: &[u8] = include_elf!("fibonacci-program");
 
 fn main() {
     // Setup logging.

--- a/examples/io/script/build.rs
+++ b/examples/io/script/build.rs
@@ -1,8 +1,3 @@
-use sp1_build::{build_program_with_args, BuildArgs};
-
 fn main() {
-    build_program_with_args(
-        "../program",
-        BuildArgs { output_directory: "io/program/elf".into(), ..Default::default() },
-    );
+    sp1_build::build_program("../program");
 }

--- a/examples/io/script/src/main.rs
+++ b/examples/io/script/src/main.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Serialize};
-use sp1_sdk::{utils, ProverClient, SP1ProofWithPublicValues, SP1Stdin};
+use sp1_sdk::{include_elf, utils, ProverClient, SP1ProofWithPublicValues, SP1Stdin};
 
 /// The ELF we want to execute inside the zkVM.
-const ELF: &[u8] = include_bytes!("../../program/elf/riscv32im-succinct-zkvm-elf");
+const ELF: &[u8] = include_elf!("io-program");
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 struct MyPointUnaligned {

--- a/examples/is-prime/script/build.rs
+++ b/examples/is-prime/script/build.rs
@@ -1,8 +1,3 @@
-use sp1_build::{build_program_with_args, BuildArgs};
-
 fn main() {
-    build_program_with_args(
-        "../program",
-        BuildArgs { output_directory: "is-prime/program/elf".into(), ..Default::default() },
-    );
+    sp1_build::build_program("../program");
 }

--- a/examples/is-prime/script/src/main.rs
+++ b/examples/is-prime/script/src/main.rs
@@ -1,7 +1,7 @@
 //! A program that takes a number `n` as input, and writes if `n` is prime as an output.
-use sp1_sdk::{utils, ProverClient, SP1ProofWithPublicValues, SP1Stdin};
+use sp1_sdk::{include_elf, utils, ProverClient, SP1ProofWithPublicValues, SP1Stdin};
 
-const ELF: &[u8] = include_bytes!("../../program/elf/riscv32im-succinct-zkvm-elf");
+const ELF: &[u8] = include_elf!("is-prime-program");
 
 fn main() {
     // Setup a tracer for logging.

--- a/examples/json/script/build.rs
+++ b/examples/json/script/build.rs
@@ -1,8 +1,3 @@
-use sp1_build::{build_program_with_args, BuildArgs};
-
 fn main() {
-    build_program_with_args(
-        "../program",
-        BuildArgs { output_directory: "json/program/elf".into(), ..Default::default() },
-    );
+    sp1_build::build_program("../program");
 }

--- a/examples/json/script/src/main.rs
+++ b/examples/json/script/src/main.rs
@@ -1,9 +1,9 @@
 //! A simple script to generate and verify the proof of a given program.
 
 use lib::{Account, Transaction};
-use sp1_sdk::{utils, ProverClient, SP1ProofWithPublicValues, SP1Stdin};
+use sp1_sdk::{include_elf, utils, ProverClient, SP1ProofWithPublicValues, SP1Stdin};
 
-const JSON_ELF: &[u8] = include_bytes!("../../program/elf/riscv32im-succinct-zkvm-elf");
+const JSON_ELF: &[u8] = include_elf!("json-program");
 
 fn main() {
     // setup tracer for logging.

--- a/examples/patch-testing/script/build.rs
+++ b/examples/patch-testing/script/build.rs
@@ -1,8 +1,3 @@
-use sp1_build::{build_program_with_args, BuildArgs};
-
 fn main() {
-    build_program_with_args(
-        "../program",
-        BuildArgs { output_directory: "patch-testing/program/elf".into(), ..Default::default() },
-    );
+    sp1_build::build_program("../program");
 }

--- a/examples/patch-testing/script/src/main.rs
+++ b/examples/patch-testing/script/src/main.rs
@@ -1,6 +1,6 @@
-use sp1_sdk::{utils, ProverClient, SP1Stdin};
+use sp1_sdk::{include_elf, utils, ProverClient, SP1Stdin};
 
-const PATCH_TEST_ELF: &[u8] = include_bytes!("../../program/elf/riscv32im-succinct-zkvm-elf");
+const PATCH_TEST_ELF: &[u8] = include_elf!("patch-testing-program");
 
 /// This script is used to test that SP1 patches are correctly applied and syscalls are triggered.
 pub fn main() {

--- a/examples/regex/script/build.rs
+++ b/examples/regex/script/build.rs
@@ -1,8 +1,3 @@
-use sp1_build::{build_program_with_args, BuildArgs};
-
 fn main() {
-    build_program_with_args(
-        "../program",
-        BuildArgs { output_directory: "regex/program/elf".into(), ..Default::default() },
-    );
+    sp1_build::build_program("../program");
 }

--- a/examples/regex/script/src/main.rs
+++ b/examples/regex/script/src/main.rs
@@ -1,7 +1,7 @@
-use sp1_sdk::{utils, ProverClient, SP1ProofWithPublicValues, SP1Stdin};
+use sp1_sdk::{include_elf, utils, ProverClient, SP1ProofWithPublicValues, SP1Stdin};
 
 /// The ELF we want to execute inside the zkVM.
-const REGEX_IO_ELF: &[u8] = include_bytes!("../../program/elf/riscv32im-succinct-zkvm-elf");
+const REGEX_IO_ELF: &[u8] = include_elf!("regex-program");
 
 fn main() {
     // Setup a tracer for logging.

--- a/examples/rsa/script/build.rs
+++ b/examples/rsa/script/build.rs
@@ -1,8 +1,3 @@
-use sp1_build::{build_program_with_args, BuildArgs};
-
 fn main() {
-    build_program_with_args(
-        "../program",
-        BuildArgs { output_directory: "rsa/program/elf".into(), ..Default::default() },
-    );
+    sp1_build::build_program("../program");
 }

--- a/examples/rsa/script/src/main.rs
+++ b/examples/rsa/script/src/main.rs
@@ -2,11 +2,11 @@ use rsa::{
     pkcs8::{DecodePrivateKey, DecodePublicKey},
     RsaPrivateKey, RsaPublicKey,
 };
-use sp1_sdk::{utils, ProverClient, SP1ProofWithPublicValues, SP1Stdin};
+use sp1_sdk::{include_elf, utils, ProverClient, SP1ProofWithPublicValues, SP1Stdin};
 use std::vec;
 
 /// The ELF we want to execute inside the zkVM.
-const RSA_ELF: &[u8] = include_bytes!("../../program/elf/riscv32im-succinct-zkvm-elf");
+const RSA_ELF: &[u8] = include_elf!("rsa-program");
 
 const RSA_2048_PRIV_DER: &[u8] = include_bytes!("rsa2048-priv.der");
 const RSA_2048_PUB_DER: &[u8] = include_bytes!("rsa2048-pub.der");

--- a/examples/rsp/script/build.rs
+++ b/examples/rsp/script/build.rs
@@ -1,8 +1,3 @@
-use sp1_build::{build_program_with_args, BuildArgs};
-
 fn main() {
-    build_program_with_args(
-        "../program",
-        BuildArgs { output_directory: "rsp/program/elf".into(), ..Default::default() },
-    );
+    sp1_build::build_program("../program");
 }

--- a/examples/rsp/script/src/main.rs
+++ b/examples/rsp/script/src/main.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 use rsp_client_executor::{io::ClientExecutorInput, CHAIN_ID_ETH_MAINNET};
 use std::path::PathBuf;
 
-use sp1_sdk::{utils, ProverClient, SP1Stdin};
+use sp1_sdk::{include_elf, utils, ProverClient, SP1Stdin};
 
 #[derive(Parser, Debug)]
 struct Args {
@@ -34,7 +34,7 @@ fn main() {
     let client = ProverClient::new();
 
     // Setup the proving key and verification key.
-    let (pk, vk) = client.setup(include_bytes!("../../program/elf/riscv32im-succinct-zkvm-elf"));
+    let (pk, vk) = client.setup(include_elf!("rsp-program"));
 
     // Write the block to the program's stdin.
     let mut stdin = SP1Stdin::new();

--- a/examples/ssz-withdrawals/script/build.rs
+++ b/examples/ssz-withdrawals/script/build.rs
@@ -1,8 +1,3 @@
-use sp1_build::{build_program_with_args, BuildArgs};
-
 fn main() {
-    build_program_with_args(
-        "../program",
-        BuildArgs { output_directory: "ssz-withdrawals/program/elf".into(), ..Default::default() },
-    );
+    sp1_build::build_program("../program");
 }

--- a/examples/ssz-withdrawals/script/src/main.rs
+++ b/examples/ssz-withdrawals/script/src/main.rs
@@ -1,6 +1,6 @@
-use sp1_sdk::{utils, ProverClient, SP1ProofWithPublicValues, SP1Stdin};
+use sp1_sdk::{include_elf, utils, ProverClient, SP1ProofWithPublicValues, SP1Stdin};
 
-const ELF: &[u8] = include_bytes!("../../program/elf/riscv32im-succinct-zkvm-elf");
+const ELF: &[u8] = include_elf!("ssz-withdrawals-program");
 
 fn main() {
     // Generate proof.

--- a/examples/tendermint/script/build.rs
+++ b/examples/tendermint/script/build.rs
@@ -1,8 +1,3 @@
-use sp1_build::{build_program_with_args, BuildArgs};
-
 fn main() {
-    build_program_with_args(
-        "../program",
-        BuildArgs { output_directory: "tendermint/program/elf".into(), ..Default::default() },
-    );
+    sp1_build::build_program("../program");
 }

--- a/examples/tendermint/script/src/main.rs
+++ b/examples/tendermint/script/src/main.rs
@@ -1,4 +1,4 @@
-use sp1_sdk::SP1ProofWithPublicValues;
+use sp1_sdk::{include_elf, SP1ProofWithPublicValues};
 use std::time::Duration;
 
 use sp1_sdk::{utils, ProverClient, SP1Stdin};
@@ -9,7 +9,7 @@ use tendermint_light_client_verifier::{
 
 use crate::util::load_light_block;
 
-const TENDERMINT_ELF: &[u8] = include_bytes!("../../program/elf/riscv32im-succinct-zkvm-elf");
+const TENDERMINT_ELF: &[u8] = include_elf!("tendermint-program");
 
 mod util;
 


### PR DESCRIPTION
Adds a new mechanism of importing ELF files without breaking the existing ELF-copying behaviour. Note that this backward-compatibility is preserved only when building a single target, which is fine as building multiple binary targets doesn't even work at the moment in the first place.

A follow-up PR should add an option to turn off the ELF-copying behaviour.