### PR TITLE
fix: const test iterations

### DIFF
--- a/patch-testing/k256/program/bin/recover.rs
+++ b/patch-testing/k256/program/bin/recover.rs
@@ -5,7 +5,7 @@ use ecdsa_core::RecoveryId;
 use k256::ecdsa::{Signature, VerifyingKey};
 
 pub fn main() {
-    let times = sp1_zkvm::io::read::<u16>();
+    let times = sp1_zkvm::io::read::<u8>();
 
     for _ in 0..times {
         let vk = inner();

--- a/patch-testing/k256/src/lib.rs
+++ b/patch-testing/k256/src/lib.rs
@@ -7,7 +7,7 @@ pub fn test_verify_rand_lte_100(
         elliptic_curve::rand_core::OsRng,
     };
 
-    let times = rand::random::<u8>().min(100);
+    let times = 100_u8;
     stdin.write(&times);
 
     for _ in 0..times {
@@ -38,7 +38,7 @@ pub fn test_recover_rand_lte_100(
         elliptic_curve::rand_core::OsRng,
     };
 
-    let times = rand::random::<u8>().min(100);
+    let times = 100_u8;
     stdin.write(&(times as u16));
 
     let mut vkeys = Vec::with_capacity(times as usize);
@@ -71,7 +71,7 @@ pub fn test_recover_high_hash_high_recid(
     use ecdsa_core::RecoveryId;
     use k256::{ecdsa::Signature, ecdsa::VerifyingKey};
 
-    let times = 10000u16;
+    let times = 100_u8;
     stdin.write(&times);
 
     let mut vkeys = Vec::with_capacity(times as usize);
@@ -125,7 +125,7 @@ pub fn test_recover_pubkey_infinity(
     use ecdsa_core::RecoveryId;
     use k256::{ecdsa::Signature, ecdsa::VerifyingKey};
 
-    let times = 3u16;
+    let times = 100_u8;
     stdin.write(&times);
 
     let mut vkeys = Vec::with_capacity(times as usize);

--- a/patch-testing/p256/program/bin/recover.rs
+++ b/patch-testing/p256/program/bin/recover.rs
@@ -5,7 +5,7 @@ use ecdsa_core::RecoveryId;
 use p256::ecdsa::{Signature, VerifyingKey};
 
 pub fn main() {
-    let times = sp1_zkvm::io::read::<u16>();
+    let times = sp1_zkvm::io::read::<u8>();
 
     for _ in 0..times {
         let vk = inner();

--- a/patch-testing/p256/src/lib.rs
+++ b/patch-testing/p256/src/lib.rs
@@ -4,7 +4,7 @@ pub fn test_verify_rand_lte_100(
 ) -> impl FnOnce(sp1_sdk::SP1PublicValues) {
     use p256::{ecdsa::SigningKey, elliptic_curve::rand_core::OsRng};
 
-    let times = rand::random::<u8>().min(100);
+    let times = 100_u8;
     stdin.write(&times);
 
     for _ in 0..times {
@@ -30,7 +30,7 @@ pub fn test_recover_rand_lte_100(
 ) -> impl FnOnce(sp1_sdk::SP1PublicValues) {
     use p256::{ecdsa::SigningKey, elliptic_curve::rand_core::OsRng};
 
-    let times = rand::random::<u8>().min(100);
+    let times = 100_u8;
     stdin.write(&(times as u16));
 
     let mut vkeys = Vec::with_capacity(times as usize);
@@ -61,7 +61,7 @@ pub fn test_recover_high_hash_high_recid(
     use ecdsa_core::RecoveryId;
     use p256::{ecdsa::Signature, ecdsa::VerifyingKey};
 
-    let times = 10000u16;
+    let times = 100_u8;
     stdin.write(&times);
 
     let mut vkeys = Vec::with_capacity(times as usize);
@@ -113,7 +113,7 @@ pub fn test_recover_pubkey_infinity(
     use ecdsa_core::RecoveryId;
     use p256::{ecdsa::Signature, ecdsa::VerifyingKey};
 
-    let times = 3u16;
+    let times = 100_u8;
     stdin.write(&times);
 
     let mut vkeys = Vec::with_capacity(times as usize);

--- a/patch-testing/secp256k1/src/lib.rs
+++ b/patch-testing/secp256k1/src/lib.rs
@@ -5,7 +5,7 @@ use secp256k1::{Message, PublicKey, Secp256k1};
 fn test_recover_rand_lte_100(
     stdin: &mut sp1_sdk::SP1Stdin,
 ) -> impl FnOnce(sp1_sdk::SP1PublicValues) {
-    let times = rand::random::<u8>().min(100);
+    let times = 100_u8;
 
     stdin.write(&times);
 
@@ -47,7 +47,7 @@ fn test_recover_rand_lte_100(
 fn test_verify_rand_lte_100(
     stdin: &mut sp1_sdk::SP1Stdin,
 ) -> impl FnOnce(sp1_sdk::SP1PublicValues) {
-    let times = rand::random::<u8>().min(100);
+    let times = 100_u8;
     stdin.write(&times);
 
     let secp = Secp256k1::new();


### PR DESCRIPTION
The test benchmarking requires a fixed number of iterations to be comparable. 

The benchmarker assumes old tests are equivalent, and uses old code to get the comparison cycle counts, therefore, either the old tests must be conducive to passing the number off to the benchmarker, or they can simply use a fixed number of iterations. 

For now, this PR does the latter.