### PR TITLE
fix: Incorrect cargo::rerun-if-changed directive syntax

### DIFF
--- a/crates/build/src/utils.rs
+++ b/crates/build/src/utils.rs
@@ -20,7 +20,7 @@ pub(crate) fn cargo_rerun_if_changed(metadata: &Metadata, program_dir: &Path) {
     ];
     for dir in dirs {
         if dir.exists() {
-            println!("cargo::rerun-if-changed={}", dir.canonicalize().unwrap().display());
+            println!("cargo:rerun-if-changed={}", dir.canonicalize().unwrap().display());
         }
     }
 


### PR DESCRIPTION
## Motivation

While reviewing the build script, I noticed an inconsistency in the usage of the `cargo:rerun-if-changed` directive. In one instance, it was incorrectly written as `cargo::rerun-if-changed` (with a double colon), while in other parts of the code the correct single colon (`:`) was used.

This inconsistency could cause build directives to be ignored, leading to unexpected behaviors during the build process.

## Solution

- Replaced `cargo::rerun-if-changed` with the correct `cargo:rerun-if-changed` directive.
- Ensured consistency across all instances in the codebase.

## Additional Notes

- The usage of the double colon (`::`) could prevent Cargo from correctly recognizing the directive, potentially leading to cache misses or unnecessary rebuilds.
- This change ensures all `cargo:rerun-if-changed` statements are consistent and follow Cargo's expected syntax.


