### PR TITLE
fix: build errors on custom bin target names

### DIFF
--- a/crates/build/src/build.rs
+++ b/crates/build/src/build.rs
@@ -51,7 +51,7 @@ pub fn execute_build_program(
     // Temporary backward compatibility with the deprecated behavior of copying the ELF file.
     // TODO: add option to turn off this behavior
     if target_elf_paths.len() == 1 {
-        copy_elf_to_output_dir(args, &program_metadata)?;
+        copy_elf_to_output_dir(args, &program_metadata, &target_elf_paths[0].1)?;
     }
 
     Ok(target_elf_paths)


### PR DESCRIPTION
The current ELF-copying behaviour assumes that the built artifact is named the same as the crate itself. This may not be true when using custom project structures.

Usually, when explicitly using a custom structure, devs know that they need to use the `--bin` option (or the `binary` field, programmatically). However, sometimes this can happen implicitly. For example, moving `src/main.rs` to `src/bin/hello.rs` implicitly creates a `bin` target named `hello`. Since this happens without explicitly configuring `Cargo.toml`, devs may not know they need to use `--bin`. Also, since it works with the normal `cargo build` users may expect it also works with `cargo prove build`.

This PR fixes it by utilizing the target collection logic added in #1620 to accurately identify the full path to the generated ELF.