### PR TITLE
feat: add scalar_mult function to main.rs for Bn254 point multiplication

### DIFF
--- a/tests/bn254-add/src/main.rs
+++ b/tests/bn254-add/src/main.rs
@@ -2,6 +2,7 @@
 
 use sp1_curves::params::FieldParameters;
 use sp1_lib::bn254::Bn254Point;
+use sp1_lib::bn254::Bn254Scalar;
 sp1_zkvm::entrypoint!(main);
 
 // generator.
@@ -31,7 +32,10 @@ const C: [u8; 64] = [
     91, 156, 11, 180, 99, 158, 49, 117, 100, 8, 141, 124, 219, 79, 85, 41, 148, 72, 224, 190, 153,
     183, 42,
 ];
-
+pub fn scalar_mult(point: &Bn254Point, scalar: &[u8; 32]) -> Bn254Point {
+    let scalar_value = Bn254Scalar::from_bytes(scalar).expect("Valid scalar bytes");
+    point * scalar_value
+}
 pub fn main() {
     common_test_utils::weierstrass_add::test_weierstrass_add::<Bn254Point, { sp1_lib::bn254::N }>(
         &A,


### PR DESCRIPTION
scalar_mult function: This function takes a reference to a point (Bn254Point) and a scalar (32-byte array) as inputs. It performs scalar multiplication, returning a new Bn254Point that represents the resulting point after multiplication.

Bn254Scalar Conversion: The scalar byte array is converted into a Bn254Scalar using from_bytes, enabling multiplication with the point.

Usage: This function is helpful when performing cryptographic operations that require scalar multiplication of points, such as in zero-knowledge proof computations.