### PR TITLE
feat(docker-build): pass additional workspace directory

### DIFF
--- a/crates/build/src/command/docker.rs
+++ b/crates/build/src/command/docker.rs
@@ -28,7 +28,19 @@ pub(crate) fn create_docker_command(
         .expect("Failed to canonicalize program directory")
         .try_into()
         .unwrap();
-    let workspace_root = &program_metadata.workspace_root;
+
+    let workspace_root: &Utf8PathBuf = &args
+        .workspace_directory
+        .as_deref()
+        .map(|workspace_path| {
+            std::path::Path::new(workspace_path)
+                .to_path_buf()
+                .canonicalize()
+                .expect("Failed to canonicalize workspace directory")
+                .try_into()
+                .unwrap()
+        })
+        .unwrap_or_else(|| program_metadata.workspace_root.clone());
 
     // Check if docker is installed and running.
     let docker_check = Command::new("docker")

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -68,6 +68,14 @@ pub struct BuildArgs {
         default_value = DEFAULT_OUTPUT_DIR
     )]
     pub output_directory: String,
+    #[clap(
+        alias = "workspace-dir",
+        long,
+        action,
+        help = "Optional workspace directory to be used",
+        default_value = None
+    )]
+    pub workspace_directory: Option<String>,
 }
 
 // Implement default args to match clap defaults.
@@ -84,6 +92,7 @@ impl Default for BuildArgs {
             output_directory: DEFAULT_OUTPUT_DIR.to_string(),
             locked: false,
             no_default_features: false,
+            workspace_directory: None,
         }
     }
 }


### PR DESCRIPTION
Currently, docker only mounts the guest program workspace. However, mounting a different workspace can be useful. This PR allows passing an additional `workspace_directory` as `BuildArgs`.