### PR TITLE
chore: disable book for dev branch

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -5,9 +5,9 @@ name: book
 
 on:
   push:
-    branches: [dev]
+    branches: [main]
   pull_request:
-    branches: [dev]
+    branches: [main]
     paths:
       - "book/**"
   merge_group:
@@ -117,7 +117,7 @@ jobs:
 
   deploy:
     # Only deploy if a push to main
-    if: github.ref_name == 'dev' && github.event_name == 'push'
+    if: github.ref_name == 'main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     needs: [lint, build]
 


### PR DESCRIPTION
Right now, GH-pages only allows one site per repo, dev has been overriding main book deployments

closes #1820 