### PR TITLE
chore: cargo prove new

### DIFF
--- a/crates/cli/src/commands/new.rs
+++ b/crates/cli/src/commands/new.rs
@@ -59,12 +59,12 @@ impl NewCmd {
             .arg("--depth=1");
 
         // Stream output to stdout.
-        command.stdout(Stdio::inherit()).stderr(Stdio::inherit());
+        command.stdout(Stdio::inherit()).stderr(Stdio::piped());
 
         let output = command.output().expect("failed to execute command");
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(anyhow::anyhow!("failed to clone repository: {}", stderr));
+            return Err(anyhow::anyhow!("Failed to clone repository: {}", stderr));
         }
 
         // Remove the .git directory.


### PR DESCRIPTION
## Motivation

If the directory already exists, the error for `cargo prove new` isn't informative.

```
cargo prove new fibonacci --bare
     Cloning https://github.com/succinctlabs/sp1-project-template
Error: failed to clone repository:
```


## Solution

This change allows properly catching the `stderr` and piping it in the error message.
