### PR TITLE
feat: track invocation count

### DIFF
--- a/crates/core/executor/src/report.rs
+++ b/crates/core/executor/src/report.rs
@@ -17,7 +17,7 @@ pub struct ExecutionReport {
     pub syscall_counts: Box<EnumMap<SyscallCode, u64>>,
     /// The cycle tracker counts.
     pub cycle_tracker: HashMap<String, u64>,
-    /// The invocation tracker counts.
+    /// Tracker for the number of `cycle-tracker-report-*` invocations for a specific label.
     pub invocation_tracker: HashMap<String, u64>,
     /// The unique memory address counts.
     pub touched_memory_addresses: u64,

--- a/crates/core/executor/src/report.rs
+++ b/crates/core/executor/src/report.rs
@@ -17,6 +17,8 @@ pub struct ExecutionReport {
     pub syscall_counts: Box<EnumMap<SyscallCode, u64>>,
     /// The cycle tracker counts.
     pub cycle_tracker: HashMap<String, u64>,
+    /// The invocation tracker counts.
+    pub invocation_tracker: HashMap<String, u64>,
     /// The unique memory address counts.
     pub touched_memory_addresses: u64,
     /// The gas, if it was calculated.

--- a/crates/core/executor/src/syscalls/write.rs
+++ b/crates/core/executor/src/syscalls/write.rs
@@ -168,6 +168,11 @@ fn handle_cycle_tracker_command(rt: &mut Executor, command: CycleTrackerCommand)
                     .entry(name.to_string())
                     .and_modify(|cycles| *cycles += total_cycles)
                     .or_insert(total_cycles);
+                rt.report
+                    .invocation_tracker
+                    .entry(name.to_string())
+                    .and_modify(|invocations| *invocations += 1)
+                    .or_insert(1);
             }
         }
     }

--- a/crates/core/executor/src/syscalls/write.rs
+++ b/crates/core/executor/src/syscalls/write.rs
@@ -161,7 +161,7 @@ fn handle_cycle_tracker_command(rt: &mut Executor, command: CycleTrackerCommand)
         }
         CycleTrackerCommand::ReportEnd(name) => {
             // Attempt to end the cycle tracker and accumulate the total cycles in the fn_name's
-            // entry in the ExecutionReport.
+            // entry in the ExecutionReport. Also increment the number of invocations.
             if let Some(total_cycles) = end_cycle_tracker(rt, &name) {
                 rt.report
                     .cycle_tracker


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Sometimes, when using report annotations, we need to know the invocation count. My use case was to be able to track the average precompiles and opcodes cycles count.

## Solution

Adding a `invocation_tracker` map that increment by 1 for the given label each times the `ReportEnd` command is called.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes