### PR TITLE
Fix Typos and Grammar

### DIFF
--- a/book/what-is-a-zkvm.md
+++ b/book/what-is-a-zkvm.md
@@ -1,6 +1,6 @@
 # What is a zkVM?
 
-A zero-knowledge virtual machine (zkVM) is zero-knowledge proof system that allows developers to prove the execution of arbitrary Rust (or other LLVM-compiled language) programs.
+A zero-knowledge virtual machine (zkVM) is a zero-knowledge proof system that allows developers to prove the execution of arbitrary Rust (or other LLVM-compiled language) programs.
 
 Conceptually, you can think of the SP1 zkVM as proving the evaluation of a function `f(x) = y` by following the steps below:
 

--- a/crates/eval/CHANGELOG.md
+++ b/crates/eval/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - performance test + add to CI ([#1426](https://github.com/succinctlabs/sp1/pull/1426))
-- restore acknolwedgements
+- restore acknowledgements
 - update tg ([#1214](https://github.com/succinctlabs/sp1/pull/1214))
 - v1.0.1 ([#1165](https://github.com/succinctlabs/sp1/pull/1165))
 - new README img ([#226](https://github.com/succinctlabs/sp1/pull/226))


### PR DESCRIPTION
## Changes Made:
1. Corrected "(zkVM) is zero-knowledge" to "(zkVM) is a zero-knowledge" for grammatical accuracy.
2. Fixed the typo "acknolwedgements" to "acknowledgements."

## Why This Is Useful:
- Improves readability and ensures proper grammar.
- Corrects typographical errors, enhancing professionalism and clarity.