### PR TITLE
chore: expose bigint rug feature in sdk

### DIFF
--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -78,6 +78,7 @@ network = [
   "dep:backoff",
 ]
 cuda = []
+bigint-rug = ["sp1-core-machine/bigint-rug"]
 
 profiling = ["sp1-core-executor/profiling"]
 


### PR DESCRIPTION
enable this feature for faster execution in curve-op heavy workloads.