### PR TITLE
fix(ci): create ref doesn't trigger CI

### DIFF
--- a/.github/scripts/create-tag.js
+++ b/.github/scripts/create-tag.js
@@ -7,6 +7,20 @@ module.exports = async ({ github, context }, tagName) => {
             sha: context.sha,
             force: true,
         });
+
+        await github.rest.git.createWorkflowDispatch({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            workflow_id: 'docker-publish-gnark.yml',
+            ref: tagName,
+        });
+
+        await github.rest.git.createWorkflowDispatch({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            workflow_id: 'docker-publish.yml',
+            ref: tagName,
+        });
     } catch (err) {
         console.error(`Failed to create tag: ${tagName}`);
         console.error(err);


### PR DESCRIPTION
In our recent upgrade, we changed Docker deployments to only trigger on tags, however using `createRef` from github scripts didn't trigger a "push" event.