### PR TITLE
chore: remove Ubuntu 20.04 workflow tests, docs 

### DIFF
--- a/book/versioned_docs/version-4.0.0/developers/common-issues.md
+++ b/book/versioned_docs/version-4.0.0/developers/common-issues.md
@@ -139,3 +139,16 @@ The Rust compiler had breaking changes to its names of available options between
 This message indicates that you're trying to use `sp1-build` < `4.0.0` with the 1.82 toolchain,
 `sp1-build` versions >= 4.0.0 have support for the 1.82 and 1.81 toolchains.
 
+If you're using `cargo prove build` an `sp1up` should fix this.
+
+## Ubuntu 20.04 (ARM)
+
+The Succinct Rust toolchain is built on Ubuntu 22.04, which links a newer version of libc than available
+on Ubuntu 20.04.
+
+This error may manifest as:
+```bash
+   /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found 
+```
+This most commonly happens in CI runners, it is recommended to bump the runner OS to 22.04,
+the issue applies to all older linux distrubtions that dont have support for the same version of libc used to build it.


### PR DESCRIPTION
https://github.com/succinctlabs/rust/blob/db5963b699bf0b8d9bb826e700aa3cbd9593490b/.github/workflows/ci.yml#L17

Our rust toolchain is built on ubuntu 22.04 which links a newer version of `libc` than available on 20.04