### PR TITLE
chore(deps): bump rust toolchain to 1.82.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          toolchain: 1.81.0
+          toolchain: 1.82.0
           args: --release -p sp1-sdk --features native-gnark -- test_e2e_prove_plonk --nocapture
         env:
           RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0 -C target-cpu=native
@@ -72,7 +72,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          toolchain: 1.81.0
+          toolchain: 1.82.0
           args: --release -p sp1-sdk -- test_e2e_prove_plonk --nocapture
         env:
           RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0 -C target-cpu=native
@@ -203,6 +203,7 @@ jobs:
           cargo remove sp1-sdk
           cargo add sp1-sdk --path $GITHUB_WORKSPACE/crates/sdk
           SP1_DEV=1 RUST_LOG=info cargo run --release
+
   test-cuda:
     name: Test CUDA
     runs-on: nvidia-gpu-linux-x64
@@ -220,14 +221,14 @@ jobs:
             ~/.cargo/git/db/
             target/
             ~/.rustup/
-          key: rust-1.81.0-${{ hashFiles('**/Cargo.toml') }}
-          restore-keys: rust-1.81.0-
+          key: rust-1.82.0-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: rust-1.82.0-
 
       - name: Setup toolchain
         id: rustc-toolchain
         shell: bash
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.81.0 -y
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.82.0 -y
 
       - name: Run script
         run: |

--- a/tools/ci/setup.sh
+++ b/tools/ci/setup.sh
@@ -1,0 +1,7 @@
+# Updating Rust to version 1.82.0
+rustup toolchain install 1.82.0
+rustup default 1.82.0
+
+# Ensure all components are installed
+rustup component add rustfmt
+rustup component add clippy


### PR DESCRIPTION
## Motivation

Currently, the usage of fresh version of reth in the guest code is impossible because fresh reth crates require Rust >= 1.82.0. The current toolchain version (1.81.0) restricts the usage of sp1 with newer reth dependencies.

This update will enable the use of newer reth crates in the guest code and improve compatibility with modern dependencies.

## Solution

The solution involves:
1. Updating the Rust toolchain version from 1.81.0 to 1.82.0 in the CI workflow
2. Adding a setup script for consistent toolchain installation
3. Updating cache keys to match the new Rust version

Changes made:
- Updated Rust version in `.github/workflows/main.yml`
- Created `tools/ci/setup.sh` for toolchain setup
- Updated all relevant cache keys to use Rust 1.82.0

## PR Checklist

- [x] Added Tests
  - Existing tests will run with new toolchain version
- [x] Added Documentation
  - Updated toolchain version in workflow files
- [ ] Breaking changes
  - No breaking changes, only toolchain version update

Closes #1876