### PR TITLE
Updated Broken Documentation Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ SP1 is the fastest, most-feature complete zero-knowledge virtual machine (zkVM) 
 
 Today, developers can write programs, including complex, large programs like a ZK Tendermint light client or type-1 zkEVM using Reth, in Rust (with std support), generate proofs and verify them. Most Rust crates should be supported and can be used seamlessly by your program. Example programs can be found in the [examples](https://github.com/succinctlabs/sp1/tree/main/examples) folder.
 
-To get started, make sure you have [Rust](https://www.rust-lang.org/tools/install) installed. Then follow the [installation](https://succinctlabs.github.io/sp1/getting-started/install.html) guide in the SP1 book and read the [getting started](https://succinctlabs.github.io/sp1/getting-started/quickstart.html) section.
+To get started, make sure you have [Rust](https://www.rust-lang.org/tools/install) installed. Then follow the [installation](https://docs.succinct.xyz/docs/getting-started/install) guide in the SP1 book and read the [getting started](https://docs.succinct.xyz/docs/getting-started/quickstart) section.
 
 ## Security
 


### PR DESCRIPTION
### Updated Links in Documentation

The following links were updated to ensure accessibility, as the previous links were no longer functional:

- **From**: `(https://succinctlabs.github.io/sp1/getting-started/install.html)`  
  **To**: `[installation](https://docs.succinct.xyz/docs/getting-started/install)`  

- **From**: `guide in the SP1 book and read the [getting started](https://succinctlabs.github.io/sp1/getting-started/quickstart.html) section.`  
  **To**: `guide in the SP1 book and read the [getting started](https://docs.succinct.xyz/docs/getting-started/quickstart) section.`