### PR TITLE
fix: Remove evm specific code when using new with --bare template

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -44,3 +44,6 @@ prettytable-rs = "0.10"
 textwrap = "0.16.0"
 ctrlc = "3.4.2"
 cargo_metadata = "0.18.1"
+
+[dev-dependencies]
+tempfile = "3.16.0"

--- a/crates/cli/src/commands/new.rs
+++ b/crates/cli/src/commands/new.rs
@@ -9,29 +9,29 @@ use yansi::Paint;
 
 #[derive(Args)]
 #[group(required = true, multiple = false)]
-struct TemplateType {
+pub struct TemplateType {
     /// Use the `bare` template which includes just a program and script.
     #[arg(long)]
-    bare: bool,
+    pub bare: bool,
 
     /// Use the `evm` template which includes Solidity smart contracts for onchain integration.
     #[arg(long)]
-    evm: bool,
+    pub evm: bool,
 }
 
 #[derive(Parser)]
 #[command(name = "new", about = "Setup a new project that runs inside the SP1.")]
 pub struct NewCmd {
     /// The name of the project.
-    name: String,
+    pub name: String,
 
     /// The template to use for the project.
     #[command(flatten)]
-    template: TemplateType,
+    pub template: TemplateType,
 
     /// Version of sp1-project-template to use (branch or tag).
     #[arg(long, default_value = "main")]
-    version: String,
+    pub version: String,
 }
 
 const TEMPLATE_REPOSITORY_URL: &str = "https://github.com/succinctlabs/sp1-project-template";

--- a/crates/cli/tests/test_new_command.rs
+++ b/crates/cli/tests/test_new_command.rs
@@ -1,0 +1,135 @@
+#[cfg(test)]
+mod test_new_command {
+    use anyhow::Result;
+    use sp1_cli::commands::new::{NewCmd, TemplateType};
+    use std::{fs, path::PathBuf};
+    use tempfile::tempdir;
+
+    /// Helper that checks if a program (like git) is installed.
+    /// Used to skip tests that require the program.
+    fn is_program_in_path(program: &str) -> bool {
+        std::process::Command::new(program).arg("--version").output().is_ok()
+    }
+
+    /// Test that running the bare template succeeds, creates the project directory,
+    /// removes the `contracts` folder, and removes `.gitmodules` if present.
+    /// This also checks that `.git` is removed after cloning.
+    #[test]
+    fn test_newcmd_bare_template() -> Result<()> {
+        if !is_program_in_path("git") {
+            eprintln!("Skipping test_newcmd_bare_template because `git` is not available.");
+            return Ok(());
+        }
+
+        let temp = tempdir()?;
+        let project_name = "test_bare_project";
+        let project_path = temp.path().join(project_name);
+
+        let cmd = NewCmd {
+            name: project_path.to_string_lossy().to_string(),
+            template: TemplateType { bare: true, evm: false },
+            version: "main".to_string(),
+        };
+
+        // Run the command
+        cmd.run()?;
+
+        // Check the project directory exists
+        assert!(project_path.exists());
+
+        // Check the .git directory is removed
+        assert!(!project_path.join(".git").exists());
+
+        // The "contracts" folder should be removed for a bare template
+        assert!(!project_path.join("contracts").exists());
+
+        // .gitmodules file should also be removed if it existed
+        assert!(!project_path.join(".gitmodules").exists());
+
+        Ok(())
+    }
+
+    /// Test that running the evm template successfully clones and leaves the `contracts` folder in
+    /// place.
+    #[test]
+    fn test_newcmd_evm_template() -> Result<()> {
+        if !is_program_in_path("git") {
+            eprintln!("Skipping test_newcmd_evm_template because `git` is not available.");
+            return Ok(());
+        }
+
+        let temp = tempdir()?;
+        let project_name = "test_evm_project";
+        let project_path = temp.path().join(project_name);
+
+        let cmd = NewCmd {
+            name: project_path.to_string_lossy().to_string(),
+            template: TemplateType { bare: false, evm: true },
+            version: "main".to_string(),
+        };
+
+        cmd.run()?;
+
+        // Check the project directory exists
+        assert!(project_path.exists());
+
+        // The "contracts" folder should be present for EVM template
+        assert!(project_path.join("contracts").exists());
+
+        // Ensure that .git was removed
+        assert!(!project_path.join(".git").exists());
+
+        Ok(())
+    }
+
+    /// Test that references to "alloy-sol" are removed from any Cargo.toml when using the bare
+    /// template. This exercises the logic in `remove_alloy_sol_from_cargo_tomls`.
+    #[test]
+    fn test_remove_alloy_sol_from_cargo_tomls() -> Result<()> {
+        if !is_program_in_path("git") {
+            eprintln!(
+                "Skipping test_remove_alloy_sol_from_cargo_tomls because `git` is not available."
+            );
+            return Ok(());
+        }
+
+        let temp = tempdir()?;
+        let project_name = "test_bare_alloy_sol_removal";
+        let project_path = temp.path().join(project_name);
+
+        let cmd = NewCmd {
+            name: project_path.to_string_lossy().to_string(),
+            template: TemplateType { bare: true, evm: false },
+            version: "main".to_string(),
+        };
+
+        cmd.run()?;
+
+        // If test passes, we expect no references to "alloy-sol" in any Cargo.toml
+        let cargo_toml_paths = find_cargo_toml_files(&project_path);
+        for path in cargo_toml_paths {
+            let contents = fs::read_to_string(&path)?;
+            assert!(!contents.contains("alloy-sol"), "Found 'alloy-sol' reference in {:?}", path);
+        }
+
+        Ok(())
+    }
+
+    /// A simple helper to recursively find Cargo.toml files.
+    fn find_cargo_toml_files(dir: &PathBuf) -> Vec<PathBuf> {
+        let mut cargo_tomls = Vec::new();
+        if dir.is_dir() {
+            if let Ok(entries) = fs::read_dir(dir) {
+                for entry in entries.flatten() {
+                    let path = entry.path();
+                    if path.is_dir() {
+                        cargo_tomls.extend(find_cargo_toml_files(&path));
+                    } else if path.file_name().map_or(false, |p| p == "Cargo.toml") {
+                        cargo_tomls.push(path);
+                    }
+                }
+            }
+        }
+        cargo_tomls
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
When creating a new bare project using `cargo prove new --bare`, EVM-related files and dependencies were still being included, which are unnecessary for projects not requiring EVM integration. 

This PR resolves issue: https://github.com/succinctlabs/sp1/issues/1839


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
- Added functionality to remove EVM-specific files and dependencies when creating a bare project:
  - Removes the `contracts` directory and `.gitmodules` file
  - Removes the EVM-specific script file (`evm.rs`)
  - Removes any `alloy-sol` references from all `Cargo.toml` files in the project
- Added tests to verify the new behavior:
  - Tests for bare template creation
  - Tests for EVM template creation
  - Tests to ensure `alloy-sol` references are properly removed

<img width="1092" alt="image" src="https://github.com/user-attachments/assets/07f19691-fe43-42d4-b740-4a38f04819d9" />


<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes