### PR TITLE
fix: Add missing boolean constraints for `is_real` flag

### DIFF
--- a/crates/core/machine/src/syscall/precompiles/fptower/fp.rs
+++ b/crates/core/machine/src/syscall/precompiles/fptower/fp.rs
@@ -226,6 +226,9 @@ where
         builder.when_first_row().assert_zero(local.nonce);
         builder.when_transition().assert_eq(local.nonce + AB::Expr::one(), next.nonce);
 
+        // Constrain `is_real` to be boolean.
+        builder.assert_bool(local.is_real);
+
         // Check that operations flags are boolean.
         builder.assert_bool(local.is_add);
         builder.assert_bool(local.is_sub);

--- a/crates/core/machine/src/syscall/precompiles/fptower/fp2_addsub.rs
+++ b/crates/core/machine/src/syscall/precompiles/fptower/fp2_addsub.rs
@@ -234,6 +234,9 @@ where
         let next = main.row_slice(1);
         let next: &Fp2AddSubAssignCols<AB::Var, P> = (*next).borrow();
 
+        // Constrain `is_real` to be boolean.
+        builder.assert_bool(local.is_real);
+
         // Constrain the `is_add` flag to be boolean.
         builder.assert_bool(local.is_add);
 

--- a/crates/core/machine/src/syscall/precompiles/fptower/fp2_mul.rs
+++ b/crates/core/machine/src/syscall/precompiles/fptower/fp2_mul.rs
@@ -264,6 +264,9 @@ where
         let next = main.row_slice(1);
         let next: &Fp2MulAssignCols<AB::Var, P> = (*next).borrow();
 
+        // Constrain `is_real` to be boolean.
+        builder.assert_bool(local.is_real);
+
         builder.when_first_row().assert_zero(local.nonce);
         builder.when_transition().assert_eq(local.nonce + AB::Expr::one(), next.nonce);
         let num_words_field_element = <P as NumLimbs>::Limbs::USIZE / 4;

--- a/crates/core/machine/src/syscall/precompiles/keccak256/air.rs
+++ b/crates/core/machine/src/syscall/precompiles/keccak256/air.rs
@@ -33,6 +33,9 @@ where
         let local: &KeccakMemCols<AB::Var> = (*local).borrow();
         let next: &KeccakMemCols<AB::Var> = (*next).borrow();
 
+        // Constrain `is_real` to be boolean.
+        builder.assert_bool(local.is_real);
+
         // Constrain the incrementing nonce.
         builder.when_first_row().assert_zero(local.nonce);
         builder.when_transition().assert_eq(local.nonce + AB::Expr::one(), next.nonce);

--- a/crates/core/machine/src/syscall/precompiles/weierstrass/weierstrass_add.rs
+++ b/crates/core/machine/src/syscall/precompiles/weierstrass/weierstrass_add.rs
@@ -305,6 +305,9 @@ where
         let next = main.row_slice(1);
         let next: &WeierstrassAddAssignCols<AB::Var, E::BaseField> = (*next).borrow();
 
+        // Constrain `is_real` to be boolean.
+        builder.assert_bool(local.is_real);
+
         // Constrain the incrementing nonce.
         builder.when_first_row().assert_zero(local.nonce);
         builder.when_transition().assert_eq(local.nonce + AB::Expr::one(), next.nonce);

--- a/crates/core/machine/src/syscall/precompiles/weierstrass/weierstrass_decompress.rs
+++ b/crates/core/machine/src/syscall/precompiles/weierstrass/weierstrass_decompress.rs
@@ -338,6 +338,9 @@ where
         let next: &WeierstrassDecompressCols<AB::Var, E::BaseField> =
             (*next)[0..weierstrass_cols].borrow();
 
+        // Constrain `is_real` to be boolean.
+        builder.assert_bool(local.is_real);
+
         // Constrain the incrementing nonce.
         builder.when_first_row().assert_zero(local.nonce);
         builder.when_transition().assert_eq(local.nonce + AB::Expr::one(), next.nonce);

--- a/crates/core/machine/src/syscall/precompiles/weierstrass/weierstrass_double.rs
+++ b/crates/core/machine/src/syscall/precompiles/weierstrass/weierstrass_double.rs
@@ -355,6 +355,9 @@ where
         let next = main.row_slice(1);
         let next: &WeierstrassDoubleAssignCols<AB::Var, E::BaseField> = (*next).borrow();
 
+        // Constrain `is_real` to be boolean.
+        builder.assert_bool(local.is_real);
+
         // Constrain the incrementing nonce.
         builder.when_first_row().assert_zero(local.nonce);
         builder.when_transition().assert_eq(local.nonce + AB::Expr::one(), next.nonce);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

There seem to be some missing boolean checks on the `is_real` flag for some precompiles.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes