### PR TITLE
fix: patch bls and bn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ crates/prover/powersOfTau28_hez_final.ptau
 crates/prover/semaphore-gnark-11
 crates/prover/trusted-setup
 crates/prover/vk
+
+# Example legacy elf
+examples/elf 

--- a/crates/sdk/src/action.rs
+++ b/crates/sdk/src/action.rs
@@ -55,7 +55,7 @@ impl<'a> Execute<'a> {
     /// Avoid registering the default hooks in the runtime.
     ///
     /// It is not necessary to call this to override hooks --- instead, simply
-    /// register a hook with the same value of `fd` by calling [`Self::hook`].
+    /// register a hook with the same value of `fd` by calling [`Self::with_hook`].
     pub fn without_default_hooks(mut self) -> Self {
         self.context_builder.without_default_hooks();
         self
@@ -64,7 +64,7 @@ impl<'a> Execute<'a> {
     /// Set the maximum number of cpu cycles to use for execution.
     ///
     /// If the cycle limit is exceeded, execution will return
-    /// [sp1_core_machine::runtime::ExecutionError::ExceededCycleLimit].
+    /// [`sp1_core_executor::ExecutionError::ExceededCycleLimit`].
     pub fn max_cycles(mut self, max_cycles: u64) -> Self {
         self.context_builder.max_cycles(max_cycles);
         self
@@ -177,7 +177,7 @@ impl<'a> Prove<'a> {
     /// Avoid registering the default hooks in the runtime.
     ///
     /// It is not necessary to call this to override hooks --- instead, simply
-    /// register a hook with the same value of `fd` by calling [`Self::hook`].
+    /// register a hook with the same value of `fd` by calling [`Self::with_hook`].
     pub fn without_default_hooks(mut self) -> Self {
         self.context_builder.without_default_hooks();
         self
@@ -204,7 +204,7 @@ impl<'a> Prove<'a> {
     /// Set the maximum number of cpu cycles to use for execution.
     ///
     /// If the cycle limit is exceeded, execution will return
-    /// [sp1_core_machine::runtime::ExecutionError::ExceededCycleLimit].
+    /// [`sp1_core_executor::ExecutionError::ExceededCycleLimit`].
     pub fn cycle_limit(mut self, cycle_limit: u64) -> Self {
         self.context_builder.max_cycles(cycle_limit);
         self

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -194,12 +194,12 @@ impl ProverClient {
 
     /// Prepare to prove the execution of the given program with the given input in the default
     /// mode. The returned [action::Prove] may be configured via its methods before running.
-    /// For example, calling [action::Prove::compress] sets the mode to compressed mode.
+    /// For example, calling [action::Prove::compressed] sets the mode to compressed mode.
     ///
     /// To prove, call [action::Prove::run], which returns a proof of the program's execution.
     /// By default the proof generated will not be compressed to constant size.
-    /// To create a more succinct proof, use the [Self::prove_compressed],
-    /// [Self::prove_plonk], or [Self::prove_plonk] methods.
+    /// To create a more succinct proof, use the [action::Prove::compressed],
+    /// [action::Prove::plonk], or [action::Prove::groth16] methods.
     ///
     /// ### Examples
     /// ```no_run

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -71,3 +71,5 @@ sha2-v0-10-6 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", packa
 sha2-v0-9-9 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", branch = "patch-sha2-v0.9.9" }
 sha2-v0-9-8 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", branch = "patch-sha2-v0.9.8" }
 tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", branch = "patch-v2.0.2" }
+substrate-bn = { git = "https://github.com/sp1-patches/bn", rev = "43d854d45b5727b1ff2b9f346d728e785bb8395c"}
+bls12_381 = { git = "https://github.com/sp1-patches/bls12_381", branch = "patch-v0.8.0" }

--- a/examples/bls12381/program/Cargo.toml
+++ b/examples/bls12381/program/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 sp1-zkvm = { path = "../../../crates/zkvm/entrypoint" }
-bls12_381 = { git = "https://github.com/sp1-patches/bls12_381", branch = "patch-v0.8.0" }
+bls12_381 = "0.8.0"
 ff = "0.13.0"
 rand = "0.8.5"
 group = "0.13.0"

--- a/examples/bls12381/script/src/main.rs
+++ b/examples/bls12381/script/src/main.rs
@@ -7,5 +7,7 @@ fn main() {
     let stdin = SP1Stdin::new();
 
     let client = ProverClient::new();
-    let (_public_values, _) = client.execute(ELF, stdin).run().expect("failed to prove");
+    let (_public_values, report) = client.execute(ELF, stdin).run().expect("failed to prove");
+
+    println!("executed: {}", report);
 }

--- a/examples/bn254/program/Cargo.toml
+++ b/examples/bn254/program/Cargo.toml
@@ -7,5 +7,4 @@ publish = false
 [dependencies]
 sp1-zkvm = { path = "../../../crates/zkvm/entrypoint" }
 substrate-bn = "0.6.0"
-# bn = { git = "https://github.com/sp1-patches/bn", package = "substrate-bn", branch = "patch-v0.6.0"}
 rand = "0.8.5"

--- a/examples/bn254/program/Cargo.toml
+++ b/examples/bn254/program/Cargo.toml
@@ -6,6 +6,6 @@ publish = false
 
 [dependencies]
 sp1-zkvm = { path = "../../../crates/zkvm/entrypoint" }
-bn = { git = "https://github.com/sp1-patches/bn", package = "substrate-bn", rev = "43d854d45b5727b1ff2b9f346d728e785bb8395c"}
+substrate-bn = "0.6.0"
 # bn = { git = "https://github.com/sp1-patches/bn", package = "substrate-bn", branch = "patch-v0.6.0"}
 rand = "0.8.5"

--- a/examples/bn254/program/src/main.rs
+++ b/examples/bn254/program/src/main.rs
@@ -1,6 +1,6 @@
 #![no_main]
 
-use bn::{pairing, pairing_batch, Fq, Fq2, Fr, Group, G1, G2};
+use substrate_bn::{pairing, pairing_batch, Fq, Fq2, Fr, Group, G1, G2};
 
 sp1_zkvm::entrypoint!(main);
 

--- a/examples/bn254/script/src/main.rs
+++ b/examples/bn254/script/src/main.rs
@@ -7,5 +7,7 @@ fn main() {
     let stdin = SP1Stdin::new();
 
     let client = ProverClient::new();
-    let (_public_values, _) = client.execute(ELF, stdin).run().expect("failed to prove");
+    let (_public_values, report) = client.execute(ELF, stdin).run().expect("failed to prove");
+
+    println!("executed: {}", report);
 }


### PR DESCRIPTION
Before, the sp1 program imported the bn and bls patches directly, like `bn = { git = "sp1-patches/bn" }`.

Now, they import the unpatched version, and the patch is applied from examples/cargo.toml