### PR TITLE
fix(docs): broken README links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ If you have reviewed existing documentation and still have questions, or you are
 *opening a discussion**. This repository comes with a discussions board where you can also ask for help. Click the "
 Discussions" tab at the top.
 
-As SP1 is still in heavy development, the documentation can be a bit scattered. The [SP1 Book](https://succinctlabs.github.io/sp1/) is our
+As SP1 is still in heavy development, the documentation can be a bit scattered. The [SP1 Book](https://docs.succinct.xyz/) is our
 current best-effort attempt at keeping up-to-date information.
 
 ### Submitting a bug report


### PR DESCRIPTION
The commit updates the `CONTRIBUTING.md` file by changing the URL for the SP1 Book documentation. 

**Specifically:**
- Old URL: `https://succinctlabs.github.io/sp1/`
- New URL: `https://docs.succinct.xyz/`


