### PR TITLE
refactor: Improve cargo prove build reproducibility

### DIFF
--- a/crates/build/src/command/docker.rs
+++ b/crates/build/src/command/docker.rs
@@ -81,6 +81,9 @@ pub(crate) fn create_docker_command(
         format!("CARGO_TARGET_DIR={}", target_dir),
         "-e".to_string(),
         "RUSTUP_TOOLCHAIN=succinct".to_string(),
+        // TODO: remove once trim-paths is supported - https://github.com/rust-lang/rust/issues/111540
+        "-e".to_string(),
+        "RUSTC_BOOTSTRAP=1".to_string(), // allows trim-paths.
         "-e".to_string(),
         format!("CARGO_ENCODED_RUSTFLAGS={}", get_rust_compiler_flags()),
         "--entrypoint".to_string(),

--- a/crates/build/src/command/local.rs
+++ b/crates/build/src/command/local.rs
@@ -42,6 +42,8 @@ pub(crate) fn create_local_command(
         .env("CARGO_ENCODED_RUSTFLAGS", get_rust_compiler_flags())
         .env_remove("RUSTC")
         .env("CARGO_TARGET_DIR", program_metadata.target_directory.join(HELPER_TARGET_SUBDIR))
+        // TODO: remove once trim-paths is supported - https://github.com/rust-lang/rust/issues/111540
+        .env("RUSTC_BOOTSTRAP", "1") // allows trim-paths.
         .args(get_program_build_args(args));
     command
 }

--- a/crates/build/src/command/utils.rs
+++ b/crates/build/src/command/utils.rs
@@ -20,6 +20,8 @@ pub(crate) fn get_program_build_args(args: &BuildArgs) -> Vec<String> {
         build_args.push("--ignore-rust-version".to_string());
     }
 
+    build_args.push("-Ztrim-paths".to_string());
+
     if !args.binary.is_empty() {
         build_args.push("--bin".to_string());
         build_args.push(args.binary.clone());


### PR DESCRIPTION
- Added a '-Ztrim-paths' argument to the 'build_args' vector.
- Added a provisional solution to enable 'trim-paths', linking the associated Rust issue for context.

This ensures more reproducible builds through trimming the prefixes of debug paths. See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#profile-trim-paths-option

Before (note `/Users/huitseeker/tmp/sphinx/zkvm/`):
```
huitseeker@binky➜examples/lcs/program(remap-paths✗)» strings elf/riscv32im-succinc
t-zkvm-elf|grep io
deserialization failed
a formatting trait implementation returned an error
vec is too large) when slicing `assertion `left range end index PermissionDenied right` failed: AddrNotAvailable0123456789abcdef`
/Users/huitseeker/tmp/sphinx/zkvm/precompiles/src/io.rs
/Users/huitseeker/tmp/sphinx/zkvm/entrypoint/src/syscalls/io.rs
assertion failed: SYSTEM_START >= heap_pos/Users/huitseeker/tmp/sphinx/zkvm/entryp
oint/src/syscalls/memory.rs
```

After:
```
huitseeker@binky➜examples/lcs/program(remap-paths✗)» strings elf/riscv32im-succinct-zkvm-elf|grep io
deserialization failed
a formatting trait implementation returned an error
vec is too large) when slicing `assertion `left range end index PermissionDenied right` failed: AddrNotAvailable0123456789abcdef`
sphinx-precompiles-1.0.0/src/io.rs
sphinx-zkvm-1.0.0/src/syscalls/io.rs
assertion failed: SYSTEM_START >= heap_possphinx-zkvm-1.0.0/src/syscalls/memory.rs
```

See also https://github.com/argumentcomputer/zk-light-clients/issues/40 for context.