### PR TITLE
fix: non absolute build paths are relative to the build manifest

### DIFF
--- a/crates/build/src/build.rs
+++ b/crates/build/src/build.rs
@@ -54,19 +54,9 @@ pub fn execute_build_program(
 }
 
 /// Internal helper function to build the program with or without arguments.
-///
-/// If the path is not absolute, it is assumed to be relative to the `CARGO_MANIFEST_DIR`.
 pub(crate) fn build_program_internal(path: impl AsRef<Path>, args: Option<BuildArgs>) {
     // Get the root package name and metadata.
-    //
-    // Note:
-    // You _MUST_ read the `CARGO_MANIFEST_DIR` at runtime (`std::env::var` as opposed to `env!`).
-    // Otherwise it will be the manifest dir of this crate, not the caller.
-    let mut program_dir = path.as_ref().to_path_buf();
-    if program_dir.is_relative() {
-        program_dir = Path::new(&std::env::var("CARGO_MANIFEST_DIR").unwrap()).join(program_dir);
-    }
-
+    let program_dir = path.as_ref().to_path_buf();
     let metadata_file = program_dir.join("Cargo.toml");
     let mut metadata_cmd = cargo_metadata::MetadataCommand::new();
     let metadata = metadata_cmd.manifest_path(metadata_file).exec().unwrap();

--- a/crates/build/src/build.rs
+++ b/crates/build/src/build.rs
@@ -61,7 +61,7 @@ pub(crate) fn build_program_internal(path: impl AsRef<Path>, args: Option<BuildA
     //
     // Note:
     // You _MUST_ read the `CARGO_MANIFEST_DIR` at runtime (`std::env::var` as opposed to `env!`).
-    // Othewise it will be the manifest dir of this crate, not the caller.
+    // Otherwise it will be the manifest dir of this crate, not the caller.
     let mut program_dir = path.as_ref().to_path_buf();
     if program_dir.is_relative() {
         program_dir = Path::new(&std::env::var("CARGO_MANIFEST_DIR").unwrap()).join(program_dir);

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -4,6 +4,8 @@ mod utils;
 use build::build_program_internal;
 pub use build::{execute_build_program, generate_elf_paths};
 
+use std::path::Path;
+
 use clap::Parser;
 
 const BUILD_TARGET: &str = "riscv32im-succinct-zkvm-elf";
@@ -110,7 +112,7 @@ impl Default for BuildArgs {
 /// when changes are made to the source code or its dependencies.
 ///
 /// Set the `SP1_SKIP_PROGRAM_BUILD` environment variable to `true` to skip building the program.
-pub fn build_program(path: &str) {
+pub fn build_program(path: impl AsRef<Path>) {
     build_program_internal(path, None)
 }
 
@@ -123,7 +125,7 @@ pub fn build_program(path: &str) {
 /// * `args` - A [`BuildArgs`] struct that contains various build configuration options.
 ///
 /// Set the `SP1_SKIP_PROGRAM_BUILD` environment variable to `true` to skip building the program.
-pub fn build_program_with_args(path: &str, args: BuildArgs) {
+pub fn build_program_with_args(path: impl AsRef<Path>, args: BuildArgs) {
     build_program_internal(path, Some(args))
 }
 

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -117,6 +117,7 @@ impl Default for BuildArgs {
 ///
 /// ## Note: Using this function without an absolute path is not recommended.
 /// Try using the `build_program_from_path!` macro instead.
+#[deprecated(note = "Please use `build_program_from_path!` macro instead.")]
 pub fn build_program(path: impl AsRef<Path>) {
     build_program_internal(path, None)
 }
@@ -134,6 +135,7 @@ pub fn build_program(path: impl AsRef<Path>) {
 ///
 /// ## Note: Using this function without an absolute path is not recommended.
 /// Try using the `build_program_from_path!` macro instead.
+#[deprecated(note = "Please use `build_program_from_path!` macro instead.")]
 pub fn build_program_with_args(path: impl AsRef<Path>, args: BuildArgs) {
     build_program_internal(path, Some(args))
 }
@@ -143,6 +145,7 @@ pub fn build_program_with_args(path: impl AsRef<Path>, args: BuildArgs) {
 /// ### Note:
 /// This function is only exposed to support the `build_program_from_path!` macro.
 /// It is not recommended to use this function directly.
+#[doc(hidden)]
 pub fn build_program_with_maybe_args(path: impl AsRef<Path>, args: Option<BuildArgs>) {
     build_program_internal(path, args)
 }

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -126,7 +126,7 @@ pub fn build_program(path: impl AsRef<Path>) {
 ///
 /// # Arguments
 ///
-/// * `path` - A path to the guest program directory
+/// * `path` - A path to the guest program directory.
 ///
 /// * `args` - A [`BuildArgs`] struct that contains various build configuration options.
 ///
@@ -162,7 +162,7 @@ macro_rules! build_program_from_path {
         {
             // Inline this crates manifest path at compile time.
             const MANIFEST: &str = std::env!("CARGO_MANIFEST_DIR");
-            
+
             // Adjust the path to be relative to the manifest directory, unless its absolute.
             fn ___adjust_path(p: impl AsRef<::std::path::Path>) -> ::std::path::PathBuf {
                 let p = p.as_ref();

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -159,7 +159,7 @@ macro_rules! build_program_from_path {
     ($path:expr, $args:expr) => {
         const MANIFEST: &str = std::env!("CARGO_MANIFEST_DIR");
 
-        fn adjust_path(p: impl AsRef<::std::path::Path>) -> ::std::path::PathBuf {
+        fn ___adjust_path(p: impl AsRef<::std::path::Path>) -> ::std::path::PathBuf {
             let p = p.as_ref();
             if p.is_absolute() {
                 p.to_path_buf()
@@ -168,7 +168,7 @@ macro_rules! build_program_from_path {
             }
         }
 
-        ::sp1_build::build_program_with_maybe_args(adjust_path($path), $args)
+        ::sp1_build::build_program_with_maybe_args(___adjust_path($path), $args)
     };
     ($path:expr) => {
         ::sp1_build::build_program_from_path!($path, None)

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -140,8 +140,9 @@ pub fn build_program_with_args(path: impl AsRef<Path>, args: BuildArgs) {
 
 /// Builds the program with the given arguments if the program at path, or one of its dependencies,
 ///
-/// ### Note: This function is only exposed to support the `build_program_from_path!` macro.
-///          It is not recommended to use this function directly.
+/// ### Note:
+/// This function is only exposed to support the `build_program_from_path!` macro.
+/// It is not recommended to use this function directly.
 pub fn build_program_with_maybe_args(path: impl AsRef<Path>, args: Option<BuildArgs>) {
     build_program_internal(path, args)
 }

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -106,7 +106,8 @@ impl Default for BuildArgs {
 ///
 /// # Arguments
 ///
-/// * `path` - A string slice that holds the path to the program directory.
+/// * `path` - A path to the guest program directory, if not absolute, assumed to be relative to
+///            the caller manifest directory.
 ///
 /// This function is useful for automatically rebuilding the program during development
 /// when changes are made to the source code or its dependencies.
@@ -121,7 +122,9 @@ pub fn build_program(path: impl AsRef<Path>) {
 ///
 /// # Arguments
 ///
-/// * `path` - A string slice that holds the path to the program directory.
+/// * `path` - A path to the guest program directory, if not absolute, assumed to be relative to
+///            the caller manifest directory.
+///
 /// * `args` - A [`BuildArgs`] struct that contains various build configuration options.
 ///
 /// Set the `SP1_SKIP_PROGRAM_BUILD` environment variable to `true` to skip building the program.

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -113,6 +113,10 @@ impl Default for BuildArgs {
 /// when changes are made to the source code or its dependencies.
 ///
 /// Set the `SP1_SKIP_PROGRAM_BUILD` environment variable to `true` to skip building the program.
+///
+///
+/// ## Note: Using this function without an absolute path is not recommended.
+/// Try using the `build_program_from_path!` macro instead.
 pub fn build_program(path: impl AsRef<Path>) {
     build_program_internal(path, None)
 }
@@ -122,12 +126,14 @@ pub fn build_program(path: impl AsRef<Path>) {
 ///
 /// # Arguments
 ///
-/// * `path` - A path to the guest program directory, if not absolute, assumed to be relative to
-///            the caller manifest directory.
+/// * `path` - A path to the guest program directory
 ///
 /// * `args` - A [`BuildArgs`] struct that contains various build configuration options.
 ///
 /// Set the `SP1_SKIP_PROGRAM_BUILD` environment variable to `true` to skip building the program.
+///
+/// ## Note: Using this function without an absolute path is not recommended.
+/// Try using the `build_program_from_path!` macro instead.
 pub fn build_program_with_args(path: impl AsRef<Path>, args: BuildArgs) {
     build_program_internal(path, Some(args))
 }
@@ -140,11 +146,11 @@ pub fn build_program_with_maybe_args(path: impl AsRef<Path>, args: Option<BuildA
     build_program_internal(path, args)
 }
 
-/// Build a program with the given _RELATIVE_ path.
+/// Build a program at the given path.
 ///
 /// # Arguments
 /// * `path` - A path to the guest program directory, if not absolute, assumed to be relative to
-///            the caller manifest directory.
+///           the callers manifest directory.
 ///
 ///   `args` - A [`BuildArgs`] struct that contains various build configuration options.
 ///            If not provided, the default options are used.
@@ -153,7 +159,7 @@ macro_rules! build_program_from_path {
     ($path:expr, $args:expr) => {
         const MANIFEST: &str = std::env!("CARGO_MANIFEST_DIR");
 
-        fn adjust_path(p: impl AsRef<::std::path::Path>) -> ::std::path::PathBuf { 
+        fn adjust_path(p: impl AsRef<::std::path::Path>) -> ::std::path::PathBuf {
             let p = p.as_ref();
             if p.is_absolute() {
                 p.to_path_buf()
@@ -166,7 +172,7 @@ macro_rules! build_program_from_path {
     };
     ($path:expr) => {
         ::sp1_build::build_program_from_path!($path, None)
-    }
+    };
 }
 
 /// Returns the raw ELF bytes by the zkVM program target name.

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -219,7 +219,7 @@ dependencies = [
  "alloy-sol-types",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.68",
  "tracing",
 ]
 
@@ -241,7 +241,7 @@ dependencies = [
  "async-trait",
  "auto_impl",
  "futures-utils-wasm",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -426,7 +426,7 @@ dependencies = [
  "auto_impl",
  "elliptic-curve",
  "k256",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -442,7 +442,7 @@ dependencies = [
  "async-trait",
  "k256",
  "rand 0.8.5",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -1155,7 +1155,7 @@ dependencies = [
  "semver 1.0.23",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -1376,6 +1376,15 @@ name = "crc-catalog"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "crossbeam-deque"
@@ -1834,7 +1843,7 @@ dependencies = [
  "rand_core 0.6.4",
  "serde",
  "sha2 0.9.9",
- "thiserror",
+ "thiserror 1.0.68",
  "zeroize",
 ]
 
@@ -3846,7 +3855,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
 dependencies = [
  "memchr",
- "thiserror",
+ "thiserror 1.0.68",
  "ucd-trie",
 ]
 
@@ -4106,7 +4115,7 @@ dependencies = [
  "rustc-hash 2.0.0",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
  "tracing",
 ]
@@ -4123,7 +4132,7 @@ dependencies = [
  "rustc-hash 2.0.0",
  "rustls",
  "slab",
- "thiserror",
+ "thiserror 1.0.68",
  "tinyvec",
  "tracing",
 ]
@@ -4289,7 +4298,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -4407,7 +4416,7 @@ dependencies = [
  "http",
  "reqwest",
  "serde",
- "thiserror",
+ "thiserror 1.0.68",
  "tower-service",
 ]
 
@@ -4420,7 +4429,7 @@ dependencies = [
  "reth-execution-errors",
  "reth-primitives",
  "reth-storage-errors",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -4514,7 +4523,7 @@ dependencies = [
  "reth-execution-errors",
  "reth-fs-util",
  "reth-storage-errors",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -4598,7 +4607,7 @@ dependencies = [
  "reth-revm",
  "revm",
  "revm-primitives",
- "thiserror",
+ "thiserror 1.0.68",
  "tracing",
 ]
 
@@ -4637,7 +4646,7 @@ source = "git+https://github.com/sp1-patches/reth?tag=rsp-20240830#260c7ed2c9374
 dependencies = [
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -4649,7 +4658,7 @@ dependencies = [
  "alloy-rlp",
  "enr",
  "serde_with",
- "thiserror",
+ "thiserror 1.0.68",
  "url",
 ]
 
@@ -4706,7 +4715,7 @@ dependencies = [
  "reth-trie-common",
  "revm-primitives",
  "serde",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -4741,7 +4750,7 @@ dependencies = [
  "modular-bitfield",
  "reth-codecs",
  "serde",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -5090,7 +5099,7 @@ dependencies = [
  "rlp",
  "rsp-primitives",
  "serde",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -5713,7 +5722,7 @@ dependencies = [
  "sp1-stark",
  "strum",
  "strum_macros",
- "thiserror",
+ "thiserror 1.0.68",
  "tiny-keccak",
  "tracing",
  "typenum",
@@ -5758,7 +5767,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.68",
  "tracing",
  "tracing-forest",
  "tracing-subscriber",
@@ -5888,8 +5897,9 @@ dependencies = [
  "sp1-recursion-core",
  "sp1-recursion-gnark-ffi",
  "sp1-stark",
- "thiserror",
+ "thiserror 1.0.68",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
 ]
 
@@ -5973,7 +5983,7 @@ dependencies = [
  "sp1-primitives",
  "sp1-stark",
  "static_assertions",
- "thiserror",
+ "thiserror 1.0.68",
  "tracing",
  "vec_map",
  "zkhash",
@@ -6046,7 +6056,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
  "tracing",
  "twirp-rs",
@@ -6093,7 +6103,7 @@ dependencies = [
  "lazy_static",
  "sha2 0.10.8",
  "substrate-bn-succinct",
- "thiserror-no-std",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
@@ -6488,7 +6498,16 @@ version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02dd99dc800bbb97186339685293e1cc5d9df1f8fae2d0aecd9ff1c77efea892"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.68",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+dependencies = [
+ "thiserror-impl 2.0.3",
 ]
 
 [[package]]
@@ -6496,6 +6515,17 @@ name = "thiserror-impl"
 version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7c61ec9a6f64d2793d8a45faba21efbe3ced62a886d44c36a009b2b519b4c7e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6730,6 +6760,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror 1.0.68",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6758,7 +6800,7 @@ checksum = "ee40835db14ddd1e3ba414292272eddde9dad04d3d4b65509656414d1c42592f"
 dependencies = [
  "ansi_term",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.68",
  "tracing",
  "tracing-subscriber",
 ]
@@ -6814,7 +6856,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
  "tower",
  "url",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -219,7 +219,7 @@ dependencies = [
  "alloy-sol-types",
  "serde",
  "serde_json",
- "thiserror 1.0.68",
+ "thiserror",
  "tracing",
 ]
 
@@ -241,7 +241,7 @@ dependencies = [
  "async-trait",
  "auto_impl",
  "futures-utils-wasm",
- "thiserror 1.0.68",
+ "thiserror",
 ]
 
 [[package]]
@@ -426,7 +426,7 @@ dependencies = [
  "auto_impl",
  "elliptic-curve",
  "k256",
- "thiserror 1.0.68",
+ "thiserror",
 ]
 
 [[package]]
@@ -442,7 +442,7 @@ dependencies = [
  "async-trait",
  "k256",
  "rand 0.8.5",
- "thiserror 1.0.68",
+ "thiserror",
 ]
 
 [[package]]
@@ -1155,7 +1155,7 @@ dependencies = [
  "semver 1.0.23",
  "serde",
  "serde_json",
- "thiserror 1.0.68",
+ "thiserror",
 ]
 
 [[package]]
@@ -1376,15 +1376,6 @@ name = "crc-catalog"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
-dependencies = [
- "crossbeam-utils",
-]
 
 [[package]]
 name = "crossbeam-deque"
@@ -1843,7 +1834,7 @@ dependencies = [
  "rand_core 0.6.4",
  "serde",
  "sha2 0.9.9",
- "thiserror 1.0.68",
+ "thiserror",
  "zeroize",
 ]
 
@@ -3855,7 +3846,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
 dependencies = [
  "memchr",
- "thiserror 1.0.68",
+ "thiserror",
  "ucd-trie",
 ]
 
@@ -4115,7 +4106,7 @@ dependencies = [
  "rustc-hash 2.0.0",
  "rustls",
  "socket2",
- "thiserror 1.0.68",
+ "thiserror",
  "tokio",
  "tracing",
 ]
@@ -4132,7 +4123,7 @@ dependencies = [
  "rustc-hash 2.0.0",
  "rustls",
  "slab",
- "thiserror 1.0.68",
+ "thiserror",
  "tinyvec",
  "tracing",
 ]
@@ -4298,7 +4289,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror 1.0.68",
+ "thiserror",
 ]
 
 [[package]]
@@ -4416,7 +4407,7 @@ dependencies = [
  "http",
  "reqwest",
  "serde",
- "thiserror 1.0.68",
+ "thiserror",
  "tower-service",
 ]
 
@@ -4429,7 +4420,7 @@ dependencies = [
  "reth-execution-errors",
  "reth-primitives",
  "reth-storage-errors",
- "thiserror 1.0.68",
+ "thiserror",
 ]
 
 [[package]]
@@ -4523,7 +4514,7 @@ dependencies = [
  "reth-execution-errors",
  "reth-fs-util",
  "reth-storage-errors",
- "thiserror 1.0.68",
+ "thiserror",
 ]
 
 [[package]]
@@ -4607,7 +4598,7 @@ dependencies = [
  "reth-revm",
  "revm",
  "revm-primitives",
- "thiserror 1.0.68",
+ "thiserror",
  "tracing",
 ]
 
@@ -4646,7 +4637,7 @@ source = "git+https://github.com/sp1-patches/reth?tag=rsp-20240830#260c7ed2c9374
 dependencies = [
  "serde",
  "serde_json",
- "thiserror 1.0.68",
+ "thiserror",
 ]
 
 [[package]]
@@ -4658,7 +4649,7 @@ dependencies = [
  "alloy-rlp",
  "enr",
  "serde_with",
- "thiserror 1.0.68",
+ "thiserror",
  "url",
 ]
 
@@ -4715,7 +4706,7 @@ dependencies = [
  "reth-trie-common",
  "revm-primitives",
  "serde",
- "thiserror 1.0.68",
+ "thiserror",
 ]
 
 [[package]]
@@ -4750,7 +4741,7 @@ dependencies = [
  "modular-bitfield",
  "reth-codecs",
  "serde",
- "thiserror 1.0.68",
+ "thiserror",
 ]
 
 [[package]]
@@ -5099,7 +5090,7 @@ dependencies = [
  "rlp",
  "rsp-primitives",
  "serde",
- "thiserror 1.0.68",
+ "thiserror",
 ]
 
 [[package]]
@@ -5722,7 +5713,7 @@ dependencies = [
  "sp1-stark",
  "strum",
  "strum_macros",
- "thiserror 1.0.68",
+ "thiserror",
  "tiny-keccak",
  "tracing",
  "typenum",
@@ -5767,7 +5758,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "tempfile",
- "thiserror 1.0.68",
+ "thiserror",
  "tracing",
  "tracing-forest",
  "tracing-subscriber",
@@ -5897,9 +5888,8 @@ dependencies = [
  "sp1-recursion-core",
  "sp1-recursion-gnark-ffi",
  "sp1-stark",
- "thiserror 1.0.68",
+ "thiserror",
  "tracing",
- "tracing-appender",
  "tracing-subscriber",
 ]
 
@@ -5983,7 +5973,7 @@ dependencies = [
  "sp1-primitives",
  "sp1-stark",
  "static_assertions",
- "thiserror 1.0.68",
+ "thiserror",
  "tracing",
  "vec_map",
  "zkhash",
@@ -6056,7 +6046,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "tempfile",
- "thiserror 1.0.68",
+ "thiserror",
  "tokio",
  "tracing",
  "twirp-rs",
@@ -6103,7 +6093,7 @@ dependencies = [
  "lazy_static",
  "sha2 0.10.8",
  "substrate-bn-succinct",
- "thiserror 2.0.3",
+ "thiserror-no-std",
 ]
 
 [[package]]
@@ -6498,16 +6488,7 @@ version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02dd99dc800bbb97186339685293e1cc5d9df1f8fae2d0aecd9ff1c77efea892"
 dependencies = [
- "thiserror-impl 1.0.68",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
-dependencies = [
- "thiserror-impl 2.0.3",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -6515,17 +6496,6 @@ name = "thiserror-impl"
 version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7c61ec9a6f64d2793d8a45faba21efbe3ced62a886d44c36a009b2b519b4c7e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.87",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6760,18 +6730,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-appender"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
-dependencies = [
- "crossbeam-channel",
- "thiserror 1.0.68",
- "time",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "tracing-attributes"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6800,7 +6758,7 @@ checksum = "ee40835db14ddd1e3ba414292272eddde9dad04d3d4b65509656414d1c42592f"
 dependencies = [
  "ansi_term",
  "smallvec",
- "thiserror 1.0.68",
+ "thiserror",
  "tracing",
  "tracing-subscriber",
 ]
@@ -6856,7 +6814,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 1.0.68",
+ "thiserror",
  "tokio",
  "tower",
  "url",

--- a/examples/aggregation/script/build.rs
+++ b/examples/aggregation/script/build.rs
@@ -1,4 +1,4 @@
 fn main() {
-    sp1_build::build_program("../program");
-    sp1_build::build_program("../../fibonacci/program");
+    sp1_build::build_program_from_path!("../program");
+    sp1_build::build_program_from_path!("../../fibonacci/program");
 }

--- a/examples/bls12381/script/build.rs
+++ b/examples/bls12381/script/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    sp1_build::build_program("../program");
+    sp1_build::build_program_from_path!("../program");
 }

--- a/examples/bn254/script/build.rs
+++ b/examples/bn254/script/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    sp1_build::build_program("../program");
+    sp1_build::build_program_from_path!("../program");
 }

--- a/examples/chess/script/build.rs
+++ b/examples/chess/script/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    sp1_build::build_program("../program");
+    sp1_build::build_program_from_path!("../program");
 }

--- a/examples/cycle-tracking/script/build.rs
+++ b/examples/cycle-tracking/script/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    sp1_build::build_program("../program");
+    sp1_build::build_program_from_path!("../program");
 }

--- a/examples/fibonacci/script/build.rs
+++ b/examples/fibonacci/script/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    sp1_build::build_program_from_path!("../program");
+    sp1_build::build_program("../program");
 }

--- a/examples/fibonacci/script/build.rs
+++ b/examples/fibonacci/script/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    sp1_build::build_program("../program");
+    sp1_build::build_program_from_path!("../program");
 }

--- a/examples/groth16/script/build.rs
+++ b/examples/groth16/script/build.rs
@@ -1,4 +1,4 @@
 fn main() {
-    sp1_build::build_program("../program");
-    sp1_build::build_program("../../fibonacci/program");
+    sp1_build::build_program_from_path!("../program");
+    sp1_build::build_program_from_path!("../../fibonacci/program");
 }

--- a/examples/io/script/build.rs
+++ b/examples/io/script/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    sp1_build::build_program("../program");
+    sp1_build::build_program_from_path!("../program");
 }

--- a/examples/is-prime/script/build.rs
+++ b/examples/is-prime/script/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    sp1_build::build_program("../program");
+    sp1_build::build_program_from_path!("../program");
 }

--- a/examples/json/script/build.rs
+++ b/examples/json/script/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    sp1_build::build_program("../program");
+    sp1_build::build_program_from_path!("../program");
 }

--- a/examples/patch-testing/script/build.rs
+++ b/examples/patch-testing/script/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    sp1_build::build_program("../program");
+    sp1_build::build_program_from_path!("../program");
 }

--- a/examples/regex/script/build.rs
+++ b/examples/regex/script/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    sp1_build::build_program("../program");
+    sp1_build::build_program_from_path!("../program");
 }

--- a/examples/rsa/script/build.rs
+++ b/examples/rsa/script/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    sp1_build::build_program("../program");
+    sp1_build::build_program_from_path!("../program");
 }

--- a/examples/rsp/script/build.rs
+++ b/examples/rsp/script/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    sp1_build::build_program("../program");
+    sp1_build::build_program_from_path!("../program");
 }

--- a/examples/ssz-withdrawals/script/build.rs
+++ b/examples/ssz-withdrawals/script/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    sp1_build::build_program("../program");
+    sp1_build::build_program_from_path!("../program");
 }

--- a/examples/tendermint/script/build.rs
+++ b/examples/tendermint/script/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    sp1_build::build_program("../program");
+    sp1_build::build_program_from_path!("../program");
 }


### PR DESCRIPTION
sp1 build searches for the programs from the current dir

this can have unexpected behaviour if calling from an importing crate in a differnt location

opt in, but deprecating, way to have more reliable program resolution