### PR TITLE
chore: crates substrate_bn version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5876,7 +5876,7 @@ dependencies = [
  "num-traits",
  "sha2 0.10.8",
  "sp1-sdk",
- "substrate-bn",
+ "substrate-bn-succinct",
  "thiserror-no-std",
 ]
 
@@ -6032,9 +6032,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "substrate-bn"
+name = "substrate-bn-succinct"
 version = "0.6.0"
-source = "git+https://github.com/sp1-patches/bn?tag=substrate_bn-v0.6.0-patch-v2#8ef05d3969312eca34fa9f1f566a469022badda6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "114c855c26ad0594c830129cb868552fb41415603a6133276c2ecdd9e5ef4255"
 dependencies = [
  "bytemuck",
  "byteorder",

--- a/crates/verifier/Cargo.toml
+++ b/crates/verifier/Cargo.toml
@@ -10,7 +10,7 @@ keywords = { workspace = true }
 categories = { workspace = true }
 
 [dependencies]
-bn = { git = "https://github.com/sp1-patches/bn", version = "0.6.0", tag = "substrate_bn-v0.6.0-patch-v2", package = "substrate-bn" }
+bn = { version = "0.6.0", package = "substrate-bn-succinct" }
 sha2 = { version = "0.10.8", default-features = false }
 thiserror-no-std = "2.0.2"
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }


### PR DESCRIPTION
Uses the crates version of the bn patch instead of git. 