### PR TITLE
Update proof-types.md

### DIFF
--- a/book/generating-proofs/proof-types.md
+++ b/book/generating-proofs/proof-types.md
@@ -28,7 +28,7 @@ client.prove(&pk, stdin).compressed().run().unwrap();
 
 ## Groth16 (Recommended)
 
-The Groth16 prover mode generate a SNARK proof that is ~260 bytes large and can be verified onchain for around ~270k gas. 
+The Groth16 prover mode generates a SNARK proof that is ~260 bytes large and can be verified onchain for around ~270k gas. 
 
 The trusted setup for the Groth16 circuit keys uses the [Aztec Ignition ceremony](https://github.com/AztecProtocol/ignition-verification) + entropy contributions from members of the Succinct team.
 
@@ -39,7 +39,7 @@ client.prove(&pk, stdin).groth16().run().unwrap();
 
 ## PLONK
 
-The PLONK prover mode generate a SNARK proof that is ~868 bytes large and can also be verified onchain for around ~300k gas. Plonk proofs take about ~1m30s longer to generate over a compressed proof.
+The PLONK prover mode generates a SNARK proof that is ~868 bytes large and can also be verified onchain for around ~300k gas. Plonk proofs take about ~1m30s longer to generate over a compressed proof.
 
 PLONK does not require a trusted setup.
 


### PR DESCRIPTION
### Two grammatical errors found in the text

**In the Groth16 (Recommended) section:**

The phrase "The Groth16 prover mode generate a SNARK proof..." should be "**generates**," as "mode" is singular.

**In the PLONK section:**

The phrase "The PLONK prover mode generate a SNARK proof..." should also use "**generates**" because "mode" is singular here as well.
