### PR TITLE
docs: Add GitHub token usage example for sp1up

### DIFF
--- a/book/versioned_docs/version-3.4.0/getting-started/install.md
+++ b/book/versioned_docs/version-3.4.0/getting-started/install.md
@@ -57,6 +57,12 @@ If you experience [rate-limiting](https://docs.github.com/en/rest/using-the-rest
 
 <!-- TODO: We should add an example command here -->
 
+```bash
+sp1up --token YOUR_GITHUB_TOKEN
+```
+
+Note: Replace `YOUR_GITHUB_TOKEN` with your actual GitHub Personal Access Token.
+
 #### Unsupported OS Architectures
 
 Currently our prebuilt binaries are built on Ubuntu 20.04 (22.04 on ARM) and macOS. If your OS uses an older GLIBC version, it's possible these may not work and you will need to [build the toolchain from source](#option-2-building-from-source).

--- a/book/versioned_docs/version-4.0.0/getting-started/install.md
+++ b/book/versioned_docs/version-4.0.0/getting-started/install.md
@@ -57,6 +57,12 @@ If you experience [rate-limiting](https://docs.github.com/en/rest/using-the-rest
 
 <!-- TODO: We should add an example command here -->
 
+```bash
+sp1up --token YOUR_GITHUB_TOKEN
+```
+
+Note: Replace `YOUR_GITHUB_TOKEN` with your actual GitHub Personal Access Token.
+
 #### Unsupported OS Architectures
 
 Currently our prebuilt binaries are built on Ubuntu 20.04 (22.04 on ARM) and macOS. If your OS uses an older GLIBC version, it's possible these may not work and you will need to [build the toolchain from source](#option-2-building-from-source).


### PR DESCRIPTION
- Adds example command for sp1up --token flag in installation docs
- Updates both v3.4.0 and v4.0.0 documentation
- Resolves TODO comment in rate-limiting section