### PR TITLE
feat: better failure messages when reading too much input

### DIFF
--- a/crates/core/executor/src/syscalls/hint.rs
+++ b/crates/core/executor/src/syscalls/hint.rs
@@ -10,7 +10,7 @@ impl Syscall for HintLenSyscall {
         _arg1: u32,
         _arg2: u32,
     ) -> Option<u32> {
-        // Note: This cast could be truncating on 64bit systems.
+        // Note: If the user supplies an input > than length 2^32, then the length returned will be truncated to 32-bits. Reading from the syscall will definitely fail in that case, as the BabyBear field is < 2^32.
         Some(ctx.rt.state.input_stream.front().map_or(u32::MAX, |data| data.len() as u32))
     }
 }

--- a/crates/core/executor/src/syscalls/hint.rs
+++ b/crates/core/executor/src/syscalls/hint.rs
@@ -10,10 +10,8 @@ impl Syscall for HintLenSyscall {
         _arg1: u32,
         _arg2: u32,
     ) -> Option<u32> {
-        panic_if_input_exhausted(ctx);
-
-        // Note: This cast could be truncating
-        ctx.rt.state.input_stream.front().map(|data| data.len() as u32)
+        // Note: This cast could be truncating on 64bit systems.
+        Some(ctx.rt.state.input_stream.front().map_or(u32::MAX, |data| data.len() as u32))
     }
 }
 

--- a/crates/zkvm/entrypoint/src/allocators/embedded.rs
+++ b/crates/zkvm/entrypoint/src/allocators/embedded.rs
@@ -32,11 +32,11 @@ pub fn init() {
 }
 
 pub fn used() -> usize {
-    critical_section::with(|cs| INNER_HEAP.used())
+    critical_section::with(|_cs| INNER_HEAP.used())
 }
 
 pub fn free() -> usize {
-    critical_section::with(|cs| INNER_HEAP.free())
+    critical_section::with(|_cs| INNER_HEAP.free())
 }
 
 struct EmbeddedAlloc;

--- a/crates/zkvm/entrypoint/src/lib.rs
+++ b/crates/zkvm/entrypoint/src/lib.rs
@@ -62,7 +62,7 @@ pub struct ReadVecResult {
 ///
 /// When there is no allocator selected, the program will fail to compile.
 ///
-/// If the input stream is exhausted, the failed flag will be returned as true. In this case, the other outputs from the function are likely incorrect.
+/// If the input stream is exhausted, the failed flag will be returned as true. In this case, the other outputs from the function are likely incorrect, which is fine as `sp1-lib` always panics in the case that the input stream is exhausted.
 #[no_mangle]
 pub extern "C" fn read_vec_raw() -> ReadVecResult {
     #[cfg(not(target_os = "zkvm"))]

--- a/crates/zkvm/entrypoint/src/lib.rs
+++ b/crates/zkvm/entrypoint/src/lib.rs
@@ -64,7 +64,6 @@ pub struct ReadVecResult {
 /// When there is no allocator selected, the program will fail to compile.
 ///
 /// If the input stream is exhausted, the failed flag will be returned as true. In this case, the other outputs from the function are likely incorrect.
-/// is exhausted.
 #[no_mangle]
 pub extern "C" fn read_vec_raw() -> ReadVecResult {
     #[cfg(not(target_os = "zkvm"))]

--- a/crates/zkvm/entrypoint/src/lib.rs
+++ b/crates/zkvm/entrypoint/src/lib.rs
@@ -49,7 +49,6 @@ pub struct ReadVecResult {
     pub ptr: *mut u8,
     pub len: usize,
     pub capacity: usize,
-    pub failed: bool,
 }
 
 /// Read a buffer from the input stream.
@@ -76,7 +75,7 @@ pub extern "C" fn read_vec_raw() -> ReadVecResult {
 
         // If the length is u32::MAX, then the input stream is exhausted.
         if len == usize::MAX {
-            return ReadVecResult { ptr: std::ptr::null_mut(), len: 0, capacity: 0, failed: true };
+            return ReadVecResult { ptr: std::ptr::null_mut(), len: 0, capacity: 0 };
         }
 
         // Round up to multiple of 4 for whole-word alignment.
@@ -104,7 +103,6 @@ pub extern "C" fn read_vec_raw() -> ReadVecResult {
                     ptr: ptr as *mut u8,
                     len,
                     capacity,
-                    failed: false,
                 }
             } else if #[cfg(feature = "bump")] {
                 // Allocate a buffer of the required length that is 4 byte aligned.
@@ -123,7 +121,6 @@ pub extern "C" fn read_vec_raw() -> ReadVecResult {
                     ptr: ptr as *mut u8,
                     len,
                     capacity,
-                    failed: false,
                 }
             } else {
                 // An allocator must be selected.

--- a/crates/zkvm/entrypoint/src/lib.rs
+++ b/crates/zkvm/entrypoint/src/lib.rs
@@ -63,7 +63,7 @@ pub struct ReadVecResult {
 ///
 /// When there is no allocator selected, the program will fail to compile.
 ///
-/// This function will return with junk data and set the `failed` flag to true if the input stream
+/// If the input stream is exhausted, the failed flag will be returned as true. In this case, the other outputs from the function are likely incorrect.
 /// is exhausted.
 #[no_mangle]
 pub extern "C" fn read_vec_raw() -> ReadVecResult {

--- a/crates/zkvm/lib/src/io.rs
+++ b/crates/zkvm/lib/src/io.rs
@@ -40,9 +40,9 @@ impl Write for SyscallWriter {
 /// ```
 #[track_caller]
 pub fn read_vec() -> Vec<u8> {
-    let ReadVecResult { ptr, len, capacity, failed } = unsafe { read_vec_raw() };
+    let ReadVecResult { ptr, len, capacity } = unsafe { read_vec_raw() };
 
-    if failed {
+    if ptr.is_null() {
         panic!(
             "Tried to read from the input stream, but it was empty @ {} \n
             Was the correct data written into SP1Stdin?",
@@ -69,9 +69,9 @@ pub fn read_vec() -> Vec<u8> {
 /// ```
 #[track_caller]
 pub fn read<T: DeserializeOwned>() -> T {
-    let ReadVecResult { ptr, len, capacity, failed } = unsafe { read_vec_raw() };
+    let ReadVecResult { ptr, len, capacity } = unsafe { read_vec_raw() };
 
-    if failed {
+    if ptr.is_null() {
         panic!(
             "Tried to read from the input stream, but it was empty @ {} \n
             Was the correct data written into SP1Stdin?",

--- a/crates/zkvm/lib/src/io.rs
+++ b/crates/zkvm/lib/src/io.rs
@@ -44,7 +44,8 @@ pub fn read_vec() -> Vec<u8> {
 
     if failed {
         panic!(
-            "The input stream was exhausted before the call to read_vec @ {}",
+            "Tried to read from the input stream, but it was empty @ {} \n
+            Was the correct data written into SP1Stdin?",
             std::panic::Location::caller()
         )
     }
@@ -72,7 +73,8 @@ pub fn read<T: DeserializeOwned>() -> T {
 
     if failed {
         panic!(
-            "The input stream was exhausted before the call to read @ {}",
+            "Tried to read from the input stream, but it was empty @ {} \n
+            Was the correct data written into SP1Stdin?",
             std::panic::Location::caller()
         )
     }

--- a/crates/zkvm/lib/src/io.rs
+++ b/crates/zkvm/lib/src/io.rs
@@ -72,7 +72,7 @@ pub fn read<T: DeserializeOwned>() -> T {
 
     if failed {
         panic!(
-            "The input stream was exhausted before the call to read_vec @ {}",
+            "The input stream was exhausted before the call to read @ {}",
             std::panic::Location::caller()
         )
     }

--- a/crates/zkvm/lib/src/lib.rs
+++ b/crates/zkvm/lib/src/lib.rs
@@ -154,5 +154,4 @@ pub struct ReadVecResult {
     pub ptr: *mut u8,
     pub len: usize,
     pub capacity: usize,
-    pub failed: bool,
 }

--- a/crates/zkvm/lib/src/lib.rs
+++ b/crates/zkvm/lib/src/lib.rs
@@ -154,4 +154,5 @@ pub struct ReadVecResult {
     pub ptr: *mut u8,
     pub len: usize,
     pub capacity: usize,
+    pub failed: bool,
 }


### PR DESCRIPTION
Previously, reading to much input would panic the executor and lead to ambiguous error messages, 

this change means that u32::MAX len vecs will fail. It displays the callsite of `read` or `read_vec`