### PR TITLE
perf: 1.8x or greater speed improvements in proof recursion

### DIFF
--- a/crates/recursion/core/src/shape.rs
+++ b/crates/recursion/core/src/shape.rs
@@ -103,6 +103,17 @@ impl<F: PrimeField32 + BinomiallyExtendable<D>, const DEGREE: usize> Default
         // Specify allowed shapes.
         let allowed_shapes = [
             [
+                (base_alu.clone(), 16),
+                (mem_var.clone(), 19),
+                (ext_alu.clone(), 16),
+                (exp_reverse_bits_len.clone(), 18),
+                (mem_const.clone(), 17),
+                (poseidon2_wide.clone(), 17),
+                (batch_fri.clone(), 18),
+                (select.clone(), 19),
+                (public_values.clone(), PUB_VALUES_LOG_HEIGHT),
+            ],
+            [
                 (base_alu.clone(), 20),
                 (mem_var.clone(), 18),
                 (ext_alu.clone(), 18),


### PR DESCRIPTION
This PR improves recursion speed for SP1 by introducing a shape that is closer to the recursion threshold.
See my [twitter post](https://x.com/sai_deng/status/1864704153421008985) for implementation details.

In my test of the aggregation example: (Macbook M3 Pro)

Total time
Old time: ~10m
New time: ~7m

Time for proof compression (core proof -> reduced proof):
Old time: 157s
New time: 85s

It is expected to provide even greater speed improvements for larger programs, although these have not yet been tested. (e.g. ETH block proving)

Before

```assembly
2024-12-05T14:42:04.653193Z  INFO generate fibonacci proof n=10:prove_core: execution report (totals): total_cycles=1528, total_syscall_cycles=24, touched_memory_addresses=10967
2024-12-05T14:42:04.821083Z  INFO generate fibonacci proof n=10:prove_core: summary: cycles=1528, gas=19268, e2e=8.294833417s, khz=0.18, proofSize=5264780
2024-12-05T14:42:04.827293Z  INFO generate fibonacci proof n=10:prove_core: close time.busy=8.45s time.idle=44.1ms
2024-12-05T14:43:17.809651Z  INFO generate fibonacci proof n=10:compress: close time.busy=73.0s time.idle=1.87ms
2024-12-05T14:43:17.816959Z  INFO generate fibonacci proof n=10: close time.busy=81.5s time.idle=18.1µs
2024-12-05T14:43:26.729970Z  INFO generate fibonacci proof n=20:prove_core: execution report (totals): total_cycles=1648, total_syscall_cycles=24, touched_memory_addresses=10967
2024-12-05T14:43:26.897492Z  INFO generate fibonacci proof n=20:prove_core: summary: cycles=1648, gas=19421, e2e=8.627063667s, khz=0.19, proofSize=5264780
2024-12-05T14:43:26.906222Z  INFO generate fibonacci proof n=20:prove_core: close time.busy=8.78s time.idle=302ms
2024-12-05T14:44:37.150617Z  INFO generate fibonacci proof n=20:compress: close time.busy=70.2s time.idle=2.44ms
2024-12-05T14:44:37.152156Z  INFO generate fibonacci proof n=20: close time.busy=79.3s time.idle=1.13µs
2024-12-05T14:44:45.616239Z  INFO generate fibonacci proof n=30:prove_core: execution report (totals): total_cycles=1768, total_syscall_cycles=24, touched_memory_addresses=10967
2024-12-05T14:44:45.788387Z  INFO generate fibonacci proof n=30:prove_core: summary: cycles=1768, gas=19573, e2e=8.399349833s, khz=0.21, proofSize=5264780
2024-12-05T14:44:45.795443Z  INFO generate fibonacci proof n=30:prove_core: close time.busy=8.55s time.idle=80.7ms
2024-12-05T14:45:55.829325Z  INFO generate fibonacci proof n=30:compress: close time.busy=70.0s time.idle=2.17ms
2024-12-05T14:45:55.831323Z  INFO generate fibonacci proof n=30: close time.busy=78.7s time.idle=1.38µs
2024-12-05T14:45:56.562926Z  INFO aggregate the proofs:prove_core:verify: close time.busy=94.6ms time.idle=1.00µs
2024-12-05T14:45:56.641197Z  INFO aggregate the proofs:prove_core:verify: close time.busy=72.7ms time.idle=1.17µs
2024-12-05T14:45:56.717933Z  INFO aggregate the proofs:prove_core:verify: close time.busy=70.3ms time.idle=1.29µs
2024-12-05T14:46:31.113021Z  INFO aggregate the proofs:prove_core: execution report (totals): total_cycles=490959, total_syscall_cycles=37, touched_memory_addresses=19814
2024-12-05T14:46:31.295446Z  INFO aggregate the proofs:prove_core: summary: cycles=490959, gas=615003, e2e=34.654896625s, khz=14.17, proofSize=6753576
2024-12-05T14:46:31.305659Z  INFO aggregate the proofs:prove_core: close time.busy=34.5s time.idle=952ms
2024-12-05T14:49:08.798879Z  INFO aggregate the proofs:compress: close time.busy=157s time.idle=3.37ms
2024-12-05T14:49:21.205893Z  INFO aggregate the proofs:shrink:prove_shards: close time.busy=10.3s time.idle=2.17µs
2024-12-05T14:49:21.236509Z  INFO aggregate the proofs:shrink: close time.busy=12.4s time.idle=1.21µs
2024-12-05T14:51:55.968712Z  INFO aggregate the proofs:wrap_bn254:prove_shards: close time.busy=109s time.idle=1.62µs
2024-12-05T14:51:56.070030Z  INFO aggregate the proofs:wrap_bn254:verify: close time.busy=101ms time.idle=1.42µs
2024-12-05T14:51:56.070046Z  INFO aggregate the proofs:wrap_bn254: wrapping successful
2024-12-05T14:51:56.099924Z  INFO aggregate the proofs:wrap_bn254: close time.busy=155s time.idle=959ns
2024-12-05T14:51:56.163516Z  INFO aggregate the proofs:wrap_plonk_bn254: close time.busy=63.5ms time.idle=1.42µs
2024-12-05T14:51:56.165479Z  INFO aggregate the proofs: close time.busy=360s time.idle=3.75µs
``` 

After

```assembly
2024-12-05T14:53:37.333113Z  INFO generate fibonacci proof n=10:prove_core: execution report (totals): total_cycles=1528, total_syscall_cycles=24, touched_memory_addresses=10967
2024-12-05T14:53:37.498666Z  INFO generate fibonacci proof n=10:prove_core: summary: cycles=1528, gas=19268, e2e=8.815039875s, khz=0.17, proofSize=5264780
2024-12-05T14:53:37.504200Z  INFO generate fibonacci proof n=10:prove_core: close time.busy=8.96s time.idle=40.1ms
2024-12-05T14:54:14.990842Z  INFO generate fibonacci proof n=10:compress: close time.busy=37.5s time.idle=2.17ms
2024-12-05T14:54:14.992167Z  INFO generate fibonacci proof n=10: close time.busy=46.5s time.idle=18.6µs
2024-12-05T14:54:23.369209Z  INFO generate fibonacci proof n=20:prove_core: execution report (totals): total_cycles=1648, total_syscall_cycles=24, touched_memory_addresses=10967
2024-12-05T14:54:23.533124Z  INFO generate fibonacci proof n=20:prove_core: summary: cycles=1648, gas=19421, e2e=8.312527166s, khz=0.20, proofSize=5264780
2024-12-05T14:54:23.539365Z  INFO generate fibonacci proof n=20:prove_core: close time.busy=8.45s time.idle=89.0ms
2024-12-05T14:55:01.194179Z  INFO generate fibonacci proof n=20:compress: close time.busy=37.7s time.idle=2.29ms
2024-12-05T14:55:01.195131Z  INFO generate fibonacci proof n=20: close time.busy=46.2s time.idle=1.38µs
2024-12-05T14:55:09.794130Z  INFO generate fibonacci proof n=30:prove_core: execution report (totals): total_cycles=1768, total_syscall_cycles=24, touched_memory_addresses=10967
2024-12-05T14:55:09.962616Z  INFO generate fibonacci proof n=30:prove_core: summary: cycles=1768, gas=19573, e2e=8.566733416s, khz=0.21, proofSize=5264780
2024-12-05T14:55:09.970812Z  INFO generate fibonacci proof n=30:prove_core: close time.busy=8.72s time.idle=44.3ms
2024-12-05T14:55:46.638531Z  INFO generate fibonacci proof n=30:compress: close time.busy=36.7s time.idle=2.30ms
2024-12-05T14:55:46.639319Z  INFO generate fibonacci proof n=30: close time.busy=45.4s time.idle=2.33µs
2024-12-05T14:55:46.768640Z  INFO aggregate the proofs:prove_core:verify: close time.busy=60.7ms time.idle=792ns
2024-12-05T14:55:46.835416Z  INFO aggregate the proofs:prove_core:verify: close time.busy=61.7ms time.idle=168ns
2024-12-05T14:55:46.903121Z  INFO aggregate the proofs:prove_core:verify: close time.busy=61.5ms time.idle=582ns
2024-12-05T14:56:17.370292Z  INFO aggregate the proofs:prove_core: execution report (totals): total_cycles=490959, total_syscall_cycles=37, touched_memory_addresses=19814
2024-12-05T14:56:17.545689Z  INFO aggregate the proofs:prove_core: summary: cycles=490959, gas=615003, e2e=30.666580458s, khz=16.01, proofSize=6753576
2024-12-05T14:56:17.553734Z  INFO aggregate the proofs:prove_core: close time.busy=30.6s time.idle=282ms
2024-12-05T14:57:42.551200Z  INFO aggregate the proofs:compress: close time.busy=85.0s time.idle=3.50ms
2024-12-05T14:57:55.253216Z  INFO aggregate the proofs:shrink:prove_shards: close time.busy=10.5s time.idle=2.54µs
2024-12-05T14:57:55.284132Z  INFO aggregate the proofs:shrink: close time.busy=12.7s time.idle=1.58µs
2024-12-05T15:00:30.727902Z  INFO aggregate the proofs:wrap_bn254:prove_shards: close time.busy=109s time.idle=5.17µs
2024-12-05T15:00:30.826280Z  INFO aggregate the proofs:wrap_bn254:verify: close time.busy=97.3ms time.idle=1.37µs
2024-12-05T15:00:30.826309Z  INFO aggregate the proofs:wrap_bn254: wrapping successful
2024-12-05T15:00:30.901809Z  INFO aggregate the proofs:wrap_bn254: close time.busy=156s time.idle=1.33µs
2024-12-05T15:00:30.967158Z  INFO aggregate the proofs:wrap_plonk_bn254: close time.busy=65.3ms time.idle=833ns
2024-12-05T15:00:30.968733Z  INFO aggregate the proofs: close time.busy=284s time.idle=5.00µs
``` 
