### PR TITLE
docs: Update example commands from cd script to cd ../script

### DIFF
--- a/book/getting-started/quickstart.md
+++ b/book/getting-started/quickstart.md
@@ -73,7 +73,7 @@ Note: the `build.rs` file in the `script` directory will use run the above comma
 To test your program, you can first execute your program without generating a proof. In general this is helpful for iterating on your program and verifying that it is correct. 
 
 ```bash
-cd script
+cd ../script
 RUST_LOG=info cargo run --release -- --execute
 ```
 
@@ -82,7 +82,7 @@ RUST_LOG=info cargo run --release -- --execute
 When you are ready to generate a proof, you should run the script with the `--prove` flag that will generate a proof.
 
 ```bash
-cd script
+cd ../script
 RUST_LOG=info cargo run --release -- --prove
 ```
 


### PR DESCRIPTION
Under executing the program, you have to switch directory from program to script. The example command does not work as a direct copy/paste because the user is in the /program dir and needs to go up one.  Just changing from "cd script"  to "cd ../script" would make life easier for newbies. 


And for the step of generating a proof, the "cd script" is repeated which fails when copy/pasted. Again "cd ../script" will work nicely here.