### PR TITLE
docs: add example command for GitHub token usage in sp1up

### DIFF
--- a/book/versioned_docs/version-3.4.0/getting-started/install.md
+++ b/book/versioned_docs/version-3.4.0/getting-started/install.md
@@ -55,7 +55,10 @@ If this works, go to the [next section](./quickstart.md) to compile and prove a 
 
 If you experience [rate-limiting](https://docs.github.com/en/rest/using-the-rest-api/getting-started-with-the-rest-api?apiVersion=2022-11-28#rate-limiting) when using the `sp1up` command, you can resolve this by using the `--token` flag and providing your GitHub token. To create a Github token, follow the instructions [here](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic).
 
-<!-- TODO: We should add an example command here -->
+Example:
+```bash
+sp1up --token ghp_YOUR_GITHUB_TOKEN_HERE
+```
 
 #### Unsupported OS Architectures
 


### PR DESCRIPTION
## Motivation

The installation documentation mentions the ability to use a GitHub token with `sp1up` to avoid rate-limiting issues, but it doesn't provide a concrete example of how to use this feature. This lack of example might confuse users who are trying to resolve rate-limiting issues.

## Solution

Added a clear example command showing how to use the `--token` flag with `sp1up`, making it immediately obvious how users should format their command when using a GitHub token.

The example uses a placeholder token format that follows GitHub's standard pattern (`ghp_YOUR_GITHUB_TOKEN_HERE`), making it clear where users should insert their actual token.

## PR Checklist

- [x] Added Tests
  - N/A (Documentation change only)
- [x] Added Documentation
  - Added example command in installation guide
- [ ] Breaking changes
  - No breaking changes