### PR TITLE
fix: additional guards on entrypoint macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7201,7 +7201,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "cfg-if",
  "getrandom 0.2.15",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,10 @@ sp1-sdk = { path = "crates/sdk", version = "3.0.0" }
 sp1-cuda = { path = "crates/cuda", version = "3.0.0" }
 sp1-stark = { path = "crates/stark", version = "3.0.0" }
 sp1-lib = { path = "crates/zkvm/lib", version = "3.0.0", default-features = false }
-sp1-zkvm = { path = "crates/zkvm/entrypoint", version = "3.0.0", default-features = false }
+
+# NOTE: The version in this crate is manually set to 3.0.1 right now. When upgrading SP1 versions,
+# make sure to update this crate.
+sp1-zkvm = { path = "crates/zkvm/entrypoint", version = "3.0.1", default-features = false }
 
 # p3
 p3-air = "0.1.4-succinct"

--- a/crates/zkvm/entrypoint/Cargo.toml
+++ b/crates/zkvm/entrypoint/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sp1-zkvm"
 description = "SP1 is a performant, 100% open-source, contributor-friendly zkVM."
 readme = "../../../README.md"
-version = { workspace = true }
+version = "3.0.1"
 edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }

--- a/crates/zkvm/entrypoint/src/lib.rs
+++ b/crates/zkvm/entrypoint/src/lib.rs
@@ -95,6 +95,7 @@ macro_rules! entrypoint {
 
         use $crate::heap::SimpleAlloc;
 
+        #[cfg(target_os = "zkvm")]
         #[global_allocator]
         static HEAP: SimpleAlloc = SimpleAlloc;
 
@@ -102,15 +103,19 @@ macro_rules! entrypoint {
 
             #[no_mangle]
             fn main() {
-                // Link to the actual entrypoint only when compiling for zkVM. Doing this avoids
-                // compilation errors when building for the host target.
+                // Link to the actual entrypoint only when compiling for zkVM, otherwise run a
+                // simple noop. Doing this avoids compilation errors when building for the host
+                // target.
                 //
                 // Note that, however, it's generally considered wasted effort compiling zkVM
                 // programs against the host target. This just makes it such that doing so wouldn't
                 // result in an error, which can happen when building a Cargo workspace containing
                 // zkVM program crates.
-                #[cfg(target_os = "zkvm")]
-                super::ZKVM_ENTRY()
+                if cfg!(target_os = "zkvm") {
+                    super::ZKVM_ENTRY()
+                } else {
+                    println!("Not running in zkVM, skipping entrypoint");
+                }
             }
         }
     };


### PR DESCRIPTION
These additional checks ensure attempting to run an sp1 program on a non-zkvm host will silently noop instead of error.