### PR TITLE
chore: remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,12 +458,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anes"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
-
-[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1365,12 +1359,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cast"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
-
-[[package]]
 name = "cbindgen"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1431,33 +1419,6 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "ciborium"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
-dependencies = [
- "ciborium-io",
- "ciborium-ll",
- "serde",
-]
-
-[[package]]
-name = "ciborium-io"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
-
-[[package]]
-name = "ciborium-ll"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
-dependencies = [
- "ciborium-io",
- "half",
 ]
 
 [[package]]
@@ -1679,42 +1640,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
-name = "criterion"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
-dependencies = [
- "anes",
- "cast",
- "ciborium",
- "clap",
- "criterion-plot",
- "is-terminal",
- "itertools 0.10.5",
- "num-traits",
- "once_cell",
- "oorandom",
- "plotters",
- "rayon",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
- "tinytemplate",
- "walkdir",
-]
-
-[[package]]
-name = "criterion-plot"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
-dependencies = [
- "cast",
- "itertools 0.10.5",
-]
-
-[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1790,27 +1715,6 @@ checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
 dependencies = [
  "generic-array 0.14.7",
  "subtle",
-]
-
-[[package]]
-name = "csv"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
-dependencies = [
- "csv-core",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -2068,16 +1972,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
 name = "dirs-sys"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2087,17 +1981,6 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
 ]
 
 [[package]]
@@ -2379,12 +2262,6 @@ dependencies = [
  "rustc-hex",
  "static_assertions",
 ]
-
-[[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flume"
@@ -2701,17 +2578,6 @@ dependencies = [
 
 [[package]]
 name = "goblin"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b363a30c165f666402fe6a3024d3bec7ebc898f96a4a23bd1c99f8dbf3f4f47"
-dependencies = [
- "log",
- "plain",
- "scroll",
-]
-
-[[package]]
-name = "goblin"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daa0a64d21a7eb230583b4c5f4e23b7e4e57974f96620f42a7e75e08ae66d745"
@@ -2761,16 +2627,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
-]
-
-[[package]]
-name = "half"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
-dependencies = [
- "cfg-if",
- "crunchy",
 ]
 
 [[package]]
@@ -3335,17 +3191,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
-name = "is-terminal"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
-dependencies = [
- "hermit-abi 0.4.0",
- "libc",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3673,12 +3518,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "multimap"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
-
-[[package]]
 name = "native-tls"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3706,12 +3545,6 @@ dependencies = [
  "cfg_aliases",
  "libc",
 ]
-
-[[package]]
-name = "nohash-hasher"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
@@ -3921,12 +3754,6 @@ name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
-
-[[package]]
-name = "oorandom"
-version = "11.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
 name = "opaque-debug"
@@ -4385,16 +4212,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "petgraph"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
-dependencies = [
- "fixedbitset",
- "indexmap 2.7.1",
-]
-
-[[package]]
 name = "pin-project"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4460,34 +4277,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
-name = "plotters"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
-dependencies = [
- "num-traits",
- "plotters-backend",
- "plotters-svg",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "plotters-backend"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
-
-[[package]]
-name = "plotters-svg"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
-dependencies = [
- "plotters-backend",
-]
-
-[[package]]
 name = "polling"
 version = "3.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4542,20 +4331,6 @@ checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
 dependencies = [
  "proc-macro2",
  "syn 2.0.96",
-]
-
-[[package]]
-name = "prettytable-rs"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eea25e07510aa6ab6547308ebe3c036016d162b8da920dbb079e3ba8acf3d95a"
-dependencies = [
- "csv",
- "encode_unicode",
- "is-terminal",
- "lazy_static",
- "term",
- "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -4665,26 +4440,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-build"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f3e5beed80eb580c68e2c600937ac2c4eedabdfd5ef1e5b7ea4f3fba84497b"
-dependencies = [
- "heck 0.5.0",
- "itertools 0.13.0",
- "log",
- "multimap",
- "once_cell",
- "petgraph",
- "prettyplease",
- "prost",
- "prost-types",
- "regex",
- "syn 2.0.96",
- "tempfile",
-]
-
-[[package]]
 name = "prost-derive"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4695,15 +4450,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.96",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2f1e56baa61e93533aebc21af4d2134b70f66275e0fcdf3cbe43d77ff7e8fc"
-dependencies = [
- "prost",
 ]
 
 [[package]]
@@ -5306,15 +5052,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "scale-info"
 version = "2.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5716,12 +5453,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "size"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fed904c7fb2856d868b92464fc8fa597fce366edea1a9cbfaa8cb5fe080bd6d"
-
-[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5771,12 +5502,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "smawk"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
-
-[[package]]
 name = "snowbridge-amcl"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5811,26 +5536,16 @@ dependencies = [
 name = "sp1-cli"
 version = "4.1.3"
 dependencies = [
- "anstyle",
  "anyhow",
  "cargo_metadata",
  "clap",
- "ctrlc",
  "dirs",
- "goblin 0.8.2",
- "hex",
- "indicatif",
- "prettytable-rs",
  "rand 0.8.5",
- "regex",
  "reqwest",
- "rustc-demangle",
  "serde_json",
  "sp1-build",
- "sp1-core-machine",
  "sp1-sdk",
  "target-lexicon",
- "textwrap",
  "tokio",
  "vergen",
  "yansi",
@@ -5847,18 +5562,15 @@ dependencies = [
  "enum-map",
  "eyre",
  "gecko_profile",
- "goblin 0.9.3",
+ "goblin",
  "hashbrown 0.14.5",
  "hex",
  "indicatif",
  "itertools 0.13.0",
- "nohash-hasher",
  "num",
  "p3-baby-bear",
  "p3-field",
  "p3-maybe-rayon",
- "p3-util",
- "rand 0.8.5",
  "range-set-blaze",
  "rrs-succinct",
  "rustc-demangle",
@@ -5887,7 +5599,6 @@ dependencies = [
  "cbindgen",
  "cc",
  "cfg-if",
- "criterion",
  "elliptic-curve",
  "generic-array 1.1.0",
  "glob",
@@ -5900,13 +5611,11 @@ dependencies = [
  "p256",
  "p3-air",
  "p3-baby-bear",
- "p3-challenger",
  "p3-field",
  "p3-keccak-air",
  "p3-matrix",
  "p3-maybe-rayon",
  "p3-poseidon2",
- "p3-symmetric",
  "p3-uni-stark",
  "p3-util",
  "pathdiff",
@@ -5915,7 +5624,6 @@ dependencies = [
  "rayon-scan",
  "serde",
  "serde_json",
- "size",
  "snowbridge-amcl",
  "sp1-core-executor",
  "sp1-curves",
@@ -5923,7 +5631,6 @@ dependencies = [
  "sp1-primitives 4.1.3",
  "sp1-stark",
  "sp1-zkvm",
- "static_assertions",
  "strum",
  "strum_macros",
  "tempfile",
@@ -5944,14 +5651,11 @@ dependencies = [
  "bincode",
  "ctrlc",
  "prost",
- "prost-build",
  "serde",
  "sp1-core-machine",
  "sp1-prover",
- "test-artifacts",
  "tokio",
  "tracing",
- "twirp-build-rs",
  "twirp-rs",
 ]
 
@@ -5999,7 +5703,6 @@ dependencies = [
  "sp1-prover",
  "sp1-sdk",
  "sp1-stark",
- "time 0.3.37",
  "tokio",
 ]
 
@@ -6039,7 +5742,6 @@ dependencies = [
  "clap",
  "p3-baby-bear",
  "rand 0.8.5",
- "serde_json",
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-cuda",
@@ -6047,8 +5749,6 @@ dependencies = [
  "sp1-sdk",
  "sp1-stark",
  "test-artifacts",
- "time 0.3.37",
- "tracing",
 ]
 
 [[package]]
@@ -6103,7 +5803,6 @@ dependencies = [
  "num-bigint 0.4.6",
  "p3-baby-bear",
  "p3-bn254-fr",
- "p3-challenger",
  "p3-commit",
  "p3-field",
  "p3-matrix",
@@ -6133,7 +5832,6 @@ dependencies = [
 name = "sp1-recursion-circuit"
 version = "4.1.3"
 dependencies = [
- "ff 0.13.0",
  "hashbrown 0.14.5",
  "itertools 0.13.0",
  "num-traits",
@@ -6146,10 +5844,7 @@ dependencies = [
  "p3-field",
  "p3-fri",
  "p3-matrix",
- "p3-merkle-tree",
- "p3-poseidon2",
  "p3-symmetric",
- "p3-uni-stark",
  "p3-util",
  "rand 0.8.5",
  "rayon",
@@ -6172,14 +5867,10 @@ name = "sp1-recursion-compiler"
 version = "4.1.3"
 dependencies = [
  "backtrace",
- "criterion",
  "itertools 0.13.0",
  "p3-baby-bear",
  "p3-bn254-fr",
- "p3-challenger",
- "p3-dft",
  "p3-field",
- "p3-merkle-tree",
  "p3-symmetric",
  "rand 0.8.5",
  "serde",
@@ -6204,7 +5895,6 @@ dependencies = [
  "glob",
  "hashbrown 0.14.5",
  "itertools 0.13.0",
- "num_cpus",
  "p3-air",
  "p3-baby-bear",
  "p3-bn254-fr",
@@ -6231,7 +5921,6 @@ dependencies = [
  "static_assertions",
  "thiserror 1.0.69",
  "tracing",
- "vec_map",
  "zkhash",
 ]
 
@@ -6259,7 +5948,6 @@ dependencies = [
  "anyhow",
  "bincode",
  "bindgen",
- "cc",
  "cfg-if",
  "hex",
  "num-bigint 0.4.6",
@@ -6269,7 +5957,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.8",
- "sp1-core-machine",
  "sp1-recursion-compiler",
  "sp1-stark",
  "tempfile",
@@ -6283,7 +5970,6 @@ dependencies = [
  "alloy-primitives",
  "alloy-signer",
  "alloy-signer-local",
- "alloy-sol-types",
  "anyhow",
  "async-trait",
  "backoff",
@@ -6302,7 +5988,6 @@ dependencies = [
  "reqwest",
  "reqwest-middleware",
  "serde",
- "serde_json",
  "sp1-build",
  "sp1-core-executor",
  "sp1-core-machine",
@@ -6316,10 +6001,8 @@ dependencies = [
  "test-artifacts",
  "thiserror 1.0.69",
  "tokio",
- "tokio-test",
  "tonic",
  "tracing",
- "twirp-rs",
 ]
 
 [[package]]
@@ -6369,8 +6052,6 @@ dependencies = [
  "cfg-if",
  "hex",
  "lazy_static",
- "num-bigint 0.4.6",
- "num-traits",
  "serial_test",
  "sha2 0.10.8",
  "sp1-sdk",
@@ -6721,32 +6402,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "term"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
-dependencies = [
- "dirs-next",
- "rustversion",
- "winapi",
-]
-
-[[package]]
 name = "test-artifacts"
 version = "4.1.3"
 dependencies = [
  "sp1-build",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
-dependencies = [
- "smawk",
- "unicode-linebreak",
- "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -6899,16 +6558,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinytemplate"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
-dependencies = [
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "tinyvec"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6981,19 +6630,6 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "tokio-test"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468baabc3311435b55dd935f702f42cd1b8abb7e754fb7dfb16bd36aa88f9f7"
-dependencies = [
- "async-stream",
- "bytes 1.9.0",
- "futures-core",
- "tokio",
- "tokio-stream",
 ]
 
 [[package]]
@@ -7267,15 +6903,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "twirp-build-rs"
-version = "0.13.0-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8160cc3d9282e192ec842f1ab44e9d396312ff5472bdab58f5e7f4d882b22eea"
-dependencies = [
- "prost-build",
-]
-
-[[package]]
 name = "twirp-rs"
 version = "0.13.0-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7338,12 +6965,6 @@ name = "unicode-ident"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
-
-[[package]]
-name = "unicode-linebreak"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-width"
@@ -7487,16 +7108,6 @@ name = "waker-fn"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
-
-[[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
-]
 
 [[package]]
 name = "want"
@@ -7675,15 +7286,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
-dependencies = [
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6001,6 +6001,7 @@ dependencies = [
  "test-artifacts",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-test",
  "tonic",
  "tracing",
 ]
@@ -6630,6 +6631,19 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-test"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2468baabc3311435b55dd935f702f42cd1b8abb7e754fb7dfb16bd36aa88f9f7"
+dependencies = [
+ "async-stream",
+ "bytes 1.9.0",
+ "futures-core",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -22,25 +22,15 @@ anyhow = { version = "1.0.83", features = ["backtrace"] }
 clap = { version = "4.5.9", features = ["derive", "env"] }
 sp1-build = { workspace = true }
 sp1-sdk = { workspace = true }
-sp1-core-machine = { workspace = true }
 reqwest = { version = "0.12.4", features = [
   "stream",
   "json",
   "rustls-tls",
 ], default-features = false }
-indicatif = "0.17.8"
 tokio = { version = "1", features = ["full"] }
 dirs = "5.0"
 rand = "0.8"
 serde_json = { workspace = true }
 yansi = "1.0.1"
-hex = "0.4.3"
-anstyle = "1.0.8"
 target-lexicon = "0.12.15"
-rustc-demangle = "0.1.18"
-goblin = "0.8"
-regex = "1.5.4"
-prettytable-rs = "0.10"
-textwrap = "0.16.0"
-ctrlc = "3.4.2"
 cargo_metadata = "0.18.1"

--- a/crates/core/executor/Cargo.toml
+++ b/crates/core/executor/Cargo.toml
@@ -19,7 +19,6 @@ sp1-stark = { workspace = true }
 p3-field = { workspace = true }
 p3-baby-bear = { workspace = true }
 p3-maybe-rayon = { workspace = true, features = ["parallel"] }
-p3-util = { workspace = true }
 
 # misc
 serde = { workspace = true, features = ["derive", "rc"] }
@@ -30,10 +29,8 @@ eyre = "0.6.12"
 bincode = "1.3.3"
 hashbrown = { workspace = true, features = ["serde", "inline-more"] }
 itertools = { workspace = true }
-rand = "0.8.5"
 num = { version = "0.4.3" }
 typenum = "1.17.0"
-nohash-hasher = "0.2.0"
 thiserror = "1.0.63"
 tracing = { workspace = true }
 strum_macros = "0.26.4"

--- a/crates/core/machine/Cargo.toml
+++ b/crates/core/machine/Cargo.toml
@@ -18,14 +18,12 @@ itertools = { workspace = true }
 num = { version = "0.4.3" }
 p3-air = { workspace = true }
 p3-baby-bear = { workspace = true }
-p3-challenger = { workspace = true }
 p3-field = { workspace = true }
 p3-keccak-air = { workspace = true }
 p3-matrix = { workspace = true }
 p3-maybe-rayon = { workspace = true, features = ["parallel"] }
 p3-uni-stark = { workspace = true }
 p3-util = { workspace = true }
-p3-symmetric = { workspace = true }
 sp1-derive = { workspace = true }
 sp1-primitives = { workspace = true }
 
@@ -44,7 +42,6 @@ k256 = { version = "0.13.3", features = ["expose-field"] }
 p256 = { version = "0.13.2", features = ["expose-field"] }
 
 num_cpus = "1.16.0"
-size = "0.4.1"
 tempfile = "3.10.1"
 tracing = { workspace = true }
 tracing-forest = { version = "0.1.6", features = ["ansi", "smallvec"] }
@@ -55,7 +52,6 @@ web-time = "1.1.0"
 thiserror = "1.0.63"
 rand = "0.8.5"
 hashbrown = { workspace = true, features = ["serde", "inline-more"] }
-static_assertions = "1.1.0"
 
 sp1-stark = { workspace = true }
 sp1-core-executor = { workspace = true }
@@ -64,7 +60,6 @@ p3-poseidon2 = { workspace = true }
 
 [dev-dependencies]
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }
-criterion = "0.5.1"
 num = { version = "0.4.3", features = ["rand"] }
 rand = "0.8.5"
 sp1-zkvm = { path = "../../zkvm/entrypoint" }

--- a/crates/cuda/Cargo.toml
+++ b/crates/cuda/Cargo.toml
@@ -20,17 +20,18 @@ tracing = { workspace = true }
 twirp = { package = "twirp-rs", version = "0.13.0-succinct" }
 ctrlc = "3.4.4"
 
-[build-dependencies]
-prost-build = { version = "0.13", optional = true }
-twirp-build = { package = "twirp-build-rs", version = "0.13.0-succinct", optional = true }
+# Commented out for the same reason that the logic in `build.rs` is commented out.
+# [build-dependencies]
+# prost-build = { version = "0.13", optional = true }
+# twirp-build = { package = "twirp-build-rs", version = "0.13.0-succinct", optional = true }
 
 [dev-dependencies]
 sp1-core-machine = { path = "../core/machine" }
-test-artifacts = { path = "../test-artifacts" }
 
 [features]
 default = []
-protobuf = ["dep:prost-build", "dep:twirp-build"]
+# Does nothing for now.
+protobuf = [] # ["dep:prost-build", "dep:twirp-build"]
 
 [lints]
 workspace = true

--- a/crates/eval/Cargo.toml
+++ b/crates/eval/Cargo.toml
@@ -18,7 +18,6 @@ anyhow = "1.0.83"
 clap = { version = "4.5.9", features = ["derive"] }
 serde = { workspace = true }
 bincode = "1.3.3"
-time = "0.3.26"
 slack-rust = { package = "slack-rust-rs", version = "0.0.1" }
 tokio = { version = "1.39.0", features = ["full"] }
 reqwest = { version = "0.12.4", features = ["json"] }

--- a/crates/perf/Cargo.toml
+++ b/crates/perf/Cargo.toml
@@ -20,12 +20,9 @@ p3-baby-bear = { workspace = true }
 sp1-stark = { workspace = true }
 sp1-cuda = { workspace = true }
 test-artifacts = { workspace = true }
-tracing = { workspace = true }
-serde_json = { workspace = true }
 rand = "0.8.5"
 clap = { version = "4.5.9", features = ["derive"] }
 bincode = "1.3.3"
-time = "0.3.26"
 
 [[bin]]
 name = "sp1-perf"

--- a/crates/prover/Cargo.toml
+++ b/crates/prover/Cargo.toml
@@ -22,7 +22,6 @@ p3-symmetric = { workspace = true }
 sp1-core-executor = { workspace = true }
 sp1-primitives = { workspace = true }
 p3-field = { workspace = true }
-p3-challenger = { workspace = true }
 p3-baby-bear = { workspace = true }
 p3-bn254-fr = { workspace = true }
 p3-commit = { workspace = true }

--- a/crates/recursion/circuit/Cargo.toml
+++ b/crates/recursion/circuit/Cargo.toml
@@ -21,7 +21,6 @@ p3-challenger = { workspace = true }
 p3-dft = { workspace = true }
 p3-bn254-fr = { workspace = true }
 p3-baby-bear = { workspace = true }
-p3-uni-stark = { workspace = true }
 
 sp1-core-machine = { workspace = true }
 sp1-core-executor = { workspace = true }
@@ -43,12 +42,9 @@ rayon = "1.10.0"
 [dev-dependencies]
 sp1-core-executor = { path = "../../core/executor" }
 sp1-recursion-core = { path = "../core", features = ["program_validation"] }
-ff = { version = "0.13", features = ["derive", "derive_bits"] }
 p3-challenger = { workspace = true }
 p3-symmetric = { workspace = true }
 p3-dft = { workspace = true }
-p3-merkle-tree = { workspace = true }
-p3-poseidon2 = { workspace = true }
 zkhash = "0.2.0"
 rand = "0.8.5"
 test-artifacts = { path = "../../test-artifacts" }

--- a/crates/recursion/compiler/Cargo.toml
+++ b/crates/recursion/compiler/Cargo.toml
@@ -29,11 +29,7 @@ vec_map = "0.8.2"
 
 [dev-dependencies]
 sp1-recursion-core = { path = "../core", features = ["program_validation"] }
-p3-challenger = { workspace = true }
-p3-dft = { workspace = true }
-p3-merkle-tree = { workspace = true }
 rand = "0.8.5"
-criterion = { version = "0.5.1", features = ["html_reports"] }
 
 [features]
 default = ["debug"]

--- a/crates/recursion/core/Cargo.toml
+++ b/crates/recursion/core/Cargo.toml
@@ -38,7 +38,6 @@ serde = { workspace = true, features = ["derive", "rc"] }
 backtrace = { version = "0.3.71", features = ["serde"] }
 static_assertions = "1.1.0"
 thiserror = "1.0.60"
-vec_map = "0.8.2"
 range-set-blaze = { version = "0.1.16", optional = true }
 smallvec = { version = "1.13.2", features = [
     "const_generics",
@@ -47,7 +46,6 @@ smallvec = { version = "1.13.2", features = [
     "union",
     "write",
 ], optional = true }
-num_cpus = "1.16.0"
 rand = "0.8.5"
 cfg-if = "1.0.0"
 

--- a/crates/recursion/gnark-ffi/Cargo.toml
+++ b/crates/recursion/gnark-ffi/Cargo.toml
@@ -14,7 +14,6 @@ p3-field = { workspace = true }
 p3-symmetric = { workspace = true }
 p3-baby-bear = { workspace = true }
 sp1-recursion-compiler = { workspace = true }
-sp1-core-machine = { workspace = true }
 sp1-stark = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -29,7 +28,6 @@ hex = "0.4.3"
 
 [build-dependencies]
 bindgen = "0.70.1"
-cc = "1.1"
 cfg-if = "1.0"
 
 [features]

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -52,6 +52,7 @@ backoff = { version = "0.4", features = ["tokio"], optional = true }
 
 [dev-dependencies]
 test-artifacts = { path = "../test-artifacts" }
+tokio-test = { version = "0.4" }
 
 [features]
 default = ["network"]

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -12,8 +12,6 @@ categories = { workspace = true }
 [dependencies]
 prost = { version = "0.13", optional = true }
 serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true }
-twirp = { package = "twirp-rs", version = "0.13.0-succinct", optional = true }
 async-trait = "0.1.81"
 reqwest-middleware = { version = "0.3.2", optional = true }
 reqwest = { version = "0.12.4", default-features = false, features = [
@@ -47,7 +45,6 @@ sp1-stark = { workspace = true }
 sp1-primitives = { workspace = true }
 itertools = { workspace = true }
 tonic = { version = "0.12", features = ["tls", "tls-roots"], optional = true }
-alloy-sol-types = { version = "0.8", default-features = false, optional = true }
 alloy-primitives = { version = "0.8", default-features = false, optional = true }
 alloy-signer = { version = "0.11", default-features = false, optional = true }
 alloy-signer-local = { version = "0.11", default-features = false, optional = true }
@@ -55,7 +52,6 @@ backoff = { version = "0.4", features = ["tokio"], optional = true }
 
 [dev-dependencies]
 test-artifacts = { path = "../test-artifacts" }
-tokio-test = { version = "0.4" }
 
 [features]
 default = ["network"]
@@ -64,14 +60,12 @@ native-gnark = ["sp1-prover/native-gnark"]
 # dependency resolution issues.
 network = [
   "dep:prost",
-  "dep:alloy-sol-types",
   "dep:alloy-signer",
   "dep:alloy-signer-local",
   "dep:alloy-primitives",
   "dep:tokio",
   "dep:alloy-signer",
   "dep:reqwest",
-  "dep:twirp",
   "dep:reqwest-middleware",
   "dep:tonic",
   "dep:backoff",

--- a/crates/verifier/Cargo.toml
+++ b/crates/verifier/Cargo.toml
@@ -28,8 +28,6 @@ ark-ec = { version = "0.4.0", optional = true }
 [dev-dependencies]
 sp1-sdk = { path = "../sdk" }
 test-artifacts = { path = "../test-artifacts" }
-num-bigint = "0.4.6"
-num-traits = "0.2.19"
 cfg-if = "1.0.0"
 serial_test = "3.2.0"
 

--- a/patch-testing/Cargo.lock
+++ b/patch-testing/Cargo.lock
@@ -2299,12 +2299,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nohash-hasher"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
-
-[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3906,12 +3900,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "size"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fed904c7fb2856d868b92464fc8fa597fce366edea1a9cbfaa8cb5fe080bd6d"
-
-[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3970,13 +3958,10 @@ dependencies = [
  "hashbrown 0.14.5",
  "hex",
  "itertools 0.13.0",
- "nohash-hasher",
  "num",
  "p3-baby-bear",
  "p3-field",
  "p3-maybe-rayon",
- "p3-util",
- "rand",
  "range-set-blaze",
  "rrs-succinct",
  "serde",
@@ -4014,13 +3999,11 @@ dependencies = [
  "p256 0.13.2",
  "p3-air",
  "p3-baby-bear",
- "p3-challenger",
  "p3-field",
  "p3-keccak-air",
  "p3-matrix",
  "p3-maybe-rayon",
  "p3-poseidon2",
- "p3-symmetric",
  "p3-uni-stark",
  "p3-util",
  "pathdiff",
@@ -4029,14 +4012,12 @@ dependencies = [
  "rayon-scan",
  "serde",
  "serde_json",
- "size",
  "snowbridge-amcl",
  "sp1-core-executor",
  "sp1-curves",
  "sp1-derive",
  "sp1-primitives",
  "sp1-stark",
- "static_assertions",
  "strum",
  "strum_macros",
  "tempfile",
@@ -4135,7 +4116,6 @@ dependencies = [
  "num-bigint 0.4.6",
  "p3-baby-bear",
  "p3-bn254-fr",
- "p3-challenger",
  "p3-commit",
  "p3-field",
  "p3-matrix",
@@ -4177,7 +4157,6 @@ dependencies = [
  "p3-fri",
  "p3-matrix",
  "p3-symmetric",
- "p3-uni-stark",
  "p3-util",
  "rand",
  "rayon",
@@ -4225,7 +4204,6 @@ dependencies = [
  "glob",
  "hashbrown 0.14.5",
  "itertools 0.13.0",
- "num_cpus",
  "p3-air",
  "p3-baby-bear",
  "p3-bn254-fr",
@@ -4250,7 +4228,6 @@ dependencies = [
  "static_assertions",
  "thiserror 1.0.69",
  "tracing",
- "vec_map",
  "zkhash",
 ]
 
@@ -4269,7 +4246,6 @@ dependencies = [
  "anyhow",
  "bincode",
  "bindgen",
- "cc",
  "cfg-if",
  "hex",
  "num-bigint 0.4.6",
@@ -4279,7 +4255,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp1-core-machine",
  "sp1-recursion-compiler",
  "sp1-stark",
  "tempfile",
@@ -4304,7 +4279,6 @@ dependencies = [
  "p3-field",
  "p3-fri",
  "serde",
- "serde_json",
  "sp1-build",
  "sp1-core-executor",
  "sp1-core-machine",


### PR DESCRIPTION
Removes unused dependencies across all of the member crates in the main workspace.