### PR TITLE
typo inputs-and-outputs.md

### DIFF
--- a/book/writing-programs/inputs-and-outputs.md
+++ b/book/writing-programs/inputs-and-outputs.md
@@ -56,7 +56,7 @@ struct MyStruct {
 }
 ```
 
-For more complex usecases, refer to the [Serde docs](https://serde.rs/).
+For more complex use cases, refer to the [Serde docs](https://serde.rs/).
 
 ## Example
 


### PR DESCRIPTION
<img width="584" alt="Снимок экрана 2024-11-03 в 12 48 19" src="https://github.com/user-attachments/assets/22a38678-b4c0-4945-9df2-9df0010c5d88">

The phrase "For more complex usecases" should be written as "use cases" (two words) instead of "usecases."