### PR TITLE
fix: gnark-ffi memory handling

### DIFF
--- a/crates/recursion/gnark-ffi/build.rs
+++ b/crates/recursion/gnark-ffi/build.rs
@@ -46,9 +46,6 @@ fn main() {
             let header_path = dest_path.join(format!("lib{}.h", lib_name));
             let bindings = bindgen::Builder::default()
                 .header(header_path.to_str().unwrap())
-                // `rerun_on_header_files` needs to be turned off as `libsp1gnark.h` is regenerated
-                // on each run.
-                .parse_callbacks(Box::new(CargoCallbacks::new().rerun_on_header_files(false)))
                 .generate()
                 .expect("Unable to generate bindings");
 

--- a/crates/recursion/gnark-ffi/go/main.go
+++ b/crates/recursion/gnark-ffi/go/main.go
@@ -2,6 +2,7 @@ package main
 
 /*
 #include "./babybear.h"
+#include <stdlib.h>
 
 typedef struct {
 	char *PublicInputs[2];
@@ -21,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"sync"
+	"unsafe"
 
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/backend/groth16"
@@ -54,6 +56,15 @@ func ProvePlonkBn254(dataDir *C.char, witnessPath *C.char) *C.C_PlonkBn254Proof 
 	structPtr.EncodedProof = C.CString(sp1PlonkBn254Proof.EncodedProof)
 	structPtr.RawProof = C.CString(sp1PlonkBn254Proof.RawProof)
 	return structPtr
+}
+
+//export FreePlonkBn254Proof
+func FreePlonkBn254Proof(proof *C.C_PlonkBn254Proof) {
+	C.free(unsafe.Pointer(proof.EncodedProof))
+	C.free(unsafe.Pointer(proof.RawProof))
+	C.free(unsafe.Pointer(proof.PublicInputs[0]))
+	C.free(unsafe.Pointer(proof.PublicInputs[1]))
+	C.free(unsafe.Pointer(proof))
 }
 
 //export BuildPlonkBn254
@@ -114,6 +125,15 @@ func ProveGroth16Bn254(dataDir *C.char, witnessPath *C.char) *C.C_Groth16Bn254Pr
 	structPtr.EncodedProof = C.CString(sp1Groth16Bn254Proof.EncodedProof)
 	structPtr.RawProof = C.CString(sp1Groth16Bn254Proof.RawProof)
 	return structPtr
+}
+
+//export FreeGroth16Bn254Proof
+func FreeGroth16Bn254Proof(proof *C.C_Groth16Bn254Proof) {
+	C.free(unsafe.Pointer(proof.EncodedProof))
+	C.free(unsafe.Pointer(proof.RawProof))
+	C.free(unsafe.Pointer(proof.PublicInputs[0]))
+	C.free(unsafe.Pointer(proof.PublicInputs[1]))
+	C.free(unsafe.Pointer(proof))
 }
 
 //export BuildGroth16Bn254
@@ -279,4 +299,9 @@ func TestPoseidonBabyBear2() *C.char {
 	}
 
 	return nil
+}
+
+//export FreeString
+func FreeString(s *C.char) {
+	C.free(unsafe.Pointer(s))
 }


### PR DESCRIPTION
char pointers and struct pointers returned from go FFI to rust must be deallocated in go as well. Particularly, we were using `CString::from_raw` on char pointers allocated in go, [which is incorrect](https://doc.rust-lang.org/std/ffi/struct.CString.html#safety-1).

This PR exposes functions to free structs and strings allocated in go, and uses those instead.