### PR TITLE
fix: workflow should force install just in case

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           cargo run -p sp1-cli -- prove install-toolchain
           cd crates/cli
-          cargo install --locked --path .
+          cargo install --force --locked --path .
           cargo clean
 
       - name: Run cargo check
@@ -85,7 +85,7 @@ jobs:
         run: |
           cargo run -p sp1-cli -- prove install-toolchain
           cd crates/cli
-          cargo install --locked --path .
+          cargo install --force --locked --path .
           cargo clean
 
       - name: Run cargo check
@@ -122,7 +122,7 @@ jobs:
         run: |
           cargo run -p sp1-cli -- prove install-toolchain
           cd crates/cli
-          cargo install --locked --path .
+          cargo install --force --locked --path .
           cargo clean
 
       - name: Run cargo fmt
@@ -165,7 +165,7 @@ jobs:
         run: |
           cargo run -p sp1-cli -- prove install-toolchain
           cd crates/cli
-          cargo install --locked --path .
+          cargo install --force --locked --path .
           cargo clean
 
       - name: Check workspace no features
@@ -209,7 +209,7 @@ jobs:
         run: |
           cargo run -p sp1-cli -- prove install-toolchain
           cd crates/cli
-          cargo install --locked --path .
+          cargo install --force --locked --path .
           cargo clean
 
       - name: Run cargo fmt
@@ -243,7 +243,7 @@ jobs:
         run: |
           cargo run -p sp1-cli -- prove install-toolchain
           cd crates/cli
-          cargo install --locked --path .
+          cargo install --force --locked --path .
           cargo clean
 
       - name: Run cargo prove new
@@ -277,7 +277,7 @@ jobs:
         run: |
           cargo run -p sp1-cli -- prove install-toolchain
           cd crates/cli
-          cargo install --locked --path .
+          cargo install --force --locked --path .
           cargo clean
 
       - name: Run Evaluation
@@ -324,7 +324,7 @@ jobs:
         run: |
           cargo run -p sp1-cli -- prove install-toolchain
           cd crates/cli
-          cargo install --locked --path .
+          cargo install --force --locked --path .
           cargo clean
 
       - name: Run tendermint script
@@ -369,7 +369,7 @@ jobs:
 
   #     - name: "Install cargo-prove"
   #       run: |
-  #         cargo install --locked --path ./crates/cli
+  #         cargo install --force --locked --path ./crates/cli
 
   #     - name: "Install SP1 toolchain"
   #       run: |

--- a/crates/prover/src/lib.rs
+++ b/crates/prover/src/lib.rs
@@ -1540,8 +1540,8 @@ pub mod tests {
         setup_logger();
         let prover = SP1Prover::<DefaultProverComponents>::new();
         let program = test_artifacts::FIBONACCI_ELF;
-        let (pk, vk) = prover.setup(&program);
-        let pk2 = prover.setup(&program).0;
+        let (pk, _) = prover.setup(program);
+        let pk2 = prover.setup(program).0;
         assert_eq!(pk.pk.commit, pk2.pk.commit);
     }
 }


### PR DESCRIPTION
Workflows may cache some build artifacts, which may be cargo prove, which can cause this workflow to fail on toolchain install.

Force overwrite any binary, because caching appears to be non deterministic 