### PR TITLE
fix: update SHA2 dependency reference and clean up TODOs

### DIFF
--- a/patch-testing/sha/program/Cargo.toml
+++ b/patch-testing/sha/program/Cargo.toml
@@ -16,8 +16,7 @@ path = "bin/sha3.rs"
 sp1-zkvm = { path = "../../../crates/zkvm/entrypoint" }
 serde = { version = "1.0.215", features = ["derive"] }
 
-# note: 9.8 was yanked 
-sha2-v0-9-8 = { version = "0.9.9", package = "sha2" }
+sha2-v0-9-9 = { version = "0.9.9", package = "sha2" }
 sha2-v0-10-8 = { version = "0.10.8", package = "sha2" }
 
 sha3 = { version = "0.10.8", package = "sha3" }
@@ -26,5 +25,4 @@ sha3 = { version = "0.10.8", package = "sha3" }
 sha3 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha3", tag = "patch-sha3-0.10.8-sp1-4.0.0" }
 
 sha2-v0-10-8 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.10.8-sp1-4.0.0" }
-# todo: 0.9.8 is yanked?
 sha2-v0-9-9 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "sha2-v0.9.9-patch-v1" }


### PR DESCRIPTION
## Motivation

The Cargo.toml file contained an incorrect reference to `sha2-v0-9-8`, while the actual version used was `0.9.9`. Additionally, outdated comments regarding the yanked status of `0.9.8` were still present, causing potential confusion. This PR ensures consistency in dependency definitions and removes misleading information.

Checked the `sha2` crate versions on [crates.io](https://crates.io/crates/sha2/versions) and confirmed that version 0.9.8 is yanked.
![image](https://github.com/user-attachments/assets/e1ce128e-1f25-40b0-b9cd-e2d5dd9c7fab)


## Solution

- Updated `sha2-v0-9-8 = { version = "0.9.9", package = "sha2" }` to `sha2-v0-9-9 = { version = "0.9.9", package = "sha2" }` to properly reflect the correct version reference.
- Removed outdated comments about `0.9.8` being yanked.
- Ensured dependency definitions are clear and accurate.



