### PR TITLE
chore: include rustc --version stderr in panic

### DIFF
--- a/crates/build/src/command/local.rs
+++ b/crates/build/src/command/local.rs
@@ -36,7 +36,11 @@ pub(crate) fn create_local_command(
             .expect("rustc --version should succeed");
 
         if !output.status.success() {
-            panic!("Failed to run rustc --version {:?}", String::from_utf8_lossy(&output.stdout));
+            panic!(
+                "Failed to run rustc --version {:?}\n{:?}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
         }
 
         let stdout_string =


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
rustc includes a more helpful error on stderr:

> error: override toolchain 'succinct' is not installed: the RUSTUP_TOOLCHAIN environment variable specifies an uninstalled toolchain

## Solution
also include stderr in panic
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes