### PR TITLE
Typo fix

### DIFF
--- a/crates/core/executor/src/executor.rs
+++ b/crates/core/executor/src/executor.rs
@@ -37,7 +37,7 @@ pub enum DeferredProofVerification {
 
 /// An executor for the SP1 RISC-V zkVM.
 ///
-/// The exeuctor is responsible for executing a user program and tracing important events which
+/// The executor is responsible for executing a user program and tracing important events which
 /// occur during execution (i.e., memory reads, alu operations, etc).
 pub struct Executor<'a> {
     /// The program.

--- a/crates/core/executor/src/lib.rs
+++ b/crates/core/executor/src/lib.rs
@@ -1,4 +1,4 @@
-//! An implementation of an exucutor for the SP1 RISC-V zkVM.
+//! An implementation of an executor for the SP1 RISC-V zkVM.
 
 #![warn(clippy::pedantic)]
 #![allow(clippy::similar_names)]


### PR DESCRIPTION
### Description of the Issue:
Found typos in the following files:

- `exeuctor` -> `executor` in `crates/core/executor/src/executor.rs`
- `exucutor` -> `executor` in `crates/core/executor/src/lib.rs`

### Suggested Fix:
Correct the typos by replacing them with the proper spelling: `executor`.
