### PR TITLE
chore(core): re-ignore syntax errors to allow diagnostics to run

### DIFF
--- a/crates/core/machine/build.rs
+++ b/crates/core/machine/build.rs
@@ -133,9 +133,7 @@ mod sys {
                     }
                 }
             }
-            Err(cbindgen::Error::ParseSyntaxError { error, crate_name, src_path }) => {
-                panic!("{} {} {}", error, crate_name, src_path);
-            } // Ignore parse errors so rust-analyzer can run.
+            Err(cbindgen::Error::ParseSyntaxError { .. }) => {} // Ignore parse errors so rust-analyzer can run.
             Err(e) => panic!("{:?}", e),
         }
 


### PR DESCRIPTION
Gets rid of some old debugging code. The similar build script in recursion is already set up like this.