### PR TITLE
feat(sdk): Implement `IntoFuture` for `NetworkProveBuilder`

### DIFF
--- a/crates/sdk/src/network/prove.rs
+++ b/crates/sdk/src/network/prove.rs
@@ -15,6 +15,10 @@ use crate::{
 
 use super::proto::network::FulfillmentStrategy;
 
+use std::future::Future;
+use std::future::IntoFuture;
+use std::pin::Pin;
+
 /// A builder for creating a proof request to the network.
 pub struct NetworkProveBuilder<'a> {
     pub(crate) prover: &'a NetworkProver,
@@ -374,5 +378,15 @@ impl NetworkProveBuilder<'_> {
         sp1_dump(&pk.elf, &stdin);
 
         prover.prove_impl(pk, &stdin, mode, strategy, timeout, skip_simulation, cycle_limit).await
+    }
+}
+
+impl<'a> IntoFuture for NetworkProveBuilder<'a> {
+    type Output = Result<SP1ProofWithPublicValues>;
+
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send + 'a>>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        Box::pin(self.run_async())
     }
 }


### PR DESCRIPTION
Changes

```rust
        self.prover
            .prove(&self.pk, &stdin)
            .strategy(FulfillmentStrategy::Reserved)
            .skip_simulation(true)
            .plonk()
            .timeout(Duration::from_secs(PROOF_TIMEOUT_SECS))
            .run_async()
            .await
```

to 

```rust
        self.prover
            .prove(&self.pk, &stdin)
            .strategy(FulfillmentStrategy::Reserved)
            .skip_simulation(true)
            .plonk()
            .timeout(Duration::from_secs(PROOF_TIMEOUT_SECS))
            .await
```