### PR TITLE
fix(cli): elf name requires output directory

### DIFF
--- a/crates/build/src/build.rs
+++ b/crates/build/src/build.rs
@@ -72,8 +72,6 @@ pub fn execute_build_program(
 
             std::fs::copy(&elf_path, &output_path)?;
         }
-    } else if args.elf_name.is_some() {
-        println!("cargo:warning=ELF name is set but --output-directory is not used, the ELF will be place in the `target/` directory");
     }
 
     print_elf_paths_cargo_directives(&target_elf_paths);

--- a/crates/build/src/build.rs
+++ b/crates/build/src/build.rs
@@ -44,15 +44,15 @@ pub fn execute_build_program(
         create_local_command(args, &program_dir, &program_metadata)
     };
 
-    execute_command(cmd, args.docker)?;
-
     let target_elf_paths = generate_elf_paths(&program_metadata, Some(args))?;
 
-    if let Some(output_directory) = &args.output_directory {
-        if target_elf_paths.len() > 1 && args.elf_name.is_some() {
-            anyhow::bail!("--elf-name is not supported when --output-directory is used and multiple ELFs are built.");
-        }
+    if target_elf_paths.len() > 1 && args.elf_name.is_some() {
+        anyhow::bail!("--elf-name is not supported when --output-directory is used and multiple ELFs are built.");
+    }
 
+    execute_command(cmd, args.docker)?;
+
+    if let Some(output_directory) = &args.output_directory {
         // The path to the output directory, maybe relative or absolute.
         let output_directory = PathBuf::from(output_directory);
 

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -70,7 +70,7 @@ pub struct BuildArgs {
         num_args = 1..
     )]
     pub binaries: Vec<String>,
-    #[clap(long, action, help = "ELF binary name")]
+    #[clap(long, action, requires = "output_directory", help = "ELF binary name")]
     pub elf_name: Option<String>,
     #[clap(alias = "out-dir", long, action, help = "Copy the compiled ELF to this directory")]
     pub output_directory: Option<String>,


### PR DESCRIPTION
closes #1979

The issue brings up a good point that error message currently provided when trying to use elf name without an output directory is not clear enough.

As we want to discourage copying of ELF files, and the use of `include_elf`/ build script flow, we require output directory is set if elf name is set.

We still do not allow elf name if multiple guest targets are found.