### PR TITLE
fix: remove cargo environment vars from local build

### DIFF
--- a/crates/build/src/command/local.rs
+++ b/crates/build/src/command/local.rs
@@ -36,6 +36,8 @@ pub(crate) fn create_local_command(
     // 4. Remove the rustc configuration, otherwise in a build script it will attempt to compile the
     //    program with the toolchain of the normal build process, rather than the Succinct
     //    toolchain.
+    // 5. Remove all the environment variables related to cargo activated features and configuration
+    //    options.
     command
         .current_dir(canonicalized_program_dir)
         .env("RUSTUP_TOOLCHAIN", "succinct")
@@ -43,5 +45,9 @@ pub(crate) fn create_local_command(
         .env_remove("RUSTC")
         .env("CARGO_TARGET_DIR", program_metadata.target_directory.join(HELPER_TARGET_SUBDIR))
         .args(get_program_build_args(args));
+    env::vars()
+        .map(|v| v.0)
+        .filter(|v| v.starts_with("CARGO_FEATURE_") || v.starts_with("CARGO_CFG_"))
+        .fold(&mut command, Command::env_remove);
     command
 }


### PR DESCRIPTION
Fixes #1629

I think only `CARGO_FEATURE_*` and `CARGO_CFG_*` need to be removed, but it's possible `DEP_*` should be removed as well. I don't have much experience with `cargo::metadata`, so not sure.

Regardless, those three are the only environment variables prefixes listed in [the docs](https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts), and everything else should just get overridden by the inner `cargo` command.