### PR TITLE
feat: allow to use an existing Moongate server

### DIFF
--- a/crates/cuda/src/lib.rs
+++ b/crates/cuda/src/lib.rs
@@ -188,24 +188,24 @@ impl SP1CudaProver {
         // Start the docker container
         let rust_log_level = std::env::var("RUST_LOG").unwrap_or_else(|_| "none".to_string());
         Command::new("docker")
-                    .args([
-                        "run",
-                        "-e",
-                        &format!("RUST_LOG={}", rust_log_level),
-                        "-p",
-                        "3000:3000",
-                        "--rm",
-                        "--gpus",
-                        "all",
-                        "--name",
-                        container_name,
-                        &image_name,
-                    ])
-                    // Redirect stdout and stderr to the parent process
-                    .stdout(Stdio::inherit())
-                    .stderr(Stdio::inherit())
-                    .spawn()
-                    .map_err(|e| format!("Failed to start Docker container: {}. Please check your Docker installation and permissions.", e))?;
+            .args([
+                "run",
+                "-e",
+                &format!("RUST_LOG={}", rust_log_level),
+                "-p",
+                "3000:3000",
+                "--rm",
+                "--gpus",
+                "all",
+                "--name",
+                container_name,
+                &image_name,
+            ])
+            // Redirect stdout and stderr to the parent process
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .map_err(|e| format!("Failed to start Docker container: {}. Please check your Docker installation and permissions.", e))?;
 
         // Kill the container on control-c
         ctrlc::set_handler(move || {

--- a/crates/perf/src/main.rs
+++ b/crates/perf/src/main.rs
@@ -137,7 +137,7 @@ fn main() {
             println!("{:?}", result);
         }
         ProverMode::Cuda => {
-            let server = SP1CudaProver::new().expect("failed to initialize CUDA prover");
+            let server = SP1CudaProver::new(None).expect("failed to initialize CUDA prover");
 
             let context = SP1Context::default();
             let (report, execution_duration) =

--- a/crates/sdk/src/client.rs
+++ b/crates/sdk/src/client.rs
@@ -118,7 +118,7 @@ impl ProverClientBuilder {
     /// ```
     #[must_use]
     pub fn cuda(&self) -> CudaProverBuilder {
-        CudaProverBuilder
+        CudaProverBuilder::default()
     }
 
     /// Builds a [`NetworkProver`] specifically for proving on the network.

--- a/crates/sdk/src/cuda/builder.rs
+++ b/crates/sdk/src/cuda/builder.rs
@@ -18,8 +18,8 @@ impl CudaProverBuilder {
     /// Sets the Moongate server endpoint.
     ///
     /// # Details
-    /// This method will set the Moongate server to use, instead using the built-in Moongate server
-    /// that is inside a Docker container,
+    /// Run the CUDA prover with the provided endpoint for the Moongate (GPU prover) server.
+    /// Enables more customization and avoids `DinD` configurations.
     ///
     /// # Example
     /// ```rust,no_run

--- a/crates/sdk/src/cuda/builder.rs
+++ b/crates/sdk/src/cuda/builder.rs
@@ -30,8 +30,8 @@ impl CudaProverBuilder {
     ///     .build();
     /// ```
     #[must_use]
-    pub fn with_moongate_endpoint(mut self, endpoint: String) -> Self {
-        self.moongate_endpoint = Some(endpoint);
+    pub fn with_moongate_endpoint(mut self, endpoint: &str) -> Self {
+        self.moongate_endpoint = Some(endpoint.to_string());
         self
     }
 

--- a/crates/sdk/src/cuda/builder.rs
+++ b/crates/sdk/src/cuda/builder.rs
@@ -9,9 +9,32 @@ use super::CudaProver;
 /// A builder for the [`CudaProver`].
 ///
 /// The builder is used to configure the [`CudaProver`] before it is built.
-pub struct CudaProverBuilder;
+#[derive(Debug, Default)]
+pub struct CudaProverBuilder {
+    moongate_endpoint: Option<String>,
+}
 
 impl CudaProverBuilder {
+    /// Sets the Moongate server endpoint.
+    ///
+    /// # Details
+    /// This method will set the Moongate server to use, instead using the built-in Moongate server
+    /// that is inside a Docker container,
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// use sp1_sdk::{ProverClient};
+    ///
+    /// let prover = ProverClient::builder().cuda()
+    ///     .with_moongate_endpoint("http://...")
+    ///     .build();
+    /// ```
+    #[must_use]
+    pub fn with_moongate_endpoint(mut self, endpoint: String) -> Self {
+        self.moongate_endpoint = Some(endpoint);
+        self
+    }
+
     /// Builds a [`CudaProver`].
     ///
     /// # Details
@@ -26,6 +49,6 @@ impl CudaProverBuilder {
     /// ```
     #[must_use]
     pub fn build(self) -> CudaProver {
-        CudaProver::new(SP1Prover::new())
+        CudaProver::new(SP1Prover::new(), self.moongate_endpoint)
     }
 }

--- a/crates/sdk/src/cuda/mod.rs
+++ b/crates/sdk/src/cuda/mod.rs
@@ -26,8 +26,8 @@ pub struct CudaProver {
 
 impl CudaProver {
     /// Creates a new [`CudaProver`].
-    pub fn new(prover: SP1Prover) -> Self {
-        let cuda_prover = SP1CudaProver::new();
+    pub fn new(prover: SP1Prover, moongate_endpoint: Option<String>) -> Self {
+        let cuda_prover = SP1CudaProver::new(moongate_endpoint);
         Self {
             cpu_prover: prover,
             cuda_prover: cuda_prover.expect("Failed to initialize CUDA prover"),
@@ -168,6 +168,6 @@ impl Prover<CpuProverComponents> for CudaProver {
 
 impl Default for CudaProver {
     fn default() -> Self {
-        Self::new(SP1Prover::new())
+        Self::new(SP1Prover::new(), None)
     }
 }

--- a/crates/sdk/src/env/mod.rs
+++ b/crates/sdk/src/env/mod.rs
@@ -49,7 +49,7 @@ impl EnvProver {
             "mock" => Box::new(CpuProver::mock()),
             "cpu" => Box::new(CpuProver::new()),
             "cuda" => {
-                Box::new(CudaProver::new(SP1Prover::new()))
+                Box::new(CudaProver::new(SP1Prover::new(), None))
             }
             "network" => {
                 #[cfg(not(feature = "network"))]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

In order to be able to prove with Cuda from inside a container, we need to be able to specify a Moongate server endpoint instead of starting a container it when creating a Cuda prover.

A possible use case would be with Docker compose that includes the Moongate container.

## Solution

When the `SP1_MOONGATE_ENDPOINT` env variable is provided, use it to connect to the Moongate server instead of creating a container.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes