### PR TITLE
Fixed typos in: Update kalos.md

### DIFF
--- a/audits/kalos.md
+++ b/audits/kalos.md
@@ -55,7 +55,7 @@ zkvm
 
 # Findings
 
-## 1. [Critical] `poseidon2/external` is allows memory write at arbitrary location, and hash value is also underconstrained
+## 1. [Critical] `poseidon2/external` allows memory write at arbitrary location, and hash value is also underconstrained
 
 `Poseidon2Chip` evaluates the Poseidon2 hash in-circuit, with SBOX $x^7$, 8 external rounds and 13 internal rounds. There are several underconstrains in the codebase which lead to a break of soundness of the hash function evaluation and the memory state in general.
 
@@ -244,7 +244,7 @@ This allows us to read incorrect previous values - at clock 2, the intuitive pre
 
 The addresses of each row should be enforced to be different - this can be done by constraining that the address increases over the rows via bitwise decomposition. Note that adding this check in the initialize stage only is sufficient to resolve this issue.
 
-Also, the verifier needs to enforce that only one table of `MemoryGlobalChip` exists, so that double initializtion/finalization cannot happen using multiple tables.
+Also, the verifier needs to enforce that only one table of `MemoryGlobalChip` exists, so that double initialization/finalization cannot happen using multiple tables.
 
 As similar vulnerability was found in the Core VM, and similar defenses can be applied here.
 


### PR DESCRIPTION
Hello,

Here are two typos and correction recommendations:

1- "is allows memory write"

The phrase should be "allows memory write". The word "is" seems unnecessary.

2- "double initializtion/finalization"

"initializtion" is a typo; it should be "initialization".

Thanks.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes