### PR TITLE
fix: dont panic in ecrecover hook

### DIFF
--- a/crates/core/executor/src/hook.rs
+++ b/crates/core/executor/src/hook.rs
@@ -136,13 +136,16 @@ pub fn hook_k1_ecrecover(_: HookEnv, buf: &[u8]) -> Vec<Vec<u8>> {
     };
     let recid = RecoveryId::from_byte(recovery_id).expect("Computed recovery ID is invalid!");
 
-    let recovered_key = VerifyingKey::recover_from_prehash(&msg_hash[..], &sig, recid).unwrap();
+    let Ok(recovered_key) = VerifyingKey::recover_from_prehash(&msg_hash[..], &sig, recid) else {
+        return vec![vec![0]];
+    };
+
     let bytes = recovered_key.to_sec1_bytes();
 
     let (_, s) = sig.split_scalars();
     let s_inverse = s.invert();
 
-    vec![bytes.to_vec(), s_inverse.to_bytes().to_vec()]
+    vec![vec![1], bytes.to_vec(), s_inverse.to_bytes().to_vec()]
 }
 
 /// Recovers s inverse from the signature using the secp256r1 crate.


### PR DESCRIPTION
A bad signature may cause a panic in the executor if recovery fails for whatever reason..

In tandem with this PR https://github.com/sp1-patches/signatures/pull/7 this problem should be solved