### PR TITLE
feat: give access to used memory in the zkvm

### DIFF
--- a/crates/zkvm/entrypoint/src/syscalls/memory.rs
+++ b/crates/zkvm/entrypoint/src/syscalls/memory.rs
@@ -15,6 +15,10 @@
 // Memory addresses must be lower than BabyBear prime.
 pub const MAX_MEMORY: usize = 0x78000000;
 
+// Pointer to next heap address to use, or 0 if the heap has not yet been
+// initialized.
+static mut HEAP_POS: usize = 0;
+
 /// Allocate memory aligned to the given alignment.
 ///
 /// Only available when the `bump` feature is enabled.
@@ -26,10 +30,6 @@ pub unsafe extern "C" fn sys_alloc_aligned(bytes: usize, align: usize) -> *mut u
         // https://lld.llvm.org/ELF/linker_script.html#sections-command
         static _end: u8;
     }
-
-    // Pointer to next heap address to use, or 0 if the heap has not yet been
-    // initialized.
-    static mut HEAP_POS: usize = 0;
 
     // SAFETY: Single threaded, so nothing else can touch this while we're working.
     let mut heap_pos = unsafe { HEAP_POS };
@@ -52,4 +52,10 @@ pub unsafe extern "C" fn sys_alloc_aligned(bytes: usize, align: usize) -> *mut u
 
     unsafe { HEAP_POS = heap_pos };
     ptr
+}
+
+/// Used memory in bytes.
+#[cfg(feature = "bump")]
+pub fn used_memory() -> usize {
+    unsafe { HEAP_POS }
 }

--- a/crates/zkvm/entrypoint/src/syscalls/memory.rs
+++ b/crates/zkvm/entrypoint/src/syscalls/memory.rs
@@ -17,6 +17,7 @@ pub const MAX_MEMORY: usize = 0x78000000;
 
 // Pointer to next heap address to use, or 0 if the heap has not yet been
 // initialized.
+#[cfg(feature = "bump")]
 static mut HEAP_POS: usize = 0;
 
 /// Allocate memory aligned to the given alignment.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

For benchmarks it would be useful to have a way to access the memory usage in the zkvm, when using the bump global allocator

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Adding a `used_memory()` function that returns the used memory.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes