### PR TITLE
fix: remove stdin from SP1ProofWithPublicValues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6702,7 +6702,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-build"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -6713,7 +6713,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cli"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -6741,7 +6741,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -6774,7 +6774,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-machine"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "bincode",
  "cfg-if",
@@ -6823,7 +6823,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cuda"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "bincode",
  "ctrlc",
@@ -6840,7 +6840,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "cfg-if",
  "curve25519-dalek",
@@ -6862,7 +6862,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-derive"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -6870,7 +6870,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-eval"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6890,14 +6890,14 @@ dependencies = [
 
 [[package]]
 name = "sp1-helper"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "sp1-build",
 ]
 
 [[package]]
 name = "sp1-lib"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "bincode",
  "serde",
@@ -6905,7 +6905,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-perf"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6927,7 +6927,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "bincode",
  "hex",
@@ -6943,7 +6943,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6983,7 +6983,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-circuit"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "ff 0.13.0",
  "hashbrown 0.14.5",
@@ -7019,7 +7019,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-compiler"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "backtrace",
  "criterion",
@@ -7044,7 +7044,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-core"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "backtrace",
  "ff 0.13.0",
@@ -7079,7 +7079,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-derive"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -7087,7 +7087,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-cli"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "bincode",
  "clap",
@@ -7096,7 +7096,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-ffi"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -7120,7 +7120,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-sdk"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "alloy-primitives 0.8.8",
  "alloy-signer",
@@ -7166,7 +7166,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-stark"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "arrayref",
  "getrandom 0.2.15",
@@ -7201,7 +7201,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "cfg-if",
  "getrandom 0.2.15",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "3.0.0"
+version = "3.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/succinctlabs/sp1"
@@ -46,26 +46,26 @@ debug-assertions = true
 
 [workspace.dependencies]
 # sp1
-sp1-build = { path = "crates/build", version = "3.0.0" }
-sp1-cli = { path = "crates/cli", version = "3.0.0", default-features = false }
-sp1-core-machine = { path = "crates/core/machine", version = "3.0.0" }
-sp1-core-executor = { path = "crates/core/executor", version = "3.0.0" }
-sp1-curves = { path = "crates/curves", version = "3.0.0" }
-sp1-derive = { path = "crates/derive", version = "3.0.0" }
-sp1-eval = { path = "crates/eval", version = "3.0.0" }
-sp1-helper = { path = "crates/helper", version = "3.0.0", default-features = false }
-sp1-primitives = { path = "crates/primitives", version = "3.0.0" }
-sp1-prover = { path = "crates/prover", version = "3.0.0" }
-sp1-recursion-compiler = { path = "crates/recursion/compiler", version = "3.0.0" }
-sp1-recursion-core = { path = "crates/recursion/core", version = "3.0.0", default-features = false }
-sp1-recursion-derive = { path = "crates/recursion/derive", version = "3.0.0", default-features = false }
-sp1-recursion-gnark-ffi = { path = "crates/recursion/gnark-ffi", version = "3.0.0", default-features = false }
-sp1-recursion-circuit = { path = "crates/recursion/circuit", version = "3.0.0", default-features = false }
-sp1-sdk = { path = "crates/sdk", version = "3.0.0" }
-sp1-cuda = { path = "crates/cuda", version = "3.0.0" }
-sp1-stark = { path = "crates/stark", version = "3.0.0" }
-sp1-lib = { path = "crates/zkvm/lib", version = "3.0.0", default-features = false }
-sp1-zkvm = { path = "crates/zkvm/entrypoint", version = "3.0.0", default-features = false }
+sp1-build = { path = "crates/build", version = "3.1.0" }
+sp1-cli = { path = "crates/cli", version = "3.1.0", default-features = false }
+sp1-core-machine = { path = "crates/core/machine", version = "3.1.0" }
+sp1-core-executor = { path = "crates/core/executor", version = "3.1.0" }
+sp1-curves = { path = "crates/curves", version = "3.1.0" }
+sp1-derive = { path = "crates/derive", version = "3.1.0" }
+sp1-eval = { path = "crates/eval", version = "3.1.0" }
+sp1-helper = { path = "crates/helper", version = "3.1.0", default-features = false }
+sp1-primitives = { path = "crates/primitives", version = "3.1.0" }
+sp1-prover = { path = "crates/prover", version = "3.1.0" }
+sp1-recursion-compiler = { path = "crates/recursion/compiler", version = "3.1.0" }
+sp1-recursion-core = { path = "crates/recursion/core", version = "3.1.0", default-features = false }
+sp1-recursion-derive = { path = "crates/recursion/derive", version = "3.1.0", default-features = false }
+sp1-recursion-gnark-ffi = { path = "crates/recursion/gnark-ffi", version = "3.1.0", default-features = false }
+sp1-recursion-circuit = { path = "crates/recursion/circuit", version = "3.1.0", default-features = false }
+sp1-sdk = { path = "crates/sdk", version = "3.1.0" }
+sp1-cuda = { path = "crates/cuda", version = "3.1.0" }
+sp1-stark = { path = "crates/stark", version = "3.1.0" }
+sp1-lib = { path = "crates/zkvm/lib", version = "3.1.0", default-features = false }
+sp1-zkvm = { path = "crates/zkvm/entrypoint", version = "3.1.0", default-features = false }
 
 # p3
 p3-air = "0.1.4-succinct"

--- a/crates/core/executor/src/executor.rs
+++ b/crates/core/executor/src/executor.rs
@@ -1229,7 +1229,6 @@ impl<'a> Executor<'a> {
         let instruction = self.fetch();
 
         // Log the current state of the runtime.
-        #[cfg(debug_assertions)]
         self.log(&instruction);
 
         // Execute the instruction.
@@ -1661,7 +1660,6 @@ impl<'a> Executor<'a> {
     }
 
     #[inline]
-    #[cfg(debug_assertions)]
     fn log(&mut self, _: &Instruction) {
         // Write the current program counter to the trace buffer for the cycle tracer.
         if let Some(ref mut buf) = self.trace_buf {

--- a/crates/sdk/src/proof.rs
+++ b/crates/sdk/src/proof.rs
@@ -3,7 +3,6 @@ use std::{fmt::Debug, fs::File, path::Path};
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use sp1_core_executor::SP1ReduceProof;
-use sp1_core_machine::io::SP1Stdin;
 use sp1_primitives::io::SP1PublicValues;
 use strum_macros::{EnumDiscriminants, EnumTryAs};
 
@@ -26,7 +25,6 @@ pub enum SP1Proof {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SP1ProofWithPublicValues {
     pub proof: SP1Proof,
-    pub stdin: SP1Stdin,
     pub public_values: SP1PublicValues,
     pub sp1_version: String,
 }

--- a/crates/sdk/src/provers/cpu.rs
+++ b/crates/sdk/src/provers/cpu.rs
@@ -56,7 +56,6 @@ impl Prover<DefaultProverComponents> for CpuProver {
         if kind == SP1ProofKind::Core {
             return Ok(SP1ProofWithPublicValues {
                 proof: SP1Proof::Core(proof.proof.0),
-                stdin: proof.stdin,
                 public_values: proof.public_values,
                 sp1_version: self.version().to_string(),
             });
@@ -72,7 +71,6 @@ impl Prover<DefaultProverComponents> for CpuProver {
         if kind == SP1ProofKind::Compressed {
             return Ok(SP1ProofWithPublicValues {
                 proof: SP1Proof::Compressed(Box::new(reduce_proof)),
-                stdin,
                 public_values,
                 sp1_version: self.version().to_string(),
             });
@@ -97,7 +95,6 @@ impl Prover<DefaultProverComponents> for CpuProver {
 
             return Ok(SP1ProofWithPublicValues {
                 proof: SP1Proof::Plonk(proof),
-                stdin,
                 public_values,
                 sp1_version: self.version().to_string(),
             });
@@ -114,7 +111,6 @@ impl Prover<DefaultProverComponents> for CpuProver {
             let proof = self.prover.wrap_groth16_bn254(outer_proof, &groth16_bn254_artifacts);
             return Ok(SP1ProofWithPublicValues {
                 proof: SP1Proof::Groth16(proof),
-                stdin,
                 public_values,
                 sp1_version: self.version().to_string(),
             });

--- a/crates/sdk/src/provers/cuda.rs
+++ b/crates/sdk/src/provers/cuda.rs
@@ -52,7 +52,6 @@ impl Prover<DefaultProverComponents> for CudaProver {
         if kind == SP1ProofKind::Core {
             return Ok(SP1ProofWithPublicValues {
                 proof: SP1Proof::Core(proof.proof.0),
-                stdin: proof.stdin,
                 public_values: proof.public_values,
                 sp1_version: self.version().to_string(),
             });
@@ -67,7 +66,6 @@ impl Prover<DefaultProverComponents> for CudaProver {
         if kind == SP1ProofKind::Compressed {
             return Ok(SP1ProofWithPublicValues {
                 proof: SP1Proof::Compressed(Box::new(reduce_proof)),
-                stdin,
                 public_values,
                 sp1_version: self.version().to_string(),
             });
@@ -91,7 +89,6 @@ impl Prover<DefaultProverComponents> for CudaProver {
             let proof = self.prover.wrap_plonk_bn254(outer_proof, &plonk_bn254_artifacts);
             return Ok(SP1ProofWithPublicValues {
                 proof: SP1Proof::Plonk(proof),
-                stdin,
                 public_values,
                 sp1_version: self.version().to_string(),
             });
@@ -108,7 +105,6 @@ impl Prover<DefaultProverComponents> for CudaProver {
             let proof = self.prover.wrap_groth16_bn254(outer_proof, &groth16_bn254_artifacts);
             return Ok(SP1ProofWithPublicValues {
                 proof: SP1Proof::Groth16(proof),
-                stdin,
                 public_values,
                 sp1_version: self.version().to_string(),
             });

--- a/crates/sdk/src/provers/mock.rs
+++ b/crates/sdk/src/provers/mock.rs
@@ -59,7 +59,6 @@ impl Prover<DefaultProverComponents> for MockProver {
                 let (public_values, _) = self.prover.execute(&pk.elf, &stdin, context)?;
                 Ok(SP1ProofWithPublicValues {
                     proof: SP1Proof::Core(vec![]),
-                    stdin,
                     public_values,
                     sp1_version: self.version().to_string(),
                 })
@@ -102,7 +101,6 @@ impl Prover<DefaultProverComponents> for MockProver {
 
                 Ok(SP1ProofWithPublicValues {
                     proof,
-                    stdin,
                     public_values,
                     sp1_version: self.version().to_string(),
                 })
@@ -119,7 +117,6 @@ impl Prover<DefaultProverComponents> for MockProver {
                         raw_proof: "".to_string(),
                         plonk_vkey_hash: [0; 32],
                     }),
-                    stdin,
                     public_values,
                     sp1_version: self.version().to_string(),
                 })
@@ -136,7 +133,6 @@ impl Prover<DefaultProverComponents> for MockProver {
                         raw_proof: "".to_string(),
                         groth16_vkey_hash: [0; 32],
                     }),
-                    stdin,
                     public_values,
                     sp1_version: self.version().to_string(),
                 })


### PR DESCRIPTION
- Removes `stdin` field from `SP1ProofWithPublicValues`.
- Removes #[cfg(debug_assertions)] from self.log in the executor.