### PR TITLE
Add ELF file existence check and test script

### DIFF
--- a/eval.sh
+++ b/eval.sh
@@ -30,7 +30,11 @@ for program in "${programs[@]}"; do
 
     echo "Building $program done"
     elf_path="${program_directory}/elf/riscv32im-succinct-zkvm-elf"
-
+    if [ ! -f "$elf_path" ]; then
+        echo "ERROR: ELF file not found at $elf_path, skipping $program..."
+        continue
+    fi
+    
     cd "${root_directory}/eval"
     for hash_fn in "${hash_functions[@]}"; do
         for shard_size in "${shard_sizes[@]}"; do

--- a/tests/test_elf.sh
+++ b/tests/test_elf.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+elf_path="${1:-/path/to/elf/riscv32im-succinct-zkvm-elf}"
+
+if [ ! -f "$elf_path" ]; then
+    echo "ERROR: ELF file not found at $elf_path"
+    exit 1
+else
+    echo "ELF file found at $elf_path"
+    exit 0
+fi


### PR DESCRIPTION
### Why this is needed?
- Prevents unnecessary failures: Avoids running evaluation commands on missing ELF files.
- Improves error handling: Provides clear feedback when an ELF file is not found.
- Enhances script reliability: Ensures we only process valid builds.
- Ensures stability: The new test verifies the ELF file's existence, preventing regressions.

### Changes Made:
- Added a check for `$elf_path` using `[ ! -f "$elf_path" ]`.
- If the ELF file is missing, an error message is logged, and the program is skipped.
- Added a test script (`test_elf.sh`) to automatically verify the existence of the ELF file. The test will pass if the file is found, and fail with a clear error message if it is missing.

### How to Test?
1. Run the script as usual.
2. If a program build fails or the ELF file is not created, you should see:
   ```bash
   ERROR: ELF file not found at /path/to/elf, skipping fibonacci...
