### PR TITLE
fix memory boundary check in decode function.

### DIFF
--- a/crates/core/executor/src/disassembler/elf.rs
+++ b/crates/core/executor/src/disassembler/elf.rs
@@ -114,7 +114,7 @@ impl Elf {
             // Read the segment and decode each word as an instruction.
             for i in (0..mem_size).step_by(WORD_SIZE) {
                 let addr = vaddr.checked_add(i).ok_or_else(|| eyre::eyre!("vaddr overflow"))?;
-                if addr == MAXIMUM_MEMORY_SIZE {
+                if addr >= MAXIMUM_MEMORY_SIZE {
                     eyre::bail!(
                         "address [0x{addr:08x}] exceeds maximum address for guest programs [0x{MAXIMUM_MEMORY_SIZE:08x}]"
                     );


### PR DESCRIPTION
Replace `addr == MAXIMUM_MEMORY_SIZE` with `addr >= MAXIMUM_MEMORY_SIZE`
to correctly handle addresses that exceed the maximum limit.






