### PR TITLE
chore: fix incorrect binary name

### DIFF
--- a/sp1up/sp1up
+++ b/sp1up/sp1up
@@ -157,7 +157,7 @@ main() {
       bin_path="$SP1_BIN_DIR/$bin"
 
       # Print installed msg
-      say "installed - $(ensure "$bin_path" prove --version)"
+      say "installed - $(ensure "$bin_path" cargo-prove --version)"
 
       # Check if the default path of the binary is not in SP1_BIN_DIR
       which_path="$(command -v "$bin" || true)"


### PR DESCRIPTION
## Motivation

I noticed a typo in the version check command. The script currently uses `prove` instead of `cargo-prove`, which is the correct binary name as specified in the `BINS` array. This PR fixes the command to ensure the correct binary is checked.  

Here's the corrected line:  
```bash  
say "installed - $(ensure "$bin_path" cargo-prove --version)"  
```  

This change aligns with the intended behavior of verifying the installed version of `cargo-prove`.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes