### PR TITLE
feat: explicit `skip_simulation` flag

### DIFF
--- a/crates/sdk/src/network-v2/prover.rs
+++ b/crates/sdk/src/network-v2/prover.rs
@@ -41,7 +41,7 @@ impl NetworkProver {
         Self::new_from_key(&private_key)
     }
 
-    /// Skip simulation when running `prove`.
+    /// Set skip simulation when running `request_proof`.
     pub fn set_skip_simulation(&mut self, skip: bool) {
         self.skip_simulation = skip;
     }

--- a/crates/sdk/src/network/prover.rs
+++ b/crates/sdk/src/network/prover.rs
@@ -45,7 +45,7 @@ impl NetworkProver {
         Self { client: NetworkClient::new(private_key), local_prover, skip_simulation: false }
     }
 
-    /// Skip simulation when running `prove`.
+    /// Set skip simulation when running `request_proof`.
     pub fn set_skip_simulation(&mut self, skip: bool) {
         self.skip_simulation = skip;
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

User flags that are used to modify the behavior of the runtime should use a builder pattern rather than enshrined environment variables.

Note: This is not backwards compatible because you must set the `skip_simulation` flag on the `NetworkProver` directly. Now `ProverClient`'s will not have access to `skip_simulation`.

## Solution

Modify the `SKIP_SIMULATION` environment variable to instead by explicitly set on the `NetworkProver`.

## PR Checklist

- [X] Added Tests
- [X] Added Documentation
- [X] Breaking changes