### PR TITLE
feat(executor): Add overrides to std{io, err} for guest programs

### DIFF
--- a/crates/core/executor/src/context.rs
+++ b/crates/core/executor/src/context.rs
@@ -219,11 +219,11 @@ impl Clone for IoOptions<'_> {
     }
 }
 
-/// A trait for [`Write`] types that are also [`Send`] and [`Sync`].
-pub trait IoWriter: Write + Send + Sync {}
+/// A trait for [`Write`] types that are also [`Send`].
+pub trait IoWriter: Write + Send {}
 
 /// Generic implementation of [`IoWriter`] for any [`Write`] type that are compatible.
-impl<W: Write + Send + Sync> IoWriter for W {}
+impl<W: Write + Send> IoWriter for W {}
 
 #[cfg(test)]
 mod tests {

--- a/crates/core/executor/src/context.rs
+++ b/crates/core/executor/src/context.rs
@@ -190,13 +190,13 @@ impl<'a> SP1ContextBuilder<'a> {
     }
 
     /// Set the `stdout` writer.
-    pub fn stdout<W: IoWriter>(&mut self, writer: &'a mut W) -> &mut Self {
+    pub fn stdout<W: MakeWriter>(&mut self, writer: &'a mut W) -> &mut Self {
         self.io_options.stdout = Some(writer);
         self
     }
 
     /// Set the `stderr` writer.
-    pub fn stderr<W: IoWriter>(&mut self, writer: &'a mut W) -> &mut Self {
+    pub fn stderr<W: MakeWriter>(&mut self, writer: &'a mut W) -> &mut Self {
         self.io_options.stderr = Some(writer);
         self
     }
@@ -208,9 +208,9 @@ impl<'a> SP1ContextBuilder<'a> {
 #[derive(Default)]
 pub struct IoOptions<'a> {
     /// A writer to redirect `stdout` to.
-    pub stdout: Option<&'a mut dyn IoWriter>,
+    pub stdout: Option<&'a mut dyn MakeWriter>,
     /// A writer to redirect `stderr` to.
-    pub stderr: Option<&'a mut dyn IoWriter>,
+    pub stderr: Option<&'a mut dyn MakeWriter>,
 }
 
 impl Clone for IoOptions<'_> {
@@ -219,11 +219,38 @@ impl Clone for IoOptions<'_> {
     }
 }
 
-/// A trait for [`Write`] types that are also [`Send`].
-pub trait IoWriter: Write + Send {}
+/// A trait for [`Write`] types to be used in the executor.
+///
+/// This trait is useful as you may have a writer behind a lock,
+/// and its not ideal to have the underlying [`Write`] implentation call `.lock()`
+/// if the executor is making multiple calls to write quickly.
+///
+/// ```rust,no_run
+/// use std::sync::{Arc, Mutex};
+/// use std::io::Write;
+///
+/// struct LockedWriter {
+///     inner: Arc<Mutex<Vec<u8>>>,
+/// }
+///
+/// impl MakeWriter for LockedWriter {
+///     fn make_writer(&mut self) -> &mut dyn Write {
+///         self.inner.lock().unwrap()
+///     }
+/// }
+/// ```
+///
+/// This trait is generically implemented for any [`Write`] + [`Send`] type.
+pub trait MakeWriter: Send {
+    /// Get the underlying writer.
+    fn make_writer(&mut self) -> &mut dyn Write;
+}
 
-/// Generic implementation of [`IoWriter`] for any [`Write`] type that are compatible.
-impl<W: Write + Send> IoWriter for W {}
+impl<W: Write + Send> MakeWriter for W {
+    fn make_writer(&mut self) -> &mut dyn Write {
+        self
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/core/executor/src/context.rs
+++ b/crates/core/executor/src/context.rs
@@ -222,12 +222,13 @@ impl Clone for IoOptions<'_> {
 /// A trait for [`Write`] types to be used in the executor.
 ///
 /// This trait is useful as you may have a writer behind a lock,
-/// and its not ideal to have the underlying [`Write`] implentation call `.lock()`
+/// and its not ideal to have the underlying [`Write`] implementation call `.lock()`
 /// if the executor is making multiple calls to write quickly.
 ///
 /// ```rust,no_run
 /// use std::sync::{Arc, Mutex};
 /// use std::io::Write;
+/// use sp1_core_executor::MakeWriter;
 ///
 /// struct LockedWriter {
 ///     inner: Arc<Mutex<Vec<u8>>>,

--- a/crates/core/executor/src/context.rs
+++ b/crates/core/executor/src/context.rs
@@ -1,11 +1,11 @@
 use core::mem::take;
 
-use hashbrown::HashMap;
-
 use crate::{
     hook::{hookify, BoxedHook, HookEnv, HookRegistry},
     subproof::SubproofVerifier,
 };
+use hashbrown::HashMap;
+use std::io::Write;
 
 use sp1_primitives::consts::fd::LOWEST_ALLOWED_FD;
 
@@ -31,6 +31,9 @@ pub struct SP1Context<'a> {
     ///
     /// This option will noticeably slow down execution, so it should be disabled in most cases.
     pub calculate_gas: bool,
+
+    /// The IO options for the [`SP1Executor`].
+    pub io_options: IoOptions<'a>,
 }
 
 impl Default for SP1Context<'_> {
@@ -40,7 +43,6 @@ impl Default for SP1Context<'_> {
 }
 
 /// A builder for [`SP1Context`].
-#[derive(Clone)]
 pub struct SP1ContextBuilder<'a> {
     no_default_hooks: bool,
     hook_registry_entries: Vec<(u32, BoxedHook<'a>)>,
@@ -48,6 +50,7 @@ pub struct SP1ContextBuilder<'a> {
     max_cycles: Option<u64>,
     deferred_proof_verification: bool,
     calculate_gas: bool,
+    io_options: IoOptions<'a>,
 }
 
 impl Default for SP1ContextBuilder<'_> {
@@ -60,6 +63,7 @@ impl Default for SP1ContextBuilder<'_> {
             // Always verify deferred proofs by default.
             deferred_proof_verification: true,
             calculate_gas: true,
+            io_options: IoOptions::default(),
         }
     }
 }
@@ -121,6 +125,7 @@ impl<'a> SP1ContextBuilder<'a> {
             max_cycles: cycle_limit,
             deferred_proof_verification,
             calculate_gas,
+            io_options: IoOptions::default(),
         }
     }
 
@@ -183,7 +188,42 @@ impl<'a> SP1ContextBuilder<'a> {
         self.deferred_proof_verification = value;
         self
     }
+
+    /// Set the `stdout` writer.
+    pub fn stdout<W: IoWriter>(&mut self, writer: &'a mut W) -> &mut Self {
+        self.io_options.stdout = Some(writer);
+        self
+    }
+
+    /// Set the `stderr` writer.
+    pub fn stderr<W: IoWriter>(&mut self, writer: &'a mut W) -> &mut Self {
+        self.io_options.stderr = Some(writer);
+        self
+    }
 }
+
+/// The IO options for the [`SP1Executor`].
+///
+/// This struct is used to redirect the `stdout` and `stderr` of the [`SP1Executor`].
+#[derive(Default)]
+pub struct IoOptions<'a> {
+    /// A writer to redirect `stdout` to.
+    pub stdout: Option<&'a mut dyn IoWriter>,
+    /// A writer to redirect `stderr` to.
+    pub stderr: Option<&'a mut dyn IoWriter>,
+}
+
+impl Clone for IoOptions<'_> {
+    fn clone(&self) -> Self {
+        IoOptions { stdout: None, stderr: None }
+    }
+}
+
+/// A trait for [`Write`] types that are also [`Send`] and [`Sync`].
+pub trait IoWriter: Write + Send + Sync {}
+
+/// Generic implementation of [`IoWriter`] for any [`Write`] type that are compatible.
+impl<W: Write + Send + Sync> IoWriter for W {}
 
 #[cfg(test)]
 mod tests {

--- a/crates/core/executor/src/context.rs
+++ b/crates/core/executor/src/context.rs
@@ -125,7 +125,7 @@ impl<'a> SP1ContextBuilder<'a> {
             max_cycles: cycle_limit,
             deferred_proof_verification,
             calculate_gas,
-            io_options: IoOptions::default(),
+            io_options: take(&mut self.io_options),
         }
     }
 

--- a/crates/core/executor/src/executor.rs
+++ b/crates/core/executor/src/executor.rs
@@ -2034,6 +2034,15 @@ impl<'a> Executor<'a> {
 
             // Push the remaining execution record with memory initialize & finalize events.
             self.bump_record();
+
+            // Flush stdout and stderr.
+            if let Some(ref mut w) = self.io_options.stdout {
+                w.flush().expect("failed to flush stdout override");
+            }
+
+            if let Some(ref mut w) = self.io_options.stderr {
+                w.flush().expect("failed to flush stderr override");
+            }
         }
 
         // Push the remaining execution record, if there are any CPU events.

--- a/crates/core/executor/src/executor.rs
+++ b/crates/core/executor/src/executor.rs
@@ -2037,11 +2037,15 @@ impl<'a> Executor<'a> {
 
             // Flush stdout and stderr.
             if let Some(ref mut w) = self.io_options.stdout {
-                w.flush().expect("failed to flush stdout override");
+                if let Err(e) = w.flush() {
+                    tracing::error!("failed to flush stdout override: {e}");
+                }
             }
 
             if let Some(ref mut w) = self.io_options.stderr {
-                w.flush().expect("failed to flush stderr override");
+                if let Err(e) = w.flush() {
+                    tracing::error!("failed to flush stderr override: {e}");
+                }
             }
         }
 

--- a/crates/core/executor/src/executor.rs
+++ b/crates/core/executor/src/executor.rs
@@ -16,7 +16,7 @@ use strum::IntoEnumIterator;
 use thiserror::Error;
 
 use crate::{
-    context::SP1Context,
+    context::{IoOptions, SP1Context},
     dependencies::{
         emit_auipc_dependency, emit_branch_dependencies, emit_divrem_dependencies,
         emit_jump_dependencies, emit_memory_dependencies,
@@ -182,6 +182,9 @@ pub struct Executor<'a> {
 
     /// The maximum LDE size to allow.
     pub lde_size_threshold: u64,
+
+    /// The options for the IO.
+    pub io_options: IoOptions<'a>,
 
     /// Temporary event counts for the current shard. This is a field to reuse memory.
     event_counts: EnumMap<RiscvAirId, u64>,
@@ -350,6 +353,7 @@ impl<'a> Executor<'a> {
             lde_size_check: false,
             lde_size_threshold: 0,
             event_counts: EnumMap::default(),
+            io_options: context.io_options,
         }
     }
 

--- a/crates/core/executor/src/syscalls/write.rs
+++ b/crates/core/executor/src/syscalls/write.rs
@@ -57,9 +57,11 @@ impl Syscall for WriteSyscall {
                                 flush_s.into_iter().for_each(|mut line| {
                                     line.push('\n');
 
-                                    writer
-                                        .write_all(line.as_bytes())
-                                        .expect("failed to write to stdout io override");
+                                    if let Err(e) = writer.write_all(line.as_bytes()) {
+                                        tracing::error!(
+                                            "failed to write to stdout io override: {e}"
+                                        );
+                                    }
                                 });
                             }
                             None => {
@@ -78,9 +80,9 @@ impl Syscall for WriteSyscall {
                         flush_s.into_iter().for_each(|mut line| {
                             line.push('\n');
 
-                            writer
-                                .write_all(line.as_bytes())
-                                .expect("failed to write to stderr io override");
+                            if let Err(e) = writer.write_all(line.as_bytes()) {
+                                tracing::error!("failed to write to stderr io override: {e}");
+                            }
                         });
                     }
                     None => {

--- a/crates/core/executor/src/syscalls/write.rs
+++ b/crates/core/executor/src/syscalls/write.rs
@@ -49,17 +49,40 @@ impl Syscall for WriteSyscall {
                 Some(command) => handle_cycle_tracker_command(rt, command),
                 None => {
                     // If the string does not match any known command, print it to stdout.
-                    let flush_s = update_io_buf(ctx, fd, s);
+                    let flush_s = update_io_buf(rt, fd, s);
+
                     if !flush_s.is_empty() {
-                        flush_s.into_iter().for_each(|line| eprintln!("stdout: {}", line));
+                        match rt.io_options.stdout {
+                            Some(ref mut writer) => {
+                                flush_s.into_iter().for_each(|line| {
+                                    writer
+                                        .write_all(line.as_bytes())
+                                        .expect("failed to write to stdout io override")
+                                });
+                            }
+                            None => {
+                                flush_s.into_iter().for_each(|line| eprintln!("stdout: {}", line));
+                            }
+                        }
                     }
                 }
             }
         } else if fd == 2 {
             let s = core::str::from_utf8(slice).unwrap();
-            let flush_s = update_io_buf(ctx, fd, s);
+            let flush_s = update_io_buf(rt, fd, s);
             if !flush_s.is_empty() {
-                flush_s.into_iter().for_each(|line| eprintln!("stderr: {}", line));
+                match rt.io_options.stderr {
+                    Some(ref mut writer) => {
+                        flush_s.into_iter().for_each(|line| {
+                            writer
+                                .write_all(line.as_bytes())
+                                .expect("failed to write to stderr io override")
+                        });
+                    }
+                    None => {
+                        flush_s.into_iter().for_each(|line| eprintln!("stderr: {}", line));
+                    }
+                }
             }
         } else if fd <= LOWEST_ALLOWED_FD {
             if std::env::var("SP1_ALLOW_DEPRECATED_HOOKS")
@@ -200,8 +223,7 @@ fn end_cycle_tracker(rt: &mut Executor, name: &str) -> Option<u64> {
 
 /// Update the io buffer for the given file descriptor with the given string.
 #[allow(clippy::mut_mut)]
-fn update_io_buf(ctx: &mut SyscallContext, fd: u32, s: &str) -> Vec<String> {
-    let rt = &mut ctx.rt;
+fn update_io_buf(rt: &mut Executor<'_>, fd: u32, s: &str) -> Vec<String> {
     let entry = rt.io_buf.entry(fd).or_default();
     entry.push_str(s);
     if entry.contains('\n') {

--- a/crates/core/executor/src/syscalls/write.rs
+++ b/crates/core/executor/src/syscalls/write.rs
@@ -60,8 +60,6 @@ impl Syscall for WriteSyscall {
                                     writer
                                         .write_all(line.as_bytes())
                                         .expect("failed to write to stdout io override");
-
-                                    writer.flush().expect("failed to flush stdout io override");
                                 });
                             }
                             None => {
@@ -83,8 +81,6 @@ impl Syscall for WriteSyscall {
                             writer
                                 .write_all(line.as_bytes())
                                 .expect("failed to write to stderr io override");
-
-                            writer.flush().expect("failed to flush stderr io override");
                         });
                     }
                     None => {

--- a/crates/core/executor/src/syscalls/write.rs
+++ b/crates/core/executor/src/syscalls/write.rs
@@ -54,15 +54,11 @@ impl Syscall for WriteSyscall {
                     if !flush_s.is_empty() {
                         match rt.io_options.stdout {
                             Some(ref mut writer) => {
-                                flush_s.into_iter().for_each(|line| {
-                                    let writer = writer.make_writer();
+                                flush_s.into_iter().for_each(|mut line| {
+                                    line.push('\n');
 
                                     writer
                                         .write_all(line.as_bytes())
-                                        .expect("failed to write to stdout io override");
-
-                                    writer
-                                        .write_all(b"\n")
                                         .expect("failed to write to stdout io override");
 
                                     writer.flush().expect("failed to flush stdout io override");
@@ -81,14 +77,12 @@ impl Syscall for WriteSyscall {
             if !flush_s.is_empty() {
                 match rt.io_options.stderr {
                     Some(ref mut writer) => {
-                        flush_s.into_iter().for_each(|line| {
-                            let writer = writer.make_writer();
+                        flush_s.into_iter().for_each(|mut line| {
+                            line.push('\n');
 
                             writer
                                 .write_all(line.as_bytes())
                                 .expect("failed to write to stderr io override");
-
-                            writer.write_all(b"\n").expect("failed to write to stderr io override");
 
                             writer.flush().expect("failed to flush stderr io override");
                         });

--- a/crates/core/executor/src/syscalls/write.rs
+++ b/crates/core/executor/src/syscalls/write.rs
@@ -55,6 +55,8 @@ impl Syscall for WriteSyscall {
                         match rt.io_options.stdout {
                             Some(ref mut writer) => {
                                 flush_s.into_iter().for_each(|line| {
+                                    let writer = writer.make_writer();
+
                                     writer
                                         .write_all(line.as_bytes())
                                         .expect("failed to write to stdout io override");
@@ -80,6 +82,8 @@ impl Syscall for WriteSyscall {
                 match rt.io_options.stderr {
                     Some(ref mut writer) => {
                         flush_s.into_iter().for_each(|line| {
+                            let writer = writer.make_writer();
+
                             writer
                                 .write_all(line.as_bytes())
                                 .expect("failed to write to stderr io override");

--- a/crates/core/executor/src/syscalls/write.rs
+++ b/crates/core/executor/src/syscalls/write.rs
@@ -57,7 +57,13 @@ impl Syscall for WriteSyscall {
                                 flush_s.into_iter().for_each(|line| {
                                     writer
                                         .write_all(line.as_bytes())
-                                        .expect("failed to write to stdout io override")
+                                        .expect("failed to write to stdout io override");
+
+                                    writer
+                                        .write_all(b"\n")
+                                        .expect("failed to write to stdout io override");
+
+                                    writer.flush().expect("failed to flush stdout io override");
                                 });
                             }
                             None => {
@@ -76,7 +82,11 @@ impl Syscall for WriteSyscall {
                         flush_s.into_iter().for_each(|line| {
                             writer
                                 .write_all(line.as_bytes())
-                                .expect("failed to write to stderr io override")
+                                .expect("failed to write to stderr io override");
+
+                            writer.write_all(b"\n").expect("failed to write to stderr io override");
+
+                            writer.flush().expect("failed to flush stderr io override");
                         });
                     }
                     None => {

--- a/crates/sdk/src/cpu/execute.rs
+++ b/crates/sdk/src/cpu/execute.rs
@@ -144,7 +144,7 @@ impl<'a> CpuExecuteBuilder<'a> {
         self
     }
 
-    /// Overide the default stdout of the guest program.
+    /// Override the default stdout of the guest program.
     ///
     /// # Example
     /// ```rust,no_run
@@ -165,7 +165,7 @@ impl<'a> CpuExecuteBuilder<'a> {
         self
     }
 
-    /// Overide the default stdout of the guest program.
+    /// Override the default stdout of the guest program.
     ///
     /// # Example
     /// ```rust,no_run

--- a/crates/sdk/src/cpu/execute.rs
+++ b/crates/sdk/src/cpu/execute.rs
@@ -3,7 +3,7 @@
 //! This module provides a builder for simulating the execution of a program on the CPU.
 
 use anyhow::Result;
-use sp1_core_executor::{ExecutionReport, HookEnv, SP1ContextBuilder};
+use sp1_core_executor::{ExecutionReport, HookEnv, MakeWriter, SP1ContextBuilder};
 use sp1_core_machine::io::SP1Stdin;
 use sp1_primitives::io::SP1PublicValues;
 use sp1_prover::{components::CpuProverComponents, SP1Prover};
@@ -144,27 +144,46 @@ impl<'a> CpuExecuteBuilder<'a> {
         self
     }
 
-    /// Get the context builder.
+    /// Overide the default stdout of the guest program.
     ///
     /// # Example
     /// ```rust,no_run
     /// use sp1_sdk::{ProverClient, SP1Stdin, include_elf, Prover};
+    ///
     /// let mut stdout = Vec::new();
     ///
     /// let elf = &[1, 2, 3];
     /// let stdin = SP1Stdin::new();
     ///
     /// let client = ProverClient::builder().cpu().build();
-    /// let mut builder = client.execute(elf, &stdin);
-    ///
-    /// let mut context_builder = builder.context_builder();
-    /// context_builder.stdout(&mut stdout);
-    ///
-    /// builder.run();
+    /// client.execute(elf, &stdin).stdout(&mut stdout).run();
     /// ```
+    ///
     #[must_use]
-    pub fn context_builder(&mut self) -> &mut SP1ContextBuilder<'a> {
-        &mut self.context_builder
+    pub fn stdout<W: MakeWriter>(mut self, writer: &'a mut W) -> Self {
+        self.context_builder.stdout(writer);
+        self
+    }
+
+    /// Overide the default stdout of the guest program.
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// use sp1_sdk::{ProverClient, SP1Stdin, include_elf, Prover};
+    ///
+    /// let mut stdout = Vec::new();
+    ///
+    /// let elf = &[1, 2, 3];
+    /// let stdin = SP1Stdin::new();
+    ///
+    /// let client = ProverClient::builder().cpu().build();
+    /// client.execute(elf, &stdin).stderr(&mut stderr).run();
+    /// ```
+    ///
+    #[must_use]
+    pub fn stderr<W: MakeWriter>(mut self, writer: &'a mut W) -> Self {
+        self.context_builder.stderr(writer);
+        self
     }
 
     /// Executes the program on the input with the built arguments.

--- a/crates/sdk/src/cpu/execute.rs
+++ b/crates/sdk/src/cpu/execute.rs
@@ -3,7 +3,7 @@
 //! This module provides a builder for simulating the execution of a program on the CPU.
 
 use anyhow::Result;
-use sp1_core_executor::{ExecutionReport, HookEnv, MakeWriter, SP1ContextBuilder};
+use sp1_core_executor::{ExecutionReport, HookEnv, IoWriter, SP1ContextBuilder};
 use sp1_core_machine::io::SP1Stdin;
 use sp1_primitives::io::SP1PublicValues;
 use sp1_prover::{components::CpuProverComponents, SP1Prover};
@@ -160,7 +160,7 @@ impl<'a> CpuExecuteBuilder<'a> {
     /// ```
     ///
     #[must_use]
-    pub fn stdout<W: MakeWriter>(mut self, writer: &'a mut W) -> Self {
+    pub fn stdout<W: IoWriter>(mut self, writer: &'a mut W) -> Self {
         self.context_builder.stdout(writer);
         self
     }
@@ -171,7 +171,7 @@ impl<'a> CpuExecuteBuilder<'a> {
     /// ```rust,no_run
     /// use sp1_sdk::{ProverClient, SP1Stdin, include_elf, Prover};
     ///
-    /// let mut stdout = Vec::new();
+    /// let mut stderr = Vec::new();
     ///
     /// let elf = &[1, 2, 3];
     /// let stdin = SP1Stdin::new();
@@ -181,7 +181,7 @@ impl<'a> CpuExecuteBuilder<'a> {
     /// ```
     ///
     #[must_use]
-    pub fn stderr<W: MakeWriter>(mut self, writer: &'a mut W) -> Self {
+    pub fn stderr<W: IoWriter>(mut self, writer: &'a mut W) -> Self {
         self.context_builder.stderr(writer);
         self
     }

--- a/crates/sdk/src/cpu/execute.rs
+++ b/crates/sdk/src/cpu/execute.rs
@@ -157,7 +157,7 @@ impl<'a> CpuExecuteBuilder<'a> {
     /// let builder = client.execute(elf, &stdin);
     ///
     /// let context_builder = builder.context_builder();
-    /// context_builder.set_stdout(std::io::stdout());
+    /// context_builder.stdout(&mut std::io::stdout());
     ///
     /// builder.run();
     /// ```

--- a/crates/sdk/src/cpu/execute.rs
+++ b/crates/sdk/src/cpu/execute.rs
@@ -149,13 +149,13 @@ impl<'a> CpuExecuteBuilder<'a> {
     /// # Example
     /// ```rust,no_run
     /// use sp1_sdk::{ProverClient, SP1Stdin, include_elf, Prover};
-    /// let stdout = Vec::new();
+    /// let mut stdout = Vec::new();
     ///
     /// let elf = &[1, 2, 3];
     /// let stdin = SP1Stdin::new();
     ///
     /// let client = ProverClient::builder().cpu().build();
-    /// let builder = client.execute(elf, &stdin);
+    /// let mut builder = client.execute(elf, &stdin);
     ///
     /// let mut context_builder = builder.context_builder();
     /// context_builder.stdout(&mut stdout);

--- a/crates/sdk/src/cpu/execute.rs
+++ b/crates/sdk/src/cpu/execute.rs
@@ -149,6 +149,7 @@ impl<'a> CpuExecuteBuilder<'a> {
     /// # Example
     /// ```rust,no_run
     /// use sp1_sdk::{ProverClient, SP1Stdin, include_elf, Prover};
+    /// let stdout = Vec::new();
     ///
     /// let elf = &[1, 2, 3];
     /// let stdin = SP1Stdin::new();
@@ -156,8 +157,8 @@ impl<'a> CpuExecuteBuilder<'a> {
     /// let client = ProverClient::builder().cpu().build();
     /// let builder = client.execute(elf, &stdin);
     ///
-    /// let context_builder = builder.context_builder();
-    /// context_builder.stdout(&mut std::io::stdout());
+    /// let mut context_builder = builder.context_builder();
+    /// context_builder.stdout(&mut stdout);
     ///
     /// builder.run();
     /// ```

--- a/crates/sdk/src/cpu/execute.rs
+++ b/crates/sdk/src/cpu/execute.rs
@@ -144,6 +144,28 @@ impl<'a> CpuExecuteBuilder<'a> {
         self
     }
 
+    /// Get the context builder.
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// use sp1_sdk::{ProverClient, SP1Stdin, include_elf, Prover};
+    ///
+    /// let elf = &[1, 2, 3];
+    /// let stdin = SP1Stdin::new();
+    ///
+    /// let client = ProverClient::builder().cpu().build();
+    /// let builder = client.execute(elf, &stdin);
+    ///
+    /// let context_builder = builder.context_builder();
+    /// context_builder.set_stdout(std::io::stdout());
+    ///
+    /// builder.run();
+    /// ```
+    #[must_use]
+    pub fn context_builder(&mut self) -> &mut SP1ContextBuilder<'a> {
+        &mut self.context_builder
+    }
+
     /// Executes the program on the input with the built arguments.
     ///
     /// # Details

--- a/crates/sdk/src/cpu/prove.rs
+++ b/crates/sdk/src/cpu/prove.rs
@@ -262,7 +262,7 @@ impl<'a> CpuProveBuilder<'a> {
         self
     }
 
-    /// Overide the default stdout of the guest program.
+    /// Override the default stdout of the guest program.
     ///
     /// # Example
     /// ```rust,no_run
@@ -283,7 +283,7 @@ impl<'a> CpuProveBuilder<'a> {
         self
     }
 
-    /// Overide the default stdout of the guest program.
+    /// Override the default stdout of the guest program.
     ///
     /// # Example
     /// ```rust,no_run

--- a/crates/sdk/src/cpu/prove.rs
+++ b/crates/sdk/src/cpu/prove.rs
@@ -26,7 +26,7 @@ pub struct CpuProveBuilder<'a> {
     pub(crate) mock: bool,
 }
 
-impl CpuProveBuilder<'_> {
+impl<'a> CpuProveBuilder<'a> {
     /// Set the proof kind to [`SP1ProofKind::Core`] mode.
     ///
     /// # Details
@@ -260,6 +260,28 @@ impl CpuProveBuilder<'_> {
     pub fn deferred_proof_verification(mut self, value: bool) -> Self {
         self.context_builder.set_deferred_proof_verification(value);
         self
+    }
+
+    /// Get the context builder.
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// use sp1_sdk::{ProverClient, SP1Stdin, include_elf, Prover};
+    ///
+    /// let elf = &[1, 2, 3];
+    /// let stdin = SP1Stdin::new();
+    ///
+    /// let client = ProverClient::builder().cpu().build();
+    /// let builder = client.execute(elf, &stdin);
+    ///
+    /// let context_builder = builder.context_builder();
+    /// context_builder.set_stdout(std::io::stdout());
+    ///
+    /// builder.run();
+    /// ```
+    #[must_use]
+    pub fn context_builder(&mut self) -> &mut SP1ContextBuilder<'a> {
+        &mut self.context_builder
     }
 
     /// Run the prover with the built arguments.

--- a/crates/sdk/src/cpu/prove.rs
+++ b/crates/sdk/src/cpu/prove.rs
@@ -267,6 +267,7 @@ impl<'a> CpuProveBuilder<'a> {
     /// # Example
     /// ```rust,no_run
     /// use sp1_sdk::{ProverClient, SP1Stdin, include_elf, Prover};
+    /// let stdout = Vec::new();
     ///
     /// let elf = &[1, 2, 3];
     /// let stdin = SP1Stdin::new();
@@ -274,8 +275,8 @@ impl<'a> CpuProveBuilder<'a> {
     /// let client = ProverClient::builder().cpu().build();
     /// let builder = client.execute(elf, &stdin);
     ///
-    /// let context_builder = builder.context_builder();
-    /// context_builder.stdout(&mut std::io::stdout());
+    /// let mut context_builder = builder.context_builder();
+    /// context_builder.stdout(&mut stdout);
     ///
     /// builder.run();
     /// ```

--- a/crates/sdk/src/cpu/prove.rs
+++ b/crates/sdk/src/cpu/prove.rs
@@ -275,7 +275,7 @@ impl<'a> CpuProveBuilder<'a> {
     /// let builder = client.execute(elf, &stdin);
     ///
     /// let context_builder = builder.context_builder();
-    /// context_builder.set_stdout(std::io::stdout());
+    /// context_builder.stdout(&mut std::io::stdout());
     ///
     /// builder.run();
     /// ```

--- a/crates/sdk/src/cpu/prove.rs
+++ b/crates/sdk/src/cpu/prove.rs
@@ -3,7 +3,7 @@
 //! This module provides a builder for proving a program on the CPU.
 
 use anyhow::Result;
-use sp1_core_executor::SP1ContextBuilder;
+use sp1_core_executor::{MakeWriter, SP1ContextBuilder};
 use sp1_core_machine::io::SP1Stdin;
 use sp1_prover::SP1ProvingKey;
 use sp1_stark::{SP1CoreOpts, SP1ProverOpts};
@@ -262,7 +262,7 @@ impl<'a> CpuProveBuilder<'a> {
         self
     }
 
-    /// Get the context builder.
+    /// Overide the default stdout of the guest program.
     ///
     /// # Example
     /// ```rust,no_run
@@ -274,16 +274,34 @@ impl<'a> CpuProveBuilder<'a> {
     /// let stdin = SP1Stdin::new();
     ///
     /// let client = ProverClient::builder().cpu().build();
-    /// let mut builder = client.execute(elf, &stdin);
-    ///
-    /// let mut context_builder = builder.context_builder();
-    /// context_builder.stdout(&mut stdout);
-    ///
-    /// builder.run();
+    /// client.execute(elf, &stdin).stdout(&mut stdout).run();
     /// ```
+    ///
     #[must_use]
-    pub fn context_builder(&mut self) -> &mut SP1ContextBuilder<'a> {
-        &mut self.context_builder
+    pub fn stdout<W: MakeWriter>(mut self, writer: &'a mut W) -> Self {
+        self.context_builder.stdout(writer);
+        self
+    }
+
+    /// Overide the default stdout of the guest program.
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// use sp1_sdk::{ProverClient, SP1Stdin, include_elf, Prover};
+    ///
+    /// let mut stdout = Vec::new();
+    ///
+    /// let elf = &[1, 2, 3];
+    /// let stdin = SP1Stdin::new();
+    ///
+    /// let client = ProverClient::builder().cpu().build();
+    /// client.execute(elf, &stdin).stderr(&mut stderr).run();
+    /// ```
+    ///
+    #[must_use]
+    pub fn stderr<W: MakeWriter>(mut self, writer: &'a mut W) -> Self {
+        self.context_builder.stderr(writer);
+        self
     }
 
     /// Run the prover with the built arguments.

--- a/crates/sdk/src/cpu/prove.rs
+++ b/crates/sdk/src/cpu/prove.rs
@@ -3,7 +3,7 @@
 //! This module provides a builder for proving a program on the CPU.
 
 use anyhow::Result;
-use sp1_core_executor::{MakeWriter, SP1ContextBuilder};
+use sp1_core_executor::{IoWriter, SP1ContextBuilder};
 use sp1_core_machine::io::SP1Stdin;
 use sp1_prover::SP1ProvingKey;
 use sp1_stark::{SP1CoreOpts, SP1ProverOpts};
@@ -278,7 +278,7 @@ impl<'a> CpuProveBuilder<'a> {
     /// ```
     ///
     #[must_use]
-    pub fn stdout<W: MakeWriter>(mut self, writer: &'a mut W) -> Self {
+    pub fn stdout<W: IoWriter>(mut self, writer: &'a mut W) -> Self {
         self.context_builder.stdout(writer);
         self
     }
@@ -289,17 +289,17 @@ impl<'a> CpuProveBuilder<'a> {
     /// ```rust,no_run
     /// use sp1_sdk::{ProverClient, SP1Stdin, include_elf, Prover};
     ///
-    /// let mut stdout = Vec::new();
+    /// let mut stderr = Vec::new();
     ///
     /// let elf = &[1, 2, 3];
     /// let stdin = SP1Stdin::new();
     ///
     /// let client = ProverClient::builder().cpu().build();
     /// client.execute(elf, &stdin).stderr(&mut stderr).run();
-    /// ```
+    /// ```````
     ///
     #[must_use]
-    pub fn stderr<W: MakeWriter>(mut self, writer: &'a mut W) -> Self {
+    pub fn stderr<W: IoWriter>(mut self, writer: &'a mut W) -> Self {
         self.context_builder.stderr(writer);
         self
     }

--- a/crates/sdk/src/cpu/prove.rs
+++ b/crates/sdk/src/cpu/prove.rs
@@ -267,13 +267,14 @@ impl<'a> CpuProveBuilder<'a> {
     /// # Example
     /// ```rust,no_run
     /// use sp1_sdk::{ProverClient, SP1Stdin, include_elf, Prover};
-    /// let stdout = Vec::new();
+    ///
+    /// let mut stdout = Vec::new();
     ///
     /// let elf = &[1, 2, 3];
     /// let stdin = SP1Stdin::new();
     ///
     /// let client = ProverClient::builder().cpu().build();
-    /// let builder = client.execute(elf, &stdin);
+    /// let mut builder = client.execute(elf, &stdin);
     ///
     /// let mut context_builder = builder.context_builder();
     /// context_builder.stdout(&mut stdout);

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -124,6 +124,23 @@ mod tests {
     }
 
     #[test]
+    fn test_e2e_io_override() {
+        utils::setup_logger();
+        let client = ProverClient::builder().cpu().build();
+        let elf = test_artifacts::HELLO_WORLD_ELF;
+
+        let mut stdout = Vec::new();
+
+        // Generate proof & verify.
+        let stdin = SP1Stdin::new();
+        let mut builder = client.execute(elf, &stdin);
+        builder.context_builder().stdout(&mut stdout);
+        let _ = builder.run().unwrap();
+
+        assert_eq!(stdout, b"Hello, world!\n");
+    }
+
+    #[test]
     fn test_e2e_compressed() {
         utils::setup_logger();
         let client = ProverClient::builder().cpu().build();

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -133,9 +133,7 @@ mod tests {
 
         // Generate proof & verify.
         let stdin = SP1Stdin::new();
-        let mut builder = client.execute(elf, &stdin);
-        builder.context_builder().stdout(&mut stdout);
-        let _ = builder.run().unwrap();
+        let _ = client.execute(elf, &stdin).stdout(&mut stdout).run().unwrap();
 
         assert_eq!(stdout, b"Hello, world!\n");
     }

--- a/crates/test-artifacts/programs/Cargo.lock
+++ b/crates/test-artifacts/programs/Cargo.lock
@@ -1159,6 +1159,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hello-world-program"
+version = "1.1.0"
+dependencies = [
+ "sp1-zkvm",
+]
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/test-artifacts/programs/Cargo.toml
+++ b/crates/test-artifacts/programs/Cargo.toml
@@ -41,6 +41,7 @@ members = [
   "uint256-mul",
   "verify-proof",
   "u256x2048-mul",
+  "hello-world"
 ]
 resolver = "2"
 

--- a/crates/test-artifacts/programs/hello-world/Cargo.toml
+++ b/crates/test-artifacts/programs/hello-world/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "hello-world-program"
+version = "1.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+sp1-zkvm = { path = "../../../../crates/zkvm/entrypoint" }

--- a/crates/test-artifacts/programs/hello-world/src/main.rs
+++ b/crates/test-artifacts/programs/hello-world/src/main.rs
@@ -1,0 +1,13 @@
+//! A simple program that takes a number `n` as input, and writes the `n-1`th and `n`th fibonacci
+//! number as an output.
+
+// These two lines are necessary for the program to properly compile.
+//
+// Under the hood, we wrap your main function with some extra code so that it behaves properly
+// inside the zkVM.
+#![no_main]
+sp1_zkvm::entrypoint!(main);
+
+pub fn main() {
+    println!("Hello, world!");
+}

--- a/crates/test-artifacts/src/lib.rs
+++ b/crates/test-artifacts/src/lib.rs
@@ -10,6 +10,8 @@ use sp1_build::include_elf;
 
 pub const FIBONACCI_ELF: &[u8] = include_elf!("fibonacci-program-tests");
 
+pub const HELLO_WORLD_ELF: &[u8] = include_elf!("hello-world-program");
+
 pub const ED25519_ELF: &[u8] = include_elf!("ed25519-program");
 
 pub const CYCLE_TRACKER_ELF: &[u8] = include_elf!("cycle-tracker-test");


### PR DESCRIPTION
Closes #2121

While IO options implements `Clone` for backwards compatibility, we should decide if this really is needed, if it is, we should document that `IOOptions` clone impl resets to `None`, as writers require exclusive access. 

The other option would be to wrap it in a mutex, which is not ideal.