### PR TITLE
fix: typo in variable name 'sycall_event' to 'syscall_event'

### DIFF
--- a/crates/core/executor/src/syscalls/precompiles/uint256.rs
+++ b/crates/core/executor/src/syscalls/precompiles/uint256.rs
@@ -78,7 +78,7 @@ impl Syscall for Uint256MulSyscall {
             modulus_memory_records,
             local_mem_access: rt.postprocess(),
         });
-        let sycall_event =
+        let syscall_event =
             rt.rt.syscall_event(clk, None, None, syscall_code, arg1, arg2, rt.next_pc);
         rt.add_precompile_event(syscall_code, sycall_event, event);
 


### PR DESCRIPTION
This PR corrects a typo in the variable name from 'sycall_event' to 'syscall_event' . 
The change ensures consistency and prevents potential issues related to undefined variables.