### PR TITLE
chore(cuda): cleanup stdio piping

### DIFF
--- a/crates/cuda/src/lib.rs
+++ b/crates/cuda/src/lib.rs
@@ -1,7 +1,6 @@
 use std::{
     error::Error as StdError,
     future::Future,
-    io::{BufReader, Read, Write},
     process::{Command, Stdio},
     sync::{
         atomic::{AtomicBool, Ordering},


### PR DESCRIPTION
`Stdio::inherit` pipes the selected `io` to the parent process, this PR takes advantage of this, rather than manually spawning new threads to do the piping.