### PR TITLE
fix(docs): network

### DIFF
--- a/book/versioned_docs/version-4.0.0/generating-proofs/prover-network/usage.md
+++ b/book/versioned_docs/version-4.0.0/generating-proofs/prover-network/usage.md
@@ -17,10 +17,12 @@ let mut proof = client.prove(&pk, &stdin).run().unwrap();
 SP1_PROVER=network NETWORK_PRIVATE_KEY=... RUST_LOG=info cargo run --release
 ```
 
-- `SP1_PROVER` should be set to `network` rather than the default `cpu` when using the prover network. This variable allows you to switch between the CPU and network provers.
+- Set `SP1_PROVER` to `network` (default is `cpu`). Configuring this variable to `network` will use the prover network.
 
 - `NETWORK_PRIVATE_KEY` should be set to your [private key](./key-setup.md). You will need
   to be using a [whitelisted](../prover-network) key to use the network.
+
+- `NETWORK_RPC_URL`: Defaults to `https://rpc.production.succinct.xyz`. This is the RPC URL of the prover network.
 
 When you call any of the prove functions in ProverClient now, it will first simulate your program, then wait for it to be proven through the network and finally return the proof.
 

--- a/book/versioned_docs/version-4.0.0/generating-proofs/prover-network/versions.md
+++ b/book/versioned_docs/version-4.0.0/generating-proofs/prover-network/versions.md
@@ -5,9 +5,8 @@ The prover network currently only supports specific versions of SP1:
 | Version | Description                                                      |
 | ------- | ---------------------------------------------------------------- |
 | v4.X.X  | V4 Release. Latest performant & production ready version.        |
-| v3.X.X  | V3 Release. Previous circuit version deprecated in January 2025. |
 
-`X` denotes that any minor and patch version is supported (e.g. `v2.1.0`, `v2.1.1`).
+`X` denotes that any minor and patch version is supported (e.g. `v4.0.1`, `v4.1.0`).
 
 If you submit a proof request to the prover network and you are not using a supported version, you will receive an error message.
 


### PR DESCRIPTION
## Overview
- Add configuration for `SP1_PROVER` to `network`.
- Specify default RPC URL.
- Remove `3.X` as supported version.