### PR TITLE
fix(entrypoint): tests fail on program crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7201,7 +7201,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "cfg-if",
  "getrandom 0.2.15",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,9 @@ sp1-sdk = { path = "crates/sdk", version = "3.0.0" }
 sp1-cuda = { path = "crates/cuda", version = "3.0.0" }
 sp1-stark = { path = "crates/stark", version = "3.0.0" }
 sp1-lib = { path = "crates/zkvm/lib", version = "3.0.0", default-features = false }
-sp1-zkvm = { path = "crates/zkvm/entrypoint", version = "3.0.0", default-features = false }
+
+# On next release, don't forget to bump the version in crates/zkvm/entrypoint/Cargo.toml
+sp1-zkvm = { path = "crates/zkvm/entrypoint", version = "3.0.1", default-features = false }
 
 # p3
 p3-air = "0.1.4-succinct"

--- a/crates/zkvm/entrypoint/Cargo.toml
+++ b/crates/zkvm/entrypoint/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sp1-zkvm"
 description = "SP1 is a performant, 100% open-source, contributor-friendly zkVM."
 readme = "../../../README.md"
-version = { workspace = true }
+version = "3.0.1"
 edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }


### PR DESCRIPTION
- `cargo test` usually creates a new "fn main" to be the entry point for running tests

- when we use `!#[no_main]` the test harness has unexpected behavior and just calls our main function

- you cant just not have a main symbol because rustc will complain

- compilation is currently broken in the template repo, and was fixed here https://github.com/succinctlabs/sp1/commit/1c1f84dd389b42b9743bff840e039d347c54c958

- if were not targeting the zkvm, we return an empty main function that has return values that the harness will expect

- todo: ux? We should add a log somewhere if a user does try to make tests in the program crate

Originally from https://github.com/succinctlabs/sp1/pull/1661 