### PR TITLE
fix(ci): rust toolchain override to `stable`

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -77,15 +77,16 @@ runs:
           ~/.cargo/git/db/
           target/
           ~/.rustup/
-        key: rust-1.81.0-${{ hashFiles('**/Cargo.toml') }}-x
-        restore-keys: rust-1.81.0-
+        key: rust-
+        restore-keys: rust-
 
     - name: Setup toolchain
       id: rustc-toolchain
       shell: bash
       run: |
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.81.0 -y
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
         . "$HOME/.cargo/env" 
+        rustup show
         echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
     # install pkg-config and openssl

--- a/.github/workflows/docker-gnark.yml
+++ b/.github/workflows/docker-gnark.yml
@@ -51,7 +51,6 @@ jobs:
           RUST_BACKTRACE: 1   
         with:
           command: test
-          toolchain: 1.81.0
           args: --release -p sp1-prover -- --exact tests::test_e2e --nocapture
 
       - name: Make sure the contracts were modified

--- a/.github/workflows/executor-suite.yml
+++ b/.github/workflows/executor-suite.yml
@@ -64,7 +64,6 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: run
-          toolchain: 1.81.0
           args: --release -p sp1-perf --bin sp1-perf-executor -- --program workdir/program.bin --stdin workdir/stdin.bin --executor-mode simple
         env:
           RUST_LOG: info
@@ -117,7 +116,6 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: run
-          toolchain: 1.81.0
           args: --release -p sp1-perf --bin sp1-perf-executor -- --program workdir/program.bin --stdin workdir/stdin.bin --executor-mode checkpoint
         env:
           RUST_LOG: info
@@ -170,7 +168,6 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: run
-          toolchain: 1.81.0
           args: --release -p sp1-perf --bin sp1-perf-executor -- --program workdir/program.bin --stdin workdir/stdin.bin --executor-mode trace
         env:
           RUST_LOG: info

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,6 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          toolchain: 1.81.0
           args: --release -p sp1-sdk --features native-gnark -- test_e2e_groth16_plonk --nocapture
         env:
           RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0 -C target-cpu=native
@@ -93,7 +92,6 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          toolchain: 1.81.0
           args: --release -p sp1-sdk -- test_e2e_prove_groth16 --nocapture
         env:
           RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0 -C target-cpu=native
@@ -134,7 +132,6 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          toolchain: 1.81.0
           args: --release -p sp1-sdk --features native-gnark -- test_e2e_prove_plonk --nocapture
         env:
           RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0 -C target-cpu=native
@@ -175,7 +172,6 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          toolchain: 1.81.0
           args: --release -p sp1-sdk -- test_e2e_prove_plonk --nocapture
         env:
           RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0 -C target-cpu=native

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -53,14 +53,12 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: check
-          toolchain: 1.81.0
           args: --all-targets --all-features --tests
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1
         with:
           command: test
-          toolchain: 1.81.0
           args: --release --features native-gnark --workspace --exclude sp1-verifier
         env:
           RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0 -C target-cpu=native
@@ -99,14 +97,12 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: check
-          toolchain: 1.81.0
           args: --all-targets --all-features --tests
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1
         with:
           command: test
-          toolchain: 1.81.0
           args: --release --features native-gnark --workspace --exclude sp1-verifier
         env:
           RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0 -C target-cpu=native
@@ -145,14 +141,12 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: check
-          toolchain: 1.81.0
           args: --all-targets --all-features --tests
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1
         with:
           command: test
-          toolchain: 1.81.0
           args: --release --package sp1-verifier
         env:
           RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0 -C target-cpu=native

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,11 +113,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install nightly toolchain
+      - name: Install rust toolchain
         id: rustc-toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.81.0
           profile: minimal
           override: true
           targets: ${{ matrix.target }}

--- a/.github/workflows/suite.yml
+++ b/.github/workflows/suite.yml
@@ -74,7 +74,6 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: run
-          toolchain: 1.81.0
           args: --release -p sp1-perf -- --program workdir/program.bin --stdin workdir/stdin.bin --mode cpu
         env:
           RUST_LOG: info
@@ -136,7 +135,6 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: run
-          toolchain: 1.81.0
           args: --release -p sp1-perf -- --program workdir/program.bin --stdin workdir/stdin.bin --mode cuda
         env:
           RUST_LOG: debug
@@ -186,7 +184,6 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clean
-          toolchain: 1.81.0
 
       - name: Install SP1 toolchain from repo
         run: |
@@ -199,7 +196,6 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: run
-          toolchain: 1.81.0
           args: --release -p sp1-perf --features "native-gnark" -- --program workdir/program.bin --stdin workdir/stdin.bin --mode network
         env:
           RUST_LOG: info

--- a/Dockerfile.gnark-ffi
+++ b/Dockerfile.gnark-ffi
@@ -12,7 +12,8 @@ ENV PATH="/usr/local/go/bin:$PATH"
 WORKDIR /sp1
 
 # Install Rust toolchain
-COPY ./rust-toolchain /sp1/rust-toolchain
+COPY ./rust-toolchain.toml /sp1/rust-toolchain.toml
+RUN rustup install stable
 RUN rustup show
 
 # Copy repo

--- a/crates/core/executor/src/executor.rs
+++ b/crates/core/executor/src/executor.rs
@@ -2241,6 +2241,7 @@ mod tests {
 
     /// Runtime needs to be Send so we can use it across async calls.
     fn _assert_runtime_is_send() {
+        #[allow(clippy::used_underscore_items)]
         _assert_send::<Executor>();
     }
 

--- a/crates/core/executor/src/lib.rs
+++ b/crates/core/executor/src/lib.rs
@@ -59,6 +59,7 @@ pub use report::*;
 pub use state::*;
 pub use utils::*;
 
+/// Used for testing.
 #[cfg(test)]
 pub mod programs {
     #[allow(dead_code)]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.82.0"
+channel = "stable"
 components = ["llvm-tools", "rustc-dev"]


### PR DESCRIPTION
I believe that `rustup` used to install the override by default via any `rustup` command, however it is now throwing errors that the override toolchain is not installed!