### PR TITLE
Fix typo Update kalos.md

### DIFF
--- a/audits/kalos.md
+++ b/audits/kalos.md
@@ -244,7 +244,7 @@ This allows us to read incorrect previous values - at clock 2, the intuitive pre
 
 The addresses of each row should be enforced to be different - this can be done by constraining that the address increases over the rows via bitwise decomposition. Note that adding this check in the initialize stage only is sufficient to resolve this issue.
 
-Also, the verifier needs to enforce that only one table of `MemoryGlobalChip` exists, so that double initializtion/finalization cannot happen using multiple tables.
+Also, the verifier needs to enforce that only one table of `MemoryGlobalChip` exists, so that double initialization/finalization cannot happen using multiple tables.
 
 As similar vulnerability was found in the Core VM, and similar defenses can be applied here.
 


### PR DESCRIPTION
# Pull Request Title: Fix Typo in kalos.md (initializtion to initialization)

## Description:
This pull request fixes a typographical error in the `kalos.md` documentation. The word "initializtion" has been corrected to "initialization," ensuring the documentation remains professional and clear.

## Changes:
- Corrected "initializtion" to "initialization" in `kalos.md`.

## File(s) Modified:
- `audits/kalos.md`

## Reasoning:
Accurate and precise documentation is essential for clarity and usability. Correcting this typo improves the quality of the project documentation and ensures the message is delivered without distractions.

## Checklist:
- [x] Documentation updated.
- [x] Changes comply with the project's contribution guidelines.
- [x] No functional impact on code or logic.

## Related Issues:
N/A

## Additional Notes:
This update is strictly limited to documentation and does not impact code or functionality.
