### PR TITLE
feat: don't checkout submodules when doing `cargo prove new --evm`

### DIFF
--- a/book/docs/getting-started/quickstart.md
+++ b/book/docs/getting-started/quickstart.md
@@ -15,6 +15,12 @@ cargo prove new --evm fibonacci
 cd fibonacci
 ```
 
+:::note
+If you go with the `--evm` option, you will need to install `foundry` to compile the solidity contracts. Please follow the instructions [on the official Foundry docs](https://book.getfoundry.sh/getting-started/installation).
+
+Then, you'll have to setup contracts development by running `forge install` in the `contracts` directory.
+:::
+
 ### Option 2: Project Template (Solidity Contracts for Onchain Verification)
 
 If you want to use SP1 to generate proofs that will eventually be verified on an EVM chain, you should use the [SP1 project template](https://github.com/succinctlabs/sp1-project-template/tree/main). This Github template is scaffolded with a SP1 program, a script to generate proofs, and also a contracts folder that contains a Solidity contract that can verify SP1 proofs on any EVM chain.

--- a/book/docs/getting-started/quickstart.md
+++ b/book/docs/getting-started/quickstart.md
@@ -16,7 +16,7 @@ cd fibonacci
 ```
 
 :::note
-If you go with the `--evm` option, you will need to install `foundry` to compile the solidity contracts. Please follow the instructions [on the official Foundry docs](https://book.getfoundry.sh/getting-started/installation).
+If you use the `--evm` option, you will need to install `foundry` to compile the solidity contracts. Please follow the instructions [on the official Foundry docs](https://book.getfoundry.sh/getting-started/installation).
 
 Then, you'll have to setup contracts development by running `forge install` in the `contracts` directory.
 :::

--- a/crates/cli/src/commands/new.rs
+++ b/crates/cli/src/commands/new.rs
@@ -58,10 +58,6 @@ impl NewCmd {
             .arg(root.as_os_str())
             .arg("--depth=1");
 
-        if self.template.evm {
-            command.arg("--recurse-submodules").arg("--shallow-submodules");
-        }
-
         // Stream output to stdout.
         command.stdout(Stdio::inherit()).stderr(Stdio::inherit());
 
@@ -76,11 +72,16 @@ impl NewCmd {
 
         if self.template.evm {
             // Check if the user has `foundry` installed.
-            if Command::new("foundry").arg("--version").output().is_err() {
+            if Command::new("forge").arg("--version").output().is_err() {
                 println!(
-                    "    \x1b[1m{}\x1b[0m Make sure to install Foundry to use contracts: https://book.getfoundry.sh/getting-started/installation",
+                    "    \x1b[1m{}\x1b[0m Make sure to install Foundry and run `forge install` in the \"contracts\" folder to use contracts: https://book.getfoundry.sh/getting-started/installation",
                     Paint::yellow("Warning:"),
                 );
+            } else {
+                println!(
+                        "       \x1b[1m{}\x1b[0m Please run `forge install` in the \"contracts\" folder to setup contracts development",
+                        Paint::blue("Info:"),
+                    );
             }
         } else {
             // Remove the `contracts` directory.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Accelerate  `cargo prove new --evm`

## Solution

Don't clone submodules, instruct the user to run `forge install` instead.

Also fixed the foundry detection.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes