### PR TITLE
feat(sdk): `get_proof_status`, `request`, `cycle_limit`

### DIFF
--- a/crates/sdk/src/cpu/builder.rs
+++ b/crates/sdk/src/cpu/builder.rs
@@ -26,6 +26,10 @@ impl CpuProverBuilder {
     /// ```
     #[must_use]
     pub fn build(self) -> CpuProver {
-        if self.mock { CpuProver::mock() } else { CpuProver::new() }
+        if self.mock {
+            CpuProver::mock()
+        } else {
+            CpuProver::new()
+        }
     }
 }

--- a/crates/sdk/src/network/prove.rs
+++ b/crates/sdk/src/network/prove.rs
@@ -252,7 +252,7 @@ impl<'a> NetworkProveBuilder<'a> {
     /// ```
     pub fn request(self) -> Result<Vec<u8>> {
         let Self { prover, mode, pk, stdin, timeout, strategy, mut skip_simulation } = self;
-        prover.request_proof_impl(pk, &stdin, mode, strategy, timeout, skip_simulation)
+        block_on(prover.request_proof_impl(pk, &stdin, mode, strategy, timeout, skip_simulation))
     }
 
     /// Run the prover with the built arguments.

--- a/crates/sdk/src/network/prove.rs
+++ b/crates/sdk/src/network/prove.rs
@@ -231,6 +231,30 @@ impl<'a> NetworkProveBuilder<'a> {
         self
     }
 
+    /// Request a proof from the prover network.
+    ///
+    /// # Details
+    /// This method will request a proof from the prover network. If the prover fails to request
+    /// a proof, the method will return an error. It will not wait for the proof to be generated.
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// use sp1_sdk::{ProverClient, SP1Stdin, Prover};
+    ///
+    /// let elf = &[1, 2, 3];
+    /// let stdin = SP1Stdin::new();
+    ///
+    /// let client = ProverClient::builder().network().build();
+    /// let (pk, vk) = client.setup(elf);
+    /// let request_id = client.prove(&pk, &stdin)
+    ///     .request()
+    ///     .unwrap();
+    /// ```
+    pub fn request(self) -> Result<Vec<u8>> {
+        let Self { prover, mode, pk, stdin, timeout, strategy, mut skip_simulation } = self;
+        prover.request_proof_impl(pk, &stdin, mode, strategy, timeout, skip_simulation)
+    }
+
     /// Run the prover with the built arguments.
     ///
     /// # Details

--- a/crates/sdk/src/network/prove.rs
+++ b/crates/sdk/src/network/prove.rs
@@ -250,9 +250,9 @@ impl<'a> NetworkProveBuilder<'a> {
     ///     .request()
     ///     .unwrap();
     /// ```
-    pub fn request(self) -> Result<Vec<u8>> {
+    pub async fn request(self) -> Result<Vec<u8>> {
         let Self { prover, mode, pk, stdin, timeout, strategy, mut skip_simulation } = self;
-        block_on(prover.request_proof_impl(pk, &stdin, mode, strategy, timeout, skip_simulation))
+        prover.request_proof_impl(pk, &stdin, mode, strategy, timeout, skip_simulation).await
     }
 
     /// Run the prover with the built arguments.

--- a/crates/sdk/src/network/prove.rs
+++ b/crates/sdk/src/network/prove.rs
@@ -235,10 +235,13 @@ impl<'a> NetworkProveBuilder<'a> {
     /// Sets the cycle limit for the proof request.
     ///
     /// # Details
-    /// The cycle limit determines the maximum number of cycles that the program can execute.
-    /// By default, the cycle limit is determined by simulating the program locally. However,
-    /// you can manually set it if you know the exact cycle count needed and want to skip the
-    /// simulation step locally.
+    /// The cycle limit determines the maximum number of cycles that the program should take to
+    /// execute. By default, the cycle limit is determined by simulating the program locally.
+    /// However, you can manually set it if you know the exact cycle count needed and want to skip
+    /// the simulation step locally.
+    ///
+    /// The cycle limit ensures that a prover on the network will stop generating a proof once the
+    /// cycle limit is reached, which prevents DoS attacks.
     ///
     /// # Example
     /// ```rust,no_run
@@ -250,8 +253,8 @@ impl<'a> NetworkProveBuilder<'a> {
     /// let client = ProverClient::builder().network().build();
     /// let (pk, vk) = client.setup(elf);
     /// let proof = client.prove(&pk, &stdin)
-    ///     .cycle_limit(1_000_000) // Set 1M cycle limit
-    ///     .skip_simulation(true)  // Skip simulation since we set limit manually
+    ///     .cycle_limit(1_000_000) // Set 1M cycle limit.
+    ///     .skip_simulation(true)  // Skip simulation since the limit is set manually.
     ///     .run()
     ///     .unwrap();
     /// ```

--- a/crates/sdk/src/network/prove.rs
+++ b/crates/sdk/src/network/prove.rs
@@ -251,7 +251,7 @@ impl<'a> NetworkProveBuilder<'a> {
     ///     .unwrap();
     /// ```
     pub async fn request(self) -> Result<Vec<u8>> {
-        let Self { prover, mode, pk, stdin, timeout, strategy, mut skip_simulation } = self;
+        let Self { prover, mode, pk, stdin, timeout, strategy, skip_simulation } = self;
         prover.request_proof_impl(pk, &stdin, mode, strategy, timeout, skip_simulation).await
     }
 

--- a/crates/sdk/src/network/prover.rs
+++ b/crates/sdk/src/network/prover.rs
@@ -272,6 +272,21 @@ impl NetworkProver {
         }
     }
 
+    /// Requests a proof from the prover network.
+    pub(crate) async fn request_proof_impl(
+        &self,
+        pk: &SP1ProvingKey,
+        stdin: &SP1Stdin,
+        mode: SP1ProofMode,
+        strategy: FulfillmentStrategy,
+        timeout: Option<Duration>,
+        skip_simulation: bool,
+    ) -> Result<Vec<u8>> {
+        let vk_hash = self.register_program(&pk.vk, &pk.elf).await?;
+        let cycle_limit = self.get_cycle_limit(&pk.elf, stdin, skip_simulation)?;
+        self.request_proof(&vk_hash, stdin, mode, strategy, cycle_limit, timeout).await
+    }
+
     /// Requests a proof from the prover network and waits for it to be generated.
     pub(crate) async fn prove_impl(
         &self,
@@ -282,10 +297,8 @@ impl NetworkProver {
         timeout: Option<Duration>,
         skip_simulation: bool,
     ) -> Result<SP1ProofWithPublicValues> {
-        let vk_hash = self.register_program(&pk.vk, &pk.elf).await?;
-        let cycle_limit = self.get_cycle_limit(&pk.elf, stdin, skip_simulation)?;
         let request_id = self
-            .request_proof(&vk_hash, stdin, mode.into(), strategy, cycle_limit, timeout)
+            .request_proof_impl(pk, stdin, mode, strategy, timeout, skip_simulation)
             .await?;
         self.wait_proof(&request_id, timeout).await
     }

--- a/crates/sdk/src/network/prover.rs
+++ b/crates/sdk/src/network/prover.rs
@@ -308,10 +308,9 @@ impl NetworkProver {
 
     /// The cycle limit is determined according to the following priority:
     ///
-    /// # Details
-    /// 1. If a cycle limit was explicitly set, use the specified value.
-    /// 2. If simulation is enabled (it is by default), calculate the limit by simulating the
-    ///    execution of the program.
+    /// 1. If a cycle limit was explicitly set by the requester, use the specified value.
+    /// 2. If simulation is enabled, calculate the limit by simulating the
+    ///    execution of the program. This is the default behavior.
     /// 3. Otherwise, use the default cycle limit ([`DEFAULT_CYCLE_LIMIT`]).
     fn get_cycle_limit(
         &self,

--- a/crates/sdk/src/network/prover.rs
+++ b/crates/sdk/src/network/prover.rs
@@ -284,7 +284,7 @@ impl NetworkProver {
     ) -> Result<Vec<u8>> {
         let vk_hash = self.register_program(&pk.vk, &pk.elf).await?;
         let cycle_limit = self.get_cycle_limit(&pk.elf, stdin, skip_simulation)?;
-        self.request_proof(&vk_hash, stdin, mode, strategy, cycle_limit, timeout).await
+        self.request_proof(&vk_hash, stdin, mode.into(), strategy, cycle_limit, timeout).await
     }
 
     /// Requests a proof from the prover network and waits for it to be generated.
@@ -297,9 +297,8 @@ impl NetworkProver {
         timeout: Option<Duration>,
         skip_simulation: bool,
     ) -> Result<SP1ProofWithPublicValues> {
-        let request_id = self
-            .request_proof_impl(pk, stdin, mode, strategy, timeout, skip_simulation)
-            .await?;
+        let request_id =
+            self.request_proof_impl(pk, stdin, mode, strategy, timeout, skip_simulation).await?;
         self.wait_proof(&request_id, timeout).await
     }
 

--- a/crates/sdk/src/network/prover.rs
+++ b/crates/sdk/src/network/prover.rs
@@ -149,10 +149,10 @@ impl NetworkProver {
     /// let client = ProverClient::builder().network().build();
     /// let (status, maybe_proof) = client.get_proof_status(&request_id).await?;   
     /// ```
-    pub async fn get_proof_status<P: DeserializeOwned>(
+    pub async fn get_proof_status(
         &self,
         request_id: &[u8],
-    ) -> Result<(GetProofRequestStatusResponse, Option<P>)> {
+    ) -> Result<(GetProofRequestStatusResponse, Option<SP1ProofWithPublicValues>)> {
         self.client.get_proof_request_status(request_id).await
     }
 


### PR DESCRIPTION
## Motivation

For contexts where users are statefully tracking a set of proof requests and managing polling the proof requests manually, provide a `get_proof_status` method on the `NetworkProver`.

Users should be able to manually specify a `cycle_limit` if they're skipping simulation.

Add a `request` method to allows users to request a proof and get the proof ID back immediately.

## Solution

Add `get_proof_status`, `request` and `cycle_limit` to the `NetworkProver`.