### PR TITLE
Fix broken documentation link

### DIFF
--- a/book/generating-proofs/recommended-workflow.md
+++ b/book/generating-proofs/recommended-workflow.md
@@ -40,7 +40,7 @@ Note that **latency is not the same as cost**, because we parallelize proof gene
 
 #### Benchmarking on small vs. large programs
 
-In SP1, there is a fixed overhead for proving that is independent of your program's cycle count. This means that benchmarking on _small programs_ is not representative of the performance of larger programs. To get an idea of the scale of programs for real-world workloads, you can refer to our [benchmarking blog post](https://blog.succinct.xyz/sp1-production-benchmarks) and also some numbers below:
+In SP1, there is a fixed overhead for proving that is independent of your program's cycle count. This means that benchmarking on _small programs_ is not representative of the performance of larger programs. To get an idea of the scale of programs for real-world workloads, you can refer to our [benchmarking blog post](https://blog.succinct.xyz/sp1-benchmarks-8-6-24/) and also some numbers below:
 
 - An average Ethereum block can be between 100-500M cycles (including merkle proof verification for storage and execution of transactions) with our `keccak` and `secp256k1` precompiles.
 - For a Tendermint light client, the average cycle count can be between 10M and 50M cycles (including our ed25519 precompiles).


### PR DESCRIPTION
Fix broken documentation links
  - Replaced `https://blog.succinct.xyz/sp1-production-benchmarks`
   with `https://blog.succinct.xyz/sp1-benchmarks-8-6-24/`.
   
Hey ! I found a link that doesn’t work (404 error), but I replaced it with a working one. If you have another link that can replace the broken one, I’d be happy to help. Thank you!