### PR TITLE
feat: write all logs to stderr (vs stdout)

### DIFF
--- a/crates/core/machine/src/utils/logger.rs
+++ b/crates/core/machine/src/utils/logger.rs
@@ -37,6 +37,7 @@ pub fn setup_logger() {
                     .with_thread_names(false)
                     .with_env_filter(env_filter)
                     .with_span_events(FmtSpan::CLOSE)
+                    .with_writer(std::io::stderr)
                     .finish()
                     .init();
             }


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Currently, all logs are being written to stdout. This breaks convention for CLI apps that might want to use stdout for, well, application output (not diagnostic stuff).

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Write logs to stderr.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes