### PR TITLE
docs: Add --evm template to the command.

### DIFF
--- a/book/getting-started/quickstart.md
+++ b/book/getting-started/quickstart.md
@@ -6,13 +6,13 @@ In this section, we will show you how to create a simple Fibonacci program using
 
 ### Option 1: Cargo Prove New CLI (Recommended)
 
-You can use the `cargo prove` CLI to create a new project using the `cargo prove new <name>` command. This command will create a new folder in your current directory.
+You can use the `cargo prove` CLI to create a new project using the `cargo prove new --evm <name>` command. This command will create a new folder in your current directory. This command uses the `evm` template which includes Solidity smart contracts for onchain integration.
 
 ```bash
-cargo prove new fibonacci
+cargo prove new --evm fibonacci
 cd fibonacci
 ```
-
+      
 ### Option 2: Project Template (Solidity Contracts for Onchain Verification)
 
 If you want to use SP1 to generate proofs that will eventually be verified on an EVM chain, you should use the [SP1 project template](https://github.com/succinctlabs/sp1-project-template/tree/main). This Github template is scaffolded with a SP1 program, a script to generate proofs, and also a contracts folder that contains a Solidity contract that can verify SP1 proofs on any EVM chain.


### PR DESCRIPTION
On the first step in Option 1, I got an error which is easily fixed, and an update to the docs would prevent others from the same issue.

 % cargo prove new fibonacci

error: the following required arguments were not provided:
  <--bare|--evm>

Usage: cargo prove new <--bare|--evm> <NAME>

I propose to add the argument --evm and update the description with this line: 

This command uses the `evm` template which includes Solidity smart contracts for onchain integration.