### PR TITLE
fix(sp1-build, workflows): docker tag

### DIFF
--- a/.github/workflows/docker-publish-gnark.yml
+++ b/.github/workflows/docker-publish-gnark.yml
@@ -3,6 +3,8 @@ name: docker-gnark
 
 on:
   push:
+    branches:
+      - "main"
     tags:
       - "v*.*.*"
   schedule:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,6 +3,8 @@ name: docker
 
 on:
   push:
+    branches:
+      - "main"
     tags:
       - "v*.*.*"
   schedule:

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -7,7 +7,7 @@ pub use build::execute_build_program;
 use clap::Parser;
 
 const BUILD_TARGET: &str = "riscv32im-succinct-zkvm-elf";
-const DEFAULT_TAG: &str = "v1.1.0";
+const DEFAULT_TAG: &str = "latest";
 const DEFAULT_OUTPUT_DIR: &str = "elf";
 const HELPER_TARGET_SUBDIR: &str = "elf-compilation";
 


### PR DESCRIPTION
## Overview
The correct tag for pulling the Docker container that `sp1-build` should use is `latest`. `latest` should be created on every push to`main`.

While making this PR, I noticed that we don't trigger the `docker-publish.yml` and `docker-publish-gnark.yml` on pushes to main. This meant in the past that we manually set the `latest` tag. Now, we trigger the workflow on a push to `main`, which will auto-generate the `latest` tag.