### PR TITLE
fix: use downloadable go directive 1.22.0

### DIFF
--- a/crates/recursion/gnark-ffi/go/go.mod
+++ b/crates/recursion/gnark-ffi/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/succinctlabs/sp1-recursion-gnark
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/consensys/gnark v0.10.1-0.20240504023521-d9bfacd7cb60


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

>Caused by:
  process didn't exit successfully: `/Users/Matthias/git/rust/sp1/target/debug/build/sp1-recursion-gnark-ffi-5c63451eec7e8a67/build-script-build` (exit status: 101)
  --- stdout
  cargo:rerun-if-changed=go
  Building Go library at /Users/Matthias/git/rust/sp1/target/debug/build/sp1-recursion-gnark-ffi-d2e6560ead9a758e/out/libsp1gnark.a

>  --- stderr
  go: downloading go1.22 (darwin/arm64)
  go: download go1.22 for darwin/arm64: toolchain not available


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

according to https://github.com/golang/go/issues/65568#issuecomment-1932597413

> go 1.22 without a more specific toolchain directive is not sufficient.


https://github.com/golang/go/issues/62278#issuecomment-1693538776


> this is as expected: go 1.21 was a development version of the language, for which there is no downloadable release (because it is not a specific version). The release version would be go 1.21.0.

see also: https://go.dev/doc/devel/release#go1.22.0

I assume the CI "go-version: "1.22"" is fine because the action handles this?
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes