### PR TITLE
chore(debt): unbounded `F: Field` types on operation callsites

### DIFF
--- a/crates/core/machine/src/alu/add_sub/mod.rs
+++ b/crates/core/machine/src/alu/add_sub/mod.rs
@@ -197,7 +197,7 @@ where
         builder.when_transition().assert_eq(local.nonce + AB::Expr::one(), next.nonce);
 
         // Evaluate the addition operation.
-        AddOperation::<AB::F>::eval(
+        AddOperation::eval(
             builder,
             local.operand_1,
             local.operand_2,

--- a/crates/core/machine/src/alu/divrem/mod.rs
+++ b/crates/core/machine/src/alu/divrem/mod.rs
@@ -518,7 +518,7 @@ where
 
         // Calculate is_overflow. is_overflow = is_equal(b, -2^{31}) * is_equal(c, -1) * is_signed
         {
-            IsEqualWordOperation::<AB::F>::eval(
+            IsEqualWordOperation::eval(
                 builder,
                 local.b.map(|x| x.into()),
                 Word::from(i32::MIN as u32).map(|x: AB::F| x.into()),
@@ -526,7 +526,7 @@ where
                 local.is_real.into(),
             );
 
-            IsEqualWordOperation::<AB::F>::eval(
+            IsEqualWordOperation::eval(
                 builder,
                 local.c.map(|x| x.into()),
                 Word::from(-1i32 as u32).map(|x: AB::F| x.into()),
@@ -631,7 +631,7 @@ where
         // When division by 0, quotient must be 0xffffffff per RISC-V spec.
         {
             // Calculate whether c is 0.
-            IsZeroWordOperation::<AB::F>::eval(
+            IsZeroWordOperation::eval(
                 builder,
                 local.c.map(|x| x.into()),
                 local.is_c_0,

--- a/crates/core/machine/src/cpu/air/ecall.rs
+++ b/crates/core/machine/src/cpu/air/ecall.rs
@@ -64,7 +64,7 @@ impl CpuChip {
 
         // Compute whether this ecall is ENTER_UNCONSTRAINED.
         let is_enter_unconstrained = {
-            IsZeroOperation::<AB::F>::eval(
+            IsZeroOperation::eval(
                 builder,
                 syscall_id
                     - AB::Expr::from_canonical_u32(SyscallCode::ENTER_UNCONSTRAINED.syscall_id()),
@@ -76,7 +76,7 @@ impl CpuChip {
 
         // Compute whether this ecall is HINT_LEN.
         let is_hint_len = {
-            IsZeroOperation::<AB::F>::eval(
+            IsZeroOperation::eval(
                 builder,
                 syscall_id - AB::Expr::from_canonical_u32(SyscallCode::HINT_LEN.syscall_id()),
                 ecall_cols.is_hint_len,
@@ -238,7 +238,7 @@ impl CpuChip {
 
         // Compute whether this ecall is HALT.
         let is_halt = {
-            IsZeroOperation::<AB::F>::eval(
+            IsZeroOperation::eval(
                 builder,
                 syscall_id - AB::Expr::from_canonical_u32(SyscallCode::HALT.syscall_id()),
                 ecall_cols.is_halt,
@@ -268,7 +268,7 @@ impl CpuChip {
 
         // Compute whether this ecall is COMMIT.
         let is_commit = {
-            IsZeroOperation::<AB::F>::eval(
+            IsZeroOperation::eval(
                 builder,
                 syscall_id - AB::Expr::from_canonical_u32(SyscallCode::COMMIT.syscall_id()),
                 ecall_cols.is_commit,
@@ -279,7 +279,7 @@ impl CpuChip {
 
         // Compute whether this ecall is COMMIT_DEFERRED_PROOFS.
         let is_commit_deferred_proofs = {
-            IsZeroOperation::<AB::F>::eval(
+            IsZeroOperation::eval(
                 builder,
                 syscall_id
                     - AB::Expr::from_canonical_u32(

--- a/crates/core/machine/src/memory/global.rs
+++ b/crates/core/machine/src/memory/global.rs
@@ -289,7 +289,7 @@ where
 
         // Constrain the is_prev_addr_zero operation only in the first row.
         let is_first_row = builder.is_first_row();
-        IsZeroOperation::<AB::F>::eval(builder, prev_addr, local.is_prev_addr_zero, is_first_row);
+        IsZeroOperation::eval(builder, prev_addr, local.is_prev_addr_zero, is_first_row);
 
         // Constrain the is_first_comp column.
         builder.assert_bool(local.is_first_comp);

--- a/crates/core/machine/src/memory/program.rs
+++ b/crates/core/machine/src/memory/program.rs
@@ -178,7 +178,7 @@ where
             public_values_slice.as_slice().borrow();
 
         // Constrain `is_first_shard` to be 1 if and only if the shard is the first shard.
-        IsZeroOperation::<AB::F>::eval(
+        IsZeroOperation::eval(
             builder,
             public_values.shard.clone() - AB::F::one(),
             mult_local.is_first_shard,

--- a/crates/core/machine/src/operations/add.rs
+++ b/crates/core/machine/src/operations/add.rs
@@ -58,13 +58,15 @@ impl<F: Field> AddOperation<F> {
         expected
     }
 
-    pub fn eval<AB: SP1AirBuilder>(
+    pub fn eval<AB>(
         builder: &mut AB,
         a: Word<AB::Var>,
         b: Word<AB::Var>,
         cols: AddOperation<AB::Var>,
         is_real: AB::Expr,
-    ) {
+    ) where
+        AB: SP1AirBuilder<F = F>,
+    {
         let one = AB::Expr::one();
         let base = AB::F::from_canonical_u32(256);
 

--- a/crates/core/machine/src/operations/add4.rs
+++ b/crates/core/machine/src/operations/add4.rs
@@ -79,7 +79,7 @@ impl<F: Field> Add4Operation<F> {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn eval<AB: SP1AirBuilder>(
+    pub fn eval<AB>(
         builder: &mut AB,
         a: Word<AB::Var>,
         b: Word<AB::Var>,
@@ -87,7 +87,9 @@ impl<F: Field> Add4Operation<F> {
         d: Word<AB::Var>,
         is_real: AB::Var,
         cols: Add4Operation<AB::Var>,
-    ) {
+    ) where
+        AB: SP1AirBuilder<F = F>,
+    {
         // Range check each byte.
         {
             builder.slice_range_check_u8(&a.0, is_real);

--- a/crates/core/machine/src/operations/add5.rs
+++ b/crates/core/machine/src/operations/add5.rs
@@ -88,12 +88,14 @@ impl<F: Field> Add5Operation<F> {
         expected
     }
 
-    pub fn eval<AB: SP1AirBuilder>(
+    pub fn eval<AB>(
         builder: &mut AB,
         words: &[Word<AB::Var>; 5],
         is_real: AB::Var,
         cols: Add5Operation<AB::Var>,
-    ) {
+    ) where
+        AB: SP1AirBuilder<F = F>,
+    {
         builder.assert_bool(is_real);
         // Range check each byte.
         {

--- a/crates/core/machine/src/operations/and.rs
+++ b/crates/core/machine/src/operations/and.rs
@@ -1,4 +1,4 @@
-use p3_field::{AbstractField, Field};
+use p3_field::Field;
 use sp1_derive::AlignedBorrow;
 
 use sp1_core_executor::{
@@ -39,13 +39,15 @@ impl<F: Field> AndOperation<F> {
     }
 
     #[allow(unused_variables)]
-    pub fn eval<AB: SP1AirBuilder>(
+    pub fn eval<AB>(
         builder: &mut AB,
         a: Word<AB::Var>,
         b: Word<AB::Var>,
         cols: AndOperation<AB::Var>,
         is_real: AB::Var,
-    ) {
+    ) where
+        AB: SP1AirBuilder<F = F>,
+    {
         for i in 0..WORD_SIZE {
             builder.send_byte(
                 AB::F::from_canonical_u32(ByteOpcode::AND as u32),

--- a/crates/core/machine/src/operations/baby_bear_range.rs
+++ b/crates/core/machine/src/operations/baby_bear_range.rs
@@ -32,12 +32,14 @@ impl<F: Field> BabyBearBitDecomposition<F> {
             self.and_most_sig_byte_decomp_3_to_6 * most_sig_byte_decomp[6];
     }
 
-    pub fn range_check<AB: SP1AirBuilder>(
+    pub fn range_check<AB>(
         builder: &mut AB,
         value: AB::Var,
         cols: BabyBearBitDecomposition<AB::Var>,
         is_real: AB::Expr,
-    ) {
+    ) where
+        AB: SP1AirBuilder<F = F>,
+    {
         let mut reconstructed_value = AB::Expr::zero();
         for (i, bit) in cols.bits.iter().enumerate() {
             builder.when(is_real.clone()).assert_bool(*bit);

--- a/crates/core/machine/src/operations/baby_bear_word.rs
+++ b/crates/core/machine/src/operations/baby_bear_word.rs
@@ -33,12 +33,14 @@ impl<F: Field> BabyBearWordRangeChecker<F> {
             self.and_most_sig_byte_decomp_3_to_6 * self.most_sig_byte_decomp[6];
     }
 
-    pub fn range_check<AB: SP1AirBuilder>(
+    pub fn range_check<AB>(
         builder: &mut AB,
         value: Word<AB::Var>,
         cols: BabyBearWordRangeChecker<AB::Var>,
         is_real: AB::Expr,
-    ) {
+    ) where
+        AB: SP1AirBuilder<F = F>,
+    {
         let mut recomposed_byte = AB::Expr::zero();
         cols.most_sig_byte_decomp.iter().enumerate().for_each(|(i, value)| {
             builder.when(is_real.clone()).assert_bool(*value);

--- a/crates/core/machine/src/operations/fixed_rotate_right.rs
+++ b/crates/core/machine/src/operations/fixed_rotate_right.rs
@@ -103,13 +103,15 @@ impl<F: Field> FixedRotateRightOperation<F> {
         expected
     }
 
-    pub fn eval<AB: SP1AirBuilder>(
+    pub fn eval<AB>(
         builder: &mut AB,
         input: Word<AB::Var>,
         rotation: usize,
         cols: FixedRotateRightOperation<AB::Var>,
         is_real: AB::Var,
-    ) {
+    ) where
+        AB: SP1AirBuilder<F = F>,
+    {
         // Compute some constants with respect to the rotation needed for the rotation.
         let nb_bytes_to_shift = Self::nb_bytes_to_shift(rotation);
         let nb_bits_to_shift = Self::nb_bits_to_shift(rotation);

--- a/crates/core/machine/src/operations/fixed_shift_right.rs
+++ b/crates/core/machine/src/operations/fixed_shift_right.rs
@@ -102,13 +102,15 @@ impl<F: Field> FixedShiftRightOperation<F> {
         expected
     }
 
-    pub fn eval<AB: SP1AirBuilder>(
+    pub fn eval<AB>(
         builder: &mut AB,
         input: Word<AB::Var>,
         rotation: usize,
         cols: FixedShiftRightOperation<AB::Var>,
         is_real: AB::Var,
-    ) {
+    ) where
+        AB: SP1AirBuilder<F = F>,
+    {
         // Compute some constants with respect to the rotation needed for the rotation.
         let nb_bytes_to_shift = Self::nb_bytes_to_shift(rotation);
         let nb_bits_to_shift = Self::nb_bits_to_shift(rotation);

--- a/crates/core/machine/src/operations/is_equal_word.rs
+++ b/crates/core/machine/src/operations/is_equal_word.rs
@@ -28,13 +28,15 @@ impl<F: Field> IsEqualWordOperation<F> {
         (a_u32 == b_u32) as u32
     }
 
-    pub fn eval<AB: SP1AirBuilder>(
+    pub fn eval<AB>(
         builder: &mut AB,
         a: Word<AB::Expr>,
         b: Word<AB::Expr>,
         cols: IsEqualWordOperation<AB::Var>,
         is_real: AB::Expr,
-    ) {
+    ) where
+        AB: SP1AirBuilder<F = F>,
+    {
         builder.assert_bool(is_real.clone());
 
         // Calculate differences in limbs.
@@ -46,6 +48,6 @@ impl<F: Field> IsEqualWordOperation<F> {
         ]);
 
         // Check if the difference is 0.
-        IsZeroWordOperation::<AB::F>::eval(builder, diff, cols.is_diff_zero, is_real.clone());
+        IsZeroWordOperation::eval(builder, diff, cols.is_diff_zero, is_real.clone());
     }
 }

--- a/crates/core/machine/src/operations/is_zero.rs
+++ b/crates/core/machine/src/operations/is_zero.rs
@@ -5,7 +5,7 @@
 //! The idea is that 1 - input * inverse is exactly the boolean value indicating whether the input
 //! is 0.
 use p3_air::AirBuilder;
-use p3_field::{AbstractField, Field};
+use p3_field::Field;
 use sp1_derive::AlignedBorrow;
 
 use sp1_stark::air::SP1AirBuilder;
@@ -39,12 +39,14 @@ impl<F: Field> IsZeroOperation<F> {
         (a == F::zero()) as u32
     }
 
-    pub fn eval<AB: SP1AirBuilder>(
+    pub fn eval<AB>(
         builder: &mut AB,
         a: AB::Expr,
         cols: IsZeroOperation<AB::Var>,
         is_real: AB::Expr,
-    ) {
+    ) where
+        AB: SP1AirBuilder<F = F>,
+    {
         let one: AB::Expr = AB::F::one().into();
 
         // 1. Input == 0 => is_zero = 1 regardless of the inverse.

--- a/crates/core/machine/src/operations/is_zero_word.rs
+++ b/crates/core/machine/src/operations/is_zero_word.rs
@@ -46,15 +46,17 @@ impl<F: Field> IsZeroWordOperation<F> {
         is_zero as u32
     }
 
-    pub fn eval<AB: SP1AirBuilder>(
+    pub fn eval<AB>(
         builder: &mut AB,
         a: Word<AB::Expr>,
         cols: IsZeroWordOperation<AB::Var>,
         is_real: AB::Expr,
-    ) {
+    ) where
+        AB: SP1AirBuilder<F = F>,
+    {
         // Calculate whether each byte is 0.
         for i in 0..WORD_SIZE {
-            IsZeroOperation::<AB::F>::eval(
+            IsZeroOperation::eval(
                 builder,
                 a[i].clone(),
                 cols.is_zero_byte[i],

--- a/crates/core/machine/src/operations/not.rs
+++ b/crates/core/machine/src/operations/not.rs
@@ -1,5 +1,5 @@
 use p3_air::AirBuilder;
-use p3_field::{AbstractField, Field};
+use p3_field::Field;
 use sp1_core_executor::{events::ByteRecord, ByteOpcode};
 use sp1_derive::AlignedBorrow;
 use sp1_primitives::consts::WORD_SIZE;
@@ -25,12 +25,14 @@ impl<F: Field> NotOperation<F> {
     }
 
     #[allow(unused_variables)]
-    pub fn eval<AB: SP1AirBuilder>(
+    pub fn eval<AB>(
         builder: &mut AB,
         a: Word<AB::Var>,
         cols: NotOperation<AB::Var>,
         is_real: impl Into<AB::Expr> + Copy,
-    ) {
+    ) where
+        AB: SP1AirBuilder<F = F>,
+    {
         for i in (0..WORD_SIZE).step_by(2) {
             builder.send_byte_pair(
                 AB::F::from_canonical_u32(ByteOpcode::U8Range as u32),

--- a/crates/core/machine/src/operations/or.rs
+++ b/crates/core/machine/src/operations/or.rs
@@ -1,4 +1,4 @@
-use p3_field::{AbstractField, Field};
+use p3_field::Field;
 use sp1_core_executor::{events::ByteRecord, ByteOpcode, ExecutionRecord};
 use sp1_derive::AlignedBorrow;
 use sp1_primitives::consts::WORD_SIZE;
@@ -24,13 +24,15 @@ impl<F: Field> OrOperation<F> {
         expected
     }
 
-    pub fn eval<AB: SP1AirBuilder>(
+    pub fn eval<AB>(
         builder: &mut AB,
         a: Word<AB::Var>,
         b: Word<AB::Var>,
         cols: OrOperation<AB::Var>,
         is_real: AB::Var,
-    ) {
+    ) where
+        AB: SP1AirBuilder<F = F>,
+    {
         for i in 0..WORD_SIZE {
             builder.send_byte(
                 AB::F::from_canonical_u32(ByteOpcode::OR as u32),

--- a/crates/core/machine/src/operations/xor.rs
+++ b/crates/core/machine/src/operations/xor.rs
@@ -1,4 +1,4 @@
-use p3_field::{AbstractField, Field};
+use p3_field::Field;
 use sp1_core_executor::{
     events::{ByteLookupEvent, ByteRecord},
     ByteOpcode,
@@ -38,13 +38,15 @@ impl<F: Field> XorOperation<F> {
     }
 
     #[allow(unused_variables)]
-    pub fn eval<AB: SP1AirBuilder>(
+    pub fn eval<AB>(
         builder: &mut AB,
         a: Word<AB::Var>,
         b: Word<AB::Var>,
         cols: XorOperation<AB::Var>,
         is_real: AB::Var,
-    ) {
+    ) where
+        AB: SP1AirBuilder<F = F>,
+    {
         for i in 0..WORD_SIZE {
             builder.send_byte(
                 AB::F::from_canonical_u32(ByteOpcode::XOR as u32),

--- a/crates/core/machine/src/syscall/precompiles/sha256/compress/air.rs
+++ b/crates/core/machine/src/syscall/precompiles/sha256/compress/air.rs
@@ -289,31 +289,13 @@ impl ShaCompressChip {
 
         // S1 := (e rightrotate 6) xor (e rightrotate 11) xor (e rightrotate 25).
         // Calculate e rightrotate 6.
-        FixedRotateRightOperation::<AB::F>::eval(
-            builder,
-            local.e,
-            6,
-            local.e_rr_6,
-            local.is_compression,
-        );
+        FixedRotateRightOperation::eval(builder, local.e, 6, local.e_rr_6, local.is_compression);
         // Calculate e rightrotate 11.
-        FixedRotateRightOperation::<AB::F>::eval(
-            builder,
-            local.e,
-            11,
-            local.e_rr_11,
-            local.is_compression,
-        );
+        FixedRotateRightOperation::eval(builder, local.e, 11, local.e_rr_11, local.is_compression);
         // Calculate e rightrotate 25.
-        FixedRotateRightOperation::<AB::F>::eval(
-            builder,
-            local.e,
-            25,
-            local.e_rr_25,
-            local.is_compression,
-        );
+        FixedRotateRightOperation::eval(builder, local.e, 25, local.e_rr_25, local.is_compression);
         // Calculate (e rightrotate 6) xor (e rightrotate 11).
-        XorOperation::<AB::F>::eval(
+        XorOperation::eval(
             builder,
             local.e_rr_6.value,
             local.e_rr_11.value,
@@ -321,7 +303,7 @@ impl ShaCompressChip {
             local.is_compression,
         );
         // Calculate S1 := ((e rightrotate 6) xor (e rightrotate 11)) xor (e rightrotate 25).
-        XorOperation::<AB::F>::eval(
+        XorOperation::eval(
             builder,
             local.s1_intermediate.value,
             local.e_rr_25.value,
@@ -331,11 +313,11 @@ impl ShaCompressChip {
 
         // Calculate ch := (e and f) xor ((not e) and g).
         // Calculate e and f.
-        AndOperation::<AB::F>::eval(builder, local.e, local.f, local.e_and_f, local.is_compression);
+        AndOperation::eval(builder, local.e, local.f, local.e_and_f, local.is_compression);
         // Calculate not e.
-        NotOperation::<AB::F>::eval(builder, local.e, local.e_not, local.is_compression);
+        NotOperation::eval(builder, local.e, local.e_not, local.is_compression);
         // Calculate (not e) and g.
-        AndOperation::<AB::F>::eval(
+        AndOperation::eval(
             builder,
             local.e_not.value,
             local.g,
@@ -343,7 +325,7 @@ impl ShaCompressChip {
             local.is_compression,
         );
         // Calculate ch := (e and f) xor ((not e) and g).
-        XorOperation::<AB::F>::eval(
+        XorOperation::eval(
             builder,
             local.e_and_f.value,
             local.e_not_and_g.value,
@@ -352,7 +334,7 @@ impl ShaCompressChip {
         );
 
         // Calculate temp1 := h + S1 + ch + k[i] + w[i].
-        Add5Operation::<AB::F>::eval(
+        Add5Operation::eval(
             builder,
             &[local.h, local.s1.value, local.ch.value, local.k, local.mem.access.value],
             local.is_compression,
@@ -361,31 +343,13 @@ impl ShaCompressChip {
 
         // Calculate S0 := (a rightrotate 2) xor (a rightrotate 13) xor (a rightrotate 22).
         // Calculate a rightrotate 2.
-        FixedRotateRightOperation::<AB::F>::eval(
-            builder,
-            local.a,
-            2,
-            local.a_rr_2,
-            local.is_compression,
-        );
+        FixedRotateRightOperation::eval(builder, local.a, 2, local.a_rr_2, local.is_compression);
         // Calculate a rightrotate 13.
-        FixedRotateRightOperation::<AB::F>::eval(
-            builder,
-            local.a,
-            13,
-            local.a_rr_13,
-            local.is_compression,
-        );
+        FixedRotateRightOperation::eval(builder, local.a, 13, local.a_rr_13, local.is_compression);
         // Calculate a rightrotate 22.
-        FixedRotateRightOperation::<AB::F>::eval(
-            builder,
-            local.a,
-            22,
-            local.a_rr_22,
-            local.is_compression,
-        );
+        FixedRotateRightOperation::eval(builder, local.a, 22, local.a_rr_22, local.is_compression);
         // Calculate (a rightrotate 2) xor (a rightrotate 13).
-        XorOperation::<AB::F>::eval(
+        XorOperation::eval(
             builder,
             local.a_rr_2.value,
             local.a_rr_13.value,
@@ -393,7 +357,7 @@ impl ShaCompressChip {
             local.is_compression,
         );
         // Calculate S0 := ((a rightrotate 2) xor (a rightrotate 13)) xor (a rightrotate 22).
-        XorOperation::<AB::F>::eval(
+        XorOperation::eval(
             builder,
             local.s0_intermediate.value,
             local.a_rr_22.value,
@@ -403,13 +367,13 @@ impl ShaCompressChip {
 
         // Calculate maj := (a and b) xor (a and c) xor (b and c).
         // Calculate a and b.
-        AndOperation::<AB::F>::eval(builder, local.a, local.b, local.a_and_b, local.is_compression);
+        AndOperation::eval(builder, local.a, local.b, local.a_and_b, local.is_compression);
         // Calculate a and c.
-        AndOperation::<AB::F>::eval(builder, local.a, local.c, local.a_and_c, local.is_compression);
+        AndOperation::eval(builder, local.a, local.c, local.a_and_c, local.is_compression);
         // Calculate b and c.
-        AndOperation::<AB::F>::eval(builder, local.b, local.c, local.b_and_c, local.is_compression);
+        AndOperation::eval(builder, local.b, local.c, local.b_and_c, local.is_compression);
         // Calculate (a and b) xor (a and c).
-        XorOperation::<AB::F>::eval(
+        XorOperation::eval(
             builder,
             local.a_and_b.value,
             local.a_and_c.value,
@@ -417,7 +381,7 @@ impl ShaCompressChip {
             local.is_compression,
         );
         // Calculate maj := ((a and b) xor (a and c)) xor (b and c).
-        XorOperation::<AB::F>::eval(
+        XorOperation::eval(
             builder,
             local.maj_intermediate.value,
             local.b_and_c.value,
@@ -426,7 +390,7 @@ impl ShaCompressChip {
         );
 
         // Calculate temp2 := s0 + maj.
-        AddOperation::<AB::F>::eval(
+        AddOperation::eval(
             builder,
             local.s0.value,
             local.maj.value,
@@ -435,7 +399,7 @@ impl ShaCompressChip {
         );
 
         // Calculate d + temp1 for the new value of e.
-        AddOperation::<AB::F>::eval(
+        AddOperation::eval(
             builder,
             local.d,
             local.temp1.value,
@@ -444,7 +408,7 @@ impl ShaCompressChip {
         );
 
         // Calculate temp1 + temp2 for the new value of a.
-        AddOperation::<AB::F>::eval(
+        AddOperation::eval(
             builder,
             local.temp1.value,
             local.temp2.value,
@@ -499,7 +463,7 @@ impl ShaCompressChip {
             .assert_word_eq(filtered_operand, local.finalized_operand.map(|x| x.into()));
 
         // finalize_add.result = h[i] + finalized_operand
-        AddOperation::<AB::F>::eval(
+        AddOperation::eval(
             builder,
             local.mem.prev_value,
             local.finalized_operand,

--- a/crates/core/machine/src/syscall/precompiles/sha256/extend/air.rs
+++ b/crates/core/machine/src/syscall/precompiles/sha256/extend/air.rs
@@ -95,7 +95,7 @@ where
 
         // Compute `s0`.
         // w[i-15] rightrotate 7.
-        FixedRotateRightOperation::<AB::F>::eval(
+        FixedRotateRightOperation::eval(
             builder,
             *local.w_i_minus_15.value(),
             7,
@@ -103,7 +103,7 @@ where
             local.is_real,
         );
         // w[i-15] rightrotate 18.
-        FixedRotateRightOperation::<AB::F>::eval(
+        FixedRotateRightOperation::eval(
             builder,
             *local.w_i_minus_15.value(),
             18,
@@ -111,7 +111,7 @@ where
             local.is_real,
         );
         // w[i-15] rightshift 3.
-        FixedShiftRightOperation::<AB::F>::eval(
+        FixedShiftRightOperation::eval(
             builder,
             *local.w_i_minus_15.value(),
             3,
@@ -119,7 +119,7 @@ where
             local.is_real,
         );
         // (w[i-15] rightrotate 7) xor (w[i-15] rightrotate 18)
-        XorOperation::<AB::F>::eval(
+        XorOperation::eval(
             builder,
             local.w_i_minus_15_rr_7.value,
             local.w_i_minus_15_rr_18.value,
@@ -127,7 +127,7 @@ where
             local.is_real,
         );
         // s0 := (w[i-15] rightrotate 7) xor (w[i-15] rightrotate 18) xor (w[i-15] rightshift 3)
-        XorOperation::<AB::F>::eval(
+        XorOperation::eval(
             builder,
             local.s0_intermediate.value,
             local.w_i_minus_15_rs_3.value,
@@ -137,7 +137,7 @@ where
 
         // Compute `s1`.
         // w[i-2] rightrotate 17.
-        FixedRotateRightOperation::<AB::F>::eval(
+        FixedRotateRightOperation::eval(
             builder,
             *local.w_i_minus_2.value(),
             17,
@@ -145,7 +145,7 @@ where
             local.is_real,
         );
         // w[i-2] rightrotate 19.
-        FixedRotateRightOperation::<AB::F>::eval(
+        FixedRotateRightOperation::eval(
             builder,
             *local.w_i_minus_2.value(),
             19,
@@ -153,7 +153,7 @@ where
             local.is_real,
         );
         // w[i-2] rightshift 10.
-        FixedShiftRightOperation::<AB::F>::eval(
+        FixedShiftRightOperation::eval(
             builder,
             *local.w_i_minus_2.value(),
             10,
@@ -161,7 +161,7 @@ where
             local.is_real,
         );
         // (w[i-2] rightrotate 17) xor (w[i-2] rightrotate 19)
-        XorOperation::<AB::F>::eval(
+        XorOperation::eval(
             builder,
             local.w_i_minus_2_rr_17.value,
             local.w_i_minus_2_rr_19.value,
@@ -169,7 +169,7 @@ where
             local.is_real,
         );
         // s1 := (w[i-2] rightrotate 17) xor (w[i-2] rightrotate 19) xor (w[i-2] rightshift 10)
-        XorOperation::<AB::F>::eval(
+        XorOperation::eval(
             builder,
             local.s1_intermediate.value,
             local.w_i_minus_2_rs_10.value,
@@ -178,7 +178,7 @@ where
         );
 
         // s2 := w[i-16] + s0 + w[i-7] + s1.
-        Add4Operation::<AB::F>::eval(
+        Add4Operation::eval(
             builder,
             *local.w_i_minus_16.value(),
             local.s0.value,

--- a/crates/core/machine/src/syscall/precompiles/sha256/extend/flags.rs
+++ b/crates/core/machine/src/syscall/precompiles/sha256/extend/flags.rs
@@ -56,7 +56,7 @@ impl ShaExtendChip {
         builder.when_transition().assert_eq(local.cycle_16 * g, next.cycle_16);
 
         // Constrain `cycle_16_start.result` to be `cycle_16 - g == 0`.
-        IsZeroOperation::<AB::F>::eval(
+        IsZeroOperation::eval(
             builder,
             local.cycle_16 - AB::Expr::from(g),
             local.cycle_16_start,
@@ -64,7 +64,7 @@ impl ShaExtendChip {
         );
 
         // Constrain `cycle_16_end.result` to be `cycle_16 - 1 == 0`. Intuitively g^16 is 1.
-        IsZeroOperation::<AB::F>::eval(
+        IsZeroOperation::eval(
             builder,
             local.cycle_16 - AB::Expr::one(),
             local.cycle_16_end,

--- a/crates/core/machine/src/syscall/precompiles/uint256/air.rs
+++ b/crates/core/machine/src/syscall/precompiles/uint256/air.rs
@@ -262,7 +262,7 @@ where
         // not overflow because we are summing 32 bytes.
         let modulus_byte_sum =
             modulus_limbs.0.iter().fold(AB::Expr::zero(), |acc, &limb| acc + limb);
-        IsZeroOperation::<AB::F>::eval(
+        IsZeroOperation::eval(
             builder,
             modulus_byte_sum,
             local.modulus_is_zero,


### PR DESCRIPTION
By adding a bound on the defintion we can remove all the turbofish at the callsites.

Currently the generic on these ops is also not tied to the builder. This means any `F: Field` could be used and could cause problems if the `eval` function tried to use that `F` 