### PR TITLE
feat(sdk): Turn off `alloy-*` crate features by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,18 +182,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-json-abi"
-version = "0.8.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731ea743b3d843bc657e120fb1d1e9cc94f5dab8107e35a82125a63e6420a102"
-dependencies = [
- "alloy-primitives",
- "alloy-sol-type-parser",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "alloy-json-rpc"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,26 +402,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-sol-type-parser"
-version = "0.8.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eda2711ab2e1fb517fc6e2ffa9728c9a232e296d16810810e6957b781a1b8bc"
-dependencies = [
- "serde",
- "winnow 0.6.24",
-]
-
-[[package]]
 name = "alloy-sol-types"
 version = "0.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3b478bc9c0c4737a04cd976accde4df7eba0bdc0d90ad6ff43d58bc93cf79c1"
 dependencies = [
- "alloy-json-abi",
  "alloy-primitives",
  "alloy-sol-macro",
  "const-hex",
- "serde",
 ]
 
 [[package]]

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -48,10 +48,10 @@ sp1-stark = { workspace = true }
 sp1-primitives = { workspace = true }
 itertools = { workspace = true }
 tonic = { version = "0.12", features = ["tls", "tls-roots"], optional = true }
-alloy-sol-types = { version = "0.8", optional = true }
-alloy-signer = { version = "0.8", optional = true }
-alloy-signer-local = { version = "0.8", optional = true }
-alloy-primitives = { version = "0.8", optional = true }
+alloy-sol-types = { version = "0.8", default-features = false, optional = true }
+alloy-signer = { version = "0.8", default-features = false, optional = true }
+alloy-signer-local = { version = "0.8", default-features = false, optional = true }
+alloy-primitives = { version = "0.8", default-features = false, optional = true }
 backoff = { version = "0.4", features = ["tokio"], optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
## Problem

The issue arises because alloy-primitives features are being set to include all default features based on dependencies in OP Succinct. This causes a conflict with the kona dependency, which relies on the standard HashMap implementation.

Specifically:
	1.	sp1-sdk enables all default features of alloy-primitives unnecessarily.
	2.	This includes the map-foldhash feature, which uses foldhash::fast::RandomState.
	3.	foldhash::fast::RandomState does not implement Send + Sync.
	4.	However, spin::RwLock, which kona uses, requires its contents to be Send + Sync for thread safety.

This mismatch leads to thread-safety issues when foldhash::fast::RandomState is used in conjunction with spin::RwLock.

## Fix
The solution is to disable default features for alloy crates in `sp1-sdk`, preventing it from enabling all features of alloy-primitives. By doing so:
	•	The standard HashMap implementation will be used instead when users don't enable `alloy-primitives`.
	•	The standard HashMap uses a RandomState that implements Send + Sync, ensuring compatibility with spin::RwLock.
	
We should have never set the default features to be enabled in the first place, as they're unnecessary.

## Note
- Only `alloy-primitives` and `alloy-sol-types` have `default-features`. 