### PR TITLE
v4.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5785,7 +5785,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-build"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cli"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -5825,7 +5825,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -5852,7 +5852,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sp1-curves",
- "sp1-primitives 4.1.0",
+ "sp1-primitives 4.1.1",
  "sp1-stark",
  "sp1-zkvm",
  "strum",
@@ -5868,7 +5868,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-machine"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "bincode",
  "cbindgen",
@@ -5908,7 +5908,7 @@ dependencies = [
  "sp1-core-executor",
  "sp1-curves",
  "sp1-derive",
- "sp1-primitives 4.1.0",
+ "sp1-primitives 4.1.1",
  "sp1-stark",
  "sp1-zkvm",
  "static_assertions",
@@ -5927,7 +5927,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cuda"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "bincode",
  "ctrlc",
@@ -5945,7 +5945,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -5960,14 +5960,14 @@ dependencies = [
  "rug",
  "serde",
  "snowbridge-amcl",
- "sp1-primitives 4.1.0",
+ "sp1-primitives 4.1.1",
  "sp1-stark",
  "typenum",
 ]
 
 [[package]]
 name = "sp1-derive"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -5975,7 +5975,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-eval"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -5993,7 +5993,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-helper"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "sp1-build",
 ]
@@ -6011,17 +6011,17 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "bincode",
  "elliptic-curve",
  "serde",
- "sp1-primitives 4.1.0",
+ "sp1-primitives 4.1.1",
 ]
 
 [[package]]
 name = "sp1-perf"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "bincode",
  "clap",
@@ -6059,7 +6059,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "bincode",
  "hex",
@@ -6075,7 +6075,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6102,7 +6102,7 @@ dependencies = [
  "sha2 0.10.8",
  "sp1-core-executor",
  "sp1-core-machine",
- "sp1-primitives 4.1.0",
+ "sp1-primitives 4.1.1",
  "sp1-recursion-circuit",
  "sp1-recursion-compiler",
  "sp1-recursion-core",
@@ -6117,7 +6117,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-circuit"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "ff 0.13.0",
  "hashbrown 0.14.5",
@@ -6143,7 +6143,7 @@ dependencies = [
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-derive",
- "sp1-primitives 4.1.0",
+ "sp1-primitives 4.1.1",
  "sp1-recursion-compiler",
  "sp1-recursion-core",
  "sp1-recursion-gnark-ffi",
@@ -6155,7 +6155,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-compiler"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "backtrace",
  "criterion",
@@ -6170,7 +6170,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "sp1-core-machine",
- "sp1-primitives 4.1.0",
+ "sp1-primitives 4.1.1",
  "sp1-recursion-core",
  "sp1-recursion-derive",
  "sp1-stark",
@@ -6180,7 +6180,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-core"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "backtrace",
  "cbindgen",
@@ -6212,7 +6212,7 @@ dependencies = [
  "smallvec",
  "sp1-core-machine",
  "sp1-derive",
- "sp1-primitives 4.1.0",
+ "sp1-primitives 4.1.1",
  "sp1-stark",
  "static_assertions",
  "thiserror 1.0.69",
@@ -6223,7 +6223,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-derive"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -6231,7 +6231,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-cli"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "bincode",
  "clap",
@@ -6240,7 +6240,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-ffi"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6264,7 +6264,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-sdk"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -6294,7 +6294,7 @@ dependencies = [
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-cuda",
- "sp1-primitives 4.1.0",
+ "sp1-primitives 4.1.1",
  "sp1-prover",
  "sp1-stark",
  "strum",
@@ -6311,7 +6311,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-stark"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "arrayref",
  "hashbrown 0.14.5",
@@ -6335,7 +6335,7 @@ dependencies = [
  "rayon-scan",
  "serde",
  "sp1-derive",
- "sp1-primitives 4.1.0",
+ "sp1-primitives 4.1.1",
  "sp1-zkvm",
  "strum",
  "strum_macros",
@@ -6345,7 +6345,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-verifier"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -6367,7 +6367,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -6379,8 +6379,8 @@ dependencies = [
  "p3-field",
  "rand 0.8.5",
  "sha2 0.10.8",
- "sp1-lib 4.1.0",
- "sp1-primitives 4.1.0",
+ "sp1-lib 4.1.1",
+ "sp1-primitives 4.1.1",
 ]
 
 [[package]]
@@ -6718,7 +6718,7 @@ dependencies = [
 
 [[package]]
 name = "test-artifacts"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "sp1-build",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "4.1.0"
+version = "4.1.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 rust-version = "1.79"
@@ -51,26 +51,26 @@ debug-assertions = true
 
 [workspace.dependencies]
 # sp1
-sp1-build = { path = "crates/build", version = "4.1.0" }
-sp1-cli = { path = "crates/cli", version = "4.1.0", default-features = false }
-sp1-core-machine = { path = "crates/core/machine", version = "4.1.0" }
-sp1-core-executor = { path = "crates/core/executor", version = "4.1.0" }
-sp1-curves = { path = "crates/curves", version = "4.1.0" }
-sp1-derive = { path = "crates/derive", version = "4.1.0" }
-sp1-eval = { path = "crates/eval", version = "4.1.0" }
-sp1-helper = { path = "crates/helper", version = "4.1.0", default-features = false }
-sp1-primitives = { path = "crates/primitives", version = "4.1.0" }
-sp1-prover = { path = "crates/prover", version = "4.1.0" }
-sp1-recursion-compiler = { path = "crates/recursion/compiler", version = "4.1.0" }
-sp1-recursion-core = { path = "crates/recursion/core", version = "4.1.0" }
-sp1-recursion-derive = { path = "crates/recursion/derive", version = "4.1.0", default-features = false }
-sp1-recursion-gnark-ffi = { path = "crates/recursion/gnark-ffi", version = "4.1.0", default-features = false }
-sp1-recursion-circuit = { path = "crates/recursion/circuit", version = "4.1.0", default-features = false }
-sp1-sdk = { path = "crates/sdk", version = "4.1.0" }
-sp1-cuda = { path = "crates/cuda", version = "4.1.0" }
-sp1-stark = { path = "crates/stark", version = "4.1.0" }
-sp1-lib = { path = "crates/zkvm/lib", version = "4.1.0", default-features = false }
-sp1-zkvm = { path = "crates/zkvm/entrypoint", version = "4.1.0", default-features = false }
+sp1-build = { path = "crates/build", version = "4.1.1" }
+sp1-cli = { path = "crates/cli", version = "4.1.1", default-features = false }
+sp1-core-machine = { path = "crates/core/machine", version = "4.1.1" }
+sp1-core-executor = { path = "crates/core/executor", version = "4.1.1" }
+sp1-curves = { path = "crates/curves", version = "4.1.1" }
+sp1-derive = { path = "crates/derive", version = "4.1.1" }
+sp1-eval = { path = "crates/eval", version = "4.1.1" }
+sp1-helper = { path = "crates/helper", version = "4.1.1", default-features = false }
+sp1-primitives = { path = "crates/primitives", version = "4.1.1" }
+sp1-prover = { path = "crates/prover", version = "4.1.1" }
+sp1-recursion-compiler = { path = "crates/recursion/compiler", version = "4.1.1" }
+sp1-recursion-core = { path = "crates/recursion/core", version = "4.1.1" }
+sp1-recursion-derive = { path = "crates/recursion/derive", version = "4.1.1", default-features = false }
+sp1-recursion-gnark-ffi = { path = "crates/recursion/gnark-ffi", version = "4.1.1", default-features = false }
+sp1-recursion-circuit = { path = "crates/recursion/circuit", version = "4.1.1", default-features = false }
+sp1-sdk = { path = "crates/sdk", version = "4.1.1" }
+sp1-cuda = { path = "crates/cuda", version = "4.1.1" }
+sp1-stark = { path = "crates/stark", version = "4.1.1" }
+sp1-lib = { path = "crates/zkvm/lib", version = "4.1.1", default-features = false }
+sp1-zkvm = { path = "crates/zkvm/entrypoint", version = "4.1.1", default-features = false }
 
 # For testing.
 test-artifacts = { path = "crates/test-artifacts" }

--- a/crates/test-artifacts/programs/Cargo.lock
+++ b/crates/test-artifacts/programs/Cargo.lock
@@ -328,7 +328,7 @@ version = "1.1.0"
 dependencies = [
  "common-test-utils",
  "sp1-curves",
- "sp1-lib 4.1.0",
+ "sp1-lib 4.1.1",
  "sp1-zkvm",
 ]
 
@@ -371,7 +371,7 @@ name = "bls12381-mul-test"
 version = "1.1.0"
 dependencies = [
  "sp1-derive",
- "sp1-lib 4.1.0",
+ "sp1-lib 4.1.1",
  "sp1-zkvm",
 ]
 
@@ -381,7 +381,7 @@ version = "1.1.0"
 dependencies = [
  "common-test-utils",
  "sp1-curves",
- "sp1-lib 4.1.0",
+ "sp1-lib 4.1.1",
  "sp1-zkvm",
 ]
 
@@ -424,7 +424,7 @@ name = "bn254-mul-test"
 version = "1.1.0"
 dependencies = [
  "sp1-derive",
- "sp1-lib 4.1.0",
+ "sp1-lib 4.1.1",
  "sp1-zkvm",
 ]
 
@@ -494,7 +494,7 @@ name = "common-test-utils"
 version = "1.1.0"
 dependencies = [
  "num-bigint",
- "sp1-lib 4.1.0",
+ "sp1-lib 4.1.1",
 ]
 
 [[package]]
@@ -2197,7 +2197,7 @@ version = "1.1.0"
 dependencies = [
  "common-test-utils",
  "sp1-curves",
- "sp1-lib 4.1.0",
+ "sp1-lib 4.1.1",
  "sp1-zkvm",
 ]
 
@@ -2233,7 +2233,7 @@ dependencies = [
  "num",
  "p256",
  "sp1-curves",
- "sp1-lib 4.1.0",
+ "sp1-lib 4.1.1",
  "sp1-zkvm",
 ]
 
@@ -2254,7 +2254,7 @@ dependencies = [
  "num",
  "p256",
  "sp1-curves",
- "sp1-lib 4.1.0",
+ "sp1-lib 4.1.1",
  "sp1-zkvm",
 ]
 
@@ -2459,7 +2459,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -2479,7 +2479,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-derive"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -2511,7 +2511,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "bincode",
  "elliptic-curve",
@@ -2521,7 +2521,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "bincode",
  "hex",
@@ -2537,7 +2537,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-stark"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "arrayref",
  "hashbrown 0.14.5",
@@ -2570,7 +2570,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "cfg-if",
  "getrandom",
@@ -2580,7 +2580,7 @@ dependencies = [
  "p3-field",
  "rand",
  "sha2 0.10.8",
- "sp1-lib 4.1.0",
+ "sp1-lib 4.1.1",
  "sp1-primitives",
 ]
 

--- a/patch-testing/Cargo.lock
+++ b/patch-testing/Cargo.lock
@@ -3930,7 +3930,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-build"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -3941,7 +3941,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -3978,7 +3978,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-machine"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "bincode",
  "cbindgen",
@@ -4033,7 +4033,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cuda"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "bincode",
  "ctrlc",
@@ -4048,7 +4048,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -4068,7 +4068,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-derive"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -4076,7 +4076,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "bincode",
  "elliptic-curve",
@@ -4086,7 +4086,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "bincode",
  "hex",
@@ -4102,7 +4102,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4143,7 +4143,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-circuit"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "hashbrown 0.14.5",
  "itertools 0.13.0",
@@ -4176,7 +4176,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-compiler"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "backtrace",
  "itertools 0.13.0",
@@ -4196,7 +4196,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-core"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "backtrace",
  "cbindgen",
@@ -4237,7 +4237,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-derive"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -4245,7 +4245,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-ffi"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4269,7 +4269,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-sdk"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4303,7 +4303,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-stark"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "arrayref",
  "hashbrown 0.14.5",
@@ -4361,7 +4361,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "cfg-if",
  "getrandom 0.2.15",


### PR DESCRIPTION
Bumps version to 4.1.1, importantly includes Rust 1.85 as the new default toolchain.