### PR TITLE
Update Cargo.toml

### DIFF
--- a/examples/patch-testing/program/Cargo.toml
+++ b/examples/patch-testing/program/Cargo.toml
@@ -9,17 +9,17 @@ sp1-zkvm = { path = "../../../crates/zkvm/entrypoint" }
 
 sha2-v0-9-8 = { version = "0.9.8", package = "sha2" }
 # Note: Can't have sha2-v0-10-6 and v0-10-8 at the same time due to crate resolution.
-sha2-v0-10-6 = { version = "0.10.6", package = "sha2" }
+sha2-v0-10-6 = { version = "0.10.7", package = "sha2" }
 # sha2-v0-10-8 = { version = "0.10.8", package = "sha2" }
 
 ed25519-consensus = "2.1.0"
-ed25519-dalek = "2.1.0"
+ed25519-dalek = "2.1.1"
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }
 curve25519-dalek = { version = "4.1.3", default-features = false, features = ["alloc"] }
 curve25519-dalek-ng = { version = "4.1", default-features = false, features = ["u32_backend", "alloc"] }
 k256 = { version = "0.13.3", default-features = false, features = ["ecdsa"] }
 p256 = { version = "0.13.2", default-features = false, features = ["ecdsa"] }
-alloy-primitives = { version = "0.8", features = ["k256"] }
-secp256k1 = { version = "0.29", features = ["recovery", "global-context"] }
+alloy-primitives = { version = "0.8.2", features = ["k256"] }
+secp256k1 = { version = "0.29.2", features = ["recovery", "global-context"] }
 
 revm-precompile = { version = "11.0.1", default-features = false, features = ["kzg-rs", "secp256r1"] }


### PR DESCRIPTION

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Updated
sha2-v0-10-6 from 0.10.6 to 0.10.7:

ed25519-dalek from 2.1.0 to 2.1.1:

alloy-primitives from 0.8 to 0.8.2:

secp256k1 from 0.29 to 0.29.2:

-->

## Solution

<!--
sha2-v0-10-6 from 0.10.6 to 0.10.7:

Security fixes
Performance improvements
Bug fixes in SHA-2 hash functions
ed25519-dalek from 2.1.0 to 2.1.1:

Fixes in cryptographic operations
Stability improvements
Updates for compatibility with new dependency versions
alloy-primitives from 0.8 to 0.8.2:

Improvements in working with Ethereum primitives
Performance optimizations
Bug fixes in working with k256
secp256k1 from 0.29 to 0.29.2:

Security improvements in cryptographic operations
Performance optimizations
Bug fixes in working with elliptic curves
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes