### PR TITLE
request -> request_async

### DIFF
--- a/crates/sdk/src/network/prove.rs
+++ b/crates/sdk/src/network/prove.rs
@@ -241,7 +241,7 @@ impl<'a> NetworkProveBuilder<'a> {
     /// the simulation step locally.
     ///
     /// The cycle limit ensures that a prover on the network will stop generating a proof once the
-    /// cycle limit is reached, which prevents `DoS` attacks.
+    /// cycle limit is reached, which prevents denial of service attacks.
     ///
     /// # Example
     /// ```rust,no_run


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

We have `NetworkProve::run` and `NetworkProve::run_async`, so this PR changes `NetworkProve::request` and `NetworkProve::request_async` to match