### PR TITLE
chore: fixed inaccurate comment on Fibonacci number output

### DIFF
--- a/examples/fibonacci/program/src/main.rs
+++ b/examples/fibonacci/program/src/main.rs
@@ -1,5 +1,5 @@
-//! A simple program that takes a number `n` as input, and writes the `n-1`th and `n`th fibonacci
-//! number as an output.
+//! A simple program that takes a number `n` as input, and writes the `n-1`th and `n`th Fibonacci
+//! numbers as output (where `n-1` is stored in `a` and `n` in `b` after the loop).
 
 // These two lines are necessary for the program to properly compile.
 //


### PR DESCRIPTION
## Motivation

In the original comment, it was stated that the program outputs the `n-1`th and `nth` Fibonacci numbers. However, the program actually outputs the values stored in variables `a` and `b`, which accumulate the Fibonacci sequence during the loop. I've updated the comment to more accurately describe what is happening in the code. The revised comment now reflects that `a` and `b` correspond to the `n-1`th and `nth` Fibonacci numbers after the loop finishes.

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes