### PR TITLE
perf: rm vec allocs from words conversions

### DIFF
--- a/crates/core/machine/src/utils/mod.rs
+++ b/crates/core/machine/src/utils/mod.rs
@@ -19,7 +19,8 @@ use generic_array::ArrayLength;
 use p3_maybe_rayon::prelude::{ParallelBridge, ParallelIterator};
 
 pub use sp1_primitives::consts::{
-    words_to_bytes_le, words_to_bytes_le_vec, bytes_to_words_le, bytes_to_words_le_vec, num_to_comma_separated
+    bytes_to_words_le, bytes_to_words_le_vec, num_to_comma_separated, words_to_bytes_le,
+    words_to_bytes_le_vec,
 };
 
 pub const fn indices_arr<const N: usize>() -> [usize; N] {

--- a/crates/core/machine/src/utils/mod.rs
+++ b/crates/core/machine/src/utils/mod.rs
@@ -18,6 +18,10 @@ use crate::memory::MemoryCols;
 use generic_array::ArrayLength;
 use p3_maybe_rayon::prelude::{ParallelBridge, ParallelIterator};
 
+pub use sp1_primitives::consts::{
+    words_to_bytes_le, words_to_bytes_le_vec, bytes_to_words_le, bytes_to_words_le_vec, num_to_comma_separated
+};
+
 pub const fn indices_arr<const N: usize>() -> [usize; N] {
     let mut indices_arr = [0; N];
     let mut i = 0;
@@ -95,57 +99,6 @@ pub fn next_power_of_two(n: usize, fixed_power: Option<usize>) -> usize {
             padded_nb_rows
         }
     }
-}
-
-/// Converts a slice of words to a slice of bytes in little endian.
-pub fn words_to_bytes_le<const B: usize>(words: &[u32]) -> [u8; B] {
-    debug_assert_eq!(words.len() * 4, B);
-    words
-        .iter()
-        .flat_map(|word| word.to_le_bytes().to_vec())
-        .collect::<Vec<_>>()
-        .try_into()
-        .unwrap()
-}
-
-/// Converts a slice of words to a byte vector in little endian.
-pub fn words_to_bytes_le_vec(words: &[u32]) -> Vec<u8> {
-    words.iter().flat_map(|word| word.to_le_bytes().to_vec()).collect::<Vec<_>>()
-}
-
-/// Converts a byte array in little endian to a slice of words.
-pub fn bytes_to_words_le<const W: usize>(bytes: &[u8]) -> [u32; W] {
-    debug_assert_eq!(bytes.len(), W * 4);
-    bytes
-        .chunks_exact(4)
-        .map(|chunk| u32::from_le_bytes(chunk.try_into().unwrap()))
-        .collect::<Vec<_>>()
-        .try_into()
-        .unwrap()
-}
-
-/// Converts a byte array in little endian to a vector of words.
-pub fn bytes_to_words_le_vec(bytes: &[u8]) -> Vec<u32> {
-    bytes
-        .chunks_exact(4)
-        .map(|chunk| u32::from_le_bytes(chunk.try_into().unwrap()))
-        .collect::<Vec<_>>()
-}
-
-/// Converts a num to a string with commas every 3 digits.
-pub fn num_to_comma_separated<T: ToString>(value: T) -> String {
-    value
-        .to_string()
-        .chars()
-        .rev()
-        .collect::<Vec<_>>()
-        .chunks(3)
-        .map(|chunk| chunk.iter().collect::<String>())
-        .collect::<Vec<_>>()
-        .join(",")
-        .chars()
-        .rev()
-        .collect()
 }
 
 pub fn chunk_vec<T>(mut vec: Vec<T>, chunk_size: usize) -> Vec<Vec<T>> {

--- a/crates/primitives/src/consts.rs
+++ b/crates/primitives/src/consts.rs
@@ -66,19 +66,15 @@ pub fn words_to_bytes_le_vec(words: &[u32]) -> Vec<u8> {
 /// Converts a slice of words to a slice of bytes in little endian.
 pub fn words_to_bytes_le<const B: usize>(words: &[u32]) -> [u8; B] {
     debug_assert_eq!(words.len() * 4, B);
-    let mut iter = words
-        .iter()
-        .flat_map(|word| word.to_le_bytes().into_iter());
+    let mut iter = words.iter().flat_map(|word| word.to_le_bytes().into_iter());
     core::array::from_fn(|_| iter.next().unwrap())
 }
 
 /// Converts a byte array in little endian to a slice of words.
 pub fn bytes_to_words_le<const W: usize>(bytes: &[u8]) -> [u32; W] {
     debug_assert_eq!(bytes.len(), W * 4);
-    let mut iter =  bytes
-        .chunks_exact(4)
-        .map(|chunk| u32::from_le_bytes(chunk.try_into().unwrap()));
-   core::array::from_fn(|_| iter.next().unwrap())
+    let mut iter = bytes.chunks_exact(4).map(|chunk| u32::from_le_bytes(chunk.try_into().unwrap()));
+    core::array::from_fn(|_| iter.next().unwrap())
 }
 
 /// Converts a byte array in little endian to a vector of words.

--- a/crates/primitives/src/consts.rs
+++ b/crates/primitives/src/consts.rs
@@ -60,29 +60,25 @@ pub mod fd {
 
 /// Converts a slice of words to a byte vector in little endian.
 pub fn words_to_bytes_le_vec(words: &[u32]) -> Vec<u8> {
-    words.iter().flat_map(|word| word.to_le_bytes().to_vec()).collect::<Vec<_>>()
+    words.iter().flat_map(|word| word.to_le_bytes().into_iter()).collect::<Vec<_>>()
 }
 
 /// Converts a slice of words to a slice of bytes in little endian.
 pub fn words_to_bytes_le<const B: usize>(words: &[u32]) -> [u8; B] {
     debug_assert_eq!(words.len() * 4, B);
-    words
+    let mut iter = words
         .iter()
-        .flat_map(|word| word.to_le_bytes().to_vec())
-        .collect::<Vec<_>>()
-        .try_into()
-        .unwrap()
+        .flat_map(|word| word.to_le_bytes().into_iter());
+    core::array::from_fn(|_| iter.next().unwrap())
 }
 
 /// Converts a byte array in little endian to a slice of words.
 pub fn bytes_to_words_le<const W: usize>(bytes: &[u8]) -> [u32; W] {
     debug_assert_eq!(bytes.len(), W * 4);
-    bytes
+    let mut iter =  bytes
         .chunks_exact(4)
-        .map(|chunk| u32::from_le_bytes(chunk.try_into().unwrap()))
-        .collect::<Vec<_>>()
-        .try_into()
-        .unwrap()
+        .map(|chunk| u32::from_le_bytes(chunk.try_into().unwrap()));
+   core::array::from_fn(|_| iter.next().unwrap())
 }
 
 /// Converts a byte array in little endian to a vector of words.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
replace intermediary to_vec allocs with [`array::from_fn`](https://doc.rust-lang.org/stable/std/array/fn.from_fn.html) leveraging the available const generics
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
noticed these were duplicated, so I replaced the duplicated ones with re-exports
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes