### PR TITLE
feat(sp1-zkvm): Switch `embedded-alloc` to use `TLSFHeap`

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -314,11 +314,6 @@ jobs:
     steps:
       - name: Checkout Actions Repository
         uses: actions/checkout@v4
-
-      - name: Setup CI
-        uses: ./.github/actions/setup
-        with:
-          pull_token: ${{ secrets.PRIVATE_PULL_TOKEN }}
   
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/crates/zkvm/entrypoint/src/allocators/embedded.rs
+++ b/crates/zkvm/entrypoint/src/allocators/embedded.rs
@@ -3,7 +3,7 @@ use crate::{
 };
 use alloc::alloc::{GlobalAlloc, Layout};
 use critical_section::RawRestoreState;
-use embedded_alloc::LlffHeap as Heap;
+use embedded_alloc::TlsfHeap as Heap;
 
 #[global_allocator]
 static HEAP: EmbeddedAlloc = EmbeddedAlloc;

--- a/crates/zkvm/entrypoint/src/allocators/embedded.rs
+++ b/crates/zkvm/entrypoint/src/allocators/embedded.rs
@@ -31,14 +31,6 @@ pub fn init() {
     unsafe { INNER_HEAP.init(heap_pos, heap_size) };
 }
 
-pub fn used() -> usize {
-    critical_section::with(|_cs| INNER_HEAP.used())
-}
-
-pub fn free() -> usize {
-    critical_section::with(|_cs| INNER_HEAP.free())
-}
-
 struct EmbeddedAlloc;
 
 unsafe impl GlobalAlloc for EmbeddedAlloc {

--- a/crates/zkvm/entrypoint/src/allocators/mod.rs
+++ b/crates/zkvm/entrypoint/src/allocators/mod.rs
@@ -9,4 +9,4 @@ mod bump;
 mod embedded;
 
 #[cfg(feature = "embedded")]
-pub use embedded::{free, init, used};
+pub use embedded::init;


### PR DESCRIPTION
## Overview

On OP Succinct workloads, `TLSFHeap` has been found to be empirically cheaper. This likely extends to most other workloads. In contrast to `LLSFHeap` (which could balloon to ~300-400% more cycles), `TLSFHeap` is generally capped at ~35% more cycles.

Switch to using `TLSFHeap` instead of `LLSFHeap`.

Source PR:  https://github.com/rust-embedded/embedded-alloc/pull/78

## Miscellaneous
- `TLFSHeap` does not implement the `free` and `used` functions.
- Small CI fix for `Check Verifier no-std` job.