### PR TITLE
chore: remove redundant .run() call in prove method

### DIFF
--- a/examples/chess/script/src/main.rs
+++ b/examples/chess/script/src/main.rs
@@ -15,7 +15,7 @@ fn main() {
 
     let client = ProverClient::from_env();
     let (pk, vk) = client.setup(ELF);
-    let mut proof = client.prove(&pk, &stdin).run().unwrap();
+    let mut proof = client.prove(&pk, &stdin).unwrap();
 
     // Read output.
     let is_valid_move = proof.public_values.read::<bool>();


### PR DESCRIPTION
## Motivation
 
I noticed that the `prove` method already handles the proof execution internally, so calling `.run()` after it is unnecessary. This PR removes the redundant call to clean up the code and avoid potential confusion.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes