### PR TITLE
perf: Strip the RISC-V ELF binary

### DIFF
--- a/crates/build/src/command/utils.rs
+++ b/crates/build/src/command/utils.rs
@@ -50,9 +50,18 @@ pub(crate) fn get_program_build_args(args: &BuildArgs) -> Vec<String> {
 
 /// Rust flags for compilation of C libraries.
 pub(crate) fn get_rust_compiler_flags(args: &BuildArgs) -> String {
-    let rust_flags =
-        ["-C", "passes=loweratomic", "-C", "link-arg=-Ttext=0x00200800", "-C", "panic=abort",
-            "-C", "strip=symbols", "-C", "opt-level=z"];
+    let rust_flags = [
+        "-C",
+        "passes=loweratomic",
+        "-C",
+        "link-arg=-Ttext=0x00200800",
+        "-C",
+        "panic=abort",
+        "-C",
+        "strip=symbols",
+        "-C",
+        "opt-level=z",
+    ];
     let rust_flags: Vec<_> =
         rust_flags.into_iter().chain(args.rustflags.iter().map(String::as_str)).collect();
     rust_flags.join("\x1f")

--- a/crates/build/src/command/utils.rs
+++ b/crates/build/src/command/utils.rs
@@ -51,7 +51,8 @@ pub(crate) fn get_program_build_args(args: &BuildArgs) -> Vec<String> {
 /// Rust flags for compilation of C libraries.
 pub(crate) fn get_rust_compiler_flags(args: &BuildArgs) -> String {
     let rust_flags =
-        ["-C", "passes=loweratomic", "-C", "link-arg=-Ttext=0x00200800", "-C", "panic=abort"];
+        ["-C", "passes=loweratomic", "-C", "link-arg=-Ttext=0x00200800", "-C", "panic=abort",
+            "-C", "strip=symbols", "-C", "opt-level=z"];
     let rust_flags: Vec<_> =
         rust_flags.into_iter().chain(args.rustflags.iter().map(String::as_str)).collect();
     rust_flags.join("\x1f")


### PR DESCRIPTION
This reduces the size of produced binaries by more than 2x.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

The generated ELF binaries are pretty large: the fibonacci example from Quickstart compiles to a 118KB binary. When looking at it with the `file` utility, one can see that it's not stripped.

```
❯ la $SP1_ELF_fibonacci_program
-rwxr-xr-x@ 1 ivan  staff   118K Nov 20 16:14 /Users/ivan/src/succinct/fibonacci/target/elf-compilation/riscv32im-succinct-zkvm-elf/release/fibonacci-program

❯ file $SP1_ELF_fibonacci_program
/Users/ivan/src/succinct/fibonacci/target/elf-compilation/riscv32im-succinct-zkvm-elf/release/fibonacci-program: ELF 32-bit LSB executable, UCB RISC-V, soft-float ABI, version 1 (SYSV), statically linked, not stripped
```

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Adding "-C", "strip=symbols", "-C", "opt-level=z" to Rust compiler flags reduces the produced ELF binary size by more than 2x.

```
❯ la $SP1_ELF_fibonacci_program
-rwxr-xr-x@ 1 ivan  staff    53K Nov 20 16:20 /Users/ivan/src/succinct/fibonacci/target/elf-compilation/riscv32im-succinct-zkvm-elf/release/fibonacci-program

❯ file $SP1_ELF_fibonacci_program
/Users/ivan/src/succinct/fibonacci/target/elf-compilation/riscv32im-succinct-zkvm-elf/release/fibonacci-program: ELF 32-bit LSB executable, UCB RISC-V, soft-float ABI, version 1 (SYSV), statically linked, stripped
```

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes