### PR TITLE
fix: Small bug in docs website (couldn't find the docs repo) 

### DIFF
--- a/book/docusaurus.config.ts
+++ b/book/docusaurus.config.ts
@@ -39,6 +39,7 @@ const config: Config = {
       ({
         docs: {
           onlyIncludeVersions: ["4.0.0", "3.4.0"],
+        editUrl: 'https://github.com/succinctlabs/sp1/tree/main/book/',
         },
         blog: false,
         pages: {},


### PR DESCRIPTION
Solved issue #2088 . This fixes the incorrect redirection for the _Edit this page_ link in the Succinct docs repo.
