### PR TITLE
feat(sdk): configure grpc settings

### DIFF
--- a/crates/sdk/src/network/client.rs
+++ b/crates/sdk/src/network/client.rs
@@ -259,7 +259,7 @@ impl NetworkClient {
     }
 
     pub(crate) async fn prover_network_client(&self) -> Result<ProverNetworkClient<Channel>> {
-        let channel = grpc::configure_endpoint(self.rpc_url.clone())?.connect().await?;
+        let channel = grpc::configure_endpoint(&self.rpc_url)?.connect().await?;
         Ok(ProverNetworkClient::new(channel))
     }
 

--- a/crates/sdk/src/network/client.rs
+++ b/crates/sdk/src/network/client.rs
@@ -19,6 +19,7 @@ use tonic::{
     Code,
 };
 
+use super::grpc;
 use super::utils::Signable;
 use crate::network::proto::artifact::{
     artifact_store_client::ArtifactStoreClient, ArtifactType, CreateArtifactRequest,
@@ -258,16 +259,7 @@ impl NetworkClient {
     }
 
     pub(crate) async fn prover_network_client(&self) -> Result<ProverNetworkClient<Channel>> {
-        let rpc_url = self.rpc_url.clone();
-        let mut endpoint = Channel::from_shared(rpc_url.clone())?;
-
-        // Check if the URL scheme is HTTPS and configure TLS.
-        if rpc_url.starts_with("https://") {
-            let tls_config = ClientTlsConfig::new().with_enabled_roots();
-            endpoint = endpoint.tls_config(tls_config)?;
-        }
-
-        let channel = endpoint.connect().await?;
+        let channel = grpc::configure_endpoint(self.rpc_url.clone())?.connect().await?;
         Ok(ProverNetworkClient::new(channel))
     }
 

--- a/crates/sdk/src/network/grpc.rs
+++ b/crates/sdk/src/network/grpc.rs
@@ -1,0 +1,24 @@
+use std::time::Duration;
+use tonic::transport::{ClientTlsConfig, Endpoint, Error};
+
+/// Configures the endpoint for the gRPC client.
+///
+/// Sets reasonable settings to handle timeouts and keep-alive.
+pub fn configure_endpoint(addr: String) -> Result<Endpoint, Error> {
+    let mut endpoint = Endpoint::new(addr.clone())?
+        .timeout(Duration::from_secs(60))
+        .connect_timeout(Duration::from_secs(15))
+        .keep_alive_while_idle(true)
+        .http2_keep_alive_interval(Duration::from_secs(15))
+        .keep_alive_timeout(Duration::from_secs(15))
+        .tcp_keepalive(Some(Duration::from_secs(60)))
+        .tcp_nodelay(true);
+
+    // Configure TLS if using HTTPS.
+    if addr.starts_with("https://") {
+        let tls_config = ClientTlsConfig::new().with_enabled_roots();
+        endpoint = endpoint.tls_config(tls_config)?;
+    }
+
+    Ok(endpoint)
+}

--- a/crates/sdk/src/network/grpc.rs
+++ b/crates/sdk/src/network/grpc.rs
@@ -4,8 +4,8 @@ use tonic::transport::{ClientTlsConfig, Endpoint, Error};
 /// Configures the endpoint for the gRPC client.
 ///
 /// Sets reasonable settings to handle timeouts and keep-alive.
-pub fn configure_endpoint(addr: String) -> Result<Endpoint, Error> {
-    let mut endpoint = Endpoint::new(addr.clone())?
+pub fn configure_endpoint(addr: &str) -> Result<Endpoint, Error> {
+    let mut endpoint = Endpoint::new(addr.to_string())?
         .timeout(Duration::from_secs(60))
         .connect_timeout(Duration::from_secs(15))
         .keep_alive_while_idle(true)

--- a/crates/sdk/src/network/mod.rs
+++ b/crates/sdk/src/network/mod.rs
@@ -11,6 +11,7 @@ pub mod prover;
 pub mod proto;
 pub mod builder;
 mod error;
+mod grpc;
 pub mod prove;
 pub mod utils;
 


### PR DESCRIPTION
To prevent the processing stalling if the http connection stalls.