### PR TITLE
test: check syscalls are actually emitted

### DIFF
--- a/patch-testing/Cargo.lock
+++ b/patch-testing/Cargo.lock
@@ -3576,6 +3576,7 @@ dependencies = [
  "sha2 0.9.9",
  "sha3 0.10.6",
  "sp1-build",
+ "sp1-core-executor",
  "sp1-sdk",
  "sp1-test",
  "sp1-zkvm",

--- a/patch-testing/Cargo.lock
+++ b/patch-testing/Cargo.lock
@@ -450,6 +450,7 @@ dependencies = [
  "group 0.13.0",
  "rand",
  "sp1-build",
+ "sp1-core-executor",
  "sp1-sdk",
  "sp1-test",
  "sp1-zkvm",
@@ -461,6 +462,7 @@ version = "1.1.0"
 dependencies = [
  "rand",
  "sp1-build",
+ "sp1-core-executor",
  "sp1-sdk",
  "sp1-test",
  "sp1-zkvm",
@@ -476,7 +478,7 @@ dependencies = [
  "curve25519-dalek 4.1.3 (git+https://github.com/sp1-patches/curve25519-dalek?tag=patch-4.1.3-sp1-4.0.0)",
  "curve25519-dalek-ng 4.1.1 (git+https://github.com/sp1-patches/curve25519-dalek-ng?tag=patch-4.1.1-sp1-4.0.0)",
  "ecdsa 0.16.9 (git+https://github.com/sp1-patches/signatures?tag=patch-0.16.9-sp1-4.0.0)",
- "rsa",
+ "rsa 0.9.6",
  "secp256k1",
  "sha2 0.10.6",
  "sha2 0.10.8 (git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha2-0.10.8-sp1-4.0.0)",
@@ -812,6 +814,7 @@ dependencies = [
  "ed25519-dalek",
  "rand",
  "sp1-build",
+ "sp1-core-executor",
  "sp1-sdk",
  "sp1-test",
 ]
@@ -877,6 +880,7 @@ dependencies = [
  "curve25519-dalek-ng 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand",
  "sp1-build",
+ "sp1-core-executor",
  "sp1-sdk",
  "sp1-test",
 ]
@@ -1999,6 +2003,7 @@ dependencies = [
  "k256 0.13.3",
  "rand",
  "sp1-build",
+ "sp1-core-executor",
  "sp1-sdk",
  "sp1-test",
  "sp1-zkvm",
@@ -2010,6 +2015,7 @@ version = "1.1.0"
 dependencies = [
  "rand",
  "sp1-build",
+ "sp1-core-executor",
  "sp1-sdk",
  "sp1-test",
  "sp1-zkvm",
@@ -2281,6 +2287,7 @@ dependencies = [
  "num-iter",
  "num-traits",
  "rand",
+ "serde",
  "smallvec",
  "zeroize",
 ]
@@ -2457,6 +2464,7 @@ dependencies = [
  "p256 0.13.2",
  "rand",
  "sp1-build",
+ "sp1-core-executor",
  "sp1-sdk",
  "sp1-test",
  "sp1-zkvm",
@@ -3256,6 +3264,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsa"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47c75d7c5c6b673e58bf54d8544a9f432e3a925b0e80f7cd3602ab5c50c55519"
+dependencies = [
+ "const-oid",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core",
+ "serde",
+ "sha2 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rust_crypto_rsa"
+version = "1.1.0"
+dependencies = [
+ "rand",
+ "rsa 0.9.7",
+ "sp1-build",
+ "sp1-core-executor",
+ "sp1-sdk",
+ "sp1-test",
+ "sp1-zkvm",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3295,6 +3338,7 @@ dependencies = [
  "crypto-bigint 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand",
  "sp1-build",
+ "sp1-core-executor",
  "sp1-sdk",
  "sp1-test",
  "sp1-zkvm",
@@ -3448,6 +3492,7 @@ dependencies = [
  "rand",
  "secp256k1",
  "sp1-build",
+ "sp1-core-executor",
  "sp1-sdk",
  "sp1-test",
 ]

--- a/patch-testing/Cargo.toml
+++ b/patch-testing/Cargo.toml
@@ -10,6 +10,7 @@ members = [
   "curve25519-dalek", 
   "curve25519-dalek-ng", 
   "rustcrypto-bigint",
+  "RustCrypto-rsa",
   "bls12-381",
   "bn", "build-host",
 ]

--- a/patch-testing/Cargo.toml
+++ b/patch-testing/Cargo.toml
@@ -39,6 +39,7 @@ publish = false
 sp1-zkvm = { path = "../crates/zkvm/entrypoint" }
 sp1-build = { path = "../crates/build" }
 sp1-sdk = { path = "../crates/sdk", default-features = false }
+sp1-core-executor = { path = "../crates/core/executor" }
 serde = { version = "1.0.215", features = ["derive"] }
 sha2-v0-9-8 = { version = "0.9.8", package = "sha2" }
 sha2-v0-10-6 = { version = "0.10.6", package = "sha2" }

--- a/patch-testing/RustCrypto-rsa/Cargo.toml
+++ b/patch-testing/RustCrypto-rsa/Cargo.toml
@@ -7,6 +7,7 @@ publish.workspace = true
 [dependencies]
 sp1-zkvm = { workspace = true }
 sp1-sdk = { workspace = true }
+sp1-core-executor = { workspace = true }
 rand = { workspace = true }
 sp1-test = { workspace = true }
 rsa = { version = "0.9.7", features = ["std", "sha2", "serde"] }

--- a/patch-testing/RustCrypto-rsa/program/Cargo.lock
+++ b/patch-testing/RustCrypto-rsa/program/Cargo.lock
@@ -471,7 +471,7 @@ dependencies = [
 [[package]]
 name = "rsa"
 version = "0.9.6"
-source = "git+https://github.com/sp1-patches/RustCrypto-RSA/?branch=n/prep-4.0.0#5dc15bb011b64d7b0062850bf61a675a12a41064"
+source = "git+https://github.com/sp1-patches/RustCrypto-RSA/?tag=patch-0.9.6-sp1-4.0.0#da9913ce6a3f5f001dc6e32c9aac07336bf8b7f7"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -542,7 +542,7 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "sp1-lib"
-version = "4.0.0-rc.3"
+version = "4.0.1"
 dependencies = [
  "bincode",
  "serde",
@@ -551,7 +551,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "4.0.0-rc.3"
+version = "4.0.1"
 dependencies = [
  "bincode",
  "hex",
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "4.0.0-rc.3"
+version = "4.0.1"
 dependencies = [
  "cfg-if",
  "getrandom",

--- a/patch-testing/RustCrypto-rsa/src/lib.rs
+++ b/patch-testing/RustCrypto-rsa/src/lib.rs
@@ -6,7 +6,7 @@ use rsa::{
     RsaPublicKey,
 };
 
-#[sp1_test::sp1_test("rsa_test_verify_pkcs", gpu, prove)]
+#[sp1_test::sp1_test("rsa_test_verify_pkcs", syscalls = [U256XU2048_MUL], gpu, prove)]
 pub fn test_pkcs_verify_100(
     stdin: &mut sp1_sdk::SP1Stdin,
 ) -> impl FnOnce(sp1_sdk::SP1PublicValues) {

--- a/patch-testing/bls12-381/Cargo.toml
+++ b/patch-testing/bls12-381/Cargo.toml
@@ -7,6 +7,7 @@ publish.workspace = true
 [dependencies]
 sp1-zkvm = { workspace = true }
 sp1-sdk = { workspace = true }
+sp1-core-executor = { workspace = true }
 rand.workspace = true
 sp1-test = { workspace = true }
 

--- a/patch-testing/bls12-381/src/lib.rs
+++ b/patch-testing/bls12-381/src/lib.rs
@@ -1,5 +1,4 @@
-
-#[sp1_test::sp1_test("bls12_381_fp_test_sqrt", gpu, prove)]
+#[sp1_test::sp1_test("bls12_381_fp_test_sqrt", syscalls = [BLS12381_FP_MUL], gpu, prove)]
 pub fn test_sqrt_fp_100(stdin: &mut sp1_sdk::SP1Stdin) -> impl FnOnce(sp1_sdk::SP1PublicValues) {
     use bls12_381::fp::Fp;
 
@@ -27,7 +26,7 @@ pub fn test_sqrt_fp_100(stdin: &mut sp1_sdk::SP1Stdin) -> impl FnOnce(sp1_sdk::S
     }
 }
 
-#[sp1_test::sp1_test("bls12_381_fp_test_inverse", gpu, prove)]
+#[sp1_test::sp1_test("bls12_381_fp_test_inverse", syscalls = [BLS12381_FP_MUL], gpu, prove)]
 pub fn test_inverse_fp_100(stdin: &mut sp1_sdk::SP1Stdin) -> impl FnOnce(sp1_sdk::SP1PublicValues) {
     use bls12_381::fp::Fp;
 
@@ -55,7 +54,7 @@ pub fn test_inverse_fp_100(stdin: &mut sp1_sdk::SP1Stdin) -> impl FnOnce(sp1_sdk
     }
 }
 
-#[sp1_test::sp1_test("bls12_381_fp2_test_sqrt", gpu, prove)]
+#[sp1_test::sp1_test("bls12_381_fp2_test_sqrt", syscalls = [BLS12381_FP_MUL, BLS12381_FP2_MUL], gpu, prove)]
 pub fn test_sqrt_fp2_100(stdin: &mut sp1_sdk::SP1Stdin) -> impl FnOnce(sp1_sdk::SP1PublicValues) {
     use bls12_381::fp2::Fp2;
 
@@ -83,7 +82,7 @@ pub fn test_sqrt_fp2_100(stdin: &mut sp1_sdk::SP1Stdin) -> impl FnOnce(sp1_sdk::
     }
 }
 
-#[sp1_test::sp1_test("bls12_381_fp2_test_inverse", gpu, prove)]
+#[sp1_test::sp1_test("bls12_381_fp2_test_inverse", syscalls = [BLS12381_FP_MUL, BLS12381_FP2_MUL], gpu, prove)]
 pub fn test_inverse_fp2_100(
     stdin: &mut sp1_sdk::SP1Stdin,
 ) -> impl FnOnce(sp1_sdk::SP1PublicValues) {
@@ -113,10 +112,10 @@ pub fn test_inverse_fp2_100(
     }
 }
 
-#[sp1_test::sp1_test("bls12_381_ec_add_test", gpu, prove)]
+#[sp1_test::sp1_test("bls12_381_ec_add_test", syscalls = [BLS12381_DOUBLE, BLS12381_ADD, BLS12381_FP_MUL, BLS12381_FP_SUB], gpu, prove)]
 pub fn test_bls_add_100(stdin: &mut sp1_sdk::SP1Stdin) -> impl FnOnce(sp1_sdk::SP1PublicValues) {
-    use bls12_381::g1::G1Projective;
     use bls12_381::g1::G1Affine;
+    use bls12_381::g1::G1Projective;
     use group::Group;
 
     let times: u8 = 100;
@@ -149,10 +148,10 @@ pub fn test_bls_add_100(stdin: &mut sp1_sdk::SP1Stdin) -> impl FnOnce(sp1_sdk::S
     }
 }
 
-#[sp1_test::sp1_test("bls12_381_ec_double_test", gpu, prove)]
+#[sp1_test::sp1_test("bls12_381_ec_double_test", syscalls = [BLS12381_DOUBLE, BLS12381_ADD, BLS12381_FP_ADD, BLS12381_FP_MUL, BLS12381_FP_SUB], gpu, prove)]
 pub fn test_bls_double_100(stdin: &mut sp1_sdk::SP1Stdin) -> impl FnOnce(sp1_sdk::SP1PublicValues) {
-    use bls12_381::g1::G1Projective;
     use bls12_381::g1::G1Affine;
+    use bls12_381::g1::G1Projective;
     use group::Group;
 
     let times: u8 = 100;

--- a/patch-testing/bn/Cargo.toml
+++ b/patch-testing/bn/Cargo.toml
@@ -7,6 +7,7 @@ publish.workspace = true
 [dependencies]
 sp1-zkvm = { workspace = true }
 sp1-sdk = { workspace = true }
+sp1-core-executor = { workspace = true }
 rand = { workspace = true }
 sp1-test = { workspace = true }
 substrate-bn = "0.6.0"

--- a/patch-testing/bn/src/lib.rs
+++ b/patch-testing/bn/src/lib.rs
@@ -1,4 +1,4 @@
-#[sp1_test::sp1_test("bn_test_fq_sqrt", gpu, prove)]
+#[sp1_test::sp1_test("bn_test_fq_sqrt", syscalls = [BN254_FP_MUL], gpu, prove)]
 pub fn test_bn_test_fq_sqrt_100(
     stdin: &mut sp1_sdk::SP1Stdin,
 ) -> impl FnOnce(sp1_sdk::SP1PublicValues) {
@@ -34,7 +34,7 @@ pub fn test_bn_test_fq_sqrt_100(
     }
 }
 
-#[sp1_test::sp1_test("bn_test_fq_inverse", gpu, prove)]
+#[sp1_test::sp1_test("bn_test_fq_inverse", syscalls = [BN254_FP_MUL], gpu, prove)]
 pub fn test_bn_test_fq_inverse_100(
     stdin: &mut sp1_sdk::SP1Stdin,
 ) -> impl FnOnce(sp1_sdk::SP1PublicValues) {
@@ -70,7 +70,7 @@ pub fn test_bn_test_fq_inverse_100(
     }
 }
 
-#[sp1_test::sp1_test("bn_test_fr_inverse", gpu, prove)]
+#[sp1_test::sp1_test("bn_test_fr_inverse", syscalls = [UINT256_MUL], gpu, prove)]
 pub fn test_bn_test_fr_inverse_100(
     stdin: &mut sp1_sdk::SP1Stdin,
 ) -> impl FnOnce(sp1_sdk::SP1PublicValues) {
@@ -106,7 +106,7 @@ pub fn test_bn_test_fr_inverse_100(
     }
 }
 
-#[sp1_test::sp1_test("bn_test_g1_add", gpu, prove)]
+#[sp1_test::sp1_test("bn_test_g1_add", syscalls = [BN254_ADD, BN254_FP_ADD, BN254_FP_MUL], gpu, prove)]
 pub fn test_bn_test_g1_add_100(
     stdin: &mut sp1_sdk::SP1Stdin,
 ) -> impl FnOnce(sp1_sdk::SP1PublicValues) {
@@ -157,7 +157,7 @@ pub fn test_bn_test_g1_add_100(
     |_| {}
 }
 
-#[sp1_test::sp1_test("bn_test_g1_double", gpu, prove)]
+#[sp1_test::sp1_test("bn_test_g1_double", syscalls = [BN254_DOUBLE, BN254_FP_ADD, BN254_FP_MUL], gpu, prove)]
 pub fn test_bn_test_g1_double_100(
     stdin: &mut sp1_sdk::SP1Stdin,
 ) -> impl FnOnce(sp1_sdk::SP1PublicValues) {

--- a/patch-testing/curve25519-dalek-ng/Cargo.toml
+++ b/patch-testing/curve25519-dalek-ng/Cargo.toml
@@ -6,6 +6,7 @@ publish.workspace = true
 
 [dependencies]
 sp1-sdk = { workspace = true }
+sp1-core-executor = { workspace = true }
 curve25519-dalek-ng = { workspace = true }
 sp1-test = { workspace = true }
 rand.workspace = true

--- a/patch-testing/curve25519-dalek-ng/src/lib.rs
+++ b/patch-testing/curve25519-dalek-ng/src/lib.rs
@@ -5,10 +5,7 @@ fn test_decompressed_noncanonical(
     use curve25519_dalek_ng::edwards::CompressedEdwardsY;
 
     // non-canonical point
-    let mut bytes: [u8; 32] = [0; 32];
-    for i in 0..32 {
-        bytes[i] = 255;
-    }
+    let mut bytes: [u8; 32] = [255; 32];
     bytes[0] = 253;
     bytes[31] = 127;
     let compressed = CompressedEdwardsY(bytes);
@@ -88,7 +85,7 @@ fn test_add_then_multiply(stdin: &mut sp1_sdk::SP1Stdin) -> impl FnOnce(sp1_sdk:
     }
 
     move |mut public| {
-        for (i, expected_result) in result_vec.into_iter().enumerate() {
+        for expected_result in result_vec.into_iter() {
             let patch_result = public.read::<[u8; 32]>();
 
             assert_eq!(patch_result, expected_result);
@@ -97,7 +94,7 @@ fn test_add_then_multiply(stdin: &mut sp1_sdk::SP1Stdin) -> impl FnOnce(sp1_sdk:
 }
 
 #[sp1_test::sp1_test("curve25519_ng_zero_msm", syscalls = [ED_ADD, ED_DECOMPRESS], prove)]
-fn test_zero_msm(stdin: &mut sp1_sdk::SP1Stdin) -> impl FnOnce(sp1_sdk::SP1PublicValues) {
+fn test_zero_msm(_stdin: &mut sp1_sdk::SP1Stdin) -> impl FnOnce(sp1_sdk::SP1PublicValues) {
     use curve25519_dalek_ng::edwards::CompressedEdwardsY;
     use curve25519_dalek_ng::edwards::EdwardsPoint;
 
@@ -115,7 +112,7 @@ fn test_zero_msm(stdin: &mut sp1_sdk::SP1Stdin) -> impl FnOnce(sp1_sdk::SP1Publi
 }
 
 #[sp1_test::sp1_test("curve25519_ng_zero_mul", syscalls = [ED_ADD, ED_DECOMPRESS], prove)]
-fn test_zero_mul(stdin: &mut sp1_sdk::SP1Stdin) -> impl FnOnce(sp1_sdk::SP1PublicValues) {
+fn test_zero_mul(_stdin: &mut sp1_sdk::SP1Stdin) -> impl FnOnce(sp1_sdk::SP1PublicValues) {
     use curve25519_dalek_ng::edwards::CompressedEdwardsY;
 
     let bytes1: [u8; 32] = [3; 32];
@@ -123,7 +120,7 @@ fn test_zero_mul(stdin: &mut sp1_sdk::SP1Stdin) -> impl FnOnce(sp1_sdk::SP1Publi
     let point1 = compressed1.decompress().unwrap();
 
     let scalar1 = curve25519_dalek_ng::scalar::Scalar::from_bytes_mod_order([0u8; 32]);
-    let result = point1 * &scalar1;
+    let result = point1 * scalar1;
     println!("{:?}", result.compress());
 
     move |_| {}

--- a/patch-testing/curve25519-dalek-ng/src/lib.rs
+++ b/patch-testing/curve25519-dalek-ng/src/lib.rs
@@ -1,4 +1,4 @@
-#[sp1_test::sp1_test("curve25519_ng_decompress", prove)]
+#[sp1_test::sp1_test("curve25519_ng_decompress", syscalls = [ED_DECOMPRESS], prove)]
 fn test_decompressed_noncanonical(
     _stdin: &mut sp1_sdk::SP1Stdin,
 ) -> impl FnOnce(sp1_sdk::SP1PublicValues) {
@@ -54,7 +54,7 @@ fn test_decompressed_noncanonical(
     move |_| {}
 }
 
-#[sp1_test::sp1_test("curve25519_ng_add_then_multiply", prove)]
+#[sp1_test::sp1_test("curve25519_ng_add_then_multiply", syscalls = [ED_ADD, ED_DECOMPRESS], prove)]
 fn test_add_then_multiply(stdin: &mut sp1_sdk::SP1Stdin) -> impl FnOnce(sp1_sdk::SP1PublicValues) {
     use curve25519_dalek_ng::edwards::CompressedEdwardsY;
     use curve25519_dalek_ng::scalar::Scalar;
@@ -96,7 +96,7 @@ fn test_add_then_multiply(stdin: &mut sp1_sdk::SP1Stdin) -> impl FnOnce(sp1_sdk:
     }
 }
 
-#[sp1_test::sp1_test("curve25519_ng_zero_msm", prove)]
+#[sp1_test::sp1_test("curve25519_ng_zero_msm", syscalls = [ED_ADD, ED_DECOMPRESS], prove)]
 fn test_zero_msm(stdin: &mut sp1_sdk::SP1Stdin) -> impl FnOnce(sp1_sdk::SP1PublicValues) {
     use curve25519_dalek_ng::edwards::CompressedEdwardsY;
     use curve25519_dalek_ng::edwards::EdwardsPoint;
@@ -114,10 +114,9 @@ fn test_zero_msm(stdin: &mut sp1_sdk::SP1Stdin) -> impl FnOnce(sp1_sdk::SP1Publi
     move |_| {}
 }
 
-#[sp1_test::sp1_test("curve25519_ng_zero_mul", prove)]
+#[sp1_test::sp1_test("curve25519_ng_zero_mul", syscalls = [ED_ADD, ED_DECOMPRESS], prove)]
 fn test_zero_mul(stdin: &mut sp1_sdk::SP1Stdin) -> impl FnOnce(sp1_sdk::SP1PublicValues) {
     use curve25519_dalek_ng::edwards::CompressedEdwardsY;
-    
 
     let bytes1: [u8; 32] = [3; 32];
     let compressed1 = CompressedEdwardsY(bytes1);

--- a/patch-testing/curve25519-dalek/Cargo.toml
+++ b/patch-testing/curve25519-dalek/Cargo.toml
@@ -6,6 +6,7 @@ publish.workspace = true
 
 [dependencies]
 sp1-sdk = { workspace = true }
+sp1-core-executor = { workspace = true }
 curve25519-dalek = { workspace = true }
 sp1-test = { workspace = true }
 ed25519-dalek.workspace = true

--- a/patch-testing/curve25519-dalek/src/lib.rs
+++ b/patch-testing/curve25519-dalek/src/lib.rs
@@ -154,7 +154,7 @@ fn test_add_then_multiply(stdin: &mut sp1_sdk::SP1Stdin) -> impl FnOnce(sp1_sdk:
     }
 
     move |mut public| {
-        for (i, expected_result) in result_vec.into_iter().enumerate() {
+        for expected_result in result_vec.into_iter() {
             let patch_result = public.read::<[u8; 32]>();
 
             assert_eq!(patch_result, expected_result);
@@ -163,7 +163,7 @@ fn test_add_then_multiply(stdin: &mut sp1_sdk::SP1Stdin) -> impl FnOnce(sp1_sdk:
 }
 
 #[sp1_test::sp1_test("curve25519_zero_msm", syscalls = [ED_ADD, ED_DECOMPRESS], prove)]
-fn test_zero_msm(stdin: &mut sp1_sdk::SP1Stdin) -> impl FnOnce(sp1_sdk::SP1PublicValues) {
+fn test_zero_msm(_stdin: &mut sp1_sdk::SP1Stdin) -> impl FnOnce(sp1_sdk::SP1PublicValues) {
     use curve25519_dalek::edwards::CompressedEdwardsY;
     use curve25519_dalek::edwards::EdwardsPoint;
 
@@ -181,7 +181,7 @@ fn test_zero_msm(stdin: &mut sp1_sdk::SP1Stdin) -> impl FnOnce(sp1_sdk::SP1Publi
 }
 
 #[sp1_test::sp1_test("curve25519_zero_mul", syscalls = [ED_ADD, ED_DECOMPRESS], prove)]
-fn test_zero_mul(stdin: &mut sp1_sdk::SP1Stdin) -> impl FnOnce(sp1_sdk::SP1PublicValues) {
+fn test_zero_mul(_stdin: &mut sp1_sdk::SP1Stdin) -> impl FnOnce(sp1_sdk::SP1PublicValues) {
     use curve25519_dalek::edwards::CompressedEdwardsY;
 
     let bytes1: [u8; 32] = [3; 32];

--- a/patch-testing/curve25519-dalek/src/lib.rs
+++ b/patch-testing/curve25519-dalek/src/lib.rs
@@ -1,4 +1,4 @@
-#[sp1_test::sp1_test("curve25519_decompress")]
+#[sp1_test::sp1_test("curve25519_decompress", syscalls = [ED_DECOMPRESS])]
 fn test_decompressed_expected_value(
     stdin: &mut sp1_sdk::SP1Stdin,
 ) -> impl FnOnce(sp1_sdk::SP1PublicValues) {
@@ -65,9 +65,6 @@ fn test_decompressed_noncanonical(
 ) -> impl FnOnce(sp1_sdk::SP1PublicValues) {
     use curve25519_dalek::edwards::CompressedEdwardsY;
     use curve25519_dalek::edwards::EdwardsPoint;
-    
-    
-    
 
     let how_many_points = 1_usize;
     stdin.write(&how_many_points);
@@ -96,7 +93,7 @@ fn test_decompressed_noncanonical(
     }
 }
 
-#[sp1_test::sp1_test("ed25519_verify")]
+#[sp1_test::sp1_test("ed25519_verify", syscalls = [ED_ADD, ED_DECOMPRESS])]
 fn test_ed25519_verify(stdin: &mut sp1_sdk::SP1Stdin) -> impl FnOnce(sp1_sdk::SP1PublicValues) {
     use ed25519_dalek::Signer;
 
@@ -123,7 +120,7 @@ fn test_ed25519_verify(stdin: &mut sp1_sdk::SP1Stdin) -> impl FnOnce(sp1_sdk::SP
     }
 }
 
-#[sp1_test::sp1_test("curve25519_add_then_multiply", prove)]
+#[sp1_test::sp1_test("curve25519_add_then_multiply", syscalls = [ED_ADD, ED_DECOMPRESS], prove)]
 fn test_add_then_multiply(stdin: &mut sp1_sdk::SP1Stdin) -> impl FnOnce(sp1_sdk::SP1PublicValues) {
     use curve25519_dalek::edwards::CompressedEdwardsY;
     use curve25519_dalek::scalar::Scalar;
@@ -165,7 +162,7 @@ fn test_add_then_multiply(stdin: &mut sp1_sdk::SP1Stdin) -> impl FnOnce(sp1_sdk:
     }
 }
 
-#[sp1_test::sp1_test("curve25519_zero_msm", prove)]
+#[sp1_test::sp1_test("curve25519_zero_msm", syscalls = [ED_ADD, ED_DECOMPRESS], prove)]
 fn test_zero_msm(stdin: &mut sp1_sdk::SP1Stdin) -> impl FnOnce(sp1_sdk::SP1PublicValues) {
     use curve25519_dalek::edwards::CompressedEdwardsY;
     use curve25519_dalek::edwards::EdwardsPoint;
@@ -183,7 +180,7 @@ fn test_zero_msm(stdin: &mut sp1_sdk::SP1Stdin) -> impl FnOnce(sp1_sdk::SP1Publi
     move |_| {}
 }
 
-#[sp1_test::sp1_test("curve25519_zero_mul", prove)]
+#[sp1_test::sp1_test("curve25519_zero_mul", syscalls = [ED_ADD, ED_DECOMPRESS], prove)]
 fn test_zero_mul(stdin: &mut sp1_sdk::SP1Stdin) -> impl FnOnce(sp1_sdk::SP1PublicValues) {
     use curve25519_dalek::edwards::CompressedEdwardsY;
 

--- a/patch-testing/k256/Cargo.toml
+++ b/patch-testing/k256/Cargo.toml
@@ -7,6 +7,7 @@ publish.workspace = true
 [dependencies]
 sp1-zkvm = { workspace = true }
 sp1-sdk = { workspace = true }
+sp1-core-executor = { workspace = true }
 k256 = { workspace = true }
 hex-literal = { workspace = true }
 ecdsa-core = { workspace = true }

--- a/patch-testing/k256/src/lib.rs
+++ b/patch-testing/k256/src/lib.rs
@@ -29,7 +29,7 @@ pub fn test_verify_rand_lte_100(
     }
 }
 
-#[sp1_test::sp1_test("k256_recover", gpu, prove)]
+#[sp1_test::sp1_test("k256_recover", syscalls = [SECP256K1_ADD, SECP256K1_DOUBLE], gpu, prove)]
 pub fn test_recover_rand_lte_100(
     stdin: &mut sp1_sdk::SP1Stdin,
 ) -> impl FnOnce(sp1_sdk::SP1PublicValues) {
@@ -64,14 +64,12 @@ pub fn test_recover_rand_lte_100(
     }
 }
 
-#[sp1_test::sp1_test("k256_recover")]
+#[sp1_test::sp1_test("k256_recover", syscalls = [SECP256K1_ADD, SECP256K1_DOUBLE])]
 pub fn test_recover_high_hash_high_recid(
     stdin: &mut sp1_sdk::SP1Stdin,
 ) -> impl FnOnce(sp1_sdk::SP1PublicValues) {
     use ecdsa_core::RecoveryId;
-    use k256::{
-        ecdsa::Signature, ecdsa::VerifyingKey,
-    };
+    use k256::{ecdsa::Signature, ecdsa::VerifyingKey};
 
     let times = 10000u16;
     stdin.write(&times);
@@ -120,14 +118,12 @@ pub fn test_recover_high_hash_high_recid(
     }
 }
 
-#[sp1_test::sp1_test("k256_recover", gpu, prove)]
+#[sp1_test::sp1_test("k256_recover", syscalls = [SECP256K1_ADD, SECP256K1_DOUBLE], gpu, prove)]
 pub fn test_recover_pubkey_infinity(
     stdin: &mut sp1_sdk::SP1Stdin,
 ) -> impl FnOnce(sp1_sdk::SP1PublicValues) {
     use ecdsa_core::RecoveryId;
-    use k256::{
-        ecdsa::Signature, ecdsa::VerifyingKey,
-    };
+    use k256::{ecdsa::Signature, ecdsa::VerifyingKey};
 
     let times = 3u16;
     stdin.write(&times);

--- a/patch-testing/k256/src/lib.rs
+++ b/patch-testing/k256/src/lib.rs
@@ -56,7 +56,7 @@ pub fn test_recover_rand_lte_100(
     }
 
     move |mut public| {
-        for (i, vkey) in vkeys.into_iter().enumerate() {
+        for vkey in vkeys.into_iter() {
             let key = public.read::<Option<Vec<u8>>>();
 
             assert_eq!(key, Some(vkey.to_sec1_bytes().to_vec()));
@@ -158,12 +158,10 @@ pub fn test_recover_pubkey_infinity(
         131, 111, 153, 176, 134, 1, 241, 19, 188, 224, 54, 249,
     ];
 
-    for (idx, (msg, r)) in [(msg1, r1), (msg2, r2), (msg3, r3)].iter().enumerate() {
+    for (msg, r) in [(msg1, r1), (msg2, r2), (msg3, r3)].iter() {
         let mut signature_bytes = [0u8; 64];
-        for i in 0..32 {
-            signature_bytes[i] = r[i];
-            signature_bytes[i + 32] = r[i];
-        }
+        signature_bytes[..32].copy_from_slice(r);
+        signature_bytes[32..(32 + 32)].copy_from_slice(r);
         let recid = RecoveryId::from_byte(0u8).unwrap();
         let signature = Signature::from_slice(&signature_bytes).unwrap();
         let recovered_key = VerifyingKey::recover_from_prehash(msg, &signature, recid);
@@ -171,8 +169,7 @@ pub fn test_recover_pubkey_infinity(
         vkeys.push(recovered_key.ok().map(|vk| vk.to_sec1_bytes().to_vec()));
     }
     move |mut public| {
-        let fail_count = 0;
-        for (i, vkey) in vkeys.into_iter().enumerate() {
+        for vkey in vkeys.into_iter() {
             let key = public.read::<Option<Vec<u8>>>();
             assert_eq!(key, vkey);
             assert!(key.is_none());

--- a/patch-testing/keccak/Cargo.toml
+++ b/patch-testing/keccak/Cargo.toml
@@ -7,6 +7,7 @@ publish.workspace = true
 [dependencies]
 sp1-zkvm = { workspace = true }
 sp1-sdk = { workspace = true }
+sp1-core-executor = { workspace = true }
 tiny-keccak = { workspace = true }
 rand = { workspace = true }
 sp1-test = { workspace = true }

--- a/patch-testing/keccak/src/lib.rs
+++ b/patch-testing/keccak/src/lib.rs
@@ -1,4 +1,4 @@
-#[sp1_test::sp1_test("keccak_patch_test", gpu, prove)]
+#[sp1_test::sp1_test("keccak_patch_test", syscalls = [KECCAK_PERMUTE], gpu, prove)]
 fn test_expected_digest_lte_100(
     stdin: &mut sp1_sdk::SP1Stdin,
 ) -> impl FnOnce(sp1_sdk::SP1PublicValues) {

--- a/patch-testing/p256/Cargo.toml
+++ b/patch-testing/p256/Cargo.toml
@@ -7,6 +7,7 @@ publish.workspace = true
 [dependencies]
 sp1-zkvm = { workspace = true }
 sp1-sdk = { workspace = true }
+sp1-core-executor = { workspace = true }
 p256 = { workspace = true }
 hex-literal = { workspace = true }
 ecdsa-core = { workspace = true }

--- a/patch-testing/p256/src/lib.rs
+++ b/patch-testing/p256/src/lib.rs
@@ -46,7 +46,7 @@ pub fn test_recover_rand_lte_100(
     }
 
     move |mut public| {
-        for (i, vkey) in vkeys.into_iter().enumerate() {
+        for vkey in vkeys.into_iter() {
             let key = public.read::<Option<Vec<u8>>>();
 
             assert_eq!(key, Some(vkey.to_sec1_bytes().to_vec()));
@@ -144,10 +144,9 @@ pub fn test_recover_pubkey_infinity(
 
     for (idx, (msg, r)) in [(msg1, r1), (msg2, r2), (msg3, r3)].iter().enumerate() {
         let mut signature_bytes = [0u8; 64];
-        for i in 0..32 {
-            signature_bytes[i] = r[i];
-            signature_bytes[i + 32] = r[i];
-        }
+        signature_bytes[..32].copy_from_slice(r);
+        signature_bytes[32..(32 + 32)].copy_from_slice(r);
+
         let recid = if idx == 2 { 0u8 } else { 1u8 };
         let recid = RecoveryId::from_byte(recid).unwrap();
         let signature = Signature::from_slice(&signature_bytes).unwrap();
@@ -156,8 +155,7 @@ pub fn test_recover_pubkey_infinity(
         vkeys.push(recovered_key.ok().map(|vk| vk.to_sec1_bytes().to_vec()));
     }
     move |mut public| {
-        let fail_count = 0;
-        for (i, vkey) in vkeys.into_iter().enumerate() {
+        for vkey in vkeys.into_iter() {
             let key = public.read::<Option<Vec<u8>>>();
             assert_eq!(key, vkey);
             assert!(key.is_none());

--- a/patch-testing/p256/src/lib.rs
+++ b/patch-testing/p256/src/lib.rs
@@ -24,7 +24,7 @@ pub fn test_verify_rand_lte_100(
     }
 }
 
-#[sp1_test::sp1_test("p256_recover", gpu, prove)]
+#[sp1_test::sp1_test("p256_recover", syscalls = [SECP256R1_ADD, SECP256R1_DOUBLE], gpu, prove)]
 pub fn test_recover_rand_lte_100(
     stdin: &mut sp1_sdk::SP1Stdin,
 ) -> impl FnOnce(sp1_sdk::SP1PublicValues) {
@@ -54,14 +54,12 @@ pub fn test_recover_rand_lte_100(
     }
 }
 
-#[sp1_test::sp1_test("p256_recover")]
+#[sp1_test::sp1_test("p256_recover", syscalls = [SECP256R1_ADD, SECP256R1_DOUBLE])]
 pub fn test_recover_high_hash_high_recid(
     stdin: &mut sp1_sdk::SP1Stdin,
 ) -> impl FnOnce(sp1_sdk::SP1PublicValues) {
     use ecdsa_core::RecoveryId;
-    use p256::{
-        ecdsa::Signature, ecdsa::VerifyingKey,
-    };
+    use p256::{ecdsa::Signature, ecdsa::VerifyingKey};
 
     let times = 10000u16;
     stdin.write(&times);
@@ -108,14 +106,12 @@ pub fn test_recover_high_hash_high_recid(
     }
 }
 
-#[sp1_test::sp1_test("p256_recover", gpu, prove)]
+#[sp1_test::sp1_test("p256_recover", syscalls = [SECP256R1_ADD, SECP256R1_DOUBLE], gpu, prove)]
 pub fn test_recover_pubkey_infinity(
     stdin: &mut sp1_sdk::SP1Stdin,
 ) -> impl FnOnce(sp1_sdk::SP1PublicValues) {
     use ecdsa_core::RecoveryId;
-    use p256::{
-        ecdsa::Signature, ecdsa::VerifyingKey,
-    };
+    use p256::{ecdsa::Signature, ecdsa::VerifyingKey};
 
     let times = 3u16;
     stdin.write(&times);

--- a/patch-testing/rustcrypto-bigint/Cargo.toml
+++ b/patch-testing/rustcrypto-bigint/Cargo.toml
@@ -7,6 +7,7 @@ publish.workspace = true
 [dependencies]
 sp1-zkvm = { workspace = true }
 sp1-sdk = { workspace = true }
+sp1-core-executor = { workspace = true }
 rand = { workspace = true }
 sp1-test = { workspace = true }
 crypto-bigint = "0.5.5"

--- a/patch-testing/rustcrypto-bigint/src/lib.rs
+++ b/patch-testing/rustcrypto-bigint/src/lib.rs
@@ -1,4 +1,4 @@
-#[sp1_test::sp1_test("bigint_test_mul_mod_special", gpu, prove)]
+#[sp1_test::sp1_test("bigint_test_mul_mod_special", syscalls = [UINT256_MUL], gpu, prove)]
 pub fn test_bigint_mul_mod_special(
     stdin: &mut sp1_sdk::SP1Stdin,
 ) -> impl FnOnce(sp1_sdk::SP1PublicValues) {
@@ -36,7 +36,7 @@ pub fn test_bigint_mul_mod_special(
     }
 }
 
-#[sp1_test::sp1_test("bigint_test_mul_add_residue", gpu, prove)]
+#[sp1_test::sp1_test("bigint_test_mul_add_residue", syscalls = [UINT256_MUL], gpu, prove)]
 pub fn test_bigint_mul_add_residue(
     stdin: &mut sp1_sdk::SP1Stdin,
 ) -> impl FnOnce(sp1_sdk::SP1PublicValues) {

--- a/patch-testing/secp256k1/Cargo.toml
+++ b/patch-testing/secp256k1/Cargo.toml
@@ -6,6 +6,7 @@ publish.workspace = true
 
 [dependencies]
 sp1-sdk = { workspace = true }
+sp1-core-executor = { workspace = true }
 secp256k1 = { workspace = true }
 rand = { workspace = true }
 sp1-test = { workspace = true }

--- a/patch-testing/secp256k1/src/lib.rs
+++ b/patch-testing/secp256k1/src/lib.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 use secp256k1::{Message, PublicKey, Secp256k1};
 
-#[sp1_test::sp1_test("secp256k1_recover")]
+#[sp1_test::sp1_test("secp256k1_recover", syscalls = [SECP256K1_DOUBLE, SECP256K1_ADD])]
 fn test_recover_rand_lte_100(
     stdin: &mut sp1_sdk::SP1Stdin,
 ) -> impl FnOnce(sp1_sdk::SP1PublicValues) {

--- a/patch-testing/sha/Cargo.toml
+++ b/patch-testing/sha/Cargo.toml
@@ -7,6 +7,7 @@ publish.workspace = true
 [dependencies]
 sp1-zkvm.workspace = true
 sp1-sdk.workspace = true
+sp1-core-executor.workspace = true
 
 sha2-v0-9-8 = { version = "0.9.8", package = "sha2" }
 sha2-v0-10-6 = { version = "0.10.6", package = "sha2" }

--- a/patch-testing/sha/src/lib.rs
+++ b/patch-testing/sha/src/lib.rs
@@ -2,7 +2,7 @@
 use sp1_sdk::SP1PublicValues;
 use sp1_test::sp1_test;
 
-#[sp1_test("sha2", gpu, prove)]
+#[sp1_test("sha2", syscalls = [SHA_COMPRESS, SHA_EXTEND], gpu, prove)]
 fn test_sha2_expected_digest_lte_100_times(
     stdin: &mut sp1_sdk::SP1Stdin,
 ) -> impl FnOnce(SP1PublicValues) {

--- a/patch-testing/sha/src/lib.rs
+++ b/patch-testing/sha/src/lib.rs
@@ -44,7 +44,7 @@ fn test_sha2_expected_digest_lte_100_times(
     }
 }
 
-#[sp1_test("sha3", gpu, prove)]
+#[sp1_test("sha3", syscalls = [SHA_COMPRESS, SHA_EXTEND], gpu, prove)]
 fn test_sha3_expected_digest_lte_100_times(
     stdin: &mut sp1_sdk::SP1Stdin,
 ) -> impl FnOnce(SP1PublicValues) {

--- a/patch-testing/sp1-test-macro/src/lib.rs
+++ b/patch-testing/sp1-test-macro/src/lib.rs
@@ -106,6 +106,8 @@ pub fn sp1_test(attr: TokenStream, item: TokenStream) -> TokenStream {
         None => panic!("The SP1 test attribute requires an ELF file to be specified"),
     };
 
+    let syscalls = options.syscalls();
+
     let bounds_check = quote! {
         fn __assert_proper_cb<F: FnOnce(::sp1_sdk::SP1PublicValues)>(cb: &F) {
             let _ = cb;
@@ -149,7 +151,11 @@ pub fn sp1_test(attr: TokenStream, item: TokenStream) -> TokenStream {
 
             #maybe_client_setup
 
-            let (__macro_internal_public, _) = __macro_internal_client.execute(__MACRO_INTERNAL_ELF, &__macro_internal_stdin).run().unwrap();
+            let (__macro_internal_public, __macro_internal_execution_report) = __macro_internal_client.execute(__MACRO_INTERNAL_ELF, &__macro_internal_stdin).run().unwrap();
+
+            for syscall in [#(::sp1_core_executor::syscalls::SyscallCode::#syscalls),*] {
+                assert!(__macro_internal_execution_report.syscall_counts[syscall] > 0, "Syscall {syscall} has not been emitted");
+            }
 
             __macro_internal_cb(__macro_internal_public);
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
 
We need to ensure that the SP1 syscalls that we expect to be emitted with every patch are actually emitted.

## Solution

Add a `syscalls` attribute to `sp1_test`, and ensure that the specified syscalls counts in the execution report are > 0.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes