### PR TITLE
perf: Unify FRI configs at 100 bits

### DIFF
--- a/crates/recursion/core/src/stark/config.rs
+++ b/crates/recursion/core/src/stark/config.rs
@@ -71,6 +71,7 @@ pub fn outer_perm() -> OuterPerm {
 }
 
 /// The FRI config for outer recursion.
+/// This targets by default 100 bits of security.
 pub fn outer_fri_config() -> FriConfig<OuterChallengeMmcs> {
     let perm = outer_perm();
     let hash = OuterHash::new(perm.clone()).unwrap();
@@ -81,13 +82,14 @@ pub fn outer_fri_config() -> FriConfig<OuterChallengeMmcs> {
     } else {
         match std::env::var("FRI_QUERIES") {
             Ok(value) => value.parse().unwrap(),
-            Err(_) => 25,
+            Err(_) => 21,
         }
     };
     FriConfig { log_blowup: 4, num_queries, proof_of_work_bits: 16, mmcs: challenge_mmcs }
 }
 
 /// The FRI config for outer recursion.
+/// This targets by default 100 bits of security.
 pub fn outer_fri_config_with_blowup(log_blowup: usize) -> FriConfig<OuterChallengeMmcs> {
     let perm = outer_perm();
     let hash = OuterHash::new(perm.clone()).unwrap();
@@ -98,7 +100,7 @@ pub fn outer_fri_config_with_blowup(log_blowup: usize) -> FriConfig<OuterChallen
     } else {
         match std::env::var("FRI_QUERIES") {
             Ok(value) => value.parse().unwrap(),
-            Err(_) => 100 / log_blowup,
+            Err(_) => 84 / log_blowup,
         }
     };
     FriConfig { log_blowup, num_queries, proof_of_work_bits: 16, mmcs: challenge_mmcs }

--- a/crates/stark/src/bb31_poseidon2.rs
+++ b/crates/stark/src/bb31_poseidon2.rs
@@ -52,6 +52,7 @@ pub fn inner_perm() -> InnerPerm {
 }
 
 /// The FRI config for sp1 proofs.
+/// This targets by default 100 bits of security.
 #[must_use]
 pub fn sp1_fri_config() -> FriConfig<InnerChallengeMmcs> {
     let perm = inner_perm();
@@ -60,12 +61,13 @@ pub fn sp1_fri_config() -> FriConfig<InnerChallengeMmcs> {
     let challenge_mmcs = InnerChallengeMmcs::new(InnerValMmcs::new(hash, compress));
     let num_queries = match std::env::var("FRI_QUERIES") {
         Ok(value) => value.parse().unwrap(),
-        Err(_) => 100,
+        Err(_) => 84,
     };
     FriConfig { log_blowup: 1, num_queries, proof_of_work_bits: 16, mmcs: challenge_mmcs }
 }
 
 /// The FRI config for inner recursion.
+/// This targets by default 100 bits of security.
 #[must_use]
 pub fn inner_fri_config() -> FriConfig<InnerChallengeMmcs> {
     let perm = inner_perm();
@@ -74,7 +76,7 @@ pub fn inner_fri_config() -> FriConfig<InnerChallengeMmcs> {
     let challenge_mmcs = InnerChallengeMmcs::new(InnerValMmcs::new(hash, compress));
     let num_queries = match std::env::var("FRI_QUERIES") {
         Ok(value) => value.parse().unwrap(),
-        Err(_) => 100,
+        Err(_) => 84,
     };
     FriConfig { log_blowup: 1, num_queries, proof_of_work_bits: 16, mmcs: challenge_mmcs }
 }
@@ -208,6 +210,7 @@ pub mod baby_bear_poseidon2 {
     }
 
     #[must_use]
+    /// This targets by default 100 bits of security.
     pub fn default_fri_config() -> FriConfig<ChallengeMmcs> {
         let perm = my_perm();
         let hash = MyHash::new(perm.clone());
@@ -215,12 +218,13 @@ pub mod baby_bear_poseidon2 {
         let challenge_mmcs = ChallengeMmcs::new(ValMmcs::new(hash, compress));
         let num_queries = match std::env::var("FRI_QUERIES") {
             Ok(value) => value.parse().unwrap(),
-            Err(_) => 100,
+            Err(_) => 84,
         };
         FriConfig { log_blowup: 1, num_queries, proof_of_work_bits: 16, mmcs: challenge_mmcs }
     }
 
     #[must_use]
+    /// This targets by default 100 bits of security.
     pub fn compressed_fri_config() -> FriConfig<ChallengeMmcs> {
         let perm = my_perm();
         let hash = MyHash::new(perm.clone());
@@ -228,12 +232,13 @@ pub mod baby_bear_poseidon2 {
         let challenge_mmcs = ChallengeMmcs::new(ValMmcs::new(hash, compress));
         let num_queries = match std::env::var("FRI_QUERIES") {
             Ok(value) => value.parse().unwrap(),
-            Err(_) => 50,
+            Err(_) => 42,
         };
         FriConfig { log_blowup: 2, num_queries, proof_of_work_bits: 16, mmcs: challenge_mmcs }
     }
 
     #[must_use]
+    /// This targets by default 100 bits of security.
     pub fn ultra_compressed_fri_config() -> FriConfig<ChallengeMmcs> {
         let perm = my_perm();
         let hash = MyHash::new(perm.clone());
@@ -241,7 +246,7 @@ pub mod baby_bear_poseidon2 {
         let challenge_mmcs = ChallengeMmcs::new(ValMmcs::new(hash, compress));
         let num_queries = match std::env::var("FRI_QUERIES") {
             Ok(value) => value.parse().unwrap(),
-            Err(_) => 33,
+            Err(_) => 28,
         };
         FriConfig { log_blowup: 3, num_queries, proof_of_work_bits: 16, mmcs: challenge_mmcs }
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Unify all FRI configs to target 100 bits to match the permutation argument (currently targeting 116 vs 100 bits).
Allows to reduce the number of FRI queries for each layer (soundness level obtained as `proof_of_work_bits + log_blowup * num_queries`, cc ethSTARK paper for instance).

cc @jtguibas what I was sharing on slack

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes