### PR TITLE
create bn254 scalar field chip

### DIFF
--- a/crates/core/machine/src/syscall/precompiles/fptower/fr.rs
+++ b/crates/core/machine/src/syscall/precompiles/fptower/fr.rs
@@ -1,0 +1,10 @@
+use std::marker::PhantomData;
+pub struct FrOpChip<P> {
+    _marker: PhantomData<P>,
+}
+
+impl<P> FrOpChip<P> {
+    pub const fn new() -> Self {
+        Self { _marker: PhantomData }
+    }
+}

--- a/crates/core/machine/src/syscall/precompiles/fptower/mod.rs
+++ b/crates/core/machine/src/syscall/precompiles/fptower/mod.rs
@@ -1,10 +1,12 @@
 mod fp;
+mod fr;
 mod fp2_addsub;
 mod fp2_mul;
 
 pub use fp::*;
 pub use fp2_addsub::*;
 pub use fp2_mul::*;
+pub use fr::*;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

We want to compute [this function](https://github.com/scroll-tech/poseidon-circuit/blob/main/poseidon-base/src/hash.rs#L39) in SP1, poseidon hash over bn254 scalar, as it would be computed in a Halo2 circuit. This is for a DA integration with a zkrollup built with Halo2 KZG.

## Solution

It appears the bn254 precompiles in SP1 are for the base field, which makes sense to help verify proofs and compute pairings. However, iiuc this is not sufficient to perform computations as a halo2 circuit would, since the circuit inputs are elements of the **_scalar field_**.

Here I am developing a bn254 scalar field precompile, I expect it to be the same as Fp precompile but with a different modulus.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes