### PR TITLE
Updating missing arguments in SP1 Quickstarter

### DIFF
--- a/book/getting-started/quickstart.md
+++ b/book/getting-started/quickstart.md
@@ -6,10 +6,10 @@ In this section, we will show you how to create a simple Fibonacci program using
 
 ### Option 1: Cargo Prove New CLI (Recommended)
 
-You can use the `cargo prove` CLI to create a new project using the `cargo prove new <name>` command. This command will create a new folder in your current directory.
+You can use the `cargo prove` CLI to create a new project using the `cargo prove new <--bare|--evm> <name>` command. This command will create a new folder in your current directory which includes solidity smart contracts for onchain integration
 
 ```bash
-cargo prove new fibonacci
+cargo prove new --evm fibonacci
 cd fibonacci
 ```
 


### PR DESCRIPTION
The command `cargo prove new fibonacci` was missing <--bare|--evm> arguments

![image](https://github.com/user-attachments/assets/be075bff-70a1-42a0-bcc6-9c2f8cb2b146)
