### PR TITLE
feat: v4.0.1

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -5,9 +5,9 @@ name: book
 
 on:
   push:
-    branches: [main]
+    branches: [dev]
   pull_request:
-    branches: [main]
+    branches: [dev]
     paths:
       - "book/**"
   merge_group:
@@ -46,7 +46,7 @@ jobs:
 
   deploy:
     # Only deploy if a push to main
-    if: github.ref_name == 'main' && github.event_name == 'push'
+    if: github.ref_name == 'dev' && github.event_name == 'push'
     runs-on: ubuntu-latest
     needs: [build]
 

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -45,7 +45,7 @@ jobs:
           path: book/build
 
   deploy:
-    # Only deploy if a push to main
+    # Only deploy if a push to dev
     if: github.ref_name == 'dev' && github.event_name == 'push'
     runs-on: ubuntu-latest
     needs: [build]

--- a/.github/workflows/docker-gnark.yml
+++ b/.github/workflows/docker-gnark.yml
@@ -21,6 +21,7 @@ jobs:
       [
         runs-on,
         runner=64cpu-linux-arm64,
+        disk=large,
         spot=false,
         "run-id=${{ github.run_id }}",
       ]

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -372,3 +372,20 @@ jobs:
         run: |
           cd examples
           cargo build --all --all-targets
+
+  build-in-host:
+    name: "Build patches and zkvm in host"
+    runs-on: [runs-on, runner=16cpu-linux-x64, disk=large, "run-id=${{ github.run_id }}"]
+    steps:
+      - name: "Checkout sources"
+        uses: "actions/checkout@v4"
+
+      - name: "Setup CI"
+        uses: ./.github/actions/setup
+        with:
+          pull_token: ${{ secrets.PRIVATE_PULL_TOKEN }}
+
+      - name: "Build programs in host"
+        run: |
+          cd ./patch-testing/build-host
+          cargo build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5735,7 +5735,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-build"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -5746,7 +5746,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cli"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -5775,7 +5775,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -5802,7 +5802,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sp1-curves",
- "sp1-primitives 4.0.0",
+ "sp1-primitives 4.0.1",
  "sp1-stark",
  "sp1-zkvm",
  "strum",
@@ -5818,7 +5818,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-machine"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "bincode",
  "cbindgen",
@@ -5858,7 +5858,7 @@ dependencies = [
  "sp1-core-executor",
  "sp1-curves",
  "sp1-derive",
- "sp1-primitives 4.0.0",
+ "sp1-primitives 4.0.1",
  "sp1-stark",
  "sp1-zkvm",
  "static_assertions",
@@ -5877,7 +5877,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cuda"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "bincode",
  "ctrlc",
@@ -5895,7 +5895,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -5910,14 +5910,14 @@ dependencies = [
  "rug",
  "serde",
  "snowbridge-amcl",
- "sp1-primitives 4.0.0",
+ "sp1-primitives 4.0.1",
  "sp1-stark",
  "typenum",
 ]
 
 [[package]]
 name = "sp1-derive"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -5925,7 +5925,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-eval"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -5943,7 +5943,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-helper"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "sp1-build",
 ]
@@ -5961,16 +5961,16 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "bincode",
  "serde",
- "sp1-primitives 4.0.0",
+ "sp1-primitives 4.0.1",
 ]
 
 [[package]]
 name = "sp1-perf"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "bincode",
  "clap",
@@ -6008,7 +6008,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "bincode",
  "hex",
@@ -6024,7 +6024,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6051,7 +6051,7 @@ dependencies = [
  "sha2 0.10.8",
  "sp1-core-executor",
  "sp1-core-machine",
- "sp1-primitives 4.0.0",
+ "sp1-primitives 4.0.1",
  "sp1-recursion-circuit",
  "sp1-recursion-compiler",
  "sp1-recursion-core",
@@ -6066,7 +6066,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-circuit"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "ff 0.13.0",
  "hashbrown 0.14.5",
@@ -6091,7 +6091,7 @@ dependencies = [
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-derive",
- "sp1-primitives 4.0.0",
+ "sp1-primitives 4.0.1",
  "sp1-recursion-compiler",
  "sp1-recursion-core",
  "sp1-recursion-gnark-ffi",
@@ -6103,7 +6103,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-compiler"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "backtrace",
  "criterion",
@@ -6118,7 +6118,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "sp1-core-machine",
- "sp1-primitives 4.0.0",
+ "sp1-primitives 4.0.1",
  "sp1-recursion-core",
  "sp1-recursion-derive",
  "sp1-stark",
@@ -6128,7 +6128,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-core"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "backtrace",
  "cbindgen",
@@ -6160,7 +6160,7 @@ dependencies = [
  "smallvec",
  "sp1-core-machine",
  "sp1-derive",
- "sp1-primitives 4.0.0",
+ "sp1-primitives 4.0.1",
  "sp1-stark",
  "static_assertions",
  "thiserror 1.0.69",
@@ -6171,7 +6171,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-derive"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -6179,7 +6179,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-cli"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "bincode",
  "clap",
@@ -6188,7 +6188,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-ffi"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6212,7 +6212,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-sdk"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -6242,7 +6242,7 @@ dependencies = [
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-cuda",
- "sp1-primitives 4.0.0",
+ "sp1-primitives 4.0.1",
  "sp1-prover",
  "sp1-stark",
  "strum",
@@ -6260,7 +6260,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-stark"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "arrayref",
  "hashbrown 0.14.5",
@@ -6284,7 +6284,7 @@ dependencies = [
  "rayon-scan",
  "serde",
  "sp1-derive",
- "sp1-primitives 4.0.0",
+ "sp1-primitives 4.0.1",
  "sp1-zkvm",
  "strum",
  "strum_macros",
@@ -6294,7 +6294,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-verifier"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -6316,7 +6316,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -6328,8 +6328,8 @@ dependencies = [
  "p3-field",
  "rand 0.8.5",
  "sha2 0.10.8",
- "sp1-lib 4.0.0",
- "sp1-primitives 4.0.0",
+ "sp1-lib 4.0.1",
+ "sp1-primitives 4.0.1",
 ]
 
 [[package]]
@@ -6667,7 +6667,7 @@ dependencies = [
 
 [[package]]
 name = "test-artifacts"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "sp1-build",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "4.0.0"
+version = "4.0.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 rust-version = "1.79"
@@ -51,26 +51,26 @@ debug-assertions = true
 
 [workspace.dependencies]
 # sp1
-sp1-build = { path = "crates/build", version = "4.0.0" }
-sp1-cli = { path = "crates/cli", version = "4.0.0", default-features = false }
-sp1-core-machine = { path = "crates/core/machine", version = "4.0.0" }
-sp1-core-executor = { path = "crates/core/executor", version = "4.0.0" }
-sp1-curves = { path = "crates/curves", version = "4.0.0" }
-sp1-derive = { path = "crates/derive", version = "4.0.0" }
-sp1-eval = { path = "crates/eval", version = "4.0.0" }
-sp1-helper = { path = "crates/helper", version = "4.0.0", default-features = false }
-sp1-primitives = { path = "crates/primitives", version = "4.0.0" }
-sp1-prover = { path = "crates/prover", version = "4.0.0" }
-sp1-recursion-compiler = { path = "crates/recursion/compiler", version = "4.0.0" }
-sp1-recursion-core = { path = "crates/recursion/core", version = "4.0.0" }
-sp1-recursion-derive = { path = "crates/recursion/derive", version = "4.0.0", default-features = false }
-sp1-recursion-gnark-ffi = { path = "crates/recursion/gnark-ffi", version = "4.0.0", default-features = false }
-sp1-recursion-circuit = { path = "crates/recursion/circuit", version = "4.0.0", default-features = false }
-sp1-sdk = { path = "crates/sdk", version = "4.0.0" }
-sp1-cuda = { path = "crates/cuda", version = "4.0.0" }
-sp1-stark = { path = "crates/stark", version = "4.0.0" }
-sp1-lib = { path = "crates/zkvm/lib", version = "4.0.0", default-features = false }
-sp1-zkvm = { path = "crates/zkvm/entrypoint", version = "4.0.0", default-features = false }
+sp1-build = { path = "crates/build", version = "4.0.1" }
+sp1-cli = { path = "crates/cli", version = "4.0.1", default-features = false }
+sp1-core-machine = { path = "crates/core/machine", version = "4.0.1" }
+sp1-core-executor = { path = "crates/core/executor", version = "4.0.1" }
+sp1-curves = { path = "crates/curves", version = "4.0.1" }
+sp1-derive = { path = "crates/derive", version = "4.0.1" }
+sp1-eval = { path = "crates/eval", version = "4.0.1" }
+sp1-helper = { path = "crates/helper", version = "4.0.1", default-features = false }
+sp1-primitives = { path = "crates/primitives", version = "4.0.1" }
+sp1-prover = { path = "crates/prover", version = "4.0.1" }
+sp1-recursion-compiler = { path = "crates/recursion/compiler", version = "4.0.1" }
+sp1-recursion-core = { path = "crates/recursion/core", version = "4.0.1" }
+sp1-recursion-derive = { path = "crates/recursion/derive", version = "4.0.1", default-features = false }
+sp1-recursion-gnark-ffi = { path = "crates/recursion/gnark-ffi", version = "4.0.1", default-features = false }
+sp1-recursion-circuit = { path = "crates/recursion/circuit", version = "4.0.1", default-features = false }
+sp1-sdk = { path = "crates/sdk", version = "4.0.1" }
+sp1-cuda = { path = "crates/cuda", version = "4.0.1" }
+sp1-stark = { path = "crates/stark", version = "4.0.1" }
+sp1-lib = { path = "crates/zkvm/lib", version = "4.0.1", default-features = false }
+sp1-zkvm = { path = "crates/zkvm/entrypoint", version = "4.0.1", default-features = false }
 
 # For testing.
 test-artifacts = { path = "crates/test-artifacts" }

--- a/book/docs/developers/common-issues.md
+++ b/book/docs/developers/common-issues.md
@@ -121,3 +121,21 @@ To resolve this, ensure that you're importing both `sp1-lib` and `sp1-zkvm` with
 sp1-lib = { version = "<VERSION>", features = ["verify"] }
 sp1-zkvm = { version = "<VERSION>", features = ["verify"] }
 ```
+
+## Failed to run LLVM passes: unknown pass name 'loweratomic'
+
+The Rust compiler had breaking changes to its names of available options between 1.81 and 1.82.
+
+```bash
+  [sp1]     Compiling proc-macro2 v1.0.93
+  [sp1]     Compiling unicode-ident v1.0.14
+  [sp1]     Compiling quote v1.0.38
+  [sp1]     Compiling syn v2.0.96
+  [sp1]     Compiling serde_derive v1.0.217
+  [sp1]     Compiling serde v1.0.217
+  [sp1]  error: failed to run LLVM passes: unknown pass name 'loweratomic'
+```
+
+This message indicates that you're trying to use `sp1-build` < `4.0.0` with the 1.82 toolchain,
+`sp1-build` versions >= 4.0.0 have support for the 1.82 and 1.81 toolchains.
+

--- a/book/docs/developers/common-issues.md
+++ b/book/docs/developers/common-issues.md
@@ -5,17 +5,17 @@
 If you are using a library that has an MSRV specified, you may encounter an error like this when building your program.
 
 ```txt
-package `alloy cannot be built because it requires rustc 1.83 or newer, while the currently active rustc version is 1.81.0`
+package `alloy cannot be built because it requires rustc 1.83 or newer, while the currently active rustc version is 1.82.0`
 ```
 
 This is due to the fact that your current Succinct Rust toolchain has been built with a lower version than the MSRV of the crates you are using.
 
-You can check the version of your local Succinct Rust toolchain by running `cargo +succinct --version`. The latest release of the Succinct Rust toolchain is **1.81**. You can update to the latest version by running [`sp1up`](../getting-started/install.md).
+You can check the version of your local Succinct Rust toolchain by running `cargo +succinct --version`. The latest release of the Succinct Rust toolchain is **1.82**. You can update to the latest version by running [`sp1up`](../getting-started/install.md).
 
 ```shell
 % sp1up
 % cargo +succinct --version
-cargo 1.81.0-dev (2dbb1af80 2024-08-20)
+cargo 1.82.0-dev (8f40fc59f 2024-08-21)
 ```
 
 A Succinct Rust toolchain with version **1.82** should work for all crates that have an MSRV of **1.82** or lower.

--- a/book/docs/developers/usage-in-ci.md
+++ b/book/docs/developers/usage-in-ci.md
@@ -41,6 +41,8 @@ Try setting a github actions secret to your PAT, and then passing it into the `s
     ~/.sp1/bin/cargo-prove prove --version
 ```
 
+Note: Installing via `sp1up` always installs the latest version, its recommended to [use a release commit](https://github.com/succinctlabs/sp1/releases) via `sp1up -C <commit>`.
+
 ## Speeding up your CI workflow
 
 ### Caching

--- a/book/docs/writing-programs/patched-crates.md
+++ b/book/docs/writing-programs/patched-crates.md
@@ -115,6 +115,19 @@ Apply the following patches based on what crates are in your dependencies.
 
 While `secp256k1` doesnt usually rely on `ecdsa-core` the patched version does, so you must patch it as well.
 
+## Secp256r1 Acceleration
+
+- `p256`
+
+  ```toml
+  ecdsa-core = { git = "https://github.com/sp1-patches/signatures", package = "ecdsa", tag = "patch-0.16.9-sp1-4.0.0" }
+  ```
+
+### Notes
+
+- The curve operations for `p256` are inside of the `ecdsa-core` crate, so you don't need to patch `p256` itself, and just patching `ecdsa-core` is enough.
+- The current patch only accelerates the `ecrecover` function. In a future release, we will accelerate the `verify` function used in `P256Verify` (RIP-7212 precompile).
+
 ## BN254 Acceleration
 
 To accelerate BN254 (Also known as BN128 and Alt-BN128), you will need to patch the `substrate-bn` crate.

--- a/book/docusaurus.config.ts
+++ b/book/docusaurus.config.ts
@@ -19,7 +19,7 @@ const config: Config = {
   // If you aren't using GitHub pages, you don't need these.
   organizationName: 'succinctlabs', // Usually your GitHub org/user name.
   projectName: 'sp1', // Usually your repo name.
-  deploymentBranch: 'main',
+  deploymentBranch: 'dev',
   trailingSlash: false,
 
   onBrokenLinks: 'warn',
@@ -50,6 +50,15 @@ const config: Config = {
   ],
 
   themeConfig: {
+    algolia: {
+      apiKey: "8bfb4b393679faa73e8362e3966be8c3", // Public api key
+      appId: "P3LCHD8MFM",
+      indexName: "succinct",
+      searchPagePath: "search",
+
+      // Leaving at the default of `true` for now
+      contextualSearch: true,
+    },
     docs: {
       sidebar: {
         hideable: false,

--- a/book/docusaurus.config.ts
+++ b/book/docusaurus.config.ts
@@ -38,8 +38,7 @@ const config: Config = {
       "classic",
       ({
         docs: {
-          routeBasePath: "docs",
-          sidebarPath: require.resolve("./sidebars.ts"),
+          onlyIncludeVersions: ["4.0.0", "3.4.0"],
         },
         blog: false,
         pages: {},

--- a/book/versioned_docs/version-4.0.0/developers/common-issues.md
+++ b/book/versioned_docs/version-4.0.0/developers/common-issues.md
@@ -139,3 +139,16 @@ The Rust compiler had breaking changes to its names of available options between
 This message indicates that you're trying to use `sp1-build` < `4.0.0` with the 1.82 toolchain,
 `sp1-build` versions >= 4.0.0 have support for the 1.82 and 1.81 toolchains.
 
+If you're using `cargo prove build` an `sp1up` should fix this.
+
+## Ubuntu 20.04 (ARM)
+
+The Succinct Rust toolchain is built on Ubuntu 22.04, which links a newer version of libc than available
+on Ubuntu 20.04.
+
+This error may manifest as:
+```bash
+   /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found 
+```
+This most commonly happens in CI runners, it is recommended to bump the runner OS to 22.04,
+the issue applies to all older linux distrubtions that dont have support for the same version of libc used to build it.

--- a/book/versioned_docs/version-4.0.0/developers/common-issues.md
+++ b/book/versioned_docs/version-4.0.0/developers/common-issues.md
@@ -121,3 +121,21 @@ To resolve this, ensure that you're importing both `sp1-lib` and `sp1-zkvm` with
 sp1-lib = { version = "<VERSION>", features = ["verify"] }
 sp1-zkvm = { version = "<VERSION>", features = ["verify"] }
 ```
+
+## Failed to run LLVM passes: unknown pass name 'loweratomic'
+
+The Rust compiler had breaking changes to its names of available options between 1.81 and 1.82.
+
+```bash
+  [sp1]     Compiling proc-macro2 v1.0.93
+  [sp1]     Compiling unicode-ident v1.0.14
+  [sp1]     Compiling quote v1.0.38
+  [sp1]     Compiling syn v2.0.96
+  [sp1]     Compiling serde_derive v1.0.217
+  [sp1]     Compiling serde v1.0.217
+  [sp1]  error: failed to run LLVM passes: unknown pass name 'loweratomic'
+```
+
+This message indicates that you're trying to use `sp1-build` < `4.0.0` with the 1.82 toolchain,
+`sp1-build` versions >= 4.0.0 have support for the 1.82 and 1.81 toolchains.
+

--- a/book/versioned_docs/version-4.0.0/developers/common-issues.md
+++ b/book/versioned_docs/version-4.0.0/developers/common-issues.md
@@ -5,17 +5,17 @@
 If you are using a library that has an MSRV specified, you may encounter an error like this when building your program.
 
 ```txt
-package `alloy cannot be built because it requires rustc 1.83 or newer, while the currently active rustc version is 1.81.0`
+package `alloy cannot be built because it requires rustc 1.83 or newer, while the currently active rustc version is 1.82.0`
 ```
 
 This is due to the fact that your current Succinct Rust toolchain has been built with a lower version than the MSRV of the crates you are using.
 
-You can check the version of your local Succinct Rust toolchain by running `cargo +succinct --version`. The latest release of the Succinct Rust toolchain is **1.81**. You can update to the latest version by running [`sp1up`](../getting-started/install.md).
+You can check the version of your local Succinct Rust toolchain by running `cargo +succinct --version`. The latest release of the Succinct Rust toolchain is **1.82**. You can update to the latest version by running [`sp1up`](../getting-started/install.md).
 
 ```shell
 % sp1up
 % cargo +succinct --version
-cargo 1.81.0-dev (2dbb1af80 2024-08-20)
+cargo 1.82.0-dev (8f40fc59f 2024-08-21)
 ```
 
 A Succinct Rust toolchain with version **1.82** should work for all crates that have an MSRV of **1.82** or lower.

--- a/book/versioned_docs/version-4.0.0/developers/common-issues.md
+++ b/book/versioned_docs/version-4.0.0/developers/common-issues.md
@@ -143,12 +143,12 @@ If you're using `cargo prove build` an `sp1up` should fix this.
 
 ## Ubuntu 20.04 (ARM)
 
-The Succinct Rust toolchain is built on Ubuntu 22.04, which links a newer version of libc than available
-on Ubuntu 20.04.
+The Succinct Rust toolchain is built on Ubuntu 22.04 for ARM machines, 
+which links a newer version of libc than available on Ubuntu 20.04.
 
 This error may manifest as:
 ```bash
    /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found 
 ```
-This most commonly happens in CI runners, it is recommended to bump the runner OS to 22.04,
-the issue applies to all older linux distrubtions that dont have support for the same version of libc used to build it.
+This most commonly happens in CI runners. To solve this, bump the runner OS to 22.04. 
+This issue also applies all older Linux distributions that don't have support for the same version of libc used to build it.

--- a/book/versioned_docs/version-4.0.0/developers/usage-in-ci.md
+++ b/book/versioned_docs/version-4.0.0/developers/usage-in-ci.md
@@ -41,6 +41,8 @@ Try setting a github actions secret to your PAT, and then passing it into the `s
     ~/.sp1/bin/cargo-prove prove --version
 ```
 
+Note: Installing via `sp1up` always installs the latest version, its recommended to [use a release commit](https://github.com/succinctlabs/sp1/releases) via `sp1up -C <commit>`.
+
 ## Speeding up your CI workflow
 
 ### Caching

--- a/book/versioned_docs/version-4.0.0/generating-proofs/prover-network/usage.md
+++ b/book/versioned_docs/version-4.0.0/generating-proofs/prover-network/usage.md
@@ -17,10 +17,12 @@ let mut proof = client.prove(&pk, &stdin).run().unwrap();
 SP1_PROVER=network NETWORK_PRIVATE_KEY=... RUST_LOG=info cargo run --release
 ```
 
-- `SP1_PROVER` should be set to `network` rather than the default `cpu` when using the prover network. This variable allows you to switch between the CPU and network provers.
+- Set `SP1_PROVER` to `network` (default is `cpu`). Configuring this variable to `network` will use the prover network.
 
 - `NETWORK_PRIVATE_KEY` should be set to your [private key](./key-setup.md). You will need
   to be using a [whitelisted](../prover-network) key to use the network.
+
+- `NETWORK_RPC_URL`: Defaults to `https://rpc.production.succinct.xyz`. This is the RPC URL of the prover network.
 
 When you call any of the prove functions in ProverClient now, it will first simulate your program, then wait for it to be proven through the network and finally return the proof.
 

--- a/book/versioned_docs/version-4.0.0/generating-proofs/prover-network/versions.md
+++ b/book/versioned_docs/version-4.0.0/generating-proofs/prover-network/versions.md
@@ -5,9 +5,8 @@ The prover network currently only supports specific versions of SP1:
 | Version | Description                                                      |
 | ------- | ---------------------------------------------------------------- |
 | v4.X.X  | V4 Release. Latest performant & production ready version.        |
-| v3.X.X  | V3 Release. Previous circuit version deprecated in January 2025. |
 
-`X` denotes that any minor and patch version is supported (e.g. `v2.1.0`, `v2.1.1`).
+`X` denotes that any minor and patch version is supported (e.g. `v4.0.1`, `v4.1.0`).
 
 If you submit a proof request to the prover network and you are not using a supported version, you will receive an error message.
 

--- a/book/versioned_docs/version-4.0.0/writing-programs/patched-crates.md
+++ b/book/versioned_docs/version-4.0.0/writing-programs/patched-crates.md
@@ -115,6 +115,19 @@ Apply the following patches based on what crates are in your dependencies.
 
 While `secp256k1` doesnt usually rely on `ecdsa-core` the patched version does, so you must patch it as well.
 
+## Secp256r1 Acceleration
+
+- `p256`
+
+  ```toml
+  ecdsa-core = { git = "https://github.com/sp1-patches/signatures", package = "ecdsa", tag = "patch-0.16.9-sp1-4.0.0" }
+  ```
+
+### Notes
+
+- The curve operations for `p256` are inside of the `ecdsa-core` crate, so you don't need to patch `p256` itself, and just patching `ecdsa-core` is enough.
+- The current patch only accelerates the `ecrecover` function. In a future release, we will accelerate the `verify` function used in `P256Verify` (RIP-7212 precompile).
+
 ## BN254 Acceleration
 
 To accelerate BN254 (Also known as BN128 and Alt-BN128), you will need to patch the `substrate-bn` crate.

--- a/crates/build/src/build.rs
+++ b/crates/build/src/build.rs
@@ -72,6 +72,8 @@ pub fn execute_build_program(
 
             std::fs::copy(&elf_path, &output_path)?;
         }
+    } else if args.elf_name.is_some() {
+        println!("cargo:warning=ELF name is set but --output-directory is not used");
     }
 
     print_elf_paths_cargo_directives(&target_elf_paths);

--- a/crates/build/src/build.rs
+++ b/crates/build/src/build.rs
@@ -73,7 +73,7 @@ pub fn execute_build_program(
             std::fs::copy(&elf_path, &output_path)?;
         }
     } else if args.elf_name.is_some() {
-        println!("cargo:warning=ELF name is set but --output-directory is not used");
+        println!("cargo:warning=ELF name is set but --output-directory is not used, the ELF will be place in the `target/` directory");
     }
 
     print_elf_paths_cargo_directives(&target_elf_paths);

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -8,7 +8,7 @@ pub const RUSTUP_TOOLCHAIN_NAME: &str = "succinct";
 
 /// The latest version (github tag) of the toolchain that is supported by our build system.
 ///
-/// This tag has suppoert for older x86 libc versions (like the one found in Ubuntu 20.04).
+/// This tag has support for older x86 libc versions (like the one found in Ubuntu 20.04).
 /// This tag has support for the recent Macos and ARM targets.
 pub const LATEST_SUPPORTED_TOOLCHAIN_VERSION_TAG: &str = "succinct-1.82.0";
 

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -7,7 +7,10 @@ use std::process::{Command, Stdio};
 pub const RUSTUP_TOOLCHAIN_NAME: &str = "succinct";
 
 /// The latest version (github tag) of the toolchain that is supported by our build system.
-pub const LATEST_SUPPORTED_TOOLCHAIN_VERSION_TAG: &str = "v1.82.0";
+///
+/// This tag has suppoert for older x86 libc versions (like the one found in Ubuntu 20.04).
+/// This tag has support for the recent Macos and ARM targets.
+pub const LATEST_SUPPORTED_TOOLCHAIN_VERSION_TAG: &str = "succinct-1.82.0";
 
 pub const SP1_VERSION_MESSAGE: &str =
     concat!("sp1", " (", env!("VERGEN_GIT_SHA"), " ", env!("VERGEN_BUILD_TIMESTAMP"), ")");

--- a/crates/core/executor/src/syscalls/hint.rs
+++ b/crates/core/executor/src/syscalls/hint.rs
@@ -10,10 +10,8 @@ impl Syscall for HintLenSyscall {
         _arg1: u32,
         _arg2: u32,
     ) -> Option<u32> {
-        panic_if_input_exhausted(ctx);
-
-        // Note: This cast could be truncating
-        ctx.rt.state.input_stream.front().map(|data| data.len() as u32)
+        // Note: If the user supplies an input > than length 2^32, then the length returned will be truncated to 32-bits. Reading from the syscall will definitely fail in that case, as the BabyBear field is < 2^32.
+        Some(ctx.rt.state.input_stream.front().map_or(u32::MAX, |data| data.len() as u32))
     }
 }
 

--- a/crates/sdk/src/network/builder.rs
+++ b/crates/sdk/src/network/builder.rs
@@ -2,6 +2,7 @@
 //!
 //! This module provides a builder for the [`NetworkProver`].
 
+use crate::network::DEFAULT_NETWORK_RPC_URL;
 use crate::NetworkProver;
 
 /// A builder for the [`NetworkProver`].
@@ -83,10 +84,7 @@ impl NetworkProverBuilder {
 
         let rpc_url = match self.rpc_url {
             Some(rpc_url) => rpc_url,
-            None => std::env::var("NETWORK_RPC_URL").expect(
-                "NETWORK_RPC_URL environment variable is not set. \
-                Please set it to your rpc url or use the .rpc_url() method.",
-            ),
+            None => std::env::var("NETWORK_RPC_URL").unwrap_or(DEFAULT_NETWORK_RPC_URL.to_string()),
         };
 
         NetworkProver::new(&private_key, &rpc_url)

--- a/crates/test-artifacts/programs/Cargo.lock
+++ b/crates/test-artifacts/programs/Cargo.lock
@@ -328,7 +328,7 @@ version = "1.1.0"
 dependencies = [
  "common-test-utils",
  "sp1-curves",
- "sp1-lib 4.0.0",
+ "sp1-lib 4.0.1",
  "sp1-zkvm",
 ]
 
@@ -371,7 +371,7 @@ name = "bls12381-mul-test"
 version = "1.1.0"
 dependencies = [
  "sp1-derive",
- "sp1-lib 4.0.0",
+ "sp1-lib 4.0.1",
  "sp1-zkvm",
 ]
 
@@ -381,7 +381,7 @@ version = "1.1.0"
 dependencies = [
  "common-test-utils",
  "sp1-curves",
- "sp1-lib 4.0.0",
+ "sp1-lib 4.0.1",
  "sp1-zkvm",
 ]
 
@@ -424,7 +424,7 @@ name = "bn254-mul-test"
 version = "1.1.0"
 dependencies = [
  "sp1-derive",
- "sp1-lib 4.0.0",
+ "sp1-lib 4.0.1",
  "sp1-zkvm",
 ]
 
@@ -494,7 +494,7 @@ name = "common-test-utils"
 version = "1.1.0"
 dependencies = [
  "num-bigint",
- "sp1-lib 4.0.0",
+ "sp1-lib 4.0.1",
 ]
 
 [[package]]
@@ -2254,7 +2254,7 @@ version = "1.1.0"
 dependencies = [
  "common-test-utils",
  "sp1-curves",
- "sp1-lib 4.0.0",
+ "sp1-lib 4.0.1",
  "sp1-zkvm",
 ]
 
@@ -2290,7 +2290,7 @@ dependencies = [
  "num",
  "p256",
  "sp1-curves",
- "sp1-lib 4.0.0",
+ "sp1-lib 4.0.1",
  "sp1-zkvm",
 ]
 
@@ -2311,7 +2311,7 @@ dependencies = [
  "num",
  "p256",
  "sp1-curves",
- "sp1-lib 4.0.0",
+ "sp1-lib 4.0.1",
  "sp1-zkvm",
 ]
 
@@ -2516,7 +2516,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -2536,7 +2536,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-derive"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -2568,7 +2568,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "bincode",
  "serde",
@@ -2577,7 +2577,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "bincode",
  "hex",
@@ -2593,7 +2593,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-stark"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "arrayref",
  "hashbrown 0.14.5",
@@ -2626,7 +2626,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "cfg-if",
  "getrandom",
@@ -2636,7 +2636,7 @@ dependencies = [
  "p3-field",
  "rand",
  "sha2 0.10.8",
- "sp1-lib 4.0.0",
+ "sp1-lib 4.0.1",
  "sp1-primitives",
 ]
 

--- a/crates/zkvm/entrypoint/src/allocators/bump.rs
+++ b/crates/zkvm/entrypoint/src/allocators/bump.rs
@@ -1,11 +1,10 @@
-use core::alloc::{GlobalAlloc, Layout};
-
 use crate::syscalls::sys_alloc_aligned;
+use core::alloc::{GlobalAlloc, Layout};
 
 /// A simple heap allocator.
 ///
 /// Allocates memory from left to right, without any deallocation.
-pub struct SimpleAlloc;
+struct SimpleAlloc;
 
 unsafe impl GlobalAlloc for SimpleAlloc {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {

--- a/crates/zkvm/entrypoint/src/allocators/embedded.rs
+++ b/crates/zkvm/entrypoint/src/allocators/embedded.rs
@@ -32,11 +32,11 @@ pub fn init() {
 }
 
 pub fn used() -> usize {
-    critical_section::with(|cs| INNER_HEAP.used())
+    critical_section::with(|_cs| INNER_HEAP.used())
 }
 
 pub fn free() -> usize {
-    critical_section::with(|cs| INNER_HEAP.free())
+    critical_section::with(|_cs| INNER_HEAP.free())
 }
 
 struct EmbeddedAlloc;

--- a/crates/zkvm/entrypoint/src/allocators/embedded.rs
+++ b/crates/zkvm/entrypoint/src/allocators/embedded.rs
@@ -6,9 +6,9 @@ use critical_section::RawRestoreState;
 use embedded_alloc::LlffHeap as Heap;
 
 #[global_allocator]
-pub static HEAP: EmbeddedAlloc = EmbeddedAlloc;
+static HEAP: EmbeddedAlloc = EmbeddedAlloc;
 
-pub static INNER_HEAP: Heap = Heap::empty();
+static INNER_HEAP: Heap = Heap::empty();
 
 struct CriticalSection;
 critical_section::set_impl!(CriticalSection);
@@ -39,7 +39,7 @@ pub fn free() -> usize {
     critical_section::with(|cs| INNER_HEAP.free())
 }
 
-pub struct EmbeddedAlloc;
+struct EmbeddedAlloc;
 
 unsafe impl GlobalAlloc for EmbeddedAlloc {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {

--- a/crates/zkvm/entrypoint/src/allocators/mod.rs
+++ b/crates/zkvm/entrypoint/src/allocators/mod.rs
@@ -6,4 +6,7 @@
 mod bump;
 
 #[cfg(feature = "embedded")]
-pub mod embedded;
+mod embedded;
+
+#[cfg(feature = "embedded")]
+pub use embedded::{free, init, used};

--- a/crates/zkvm/entrypoint/src/lib.rs
+++ b/crates/zkvm/entrypoint/src/lib.rs
@@ -1,11 +1,11 @@
 #[cfg(all(target_os = "zkvm", feature = "embedded"))]
-pub use syscalls::MAX_MEMORY;
+use syscalls::MAX_MEMORY;
 
 #[cfg(target_os = "zkvm")]
-use cfg_if::cfg_if;
-
-#[cfg(target_os = "zkvm")]
-use syscalls::{syscall_hint_len, syscall_hint_read};
+use {
+    cfg_if::cfg_if,
+    syscalls::{syscall_hint_len, syscall_hint_read},
+};
 
 extern crate alloc;
 
@@ -33,16 +33,18 @@ pub const POSEIDON_NUM_WORDS: usize = 8;
 
 /// Size of the reserved region for input values with the embedded allocator.
 #[cfg(all(target_os = "zkvm", feature = "embedded"))]
-pub const EMBEDDED_RESERVED_INPUT_REGION_SIZE: usize = 1024 * 1024 * 1024;
+pub(crate) const EMBEDDED_RESERVED_INPUT_REGION_SIZE: usize = 1024 * 1024 * 1024;
+
 /// Start of the reserved region for inputs with the embedded allocator.
 #[cfg(all(target_os = "zkvm", feature = "embedded"))]
-pub const EMBEDDED_RESERVED_INPUT_START: usize = MAX_MEMORY - EMBEDDED_RESERVED_INPUT_REGION_SIZE;
+pub(crate) const EMBEDDED_RESERVED_INPUT_START: usize =
+    MAX_MEMORY - EMBEDDED_RESERVED_INPUT_REGION_SIZE;
+
 /// Pointer to the current position in the reserved region for inputs with the embedded allocator.
 #[cfg(all(target_os = "zkvm", feature = "embedded"))]
 static mut EMBEDDED_RESERVED_INPUT_PTR: usize = EMBEDDED_RESERVED_INPUT_START;
 
 #[repr(C)]
-#[cfg(target_os = "zkvm")]
 pub struct ReadVecResult {
     pub ptr: *mut u8,
     pub len: usize,
@@ -60,57 +62,62 @@ pub struct ReadVecResult {
 ///
 /// When there is no allocator selected, the program will fail to compile.
 #[no_mangle]
-#[cfg(target_os = "zkvm")]
 pub extern "C" fn read_vec_raw() -> ReadVecResult {
-    // Get the length of the input buffer.
-    let len = syscall_hint_len();
-    // Round up to multiple of 4 for whole-word alignment.
-    let capacity = (len + 3) / 4 * 4;
+    #[cfg(not(target_os = "zkvm"))]
+    unreachable!("read_vec_raw should only be called on the zkvm target.");
 
-    cfg_if! {
-        if #[cfg(feature = "embedded")] {
-            // Get the existing pointer in the reserved region which is the start of the vec.
-            // Increment the pointer by the capacity to set the new pointer to the end of the vec.
-            let ptr = unsafe { EMBEDDED_RESERVED_INPUT_PTR };
-            if ptr + capacity > MAX_MEMORY {
-                panic!("Input region overflowed.")
+    #[cfg(target_os = "zkvm")]
+    {
+        // Get the length of the input buffer.
+        let len = syscall_hint_len();
+        // Round up to multiple of 4 for whole-word alignment.
+        let capacity = (len + 3) / 4 * 4;
+
+        cfg_if! {
+            if #[cfg(feature = "embedded")] {
+                // Get the existing pointer in the reserved region which is the start of the vec.
+                // Increment the pointer by the capacity to set the new pointer to the end of the vec.
+                let ptr = unsafe { EMBEDDED_RESERVED_INPUT_PTR };
+                if ptr + capacity > MAX_MEMORY {
+                    panic!("Input region overflowed.")
+                }
+
+                // SAFETY: The VM is single threaded.
+                unsafe { EMBEDDED_RESERVED_INPUT_PTR += capacity };
+
+                // Read the vec into uninitialized memory. The syscall assumes the memory is
+                // uninitialized, which is true because the input ptr is incremented manually on each
+                // read.
+                syscall_hint_read(ptr as *mut u8, len);
+
+                // Return the result.
+                ReadVecResult {
+                    ptr: ptr as *mut u8,
+                    len,
+                    capacity,
+                }
+            } else if #[cfg(feature = "bump")] {
+                // Allocate a buffer of the required length that is 4 byte aligned.
+                let layout = std::alloc::Layout::from_size_align(capacity, 4).expect("vec is too large");
+
+                // SAFETY: The layout was made through the checked constructor.
+                let ptr = unsafe { std::alloc::alloc(layout) };
+
+                // Read the vec into uninitialized memory. The syscall assumes the memory is
+                // uninitialized, which is true because the bump allocator does not dealloc, so a new
+                // alloc is always fresh.
+                syscall_hint_read(ptr as *mut u8, len);
+
+                // Return the result.
+                ReadVecResult {
+                    ptr: ptr as *mut u8,
+                    len,
+                    capacity,
+                }
+            } else {
+                // An allocator must be selected.
+                compile_error!("There is no allocator selected. Please enable the `bump` or `embedded` feature.");
             }
-
-            // SAFETY: The VM is single threaded.
-            unsafe { EMBEDDED_RESERVED_INPUT_PTR += capacity };
-
-            // Read the vec into uninitialized memory. The syscall assumes the memory is
-            // uninitialized, which is true because the input ptr is incremented manually on each
-            // read.
-            syscall_hint_read(ptr as *mut u8, len);
-
-            // Return the result.
-            ReadVecResult {
-                ptr: ptr as *mut u8,
-                len,
-                capacity,
-            }
-        } else if #[cfg(feature = "bump")] {
-            // Allocate a buffer of the required length that is 4 byte aligned.
-            let layout = std::alloc::Layout::from_size_align(capacity, 4).expect("vec is too large");
-
-            // SAFETY: The layout was made through the checked constructor.
-            let ptr = unsafe { std::alloc::alloc(layout) };
-
-            // Read the vec into uninitialized memory. The syscall assumes the memory is
-            // uninitialized, which is true because the bump allocator does not dealloc, so a new
-            // alloc is always fresh.
-            syscall_hint_read(ptr as *mut u8, len);
-
-            // Return the result.
-            ReadVecResult {
-                ptr: ptr as *mut u8,
-                len,
-                capacity,
-            }
-        } else {
-            // An allocator must be selected.
-            compile_error!("There is no allocator selected. Please enable the `bump` or `embedded` feature.");
         }
     }
 }
@@ -137,7 +144,7 @@ mod zkvm {
     unsafe extern "C" fn __start() {
         {
             #[cfg(all(target_os = "zkvm", feature = "embedded"))]
-            crate::allocators::embedded::init();
+            crate::allocators::init();
 
             PUBLIC_VALUES_HASHER = Some(Sha256::new());
             #[cfg(feature = "verify")]

--- a/crates/zkvm/lib/src/io.rs
+++ b/crates/zkvm/lib/src/io.rs
@@ -38,11 +38,18 @@ impl Write for SyscallWriter {
 /// ```ignore
 /// let data: Vec<u8> = sp1_zkvm::io::read_vec();
 /// ```
+#[track_caller]
 pub fn read_vec() -> Vec<u8> {
     let ReadVecResult { ptr, len, capacity } = unsafe { read_vec_raw() };
-    // 1. `ptr` was allocated using alloc
-    // 2. Assume that the allocator in the VM doesn't deallocate in the input space.
-    // 3. Size and length are correct from above. Length is <= capacity.
+
+    if ptr.is_null() {
+        panic!(
+            "Tried to read from the input stream, but it was empty @ {} \n
+            Was the correct data written into SP1Stdin?",
+            std::panic::Location::caller()
+        )
+    }
+
     unsafe { Vec::from_raw_parts(ptr, len, capacity) }
 }
 
@@ -60,8 +67,23 @@ pub fn read_vec() -> Vec<u8> {
 ///
 /// let data: MyStruct = sp1_zkvm::io::read();
 /// ```
+#[track_caller]
 pub fn read<T: DeserializeOwned>() -> T {
-    let vec = read_vec();
+    let ReadVecResult { ptr, len, capacity } = unsafe { read_vec_raw() };
+
+    if ptr.is_null() {
+        panic!(
+            "Tried to read from the input stream, but it was empty @ {} \n
+            Was the correct data written into SP1Stdin?",
+            std::panic::Location::caller()
+        )
+    }
+
+    // 1. `ptr` was allocated using alloc
+    // 2. Assume that the allocator in the VM doesn't deallocate in the input space.
+    // 3. Size and length are correct from above. Length is <= capacity.
+    let vec = unsafe { Vec::from_raw_parts(ptr, len, capacity) };
+
     bincode::deserialize(&vec).expect("deserialization failed")
 }
 

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1122,14 +1122,14 @@ dependencies = [
 [[package]]
 name = "bls12_381"
 version = "0.8.0"
-source = "git+https://github.com/sp1-patches/bls12_381?tag=bls12_381-v0.8.0-patch-v1#444e109287eb3adc581425e160ed6041622dda35"
+source = "git+https://github.com/sp1-patches/bls12_381?tag=patch-0.8.0-sp1-4.0.0#36b2a9d68b40dd08d2b0ac2843769a6a16608c91"
 dependencies = [
  "cfg-if",
  "ff 0.13.0",
  "group 0.13.0",
  "pairing 0.23.0",
  "rand_core 0.6.4",
- "sp1-lib 3.4.0",
+ "sp1-lib 4.0.0",
  "subtle",
 ]
 
@@ -1601,14 +1601,13 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek-ng"
 version = "4.1.1"
-source = "git+https://github.com/sp1-patches/curve25519-dalek-ng.git?branch=patch-v4.1.1#3fb3e7f6047ddeef0f0c9212f4604bd30d64bd28"
+source = "git+https://github.com/sp1-patches/curve25519-dalek-ng?tag=patch-4.1.1-sp1-4.0.0#91543a452e80c81b03a6b65e84b726094ff39313"
 dependencies = [
- "anyhow",
  "byteorder",
  "cfg-if",
  "digest 0.9.0",
  "rand_core 0.6.4",
- "sp1-lib 3.4.0",
+ "sp1-lib 4.0.0",
  "subtle-ng",
  "zeroize",
 ]
@@ -1908,29 +1907,16 @@ checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 [[package]]
 name = "ecdsa"
 version = "0.16.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+source = "git+https://github.com/sp1-patches/signatures?tag=patch-0.16.9-sp1-4.0.0#5a0aefaef40c7a4cf991ab63f43650fea3ea0db0"
 dependencies = [
+ "cfg-if",
  "der 0.7.9",
  "digest 0.10.7",
  "elliptic-curve",
+ "hex-literal",
  "rfc6979",
  "signature",
- "spki 0.7.3",
-]
-
-[[package]]
-name = "ecdsa"
-version = "0.16.9"
-source = "git+https://github.com/sp1-patches/signatures?branch=patch-ecdsa-v0.16.9#475daa8834035cc170a567e7656329ab8de8cc44"
-dependencies = [
- "anyhow",
- "cfg-if",
- "digest 0.10.7",
- "elliptic-curve",
- "hex-literal",
- "signature",
- "sp1-lib 3.4.0",
+ "sp1-lib 4.0.0",
  "spki 0.7.3",
 ]
 
@@ -1947,7 +1933,8 @@ dependencies = [
 [[package]]
 name = "ed25519-consensus"
 version = "2.1.0"
-source = "git+https://github.com/sp1-patches/ed25519-consensus?tag=ed25519_consensus-v2.1.0-patch-v1#2b2c4b43344bc4daf5b1326f367f2d9d661eeabb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8465edc8ee7436ffea81d21a019b16676ee3db267aa8d5a8d729581ecf998b"
 dependencies = [
  "curve25519-dalek-ng",
  "hex",
@@ -3039,7 +3026,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
  "cfg-if",
- "ecdsa 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ecdsa",
  "elliptic-curve",
  "once_cell",
  "sha2 0.10.8",
@@ -3622,7 +3609,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
- "ecdsa 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ecdsa",
  "elliptic-curve",
  "primeorder",
  "sha2 0.10.8",
@@ -4249,7 +4236,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.93",
@@ -5112,8 +5099,7 @@ dependencies = [
 [[package]]
 name = "rfc6979"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+source = "git+https://github.com/sp1-patches/signatures?tag=patch-0.16.9-sp1-4.0.0#5a0aefaef40c7a4cf991ab63f43650fea3ea0db0"
 dependencies = [
  "hmac",
  "subtle",
@@ -5591,20 +5577,18 @@ dependencies = [
 [[package]]
 name = "secp256k1"
 version = "0.29.0"
-source = "git+https://github.com/sp1-patches/rust-secp256k1?tag=secp256k1-v0.29.0-patch-v1#c78195abe3c5bc11163d69588a5559ef21bdff31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0cc0f1cf93f4969faf3ea1c7d8a9faed25918d96affa959720823dfe86d4f3"
 dependencies = [
- "cfg-if",
- "ecdsa 0.16.9 (git+https://github.com/sp1-patches/signatures?branch=patch-ecdsa-v0.16.9)",
- "elliptic-curve",
- "k256",
  "rand 0.8.5",
  "secp256k1-sys",
 ]
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.10.0"
-source = "git+https://github.com/sp1-patches/rust-secp256k1?tag=secp256k1-v0.29.0-patch-v1#c78195abe3c5bc11163d69588a5559ef21bdff31"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
 dependencies = [
  "cc",
 ]
@@ -5823,7 +5807,7 @@ dependencies = [
 [[package]]
 name = "sha2"
 version = "0.9.9"
-source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=sha2-v0.9.9-patch-v1#db82a4848f8d033eab544255e1efa036cc06f054"
+source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha2-0.9.9-sp1-4.0.0#db82a4848f8d033eab544255e1efa036cc06f054"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
@@ -5835,7 +5819,7 @@ dependencies = [
 [[package]]
 name = "sha2"
 version = "0.10.8"
-source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=sha2-v0.10.8-patch-v1#1f224388fdede7cef649bce0d63876d1a9e3f515"
+source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha2-0.10.8-sp1-4.0.0#1f224388fdede7cef649bce0d63876d1a9e3f515"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -5942,7 +5926,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-build"
-version = "4.0.0-rc.10"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -5953,7 +5937,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor"
-version = "4.0.0-rc.10"
+version = "4.0.0"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -5976,7 +5960,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sp1-curves",
- "sp1-primitives 4.0.0-rc.10",
+ "sp1-primitives",
  "sp1-stark",
  "strum",
  "strum_macros",
@@ -5990,7 +5974,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-machine"
-version = "4.0.0-rc.10"
+version = "4.0.0"
 dependencies = [
  "bincode",
  "cbindgen",
@@ -6029,7 +6013,7 @@ dependencies = [
  "sp1-core-executor",
  "sp1-curves",
  "sp1-derive",
- "sp1-primitives 4.0.0-rc.10",
+ "sp1-primitives",
  "sp1-stark",
  "static_assertions",
  "strum",
@@ -6045,7 +6029,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cuda"
-version = "4.0.0-rc.10"
+version = "4.0.0"
 dependencies = [
  "bincode",
  "ctrlc",
@@ -6060,7 +6044,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "4.0.0-rc.10"
+version = "4.0.0"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -6073,14 +6057,14 @@ dependencies = [
  "p3-field",
  "serde",
  "snowbridge-amcl",
- "sp1-primitives 4.0.0-rc.10",
+ "sp1-primitives",
  "sp1-stark",
  "typenum",
 ]
 
 [[package]]
 name = "sp1-derive"
-version = "4.0.0-rc.10"
+version = "4.0.0"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -6102,55 +6086,16 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5729da1b05d56c01457e5ecabdc77f1cc941df23f2921163a2f325aec22428"
+version = "4.0.0"
 dependencies = [
  "bincode",
  "serde",
-]
-
-[[package]]
-name = "sp1-lib"
-version = "4.0.0-rc.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4d273fe1c97fd68a63850f65baa7c5a3baaf8ea5c857e661d28c01af06c3d12"
-dependencies = [
- "bincode",
- "serde",
- "sp1-primitives 4.0.0-rc.9",
-]
-
-[[package]]
-name = "sp1-lib"
-version = "4.0.0-rc.10"
-dependencies = [
- "bincode",
- "serde",
- "sp1-primitives 4.0.0-rc.10",
+ "sp1-primitives",
 ]
 
 [[package]]
 name = "sp1-primitives"
-version = "4.0.0-rc.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc1c2b768a3f34a5d352e47f5e119961544322d79b37e74c454cfebc629ded5"
-dependencies = [
- "bincode",
- "hex",
- "lazy_static",
- "num-bigint 0.4.6",
- "p3-baby-bear",
- "p3-field",
- "p3-poseidon2",
- "p3-symmetric",
- "serde",
- "sha2 0.10.8",
-]
-
-[[package]]
-name = "sp1-primitives"
-version = "4.0.0-rc.10"
+version = "4.0.0"
 dependencies = [
  "bincode",
  "hex",
@@ -6166,7 +6111,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover"
-version = "4.0.0-rc.10"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6193,7 +6138,7 @@ dependencies = [
  "sha2 0.10.8",
  "sp1-core-executor",
  "sp1-core-machine",
- "sp1-primitives 4.0.0-rc.10",
+ "sp1-primitives",
  "sp1-recursion-circuit",
  "sp1-recursion-compiler",
  "sp1-recursion-core",
@@ -6207,7 +6152,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-circuit"
-version = "4.0.0-rc.10"
+version = "4.0.0"
 dependencies = [
  "hashbrown 0.14.5",
  "itertools 0.13.0",
@@ -6229,7 +6174,7 @@ dependencies = [
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-derive",
- "sp1-primitives 4.0.0-rc.10",
+ "sp1-primitives",
  "sp1-recursion-compiler",
  "sp1-recursion-core",
  "sp1-recursion-gnark-ffi",
@@ -6239,7 +6184,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-compiler"
-version = "4.0.0-rc.10"
+version = "4.0.0"
 dependencies = [
  "backtrace",
  "itertools 0.13.0",
@@ -6249,7 +6194,7 @@ dependencies = [
  "p3-symmetric",
  "serde",
  "sp1-core-machine",
- "sp1-primitives 4.0.0-rc.10",
+ "sp1-primitives",
  "sp1-recursion-core",
  "sp1-recursion-derive",
  "sp1-stark",
@@ -6259,7 +6204,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-core"
-version = "4.0.0-rc.10"
+version = "4.0.0"
 dependencies = [
  "backtrace",
  "cbindgen",
@@ -6289,7 +6234,7 @@ dependencies = [
  "serde",
  "sp1-core-machine",
  "sp1-derive",
- "sp1-primitives 4.0.0-rc.10",
+ "sp1-primitives",
  "sp1-stark",
  "static_assertions",
  "thiserror 1.0.69",
@@ -6300,7 +6245,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-derive"
-version = "4.0.0-rc.10"
+version = "4.0.0"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -6308,7 +6253,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-ffi"
-version = "4.0.0-rc.10"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6332,7 +6277,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-sdk"
-version = "4.0.0-rc.10"
+version = "4.0.0"
 dependencies = [
  "alloy-primitives 0.8.15",
  "alloy-signer",
@@ -6362,7 +6307,7 @@ dependencies = [
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-cuda",
- "sp1-primitives 4.0.0-rc.10",
+ "sp1-primitives",
  "sp1-prover",
  "sp1-stark",
  "strum",
@@ -6378,7 +6323,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-stark"
-version = "4.0.0-rc.10"
+version = "4.0.0"
 dependencies = [
  "arrayref",
  "hashbrown 0.14.5",
@@ -6402,7 +6347,7 @@ dependencies = [
  "rayon-scan",
  "serde",
  "sp1-derive",
- "sp1-primitives 4.0.0-rc.10",
+ "sp1-primitives",
  "strum",
  "strum_macros",
  "sysinfo",
@@ -6411,7 +6356,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-verifier"
-version = "4.0.0-rc.10"
+version = "4.0.0"
 dependencies = [
  "hex",
  "lazy_static",
@@ -6422,7 +6367,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "4.0.0-rc.10"
+version = "4.0.0"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -6434,8 +6379,8 @@ dependencies = [
  "p3-field",
  "rand 0.8.5",
  "sha2 0.10.8",
- "sp1-lib 4.0.0-rc.10",
- "sp1-primitives 4.0.0-rc.10",
+ "sp1-lib 4.0.0",
+ "sp1-primitives",
 ]
 
 [[package]]
@@ -6584,16 +6529,17 @@ dependencies = [
 [[package]]
 name = "substrate-bn"
 version = "0.6.0"
-source = "git+https://github.com/sp1-patches/bn?tag=substrate_bn-v0.6.0-patch-v1#9b0e986d32ea128a08cebfe90767072beccdb45f"
+source = "git+https://github.com/sp1-patches/bn?tag=patch-0.6.0-sp1-4.0.0#1bd84110963662fae88baa5ad07c9ab92b6acdbb"
 dependencies = [
  "bytemuck",
  "byteorder",
  "cfg-if",
  "crunchy",
  "lazy_static",
+ "num-bigint 0.4.6",
  "rand 0.8.5",
  "rustc-hex",
- "sp1-lib 3.4.0",
+ "sp1-lib 4.0.0",
 ]
 
 [[package]]
@@ -6610,7 +6556,7 @@ dependencies = [
  "num-bigint 0.4.6",
  "rand 0.8.5",
  "rustc-hex",
- "sp1-lib 4.0.0-rc.9",
+ "sp1-lib 4.0.0",
 ]
 
 [[package]]
@@ -6942,7 +6888,7 @@ dependencies = [
 [[package]]
 name = "tiny-keccak"
 version = "2.0.2"
-source = "git+https://github.com/sp1-patches/tiny-keccak?tag=tiny_keccak-v2.0.2-patch-v1#bf0b28f63510a90c7b6c21ac6ff461c93ecd2331"
+source = "git+https://github.com/sp1-patches/tiny-keccak?tag=patch-2.0.2-sp1-4.0.0#d2ffd330259c8f290b07d99cc1ef1f74774382c2"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -7941,24 +7887,14 @@ dependencies = [
 [[patch.unused]]
 name = "curve25519-dalek"
 version = "4.1.3"
-source = "git+https://github.com/sp1-patches/curve25519-dalek?tag=patch-v4.1.3-v3.4.0#bfe63b8205f0b6baa0c1f4c71da33209f766e3e4"
+source = "git+https://github.com/sp1-patches/curve25519-dalek?tag=patch-4.1.3-sp1-4.0.0#ce2e36cfaeed9f9b52fe8b3f5ed398c009052866"
 
 [[patch.unused]]
-name = "curve25519-dalek-ng"
-version = "4.1.1"
-source = "git+https://github.com/sp1-patches/curve25519-dalek-ng?tag=curve25519_dalek_ng-v4.1.1-patch-v1#3fb3e7f6047ddeef0f0c9212f4604bd30d64bd28"
-
-[[patch.unused]]
-name = "ecdsa"
-version = "0.16.8"
-source = "git+https://github.com/sp1-patches/signatures?branch=umadayal%2Fsecp256r1#49b6288468aff7f88f0be8cfd3719c7c20b2ba47"
+name = "secp256k1"
+version = "0.29.1"
+source = "git+https://github.com/sp1-patches/rust-secp256k1?tag=patch-0.29.1-sp1-4.0.0#d3a398cfc7928cdb9b92ea2ab45232e6468ef230"
 
 [[patch.unused]]
 name = "sha2"
 version = "0.10.6"
-source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=sha2-v0.10.6-patch-v1#e5f8b7eaaa9801503bd998932a52b65848eee234"
-
-[[patch.unused]]
-name = "sha2"
-version = "0.9.8"
-source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=sha2-v0.9.8-patch-v1#afdbfb09c325f8a69c01d540ec9a261e3637725d"
+source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha2-0.10.6-sp1-4.0.0#e5f8b7eaaa9801503bd998932a52b65848eee234"

--- a/examples/ssz-withdrawals/program/Cargo.toml
+++ b/examples/ssz-withdrawals/program/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-sp1-zkvm = { path = "../../../crates/zkvm/entrypoint" }
+sp1-zkvm = { path = "../../../crates/zkvm/entrypoint", features = ["embedded"] }
 hex-literal = "0.4.1"
 ssz_rs = { version = "0.9.0", features = ["serde"] }
 hex = "0.4.3"

--- a/patch-testing/Cargo.lock
+++ b/patch-testing/Cargo.lock
@@ -3721,7 +3721,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-build"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -3732,7 +3732,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -3769,7 +3769,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-machine"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "bincode",
  "cbindgen",
@@ -3824,7 +3824,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cuda"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "bincode",
  "ctrlc",
@@ -3839,7 +3839,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -3859,7 +3859,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-derive"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3867,7 +3867,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "bincode",
  "serde",
@@ -3876,7 +3876,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "bincode",
  "hex",
@@ -3892,7 +3892,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3933,7 +3933,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-circuit"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "hashbrown 0.14.5",
  "itertools 0.13.0",
@@ -3965,7 +3965,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-compiler"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "backtrace",
  "itertools 0.13.0",
@@ -3985,7 +3985,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-core"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "backtrace",
  "cbindgen",
@@ -4026,7 +4026,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-derive"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -4034,7 +4034,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-ffi"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4058,7 +4058,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-sdk"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4093,7 +4093,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-stark"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "arrayref",
  "hashbrown 0.14.5",
@@ -4147,7 +4147,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "cfg-if",
  "getrandom",

--- a/patch-testing/Cargo.lock
+++ b/patch-testing/Cargo.lock
@@ -481,6 +481,8 @@ dependencies = [
  "sha2 0.10.6",
  "sha2 0.10.8 (git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha2-0.10.8-sp1-4.0.0)",
  "sha3 0.10.8",
+ "sp1-lib",
+ "sp1-zkvm",
  "substrate-bn 0.6.0 (git+https://github.com/sp1-patches/bn?tag=patch-0.6.0-sp1-4.0.0)",
  "tiny-keccak 2.0.2 (git+https://github.com/sp1-patches/tiny-keccak?tag=patch-2.0.2-sp1-4.0.0)",
 ]

--- a/patch-testing/bls12-381/program/Cargo.lock
+++ b/patch-testing/bls12-381/program/Cargo.lock
@@ -453,7 +453,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "bincode",
  "serde",
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "bincode",
  "hex",
@@ -478,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "cfg-if",
  "getrandom",

--- a/patch-testing/bn/program/Cargo.lock
+++ b/patch-testing/bn/program/Cargo.lock
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "bincode",
  "serde",
@@ -428,7 +428,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "bincode",
  "hex",
@@ -444,7 +444,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "cfg-if",
  "getrandom",

--- a/patch-testing/build-host/Cargo.toml
+++ b/patch-testing/build-host/Cargo.toml
@@ -17,3 +17,5 @@ secp256k1-patched = { workspace = true }
 substrate-bn-patched = { workspace = true }
 bls12_381-patched = { workspace = true }
 rsa-patched = { workspace = true }
+sp1-lib = { path = "../../crates/zkvm/lib" }
+sp1-zkvm = { path = "../../crates/zkvm/entrypoint" }

--- a/patch-testing/build-host/src/main.rs
+++ b/patch-testing/build-host/src/main.rs
@@ -8,9 +8,16 @@ pub use secp256k1_patched;
 pub use sha2_v0_10_6_patched;
 pub use sha2_v0_10_8_patched;
 pub use sha3_v0_10_8_patched;
+pub use sp1_lib;
+pub use sp1_zkvm;
 pub use substrate_bn_patched;
 pub use tiny_keccak_patched;
 
 fn main() {
     // Note: This file is a dummy that merely imports all the patches, to ensure that they build correctly outside our vm.
+    read_vec_in_host();
+}
+
+fn read_vec_in_host() {
+    sp1_lib::io::read_vec();
 }

--- a/patch-testing/curve25519-dalek-ng/program/Cargo.lock
+++ b/patch-testing/curve25519-dalek-ng/program/Cargo.lock
@@ -406,7 +406,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "bincode",
  "serde",
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "bincode",
  "hex",
@@ -431,7 +431,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "cfg-if",
  "getrandom",

--- a/patch-testing/curve25519-dalek/program/Cargo.lock
+++ b/patch-testing/curve25519-dalek/program/Cargo.lock
@@ -498,7 +498,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "bincode",
  "serde",
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "bincode",
  "hex",
@@ -523,7 +523,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "cfg-if",
  "getrandom",

--- a/patch-testing/k256/program/Cargo.lock
+++ b/patch-testing/k256/program/Cargo.lock
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "bincode",
  "serde",
@@ -576,7 +576,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "bincode",
  "hex",
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "cfg-if",
  "getrandom",

--- a/patch-testing/keccak/program/Cargo.lock
+++ b/patch-testing/keccak/program/Cargo.lock
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "bincode",
  "serde",
@@ -398,7 +398,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "bincode",
  "hex",
@@ -414,7 +414,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "cfg-if",
  "getrandom",

--- a/patch-testing/p256/program/Cargo.lock
+++ b/patch-testing/p256/program/Cargo.lock
@@ -577,7 +577,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "bincode",
  "serde",
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "bincode",
  "hex",
@@ -602,7 +602,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "cfg-if",
  "getrandom",

--- a/patch-testing/rustcrypto-bigint/program/Cargo.lock
+++ b/patch-testing/rustcrypto-bigint/program/Cargo.lock
@@ -394,7 +394,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "bincode",
  "serde",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "bincode",
  "hex",
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "cfg-if",
  "getrandom",

--- a/patch-testing/secp256k1/program/Cargo.lock
+++ b/patch-testing/secp256k1/program/Cargo.lock
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "bincode",
  "serde",
@@ -600,7 +600,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "bincode",
  "hex",
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "cfg-if",
  "getrandom",

--- a/patch-testing/sha/program/Cargo.lock
+++ b/patch-testing/sha/program/Cargo.lock
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "bincode",
  "serde",
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "bincode",
  "hex",
@@ -464,7 +464,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "cfg-if",
  "getrandom",


### PR DESCRIPTION
- Includes a warning message when using `cargo prove build --elf-name` without a corresponding `--output-directory`
- Includes a fix for programs failing to build on host that depend on `sp1-zkvm` & `sp1-lib`
- Bumps gnark docker test storage
- Adds docs that sp1up always installs and the newest version and you should use -C in ci
- Adds docs about potential toolchain issues with old versions of `sp1-build`
- Better panic messages on `read` / `read_vec`
- Fixes an eror when installing the cli from crates
- Updates the toolchain tag, the new version supports old libc versions on x86