### PR TITLE
refactor: simplify `verify_opening_shape` and fix install script typo

### DIFF
--- a/sp1up/install
+++ b/sp1up/install
@@ -54,7 +54,7 @@ fi
 
 # Warn MacOS users that they may need to manually install openssl via Homebrew:
 if [[ "$OSTYPE" =~ ^darwin ]] && [[ ! -f /usr/local/opt/openssl/lib/libssl.3.dylib && ! -f /opt/homebrew/opt/openssl/lib/libssl.3.dylib ]]; then
-    echo && echo "warning: libusb not found. You may need to install it manually on MacOS via Homebrew (brew install openssl)."
+    echo && echo "warning: openssl not found. You may need to install it manually on MacOS via Homebrew (brew install openssl)."
 fi
 
 echo && echo "✅ Installation complete!"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Hey! This PR improves code readability in `verifier.rs` by introducing a macro for length checks and fixes a typo in the installation script.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- Added a `check_len!` macro to handle length checks more concisely.
- Replaced redundant length checks with the macro in `verify_opening_shape`.
- Fixed the incorrect warning message in the installation script.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes