### PR TITLE
chore: use &'static str for chip names as much as possible

### DIFF
--- a/crates/core/executor/src/program.rs
+++ b/crates/core/executor/src/program.rs
@@ -84,7 +84,7 @@ impl Program {
             .map(|shape| {
                 shape
                     .inner
-                    .get(&air.name())
+                    .get(air.name())
                     .unwrap_or_else(|| panic!("Chip {} not found in specified shape", air.name()))
             })
             .copied()

--- a/crates/core/executor/src/record.rs
+++ b/crates/core/executor/src/record.rs
@@ -263,7 +263,7 @@ impl ExecutionRecord {
             .map(|shape| {
                 shape
                     .inner
-                    .get(&air.name())
+                    .get(air.name())
                     .unwrap_or_else(|| panic!("Chip {} not found in specified shape", air.name()))
             })
             .copied()

--- a/crates/core/executor/src/shape.rs
+++ b/crates/core/executor/src/shape.rs
@@ -40,7 +40,7 @@ impl CoreShape {
 
     /// Determines whether the execution record contains a trace for a given chip.
     pub fn included<F: PrimeField, A: MachineAir<F>>(&self, air: &A) -> bool {
-        self.inner.contains_key(&air.name())
+        self.inner.contains_key(air.name())
     }
 }
 

--- a/crates/core/machine/src/alu/add_sub/mod.rs
+++ b/crates/core/machine/src/alu/add_sub/mod.rs
@@ -68,8 +68,8 @@ impl<F: PrimeField> MachineAir<F> for AddSubChip {
 
     type Program = Program;
 
-    fn name(&self) -> String {
-        "AddSub".to_string()
+    fn name(&self) -> &'static str {
+        "AddSub"
     }
 
     fn generate_trace(

--- a/crates/core/machine/src/alu/bitwise/mod.rs
+++ b/crates/core/machine/src/alu/bitwise/mod.rs
@@ -62,8 +62,8 @@ impl<F: PrimeField> MachineAir<F> for BitwiseChip {
 
     type Program = Program;
 
-    fn name(&self) -> String {
-        "Bitwise".to_string()
+    fn name(&self) -> &'static str {
+        "Bitwise"
     }
 
     fn generate_trace(

--- a/crates/core/machine/src/alu/divrem/mod.rs
+++ b/crates/core/machine/src/alu/divrem/mod.rs
@@ -214,8 +214,8 @@ impl<F: PrimeField> MachineAir<F> for DivRemChip {
 
     type Program = Program;
 
-    fn name(&self) -> String {
-        "DivRem".to_string()
+    fn name(&self) -> &'static str {
+        "DivRem"
     }
 
     fn generate_trace(

--- a/crates/core/machine/src/alu/lt/mod.rs
+++ b/crates/core/machine/src/alu/lt/mod.rs
@@ -97,8 +97,8 @@ impl<F: PrimeField32> MachineAir<F> for LtChip {
 
     type Program = Program;
 
-    fn name(&self) -> String {
-        "Lt".to_string()
+    fn name(&self) -> &'static str {
+        "Lt"
     }
 
     fn generate_trace(

--- a/crates/core/machine/src/alu/mul/mod.rs
+++ b/crates/core/machine/src/alu/mul/mod.rs
@@ -129,8 +129,8 @@ impl<F: PrimeField> MachineAir<F> for MulChip {
 
     type Program = Program;
 
-    fn name(&self) -> String {
-        "Mul".to_string()
+    fn name(&self) -> &'static str {
+        "Mul"
     }
 
     fn generate_trace(

--- a/crates/core/machine/src/alu/sll/mod.rs
+++ b/crates/core/machine/src/alu/sll/mod.rs
@@ -106,8 +106,8 @@ impl<F: PrimeField> MachineAir<F> for ShiftLeft {
 
     type Program = Program;
 
-    fn name(&self) -> String {
-        "ShiftLeft".to_string()
+    fn name(&self) -> &'static str {
+        "ShiftLeft"
     }
 
     fn generate_trace(

--- a/crates/core/machine/src/alu/sr/mod.rs
+++ b/crates/core/machine/src/alu/sr/mod.rs
@@ -139,8 +139,8 @@ impl<F: PrimeField> MachineAir<F> for ShiftRightChip {
 
     type Program = Program;
 
-    fn name(&self) -> String {
-        "ShiftRight".to_string()
+    fn name(&self) -> &'static str {
+        "ShiftRight"
     }
 
     fn generate_trace(

--- a/crates/core/machine/src/bytes/trace.rs
+++ b/crates/core/machine/src/bytes/trace.rs
@@ -19,8 +19,8 @@ impl<F: Field> MachineAir<F> for ByteChip<F> {
 
     type Program = Program;
 
-    fn name(&self) -> String {
-        "Byte".to_string()
+    fn name(&self) -> &'static str {
+        "Byte"
     }
 
     fn preprocessed_width(&self) -> usize {

--- a/crates/core/machine/src/cpu/trace.rs
+++ b/crates/core/machine/src/cpu/trace.rs
@@ -24,8 +24,8 @@ impl<F: PrimeField32> MachineAir<F> for CpuChip {
 
     type Program = Program;
 
-    fn name(&self) -> String {
-        "CPU".to_string()
+    fn name(&self) -> &'static str {
+        "CPU"
     }
 
     fn generate_trace(
@@ -35,7 +35,7 @@ impl<F: PrimeField32> MachineAir<F> for CpuChip {
     ) -> RowMajorMatrix<F> {
         let n_real_rows = input.cpu_events.len();
         let padded_nb_rows = if let Some(shape) = &input.shape {
-            1 << shape.inner[&MachineAir::<F>::name(self)]
+            1 << shape.inner[MachineAir::<F>::name(self)]
         } else if n_real_rows < 16 {
             16
         } else {

--- a/crates/core/machine/src/memory/global.rs
+++ b/crates/core/machine/src/memory/global.rs
@@ -47,10 +47,10 @@ impl<F: PrimeField32> MachineAir<F> for MemoryGlobalChip {
 
     type Program = Program;
 
-    fn name(&self) -> String {
+    fn name(&self) -> &'static str {
         match self.kind {
-            MemoryChipType::Initialize => "MemoryGlobalInit".to_string(),
-            MemoryChipType::Finalize => "MemoryGlobalFinalize".to_string(),
+            MemoryChipType::Initialize => "MemoryGlobalInit",
+            MemoryChipType::Finalize => "MemoryGlobalFinalize",
         }
     }
 

--- a/crates/core/machine/src/memory/local.rs
+++ b/crates/core/machine/src/memory/local.rs
@@ -73,8 +73,8 @@ impl<F: PrimeField32> MachineAir<F> for MemoryLocalChip {
 
     type Program = Program;
 
-    fn name(&self) -> String {
-        "MemoryLocal".to_string()
+    fn name(&self) -> &'static str {
+        "MemoryLocal"
     }
 
     fn generate_dependencies(&self, _input: &ExecutionRecord, _output: &mut ExecutionRecord) {

--- a/crates/core/machine/src/memory/program.rs
+++ b/crates/core/machine/src/memory/program.rs
@@ -66,8 +66,8 @@ impl<F: PrimeField> MachineAir<F> for MemoryProgramChip {
 
     type Program = Program;
 
-    fn name(&self) -> String {
-        "MemoryProgram".to_string()
+    fn name(&self) -> &'static str {
+        "MemoryProgram"
     }
 
     fn preprocessed_width(&self) -> usize {

--- a/crates/core/machine/src/operations/field/field_den.rs
+++ b/crates/core/machine/src/operations/field/field_den.rs
@@ -194,8 +194,8 @@ mod tests {
 
         type Program = Program;
 
-        fn name(&self) -> String {
-            "FieldDen".to_string()
+        fn name(&self) -> &'static str {
+            "FieldDen"
         }
 
         fn generate_trace(

--- a/crates/core/machine/src/operations/field/field_inner_product.rs
+++ b/crates/core/machine/src/operations/field/field_inner_product.rs
@@ -182,8 +182,8 @@ mod tests {
 
         type Program = Program;
 
-        fn name(&self) -> String {
-            "FieldInnerProduct".to_string()
+        fn name(&self) -> &'static str {
+            "FieldInnerProduct"
         }
 
         fn generate_trace(

--- a/crates/core/machine/src/operations/field/field_op.rs
+++ b/crates/core/machine/src/operations/field/field_op.rs
@@ -431,8 +431,13 @@ mod tests {
 
         type Program = Program;
 
-        fn name(&self) -> String {
-            format!("FieldOp{:?}", self.operation)
+        fn name(&self) -> &'static str {
+            match self.operation {
+                FieldOperation::Add => "FieldAdd",
+                FieldOperation::Mul => "FieldMul",
+                FieldOperation::Sub => "FieldSub",
+                FieldOperation::Div => "FieldDiv",
+            }
         }
 
         fn generate_trace(

--- a/crates/core/machine/src/operations/field/field_sqrt.rs
+++ b/crates/core/machine/src/operations/field/field_sqrt.rs
@@ -193,8 +193,8 @@ mod tests {
 
         type Program = Program;
 
-        fn name(&self) -> String {
-            "EdSqrtChip".to_string()
+        fn name(&self) -> &'static str {
+            "EdSqrtChip"
         }
 
         fn generate_trace(

--- a/crates/core/machine/src/program/mod.rs
+++ b/crates/core/machine/src/program/mod.rs
@@ -56,8 +56,8 @@ impl<F: PrimeField> MachineAir<F> for ProgramChip {
 
     type Program = Program;
 
-    fn name(&self) -> String {
-        "Program".to_string()
+    fn name(&self) -> &'static str {
+        "Program"
     }
 
     fn preprocessed_width(&self) -> usize {

--- a/crates/core/machine/src/riscv/shape.rs
+++ b/crates/core/machine/src/riscv/shape.rs
@@ -87,7 +87,7 @@ impl<F: PrimeField32> CoreShapeConfig<F> {
                     let allowed_height =
                         if allowed_log_height != 0 { 1 << allowed_log_height } else { 0 };
                     if *height <= allowed_height {
-                        return Some((air.name(), allowed_log_height));
+                        return Some((air.name().to_string(), allowed_log_height));
                     }
                 }
                 None
@@ -132,12 +132,12 @@ impl<F: PrimeField32> CoreShapeConfig<F> {
                         i
                     );
                     for (air, height) in heights.iter() {
-                        if shape.inner.contains_key(&air.name()) {
+                        if shape.inner.contains_key(air.name()) {
                             tracing::debug!(
                                 "Chip {:<20}: {:<3} -> {:<3}",
                                 air.name(),
                                 log2_ceil_usize(*height),
-                                shape.inner[&air.name()],
+                                shape.inner[air.name()],
                             );
                         }
                     }
@@ -208,9 +208,11 @@ impl<F: PrimeField32> CoreShapeConfig<F> {
             .rev()
             .map(|rows_per_event| {
                 [
-                    (air.name(), allowed_log_height),
+                    (air.name().to_string(), allowed_log_height),
                     (
-                        RiscvAir::<F>::SyscallPrecompile(SyscallChip::precompile()).name(),
+                        RiscvAir::<F>::SyscallPrecompile(SyscallChip::precompile())
+                            .name()
+                            .to_string(),
                         ((1 << allowed_log_height)
                             .div_ceil(&air.rows_per_event())
                             .next_power_of_two()
@@ -218,7 +220,7 @@ impl<F: PrimeField32> CoreShapeConfig<F> {
                             .max(4),
                     ),
                     (
-                        RiscvAir::<F>::MemoryLocal(MemoryLocalChip::new()).name(),
+                        RiscvAir::<F>::MemoryLocal(MemoryLocalChip::new()).name().to_string(),
                         (((1 << allowed_log_height) * mem_events_per_row)
                             .div_ceil(NUM_LOCAL_MEMORY_ENTRIES_PER_ROW * rows_per_event)
                             .next_power_of_two()
@@ -251,12 +253,12 @@ impl<F: PrimeField32> CoreShapeConfig<F> {
         let preprocessed_heights = self
             .allowed_preprocessed_log_heights
             .iter()
-            .map(|(air, heights)| (air.name(), heights.clone()));
+            .map(|(air, heights)| (air.name().to_string(), heights.clone()));
 
         let mut memory_heights = self
             .memory_allowed_log_heights
             .iter()
-            .map(|(air, heights)| (air.name(), heights.clone()))
+            .map(|(air, heights)| (air.name().to_string(), heights.clone()))
             .collect::<HashMap<_, _>>();
         memory_heights.extend(preprocessed_heights.clone());
 
@@ -288,7 +290,7 @@ impl<F: PrimeField32> CoreShapeConfig<F> {
                 Self::generate_all_shapes_from_allowed_log_heights({
                     let mut log_heights = allowed_log_heights
                         .iter()
-                        .map(|(air, heights)| (air.name(), heights.clone()))
+                        .map(|(air, heights)| (air.name().to_string(), heights.clone()))
                         .collect::<HashMap<_, _>>();
                     log_heights.extend(preprocessed_heights.clone());
                     log_heights
@@ -299,10 +301,10 @@ impl<F: PrimeField32> CoreShapeConfig<F> {
     }
 
     pub fn maximal_core_shapes(&self) -> Vec<CoreShape> {
-        let max_preprocessed = self
-            .allowed_preprocessed_log_heights
-            .iter()
-            .map(|(air, allowed_heights)| (air.name(), allowed_heights.last().unwrap().unwrap()));
+        let max_preprocessed =
+            self.allowed_preprocessed_log_heights.iter().map(|(air, allowed_heights)| {
+                (air.name().to_string(), allowed_heights.last().unwrap().unwrap())
+            });
 
         let max_core_shapes = self
             .allowed_core_log_heights
@@ -313,7 +315,7 @@ impl<F: PrimeField32> CoreShapeConfig<F> {
                 max_preprocessed
                     .clone()
                     .chain(allowed_log_heights.iter().map(|(air, allowed_heights)| {
-                        (air.name(), allowed_heights.last().unwrap().unwrap())
+                        (air.name().to_string(), allowed_heights.last().unwrap().unwrap())
                     }))
                     .collect::<CoreShape>()
             });
@@ -799,7 +801,7 @@ pub mod tests {
         let height_map = preprocessed_log_heights
             .into_iter()
             .chain(core_log_heights)
-            .map(|(air, log_height)| (air.name(), log_height))
+            .map(|(air, log_height)| (air.name().to_string(), log_height))
             .collect::<HashMap<_, _>>();
 
         let shape = CoreShape { inner: height_map };

--- a/crates/core/machine/src/syscall/chip.rs
+++ b/crates/core/machine/src/syscall/chip.rs
@@ -70,8 +70,11 @@ impl<F: PrimeField32> MachineAir<F> for SyscallChip {
 
     type Program = Program;
 
-    fn name(&self) -> String {
-        format!("Syscall{}", self.shard_kind).to_string()
+    fn name(&self) -> &'static str {
+        match self.shard_kind {
+            SyscallShardKind::Core => "SyscallCore",
+            SyscallShardKind::Precompile => "SyscallPrecompile",
+        }
     }
 
     fn generate_dependencies(&self, _input: &ExecutionRecord, _output: &mut ExecutionRecord) {

--- a/crates/core/machine/src/syscall/precompiles/README.md
+++ b/crates/core/machine/src/syscall/precompiles/README.md
@@ -61,8 +61,8 @@ impl<F: PrimeField32> MachineAir<F> for CustomOpChip {
     type Record = ExecutionRecord;
     type Program = Program;
 
-    fn name(&self) -> String {
-        "CustomOp".to_string()
+    fn name(&self) -> &'static str {
+        "CustomOp"
     }
 
     fn generate_trace(

--- a/crates/core/machine/src/syscall/precompiles/edwards/ed_add.rs
+++ b/crates/core/machine/src/syscall/precompiles/edwards/ed_add.rs
@@ -109,8 +109,8 @@ impl<F: PrimeField32, E: EllipticCurve + EdwardsParameters> MachineAir<F> for Ed
 
     type Program = Program;
 
-    fn name(&self) -> String {
-        "EdAddAssign".to_string()
+    fn name(&self) -> &'static str {
+        "EdAddAssign"
     }
 
     fn generate_trace(

--- a/crates/core/machine/src/syscall/precompiles/edwards/ed_decompress.rs
+++ b/crates/core/machine/src/syscall/precompiles/edwards/ed_decompress.rs
@@ -207,8 +207,8 @@ impl<F: PrimeField32, E: EdwardsParameters> MachineAir<F> for EdDecompressChip<E
 
     type Program = Program;
 
-    fn name(&self) -> String {
-        "EdDecompress".to_string()
+    fn name(&self) -> &'static str {
+        "EdDecompress"
     }
 
     fn generate_trace(

--- a/crates/core/machine/src/syscall/precompiles/fptower/fp.rs
+++ b/crates/core/machine/src/syscall/precompiles/fptower/fp.rs
@@ -80,10 +80,10 @@ impl<F: PrimeField32, P: FpOpField> MachineAir<F> for FpOpChip<P> {
 
     type Program = Program;
 
-    fn name(&self) -> String {
+    fn name(&self) -> &'static str {
         match P::FIELD_TYPE {
-            FieldType::Bn254 => "Bn254FpOpAssign".to_string(),
-            FieldType::Bls12381 => "Bls12381FpOpAssign".to_string(),
+            FieldType::Bn254 => "Bn254FpOpAssign",
+            FieldType::Bls12381 => "Bls12381FpOpAssign",
         }
     }
 

--- a/crates/core/machine/src/syscall/precompiles/fptower/fp2_addsub.rs
+++ b/crates/core/machine/src/syscall/precompiles/fptower/fp2_addsub.rs
@@ -83,10 +83,10 @@ impl<F: PrimeField32, P: FpOpField> MachineAir<F> for Fp2AddSubAssignChip<P> {
 
     type Program = Program;
 
-    fn name(&self) -> String {
+    fn name(&self) -> &'static str {
         match P::FIELD_TYPE {
-            FieldType::Bn254 => "Bn254Fp2AddSubAssign".to_string(),
-            FieldType::Bls12381 => "Bls12831Fp2AddSubAssign".to_string(),
+            FieldType::Bn254 => "Bn254Fp2AddSubAssign",
+            FieldType::Bls12381 => "Bls12831Fp2AddSubAssign",
         }
     }
 

--- a/crates/core/machine/src/syscall/precompiles/fptower/fp2_mul.rs
+++ b/crates/core/machine/src/syscall/precompiles/fptower/fp2_mul.rs
@@ -132,10 +132,10 @@ impl<F: PrimeField32, P: FpOpField> MachineAir<F> for Fp2MulAssignChip<P> {
 
     type Program = Program;
 
-    fn name(&self) -> String {
+    fn name(&self) -> &'static str {
         match P::FIELD_TYPE {
-            FieldType::Bn254 => "Bn254Fp2MulAssign".to_string(),
-            FieldType::Bls12381 => "Bls12831Fp2MulAssign".to_string(),
+            FieldType::Bn254 => "Bn254Fp2MulAssign",
+            FieldType::Bls12381 => "Bls12831Fp2MulAssign",
         }
     }
 

--- a/crates/core/machine/src/syscall/precompiles/keccak256/trace.rs
+++ b/crates/core/machine/src/syscall/precompiles/keccak256/trace.rs
@@ -23,8 +23,8 @@ impl<F: PrimeField32> MachineAir<F> for KeccakPermuteChip {
     type Record = ExecutionRecord;
     type Program = Program;
 
-    fn name(&self) -> String {
-        "KeccakPermute".to_string()
+    fn name(&self) -> &'static str {
+        "KeccakPermute"
     }
 
     fn generate_dependencies(&self, input: &Self::Record, output: &mut Self::Record) {

--- a/crates/core/machine/src/syscall/precompiles/sha256/compress/trace.rs
+++ b/crates/core/machine/src/syscall/precompiles/sha256/compress/trace.rs
@@ -23,8 +23,8 @@ impl<F: PrimeField32> MachineAir<F> for ShaCompressChip {
 
     type Program = Program;
 
-    fn name(&self) -> String {
-        "ShaCompress".to_string()
+    fn name(&self) -> &'static str {
+        "ShaCompress"
     }
 
     fn generate_trace(

--- a/crates/core/machine/src/syscall/precompiles/sha256/extend/trace.rs
+++ b/crates/core/machine/src/syscall/precompiles/sha256/extend/trace.rs
@@ -18,8 +18,8 @@ impl<F: PrimeField32> MachineAir<F> for ShaExtendChip {
 
     type Program = Program;
 
-    fn name(&self) -> String {
-        "ShaExtend".to_string()
+    fn name(&self) -> &'static str {
+        "ShaExtend"
     }
 
     fn generate_trace(

--- a/crates/core/machine/src/syscall/precompiles/u256x2048_mul/air.rs
+++ b/crates/core/machine/src/syscall/precompiles/u256x2048_mul/air.rs
@@ -92,8 +92,8 @@ impl<F: PrimeField32> MachineAir<F> for U256x2048MulChip {
     type Record = ExecutionRecord;
     type Program = Program;
 
-    fn name(&self) -> String {
-        "U256XU2048Mul".to_string()
+    fn name(&self) -> &'static str {
+        "U256XU2048Mul"
     }
 
     fn generate_trace(

--- a/crates/core/machine/src/syscall/precompiles/uint256/air.rs
+++ b/crates/core/machine/src/syscall/precompiles/uint256/air.rs
@@ -96,8 +96,8 @@ impl<F: PrimeField32> MachineAir<F> for Uint256MulChip {
     type Record = ExecutionRecord;
     type Program = Program;
 
-    fn name(&self) -> String {
-        "Uint256MulMod".to_string()
+    fn name(&self) -> &'static str {
+        "Uint256MulMod"
     }
 
     fn generate_trace(

--- a/crates/core/machine/src/syscall/precompiles/weierstrass/weierstrass_add.rs
+++ b/crates/core/machine/src/syscall/precompiles/weierstrass/weierstrass_add.rs
@@ -147,12 +147,12 @@ impl<F: PrimeField32, E: EllipticCurve + WeierstrassParameters> MachineAir<F>
     type Record = ExecutionRecord;
     type Program = Program;
 
-    fn name(&self) -> String {
+    fn name(&self) -> &'static str {
         match E::CURVE_TYPE {
-            CurveType::Secp256k1 => "Secp256k1AddAssign".to_string(),
-            CurveType::Secp256r1 => "Secp256r1AddAssign".to_string(),
-            CurveType::Bn254 => "Bn254AddAssign".to_string(),
-            CurveType::Bls12381 => "Bls12381AddAssign".to_string(),
+            CurveType::Secp256k1 => "Secp256k1AddAssign",
+            CurveType::Secp256r1 => "Secp256r1AddAssign",
+            CurveType::Bn254 => "Bn254AddAssign",
+            CurveType::Bls12381 => "Bls12381AddAssign",
             _ => panic!("Unsupported curve"),
         }
     }

--- a/crates/core/machine/src/syscall/precompiles/weierstrass/weierstrass_decompress.rs
+++ b/crates/core/machine/src/syscall/precompiles/weierstrass/weierstrass_decompress.rs
@@ -145,11 +145,11 @@ impl<F: PrimeField32, E: EllipticCurve + WeierstrassParameters> MachineAir<F>
     type Record = ExecutionRecord;
     type Program = Program;
 
-    fn name(&self) -> String {
+    fn name(&self) -> &'static str {
         match E::CURVE_TYPE {
-            CurveType::Secp256k1 => "Secp256k1Decompress".to_string(),
-            CurveType::Secp256r1 => "Secp256r1Decompress".to_string(),
-            CurveType::Bls12381 => "Bls12381Decompress".to_string(),
+            CurveType::Secp256k1 => "Secp256k1Decompress",
+            CurveType::Secp256r1 => "Secp256r1Decompress",
+            CurveType::Bls12381 => "Bls12381Decompress",
             _ => panic!("Unsupported curve"),
         }
     }

--- a/crates/core/machine/src/syscall/precompiles/weierstrass/weierstrass_double.rs
+++ b/crates/core/machine/src/syscall/precompiles/weierstrass/weierstrass_double.rs
@@ -165,12 +165,12 @@ impl<F: PrimeField32, E: EllipticCurve + WeierstrassParameters> MachineAir<F>
     type Record = ExecutionRecord;
     type Program = Program;
 
-    fn name(&self) -> String {
+    fn name(&self) -> &'static str {
         match E::CURVE_TYPE {
-            CurveType::Secp256k1 => "Secp256k1DoubleAssign".to_string(),
-            CurveType::Secp256r1 => "Secp256r1DoubleAssign".to_string(),
-            CurveType::Bn254 => "Bn254DoubleAssign".to_string(),
-            CurveType::Bls12381 => "Bls12381DoubleAssign".to_string(),
+            CurveType::Secp256k1 => "Secp256k1DoubleAssign",
+            CurveType::Secp256r1 => "Secp256r1DoubleAssign",
+            CurveType::Bn254 => "Bn254DoubleAssign",
+            CurveType::Bls12381 => "Bls12381DoubleAssign",
             _ => panic!("Unsupported curve"),
         }
     }

--- a/crates/core/machine/src/utils/prove.rs
+++ b/crates/core/machine/src/utils/prove.rs
@@ -205,10 +205,12 @@ where
         // Spawn the workers for phase 1 record generation.
         let p1_record_gen_sync = Arc::new(TurnBasedSync::new());
         let p1_trace_gen_sync = Arc::new(TurnBasedSync::new());
-        let (p1_records_and_traces_tx, p1_records_and_traces_rx) =
-            sync_channel::<(Vec<ExecutionRecord>, Vec<Vec<(String, RowMajorMatrix<Val<SC>>)>>)>(
-                opts.records_and_traces_channel_capacity,
-            );
+        let (p1_records_and_traces_tx, p1_records_and_traces_rx) = sync_channel::<(
+            Vec<ExecutionRecord>,
+            Vec<Vec<(&'static str, RowMajorMatrix<Val<SC>>)>>,
+        )>(
+            opts.records_and_traces_channel_capacity,
+        );
         let p1_records_and_traces_tx = Arc::new(Mutex::new(p1_records_and_traces_tx));
         let checkpoints_rx = Arc::new(Mutex::new(checkpoints_rx));
 
@@ -438,8 +440,8 @@ where
             sync_channel::<(
                 Vec<ExecutionRecord>,
                 (
-                    Vec<Vec<(String, RowMajorMatrix<Val<SC>>)>>,
-                    Vec<Vec<(String, RowMajorMatrix<Val<SC>>)>>,
+                    Vec<Vec<(&'static str, RowMajorMatrix<Val<SC>>)>>,
+                    Vec<Vec<(&'static str, RowMajorMatrix<Val<SC>>)>>,
                 ),
             )>(opts.records_and_traces_channel_capacity);
         let p2_records_and_traces_tx = Arc::new(Mutex::new(p2_records_and_traces_tx));

--- a/crates/derive/src/lib.rs
+++ b/crates/derive/src/lib.rs
@@ -204,7 +204,7 @@ pub fn machine_air_derive(input: TokenStream) -> TokenStream {
 
                     type Program = #program_path;
 
-                    fn name(&self) -> String {
+                    fn name(&self) -> &'static str {
                         match self {
                             #(#name_arms,)*
                         }

--- a/crates/prover/src/lib.rs
+++ b/crates/prover/src/lib.rs
@@ -691,7 +691,7 @@ impl<C: SP1ProverComponents> SP1Prover<C> {
                     usize,
                     Arc<RecursionProgram<BabyBear>>,
                     ExecutionRecord<BabyBear>,
-                    Vec<(String, RowMajorMatrix<BabyBear>)>,
+                    Vec<(&'static str, RowMajorMatrix<BabyBear>)>,
                 )>(opts.recursion_opts.records_and_traces_channel_capacity);
             let record_and_trace_tx = Arc::new(Mutex::new(record_and_trace_tx));
             let record_and_trace_rx = Arc::new(Mutex::new(record_and_trace_rx));

--- a/crates/recursion/circuit/src/stark.rs
+++ b/crates/recursion/circuit/src/stark.rs
@@ -161,7 +161,7 @@ pub fn dummy_vk_and_shard_proof<A: MachineAir<BabyBear>>(
                 <BabyBearPoseidon2 as StarkGenericConfig>::Challenge,
                 <BabyBearPoseidon2 as StarkGenericConfig>::Challenger,
             >>::natural_domain_for_degree(pcs, 1 << log_height);
-            (name.to_owned(), domain, Dimensions { width: *width, height: 1 << log_height })
+            (name.to_string(), domain, Dimensions { width: *width, height: 1 << log_height })
         })
         .collect();
 
@@ -169,7 +169,7 @@ pub fn dummy_vk_and_shard_proof<A: MachineAir<BabyBear>>(
     let preprocessed_chip_ordering = preprocessed_names_and_dimensions
         .iter()
         .enumerate()
-        .map(|(i, (name, _, _))| (name.to_owned(), i))
+        .map(|(i, (name, _, _))| (name.to_string(), i))
         .collect::<HashMap<_, _>>();
 
     let vk = StarkVerifyingKey {

--- a/crates/recursion/core/src/chips/alu_base.rs
+++ b/crates/recursion/core/src/chips/alu_base.rs
@@ -64,8 +64,8 @@ impl<F: PrimeField32> MachineAir<F> for BaseAluChip {
 
     type Program = crate::RecursionProgram<F>;
 
-    fn name(&self) -> String {
-        "BaseAlu".to_string()
+    fn name(&self) -> &'static str {
+        "BaseAlu"
     }
 
     fn preprocessed_width(&self) -> usize {

--- a/crates/recursion/core/src/chips/alu_ext.rs
+++ b/crates/recursion/core/src/chips/alu_ext.rs
@@ -62,8 +62,8 @@ impl<F: PrimeField32 + BinomiallyExtendable<D>> MachineAir<F> for ExtAluChip {
 
     type Program = crate::RecursionProgram<F>;
 
-    fn name(&self) -> String {
-        "ExtAlu".to_string()
+    fn name(&self) -> &'static str {
+        "ExtAlu"
     }
 
     fn preprocessed_width(&self) -> usize {

--- a/crates/recursion/core/src/chips/batch_fri.rs
+++ b/crates/recursion/core/src/chips/batch_fri.rs
@@ -61,8 +61,8 @@ impl<F: PrimeField32, const DEGREE: usize> MachineAir<F> for BatchFRIChip<DEGREE
 
     type Program = RecursionProgram<F>;
 
-    fn name(&self) -> String {
-        "BatchFRI".to_string()
+    fn name(&self) -> &'static str {
+        "BatchFRI"
     }
 
     fn generate_dependencies(&self, _: &Self::Record, _: &mut Self::Record) {

--- a/crates/recursion/core/src/chips/exp_reverse_bits.rs
+++ b/crates/recursion/core/src/chips/exp_reverse_bits.rs
@@ -73,8 +73,8 @@ impl<F: PrimeField32, const DEGREE: usize> MachineAir<F> for ExpReverseBitsLenCh
 
     type Program = RecursionProgram<F>;
 
-    fn name(&self) -> String {
-        "ExpReverseBitsLen".to_string()
+    fn name(&self) -> &'static str {
+        "ExpReverseBitsLen"
     }
 
     fn generate_dependencies(&self, _: &Self::Record, _: &mut Self::Record) {

--- a/crates/recursion/core/src/chips/fri_fold.rs
+++ b/crates/recursion/core/src/chips/fri_fold.rs
@@ -89,8 +89,8 @@ impl<F: PrimeField32, const DEGREE: usize> MachineAir<F> for FriFoldChip<DEGREE>
 
     type Program = RecursionProgram<F>;
 
-    fn name(&self) -> String {
-        "FriFold".to_string()
+    fn name(&self) -> &'static str {
+        "FriFold"
     }
 
     fn generate_dependencies(&self, _: &Self::Record, _: &mut Self::Record) {

--- a/crates/recursion/core/src/chips/mem/constant.rs
+++ b/crates/recursion/core/src/chips/mem/constant.rs
@@ -47,8 +47,8 @@ impl<F: PrimeField32> MachineAir<F> for MemoryChip<F> {
 
     type Program = crate::RecursionProgram<F>;
 
-    fn name(&self) -> String {
-        "MemoryConst".to_string()
+    fn name(&self) -> &'static str {
+        "MemoryConst"
     }
     fn preprocessed_width(&self) -> usize {
         NUM_MEM_PREPROCESSED_INIT_COLS

--- a/crates/recursion/core/src/chips/mem/variable.rs
+++ b/crates/recursion/core/src/chips/mem/variable.rs
@@ -48,8 +48,8 @@ impl<F: PrimeField32> MachineAir<F> for MemoryChip<F> {
 
     type Program = crate::RecursionProgram<F>;
 
-    fn name(&self) -> String {
-        "MemoryVar".to_string()
+    fn name(&self) -> &'static str {
+        "MemoryVar"
     }
     fn preprocessed_width(&self) -> usize {
         NUM_MEM_PREPROCESSED_INIT_COLS

--- a/crates/recursion/core/src/chips/poseidon2_wide/columns/permutation.rs
+++ b/crates/recursion/core/src/chips/poseidon2_wide/columns/permutation.rs
@@ -181,7 +181,7 @@ pub type PermutationNoSboxHalfExternal<T> = PermutationNoSbox<T>;
 
 pub fn permutation_mut<'a, 'b: 'a, T, const DEGREE: usize>(
     row: &'b mut [T],
-) -> Box<&mut (dyn Poseidon2Mut<T> + 'a)>
+) -> Box<&'b mut (dyn Poseidon2Mut<T> + 'a)>
 where
     T: Copy,
 {

--- a/crates/recursion/core/src/chips/public_values.rs
+++ b/crates/recursion/core/src/chips/public_values.rs
@@ -53,8 +53,8 @@ impl<F: PrimeField32> MachineAir<F> for PublicValuesChip {
 
     type Program = RecursionProgram<F>;
 
-    fn name(&self) -> String {
-        "PublicValues".to_string()
+    fn name(&self) -> &'static str {
+        "PublicValues"
     }
 
     fn generate_dependencies(&self, _: &Self::Record, _: &mut Self::Record) {

--- a/crates/recursion/core/src/chips/select.rs
+++ b/crates/recursion/core/src/chips/select.rs
@@ -44,8 +44,8 @@ impl<F: PrimeField32> MachineAir<F> for SelectChip {
 
     type Program = crate::RecursionProgram<F>;
 
-    fn name(&self) -> String {
-        "Select".to_string()
+    fn name(&self) -> &'static str {
+        "Select"
     }
 
     fn preprocessed_width(&self) -> usize {

--- a/crates/recursion/core/src/machine.rs
+++ b/crates/recursion/core/src/machine.rs
@@ -164,7 +164,7 @@ impl<F: PrimeField32 + BinomiallyExtendable<D>, const DEGREE: usize> RecursionAi
                 (Self::ExpReverseBitsLen(ExpReverseBitsLenChip::<DEGREE>), 17),
                 (Self::PublicValues(PublicValuesChip), PUB_VALUES_LOG_HEIGHT),
             ]
-            .map(|(chip, log_height)| (chip.name(), log_height)),
+            .map(|(chip, log_height)| (chip.name().to_string(), log_height)),
         );
         RecursionShape { inner: shape }
     }
@@ -201,7 +201,7 @@ impl<F: PrimeField32 + BinomiallyExtendable<D>, const DEGREE: usize> RecursionAi
             ),
             (Self::PublicValues(PublicValuesChip), PUB_VALUES_LOG_HEIGHT),
         ]
-        .map(|(chip, log_height)| (chip.name(), log_height))
+        .map(|(chip, log_height)| (chip.name().to_string(), log_height))
         .to_vec()
     }
 }

--- a/crates/recursion/core/src/runtime/program.rs
+++ b/crates/recursion/core/src/runtime/program.rs
@@ -29,7 +29,7 @@ impl<F: Field> RecursionProgram<F> {
             .map(|shape| {
                 shape
                     .inner
-                    .get(&air.name())
+                    .get(air.name())
                     .unwrap_or_else(|| panic!("Chip {} not found in specified shape", air.name()))
             })
             .copied()

--- a/crates/recursion/core/src/shape.rs
+++ b/crates/recursion/core/src/shape.rs
@@ -88,17 +88,24 @@ impl<F: PrimeField32 + BinomiallyExtendable<D>, const DEGREE: usize> Default
 {
     fn default() -> Self {
         // Get the names of all the recursion airs to make the shape specification more readable.
-        let mem_const = RecursionAir::<F, DEGREE>::MemoryConst(MemoryConstChip::default()).name();
-        let mem_var = RecursionAir::<F, DEGREE>::MemoryVar(MemoryVarChip::default()).name();
-        let base_alu = RecursionAir::<F, DEGREE>::BaseAlu(BaseAluChip).name();
-        let ext_alu = RecursionAir::<F, DEGREE>::ExtAlu(ExtAluChip).name();
-        let poseidon2_wide =
-            RecursionAir::<F, DEGREE>::Poseidon2Wide(Poseidon2WideChip::<DEGREE>).name();
-        let batch_fri = RecursionAir::<F, DEGREE>::BatchFRI(BatchFRIChip::<DEGREE>).name();
-        let select = RecursionAir::<F, DEGREE>::Select(SelectChip).name();
+        let mem_const =
+            RecursionAir::<F, DEGREE>::MemoryConst(MemoryConstChip::default()).name().to_string();
+        let mem_var =
+            RecursionAir::<F, DEGREE>::MemoryVar(MemoryVarChip::default()).name().to_string();
+        let base_alu = RecursionAir::<F, DEGREE>::BaseAlu(BaseAluChip).name().to_string();
+        let ext_alu = RecursionAir::<F, DEGREE>::ExtAlu(ExtAluChip).name().to_string();
+        let poseidon2_wide = RecursionAir::<F, DEGREE>::Poseidon2Wide(Poseidon2WideChip::<DEGREE>)
+            .name()
+            .to_string();
+        let batch_fri =
+            RecursionAir::<F, DEGREE>::BatchFRI(BatchFRIChip::<DEGREE>).name().to_string();
+        let select = RecursionAir::<F, DEGREE>::Select(SelectChip).name().to_string();
         let exp_reverse_bits_len =
-            RecursionAir::<F, DEGREE>::ExpReverseBitsLen(ExpReverseBitsLenChip::<DEGREE>).name();
-        let public_values = RecursionAir::<F, DEGREE>::PublicValues(PublicValuesChip).name();
+            RecursionAir::<F, DEGREE>::ExpReverseBitsLen(ExpReverseBitsLenChip::<DEGREE>)
+                .name()
+                .to_string();
+        let public_values =
+            RecursionAir::<F, DEGREE>::PublicValues(PublicValuesChip).name().to_string();
 
         // Specify allowed shapes.
         let allowed_shapes = [

--- a/crates/stark/src/air/machine.rs
+++ b/crates/stark/src/air/machine.rs
@@ -17,7 +17,7 @@ pub trait MachineAir<F: Field>: BaseAir<F> + 'static + Send + Sync {
     type Program: MachineProgram<F>;
 
     /// A unique identifier for this AIR as part of a machine.
-    fn name(&self) -> String;
+    fn name(&self) -> &'static str;
 
     /// Generate the trace for a given execution record.
     ///

--- a/crates/stark/src/chip.rs
+++ b/crates/stark/src/chip.rs
@@ -186,7 +186,7 @@ where
 
     type Program = A::Program;
 
-    fn name(&self) -> String {
+    fn name(&self) -> &'static str {
         self.air.name()
     }
 

--- a/crates/stark/src/lookup/debug.rs
+++ b/crates/stark/src/lookup/debug.rs
@@ -14,7 +14,7 @@ use crate::{
 #[derive(Debug)]
 pub struct InteractionData<F: Field> {
     /// The chip name.
-    pub chip_name: String,
+    pub chip_name: &'static str,
     /// The kind of interaction.
     pub kind: InteractionKind,
     /// The row of the interaction.
@@ -72,7 +72,7 @@ pub fn debug_interactions<SC: StarkGenericConfig, A: MachineAir<Val<SC>>>(
     let trace = chip.generate_trace(record, &mut A::Record::default());
     let mut pre_traces = pkey.traces.clone();
     let mut preprocessed_trace =
-        pkey.chip_ordering.get(&chip.name()).map(|&index| pre_traces.get_mut(index).unwrap());
+        pkey.chip_ordering.get(chip.name()).map(|&index| pre_traces.get_mut(index).unwrap());
     let mut main = trace.clone();
     let height = trace.clone().height();
 

--- a/crates/stark/src/verifier.rs
+++ b/crates/stark/src/verifier.rs
@@ -497,9 +497,9 @@ pub enum VerificationError<SC: StarkGenericConfig> {
     /// Out-of-domain evaluation mismatch.
     ///
     /// `constraints(zeta)` did not match `quotient(zeta) Z_H(zeta)`.
-    OodEvaluationMismatch(String),
+    OodEvaluationMismatch(&'static str),
     /// The shape of the opening arguments is invalid.
-    OpeningShapeError(String, OpeningShapeError),
+    OpeningShapeError(&'static str, OpeningShapeError),
     /// The cpu chip is missing.
     MissingCpuChip,
     /// The length of the chip opening does not match the expected length.


### PR DESCRIPTION
Returning a string is an allocation, Ive at least gotten rid of it for basic comparsions but it could still use a clean up, honestly might better to make a ChipName enum.