### PR TITLE
docs: update CONTRIBUTING with corrected links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ If you have reviewed existing documentation and still have questions, or you are
 *opening a discussion**. This repository comes with a discussions board where you can also ask for help. Click the "
 Discussions" tab at the top.
 
-As SP1 is still in heavy development, the documentation can be a bit scattered. The [SP1 Book](https://succinctlabs.github.io/sp1/) is our
+As SP1 is still in heavy development, the documentation can be a bit scattered. The [SP1 Book](https://docs.succinct.xyz/docs/sp1/introduction) is our
 current best-effort attempt at keeping up-to-date information.
 
 ### Submitting a bug report
@@ -175,7 +175,7 @@ tag in the commits.
 
 _Adapted from the [Reth contributing guide](https://raw.githubusercontent.com/paradigmxyz/reth/main/CONTRIBUTING.md)_.
 
-[rust-coc]: https://github.com/rust-lang/rust/blob/master/CODE_OF_CONDUCT.md
+[rust-coc]: https://www.rust-lang.org/policies/code-of-conduct
 
 [coc-header]: #code-of-conduct
 


### PR DESCRIPTION

## Description:  
This pull request includes the following changes:

1. **Updated SP1 Book link**  
   - Replaced the outdated link to the SP1 documentation with the correct and active link:  
     `https://docs.succinct.xyz/docs/sp1/introduction`.

2. **Fixed Code of Conduct reference**  
   - Updated the Code of Conduct reference to link directly to the current page:  
     `https://www.rust-lang.org/policies/code-of-conduct`.

## Changes:
- **Addition**: Updated SP1 documentation link in `CONTRIBUTING.md`.
- **Addition**: Updated Code of Conduct URL in `CONTRIBUTING.md`.
- **Deletion**: Removed outdated SP1 documentation link.
- **Deletion**: Removed the old Code of Conduct URL.

## Testing:  
- Verified that the new links direct to the correct and active pages.

## Notes:  
These changes improve the accuracy and up-to-date information in the repository documentation.