### PR TITLE
feat: add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-FORM.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-FORM.yml
@@ -1,0 +1,56 @@
+name: Bug report
+description: File a bug report
+labels: ["T-bug", "T-needs-triage"]
+body:
+    - type: markdown
+      attributes:
+          value: |
+              Please ensure that the bug has not already been filed in the issue tracker.
+
+              Thanks for taking the time to report this bug in SP1!
+    - type: dropdown
+      attributes:
+          label: Component
+          description: What component is the bug in?
+          multiple: true
+          options:
+              - sp1-sdk
+              - sp1-zkvm
+              - cargo prove CLI/sp1up
+              - Other (please describe)
+      validations:
+          required: true
+    - type: checkboxes
+      attributes:
+          label: Have you ensured that all of these are up to date?
+          options:
+              - label: SP1 SDK
+              - label: cargo prove CLI/sp1up
+    - type: input
+      attributes:
+          label: What version of SP1 SDK are you on?
+          description: Leave empty if not relevant
+          placeholder: "Add the version from the Cargo.toml file here"
+    - type: input
+      attributes:
+          label: What version of the cargo prove CLI are you on?
+          description: Leave empty if not relevant
+          placeholder: "Run cargo prove --version and paste the output here"
+    - type: dropdown
+      attributes:
+          label: Operating System
+          description: What operating system are you on?
+          options:
+              - Windows
+              - macOS (Intel)
+              - macOS (Apple Silicon)
+              - Linux (Arch)
+              - Linux (Debian)
+              - Linux (Ubuntu)
+              - Linux (Other)
+    - type: textarea
+      attributes:
+          label: Describe the bug
+          description: Please include relevant Rust snippets/CLI commands as well if relevant.
+      validations:
+          required: true

--- a/.github/ISSUE_TEMPLATE/FEATURE-FORM.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE-FORM.yml
@@ -1,0 +1,32 @@
+name: Feature request
+description: Suggest a feature
+labels: ["T-feature", "T-needs-triage"]
+body:
+    - type: markdown
+      attributes:
+          value: |
+              Please ensure that the feature has not already been requested in the issue tracker.
+
+              Thanks for helping us improve SP1!
+    - type: dropdown
+      attributes:
+          label: Component
+          description: What component is the feature for?
+          multiple: true
+          options:
+              - sp1-sdk
+              - sp1-zkvm
+              - cargo prove CLI/sp1up
+              - Other (please describe)
+      validations:
+          required: true
+    - type: textarea
+      attributes:
+          label: Describe the feature you would like
+          description: Please also describe what the feature is aiming to solve, if relevant.
+      validations:
+          required: true
+    - type: textarea
+      attributes:
+          label: Additional context
+          description: Add any other context to the feature (like screenshots, resources)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+    - name: Support
+      url: https://t.me/+5q4kfeXaBE1hZjEx
+      about: This issue tracker is only for bugs and feature requests. Support is available on Telegram!

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,36 @@
+<!--
+Thank you for your Pull Request. Please provide a description above and review
+the requirements below.
+
+Bug fixes and new features should include tests.
+
+Typos / punctuation / trivial PRs are generally not accepted.
+
+Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md
+
+The contributors guide includes instructions for running rustfmt and building the
+documentation.
+-->
+
+<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->
+
+## Motivation
+
+<!--
+Explain the context and why you're making that change. What is the problem
+you're trying to solve? In some cases there is not a problem and this can be
+thought of as being the motivation for your change.
+-->
+
+## Solution
+
+<!--
+Summarize the solution and provide any necessary context needed to understand
+the code change.
+-->
+
+## PR Checklist
+
+- [ ] Added Tests
+- [ ] Added Documentation
+- [ ] Breaking changes


### PR DESCRIPTION
Add an issue template to the documentation.

Modeled off of https://github.com/foundry-rs/foundry/tree/master/.github/ISSUE_TEMPLATE
PR template from: https://github.com/alloy-rs/alloy/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1