### PR TITLE
feat: clean up NetworkProver environment variables

### DIFF
--- a/crates/sdk/src/network/prover.rs
+++ b/crates/sdk/src/network/prover.rs
@@ -1,10 +1,7 @@
-use std::{
-    env,
-    time::{Duration, Instant},
-};
+use std::time::{Duration, Instant};
 
 use crate::{
-    network::client::{NetworkClient, DEFAULT_PROVER_NETWORK_RPC},
+    network::client::NetworkClient,
     network::proto::network::{ProofMode, ProofStatus},
     Prover, SP1Context, SP1ProofKind, SP1ProofWithPublicValues, SP1ProvingKey, SP1VerifyingKey,
 };
@@ -26,23 +23,17 @@ const MAX_CONSECUTIVE_ERRORS: usize = 10;
 pub struct NetworkProver {
     client: NetworkClient,
     local_prover: CpuProver,
+    skip_simulation: bool,
 }
 
 impl NetworkProver {
-    /// Creates a new [NetworkProver] with the private key set in `SP1_PRIVATE_KEY`.
-    pub fn new() -> Self {
-        let private_key = env::var("SP1_PRIVATE_KEY")
-            .unwrap_or_else(|_| panic!("SP1_PRIVATE_KEY must be set for remote proving"));
-        Self::new_from_key(&private_key)
-    }
-
     /// Creates a new [NetworkProver] with the given private key.
-    pub fn new_from_key(private_key: &str) -> Self {
+    pub fn new(private_key: &str, rpc_url: Option<String>, skip_simulation: bool) -> Self {
         let version = SP1_CIRCUIT_VERSION;
         log::info!("Client circuit version: {}", version);
 
         let local_prover = CpuProver::new();
-        Self { client: NetworkClient::new(private_key), local_prover }
+        Self { client: NetworkClient::new(private_key, rpc_url), local_prover, skip_simulation }
     }
 
     /// Requests a proof from the prover network, returning the proof ID.
@@ -54,9 +45,7 @@ impl NetworkProver {
     ) -> Result<String> {
         let client = &self.client;
 
-        let skip_simulation = env::var("SKIP_SIMULATION").map(|val| val == "true").unwrap_or(false);
-
-        if !skip_simulation {
+        if !self.skip_simulation {
             let (_, report) =
                 self.local_prover.sp1_prover().execute(elf, &stdin, Default::default())?;
             log::info!("Simulation complete, cycles: {}", report.total_instruction_count());
@@ -67,7 +56,7 @@ impl NetworkProver {
         let proof_id = client.create_proof(elf, &stdin, mode, SP1_CIRCUIT_VERSION).await?;
         log::info!("Created {}", proof_id);
 
-        if NetworkClient::rpc_url() == DEFAULT_PROVER_NETWORK_RPC {
+        if self.client.is_using_prover_network {
             log::info!("View in explorer: https://explorer.succinct.xyz/{}", proof_id);
         }
         Ok(proof_id)
@@ -180,12 +169,6 @@ impl Prover<DefaultProverComponents> for NetworkProver {
     ) -> Result<SP1ProofWithPublicValues> {
         warn_if_not_default(&opts.sp1_prover_opts, &context);
         block_on(self.prove(&pk.elf, stdin, kind.into(), opts.timeout))
-    }
-}
-
-impl Default for NetworkProver {
-    fn default() -> Self {
-        Self::new()
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

We need to remove environment variables as they make SP1 difficult to use in a prod environment.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

I added a `NetworkProverClientBuilder` builder that handle the equivalent of the following environment variables:

* `SKIP_SIMULATION`
* `SP1_PRIVATE_KEY`
* `PROVER_NETWORK_RPC`

The environment variables are still used in `ProverClient::new()` for backward compatibility.

I only added a builder for the network builder as there is nothing to build for other provers.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes