### PR TITLE
fix: correct max_cycles limit check

### DIFF
--- a/crates/core/executor/src/context.rs
+++ b/crates/core/executor/src/context.rs
@@ -172,6 +172,7 @@ impl<'a> SP1ContextBuilder<'a> {
     }
 
     /// Set the maximum number of cpu cycles to use for execution.
+    /// `report.total_instruction_count()` will be less than or equal to `max_cycles`.
     pub fn max_cycles(&mut self, max_cycles: u64) -> &mut Self {
         self.max_cycles = Some(max_cycles);
         self

--- a/crates/core/executor/src/executor.rs
+++ b/crates/core/executor/src/executor.rs
@@ -1788,7 +1788,7 @@ impl<'a> Executor<'a> {
 
             // If the cycle limit is exceeded, return an error.
             if let Some(max_cycles) = self.max_cycles {
-                if self.state.global_clk >= max_cycles {
+                if self.state.global_clk > max_cycles {
                     return Err(ExecutionError::ExceededCycleLimit(max_cycles));
                 }
             }
@@ -2309,7 +2309,7 @@ mod tests {
         simple_memory_program, simple_program, ssz_withdrawals_program, u256xu2048_mul_program,
     };
 
-    use crate::Register;
+    use crate::{Register, SP1Context};
 
     use super::{Executor, Instruction, Opcode, Program};
 
@@ -2333,6 +2333,20 @@ mod tests {
     fn test_fibonacci_program_run() {
         let program = fibonacci_program();
         let mut runtime = Executor::new(program, SP1CoreOpts::default());
+        runtime.run().unwrap();
+    }
+
+    #[test]
+    fn test_fibonacci_program_run_with_max_cycles() {
+        let program = fibonacci_program();
+        let mut runtime = Executor::new(program, SP1CoreOpts::default());
+        runtime.run().unwrap();
+
+        let max_cycles = runtime.state.global_clk;
+
+        let program = fibonacci_program();
+        let context = SP1Context::builder().max_cycles(max_cycles).build();
+        let mut runtime = Executor::with_context(program, SP1CoreOpts::default(), context);
         runtime.run().unwrap();
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

Fix `max_cycles` limit check when running and proving programs with a context.

## Motivation

When a user runs a program, gets the report, takes `report.total_instruction_count()`, uses it as `max_cycles` and tries to run the same program with it, it does not work. 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

The check if `max_cycles` was exceeded, is currently off by 1:
```rust
    if self.state.global_clk >= max_cycles {
        return Err(ExecutionError::ExceededCycleLimit(max_cycles));
    }
```

This breaks at the very last legitimate cycle if `max_cycles` is set to the exact number of the program cycles.

This PR fixes the check to be `if self.state.global_clk > max_cycles {`, because 
`self.state.global_clk == max_cycles` is still ok.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [X] Added Tests
- [X] Added Documentation
- [ ] Breaking changes