### PR TITLE
feat: Add `skip_deferred_proof_verification`

### DIFF
--- a/crates/core/executor/src/context.rs
+++ b/crates/core/executor/src/context.rs
@@ -21,6 +21,9 @@ pub struct SP1Context<'a> {
 
     /// The maximum number of cpu cycles to use for execution.
     pub max_cycles: Option<u64>,
+
+    /// Skip deferred proof verification.
+    pub skip_deferred_proof_verification: bool,
 }
 
 /// A builder for [`SP1Context`].
@@ -30,6 +33,7 @@ pub struct SP1ContextBuilder<'a> {
     hook_registry_entries: Vec<(u32, BoxedHook<'a>)>,
     subproof_verifier: Option<Arc<dyn SubproofVerifier + 'a>>,
     max_cycles: Option<u64>,
+    skip_deferred_proof_verification: bool,
 }
 
 impl<'a> SP1Context<'a> {
@@ -68,7 +72,13 @@ impl<'a> SP1ContextBuilder<'a> {
             });
         let subproof_verifier = take(&mut self.subproof_verifier);
         let cycle_limit = take(&mut self.max_cycles);
-        SP1Context { hook_registry, subproof_verifier, max_cycles: cycle_limit }
+        let skip_deferred_proof_verification = take(&mut self.skip_deferred_proof_verification);
+        SP1Context {
+            hook_registry,
+            subproof_verifier,
+            max_cycles: cycle_limit,
+            skip_deferred_proof_verification,
+        }
     }
 
     /// Add a runtime [Hook](super::Hook) into the context.
@@ -110,6 +120,12 @@ impl<'a> SP1ContextBuilder<'a> {
         self.max_cycles = Some(max_cycles);
         self
     }
+
+    /// Set the skip deferred proof verification flag.
+    pub fn set_skip_deferred_proof_verification(&mut self, skip: bool) -> &mut Self {
+        self.skip_deferred_proof_verification = skip;
+        self
+    }
 }
 
 #[cfg(test)]
@@ -120,7 +136,7 @@ mod tests {
 
     #[test]
     fn defaults() {
-        let SP1Context { hook_registry, subproof_verifier, max_cycles: cycle_limit } =
+        let SP1Context { hook_registry, subproof_verifier, max_cycles: cycle_limit, .. } =
             SP1Context::builder().build();
         assert!(hook_registry.is_none());
         assert!(subproof_verifier.is_none());

--- a/crates/core/executor/src/executor.rs
+++ b/crates/core/executor/src/executor.rs
@@ -80,6 +80,9 @@ pub struct Executor<'a> {
     /// The maximum number of cpu cycles to use for execution.
     pub max_cycles: Option<u64>,
 
+    /// Skip deferred proof verification.
+    pub skip_deferred_proof_verification: bool,
+
     /// The state of the execution.
     pub state: ExecutionState,
 
@@ -231,6 +234,7 @@ impl<'a> Executor<'a> {
             hook_registry,
             opts,
             max_cycles: context.max_cycles,
+            skip_deferred_proof_verification: context.skip_deferred_proof_verification,
             memory_checkpoint: PagedMemory::new_preallocated(),
             uninitialized_memory_checkpoint: PagedMemory::new_preallocated(),
             local_memory_access: HashMap::new(),

--- a/crates/core/executor/src/executor.rs
+++ b/crates/core/executor/src/executor.rs
@@ -26,6 +26,15 @@ use crate::{
     Instruction, Opcode, Program, Register,
 };
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Whether to verify deferred proofs during execution.
+pub enum DeferredProofVerification {
+    /// Verify deferred proofs during execution.
+    Enabled,
+    /// Skip verification of deferred proofs
+    Disabled,
+}
+
 /// An executor for the SP1 RISC-V zkVM.
 ///
 /// The exeuctor is responsible for executing a user program and tracing important events which
@@ -81,7 +90,7 @@ pub struct Executor<'a> {
     pub max_cycles: Option<u64>,
 
     /// Skip deferred proof verification.
-    pub skip_deferred_proof_verification: bool,
+    pub deferred_proof_verification: DeferredProofVerification,
 
     /// The state of the execution.
     pub state: ExecutionState,
@@ -234,7 +243,11 @@ impl<'a> Executor<'a> {
             hook_registry,
             opts,
             max_cycles: context.max_cycles,
-            skip_deferred_proof_verification: context.skip_deferred_proof_verification,
+            deferred_proof_verification: if context.skip_deferred_proof_verification {
+                DeferredProofVerification::Disabled
+            } else {
+                DeferredProofVerification::Enabled
+            },
             memory_checkpoint: PagedMemory::new_preallocated(),
             uninitialized_memory_checkpoint: PagedMemory::new_preallocated(),
             local_memory_access: HashMap::new(),

--- a/crates/core/executor/src/syscalls/verify.rs
+++ b/crates/core/executor/src/syscalls/verify.rs
@@ -48,7 +48,7 @@ impl Syscall for VerifySyscall {
                         )
                     });
             }
-            DeferredProofVerification::Disabled => {},
+            DeferredProofVerification::Disabled => {}
         }
 
         None

--- a/crates/core/executor/src/syscalls/verify.rs
+++ b/crates/core/executor/src/syscalls/verify.rs
@@ -32,16 +32,19 @@ impl Syscall for VerifySyscall {
         let vkey_bytes: [u32; 8] = vkey.try_into().unwrap();
         let pv_digest_bytes: [u32; 8] = pv_digest.try_into().unwrap();
 
-        ctx.rt
-            .subproof_verifier
-            .verify_deferred_proof(proof, proof_vk, vkey_bytes, pv_digest_bytes)
-            .unwrap_or_else(|e| {
-                panic!(
-                    "Failed to verify proof {proof_index} with digest {}: {}",
-                    hex::encode(bytemuck::cast_slice(&pv_digest_bytes)),
-                    e
-                )
-            });
+        // Skip deferred proof verification if the corresponding runtime flag is set.
+        if !ctx.rt.skip_deferred_proof_verification {
+            ctx.rt
+                .subproof_verifier
+                .verify_deferred_proof(proof, proof_vk, vkey_bytes, pv_digest_bytes)
+                .unwrap_or_else(|e| {
+                    panic!(
+                        "Failed to verify proof {proof_index} with digest {}: {}",
+                        hex::encode(bytemuck::cast_slice(&pv_digest_bytes)),
+                        e
+                    )
+                });
+        }
 
         None
     }

--- a/crates/sdk/src/action.rs
+++ b/crates/sdk/src/action.rs
@@ -88,7 +88,6 @@ pub struct Prove<'a> {
     core_opts: SP1CoreOpts,
     recursion_opts: SP1CoreOpts,
     timeout: Option<Duration>,
-    skip_deferred_proof_verification: bool,
 }
 
 impl<'a> Prove<'a> {
@@ -110,7 +109,6 @@ impl<'a> Prove<'a> {
             core_opts: SP1CoreOpts::default(),
             recursion_opts: SP1CoreOpts::recursion(),
             timeout: None,
-            skip_deferred_proof_verification: false,
         }
     }
 
@@ -125,11 +123,9 @@ impl<'a> Prove<'a> {
             core_opts,
             recursion_opts,
             timeout,
-            skip_deferred_proof_verification,
         } = self;
         let opts = SP1ProverOpts { core_opts, recursion_opts };
         let proof_opts = ProofOpts { sp1_prover_opts: opts, timeout };
-        context_builder.set_skip_deferred_proof_verification(skip_deferred_proof_verification);
         let context = context_builder.build();
 
         // Dump the program and stdin to files for debugging if `SP1_DUMP` is set.
@@ -230,7 +226,7 @@ impl<'a> Prove<'a> {
 
     /// Set the skip deferred proof verification flag.
     pub fn set_skip_deferred_proof_verification(mut self, value: bool) -> Self {
-        self.skip_deferred_proof_verification = value;
+        self.context_builder.set_skip_deferred_proof_verification(value);
         self
     }
 }

--- a/crates/sdk/src/action.rs
+++ b/crates/sdk/src/action.rs
@@ -69,6 +69,12 @@ impl<'a> Execute<'a> {
         self.context_builder.max_cycles(max_cycles);
         self
     }
+
+    /// Skip deferred proof verification.
+    pub fn set_skip_deferred_proof_verification(mut self, value: bool) -> Self {
+        self.context_builder.set_skip_deferred_proof_verification(value);
+        self
+    }
 }
 
 /// Builder to prepare and configure proving execution of a program on an input.
@@ -82,6 +88,7 @@ pub struct Prove<'a> {
     core_opts: SP1CoreOpts,
     recursion_opts: SP1CoreOpts,
     timeout: Option<Duration>,
+    skip_deferred_proof_verification: bool,
 }
 
 impl<'a> Prove<'a> {
@@ -103,6 +110,7 @@ impl<'a> Prove<'a> {
             core_opts: SP1CoreOpts::default(),
             recursion_opts: SP1CoreOpts::recursion(),
             timeout: None,
+            skip_deferred_proof_verification: false,
         }
     }
 
@@ -117,9 +125,11 @@ impl<'a> Prove<'a> {
             core_opts,
             recursion_opts,
             timeout,
+            skip_deferred_proof_verification,
         } = self;
         let opts = SP1ProverOpts { core_opts, recursion_opts };
         let proof_opts = ProofOpts { sp1_prover_opts: opts, timeout };
+        context_builder.set_skip_deferred_proof_verification(skip_deferred_proof_verification);
         let context = context_builder.build();
 
         // Dump the program and stdin to files for debugging if `SP1_DUMP` is set.
@@ -215,6 +225,12 @@ impl<'a> Prove<'a> {
     /// This parameter is only used when the prover is run in network mode.
     pub fn timeout(mut self, timeout: Duration) -> Self {
         self.timeout = Some(timeout);
+        self
+    }
+
+    /// Set the skip deferred proof verification flag.
+    pub fn set_skip_deferred_proof_verification(mut self, value: bool) -> Self {
+        self.skip_deferred_proof_verification = value;
         self
     }
 }


### PR DESCRIPTION
Systems such as `op-succinct` require an additional flag to skip deferred proof verification when generating mock proofs, because their execution relies on the verification of compressed proofs (deferred proofs) which are invalid in mock mode.