### PR TITLE
feat: avoid panic when verify Groth16 and Plonk proofs

### DIFF
--- a/crates/verifier/src/constants.rs
+++ b/crates/verifier/src/constants.rs
@@ -8,6 +8,13 @@ pub(crate) const COMPRESSED_POSITIVE: u8 = 0b10 << 6;
 pub(crate) const COMPRESSED_NEGATIVE: u8 = 0b11 << 6;
 pub(crate) const COMPRESSED_INFINITY: u8 = 0b01 << 6;
 
+pub(crate) const VK_HASH_PREFIX_LENGTH: usize = 4;
+pub(crate) const GROTH16_PROOF_LENGTH: usize = 256;
+pub(crate) const PLONK_CLAIMED_VALUES_COUNT: usize = 5;
+pub(crate) const PLONK_CLAIMED_VALUES_OFFSET: usize = 384;
+pub(crate) const PLONK_Z_SHIFTED_OPENING_VALUE_OFFSET: usize = 96;
+pub(crate) const PLONK_Z_SHIFTED_OPENING_H_OFFSET: usize = 128;
+
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum CompressedPointFlag {
     Positive = COMPRESSED_POSITIVE as isize,

--- a/crates/verifier/src/groth16/converter.rs
+++ b/crates/verifier/src/groth16/converter.rs
@@ -5,6 +5,7 @@ use crate::{
         unchecked_compressed_x_to_g1_point, unchecked_compressed_x_to_g2_point,
         uncompressed_bytes_to_g1_point, uncompressed_bytes_to_g2_point,
     },
+    error::Error,
     groth16::{Groth16G1, Groth16G2, Groth16Proof, Groth16VerifyingKey},
 };
 
@@ -15,6 +16,10 @@ use super::error::Groth16Error;
 /// The byte slice is represented as 2 uncompressed g1 points, and one uncompressed g2 point,
 /// as outputted from Gnark.
 pub(crate) fn load_groth16_proof_from_bytes(buffer: &[u8]) -> Result<Groth16Proof, Groth16Error> {
+    if buffer.len() < 256 {
+        return Err(Groth16Error::GeneralError(Error::InvalidData));
+    }
+
     let ar = uncompressed_bytes_to_g1_point(&buffer[..64])?;
     let bs = uncompressed_bytes_to_g2_point(&buffer[64..192])?;
     let krs = uncompressed_bytes_to_g1_point(&buffer[192..256])?;

--- a/crates/verifier/src/groth16/converter.rs
+++ b/crates/verifier/src/groth16/converter.rs
@@ -1,6 +1,7 @@
 use alloc::vec::Vec;
 
 use crate::{
+    constants::GROTH16_PROOF_LENGTH,
     converter::{
         unchecked_compressed_x_to_g1_point, unchecked_compressed_x_to_g2_point,
         uncompressed_bytes_to_g1_point, uncompressed_bytes_to_g2_point,
@@ -16,7 +17,7 @@ use super::error::Groth16Error;
 /// The byte slice is represented as 2 uncompressed g1 points, and one uncompressed g2 point,
 /// as outputted from Gnark.
 pub(crate) fn load_groth16_proof_from_bytes(buffer: &[u8]) -> Result<Groth16Proof, Groth16Error> {
-    if buffer.len() < 256 {
+    if buffer.len() < GROTH16_PROOF_LENGTH {
         return Err(Groth16Error::GeneralError(Error::InvalidData));
     }
 

--- a/crates/verifier/src/groth16/mod.rs
+++ b/crates/verifier/src/groth16/mod.rs
@@ -47,6 +47,10 @@ impl Groth16Verifier {
         sp1_vkey_hash: &str,
         groth16_vk: &[u8],
     ) -> Result<(), Groth16Error> {
+        if proof.len() < 4 {
+            return Err(Groth16Error::GeneralError(Error::InvalidData));
+        }
+
         // Hash the vk and get the first 4 bytes.
         let groth16_vk_hash: [u8; 4] = Sha256::digest(groth16_vk)[..4]
             .try_into()
@@ -96,8 +100,8 @@ impl Groth16Verifier {
         public_inputs: &[[u8; 32]],
         groth16_vk: &[u8],
     ) -> Result<(), Groth16Error> {
-        let proof = load_groth16_proof_from_bytes(proof).unwrap();
-        let groth16_vk = load_groth16_verifying_key_from_bytes(groth16_vk).unwrap();
+        let proof = load_groth16_proof_from_bytes(proof)?;
+        let groth16_vk = load_groth16_verifying_key_from_bytes(groth16_vk)?;
 
         let public_inputs =
             public_inputs.iter().map(|input| Fr::from_slice(input).unwrap()).collect::<Vec<_>>();

--- a/crates/verifier/src/plonk/converter.rs
+++ b/crates/verifier/src/plonk/converter.rs
@@ -118,6 +118,12 @@ pub(crate) fn load_plonk_proof_from_bytes(
     buffer: &[u8],
     num_bsb22_commitments: usize,
 ) -> Result<PlonkProof, PlonkError> {
+    if buffer.len()
+        < 384 + 5 * 32 + 96 + 128 + num_bsb22_commitments * 32 + num_bsb22_commitments * 64
+    {
+        return Err(PlonkError::GeneralError(Error::InvalidData));
+    }
+
     let lro0 = uncompressed_bytes_to_g1_point(&buffer[..64])?;
     let lro1 = uncompressed_bytes_to_g1_point(&buffer[64..128])?;
     let lro2 = uncompressed_bytes_to_g1_point(&buffer[128..192])?;

--- a/crates/verifier/src/plonk/mod.rs
+++ b/crates/verifier/src/plonk/mod.rs
@@ -54,6 +54,10 @@ impl PlonkVerifier {
         sp1_vkey_hash: &str,
         plonk_vk: &[u8],
     ) -> Result<(), PlonkError> {
+        if proof.len() < 4 {
+            return Err(PlonkError::GeneralError(Error::InvalidData));
+        }
+
         // Hash the vk and get the first 4 bytes.
         let plonk_vk_hash: [u8; 4] = Sha256::digest(plonk_vk)[..4]
             .try_into()

--- a/crates/verifier/src/plonk/mod.rs
+++ b/crates/verifier/src/plonk/mod.rs
@@ -22,7 +22,9 @@ use bn::Fr;
 use error::PlonkError;
 use sha2::{Digest, Sha256};
 
-use crate::{decode_sp1_vkey_hash, error::Error, hash_public_inputs};
+use crate::{
+    constants::VK_HASH_PREFIX_LENGTH, decode_sp1_vkey_hash, error::Error, hash_public_inputs,
+};
 /// A verifier for Plonk zero-knowledge proofs.
 #[derive(Debug)]
 pub struct PlonkVerifier;
@@ -54,12 +56,12 @@ impl PlonkVerifier {
         sp1_vkey_hash: &str,
         plonk_vk: &[u8],
     ) -> Result<(), PlonkError> {
-        if proof.len() < 4 {
+        if proof.len() < VK_HASH_PREFIX_LENGTH {
             return Err(PlonkError::GeneralError(Error::InvalidData));
         }
 
         // Hash the vk and get the first 4 bytes.
-        let plonk_vk_hash: [u8; 4] = Sha256::digest(plonk_vk)[..4]
+        let plonk_vk_hash: [u8; 4] = Sha256::digest(plonk_vk)[..VK_HASH_PREFIX_LENGTH]
             .try_into()
             .map_err(|_| PlonkError::GeneralError(Error::InvalidData))?;
 
@@ -68,14 +70,14 @@ impl PlonkVerifier {
         //
         // SP1 prepends the raw Plonk proof with the first 4 bytes of the plonk vkey to
         // facilitate this check.
-        if plonk_vk_hash != proof[..4] {
+        if plonk_vk_hash != proof[..VK_HASH_PREFIX_LENGTH] {
             return Err(PlonkError::PlonkVkeyHashMismatch);
         }
 
         let sp1_vkey_hash = decode_sp1_vkey_hash(sp1_vkey_hash)?;
 
         Self::verify_gnark_proof(
-            &proof[4..],
+            &proof[VK_HASH_PREFIX_LENGTH..],
             &[sp1_vkey_hash, hash_public_inputs(sp1_public_inputs)],
             plonk_vk,
         )

--- a/crates/verifier/src/tests.rs
+++ b/crates/verifier/src/tests.rs
@@ -2,6 +2,8 @@ use serial_test::serial;
 use sp1_sdk::{install::try_install_circuit_artifacts, HashableKey, ProverClient, SP1Stdin};
 use test_artifacts::FIBONACCI_ELF;
 
+use crate::{error::Error, Groth16Error, PlonkError};
+
 #[serial]
 #[test]
 fn test_verify_groth16() {
@@ -54,6 +56,52 @@ fn test_verify_groth16() {
 
 #[serial]
 #[test]
+fn test_verify_invalid_groth16() {
+    // Set up the pk and vk.
+    let client = ProverClient::from_env();
+    let (pk, vk) = client.setup(FIBONACCI_ELF);
+
+    // Generate the Groth16 proof.
+    let sp1_proof_with_public_values = client.prove(&pk, &SP1Stdin::new()).groth16().run().unwrap();
+
+    // Extract the proof and public inputs.
+    let proof = sp1_proof_with_public_values.bytes();
+    let public_inputs = sp1_proof_with_public_values.public_values.to_vec();
+
+    // Get the vkey hash.
+    let vkey_hash = vk.bytes32();
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "ark")] {
+            use ark_bn254::Bn254;
+            use ark_groth16::{r1cs_to_qap::LibsnarkReduction, Groth16};
+            use crate::{
+                decode_sp1_vkey_hash, hash_public_inputs, load_ark_groth16_verifying_key_from_bytes,
+                load_ark_proof_from_bytes, load_ark_public_inputs_from_bytes,
+            };
+            let ark_proof = load_ark_proof_from_bytes(&proof[4..]).unwrap();
+            let ark_vkey = load_ark_groth16_verifying_key_from_bytes(&crate::GROTH16_VK_BYTES).unwrap();
+
+            let ark_public_inputs = load_ark_public_inputs_from_bytes(
+                &decode_sp1_vkey_hash(&vkey_hash).unwrap(),
+                &hash_public_inputs(&public_inputs),
+            );
+            Groth16::<Bn254, LibsnarkReduction>::verify_proof(&ark_vkey.into(), &ark_proof, &ark_public_inputs)
+            .unwrap();
+        }
+    }
+
+    let result = crate::Groth16Verifier::verify(
+        &proof[..1], // Invalid proof (missing the last byte)
+        &public_inputs,
+        &vkey_hash,
+        &crate::GROTH16_VK_BYTES,
+    );
+
+    assert!(matches!(result, Err(Groth16Error::GeneralError(Error::InvalidData))));
+}
+
+#[serial]
+#[test]
 fn test_verify_plonk() {
     const PLONK_ELF: &[u8] = include_bytes!("../guest-verify-programs/plonk_verify");
 
@@ -81,6 +129,33 @@ fn test_verify_plonk() {
     stdin.write(&vkey_hash);
 
     let _ = client.execute(PLONK_ELF, &stdin).run().unwrap();
+}
+
+#[serial]
+#[test]
+fn test_verify_invalid_plonk() {
+    // Set up the pk and vk.
+    let client = ProverClient::from_env();
+    let (pk, vk) = client.setup(FIBONACCI_ELF);
+
+    // Generate the Plonk proof.
+    let sp1_proof_with_public_values = client.prove(&pk, &SP1Stdin::new()).plonk().run().unwrap();
+
+    // Extract the proof and public inputs.
+    let proof = sp1_proof_with_public_values.bytes();
+    let public_inputs = sp1_proof_with_public_values.public_values.to_vec();
+
+    // Get the vkey hash.
+    let vkey_hash = vk.bytes32();
+
+    let result = crate::PlonkVerifier::verify(
+        &proof[..1], // Invalid proof (missing the last byte)
+        &public_inputs,
+        &vkey_hash,
+        &crate::PLONK_VK_BYTES,
+    );
+
+    assert!(matches!(result, Err(PlonkError::GeneralError(Error::InvalidData))));
 }
 
 #[serial]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

On sp1-verifier, Groth16Verifier and PlonkVerifier, the verify function directly slices arrays that can cause panic. 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Check the slices length and return an `InvalidData` error.

Closes #1920

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
