### PR TITLE
fix: return error instead of panic when fail to upload artifact

### DIFF
--- a/crates/sdk/src/network/client.rs
+++ b/crates/sdk/src/network/client.rs
@@ -261,9 +261,9 @@ impl NetworkClient {
             self.http.put(&presigned_url).body(bincode::serialize::<T>(item)?).send().await?;
 
         if !response.status().is_success() {
-            log::debug!("Artifact upload failed with status: {}", response.status());
+            log::error!("Artifact upload failed with status: {}", response.status());
+            return Err(anyhow::anyhow!("failed to upload artifact: HTTP {}", response.status()));
         }
-        assert!(response.status().is_success());
 
         Ok(uri)
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

The previous implementation used an assertion to handle upload failures, which isn't ideal for production code. This change provides better error handling and logging.


## Solution


<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- Replace assertion with proper error handling in `create_artifact_with_content`
- change debug log to error log for failed artifacts uploads