### PR TITLE
fix(sdk): retry network client creation failures

### DIFF
--- a/crates/sdk/src/network/client.rs
+++ b/crates/sdk/src/network/client.rs
@@ -339,13 +339,25 @@ impl NetworkClient {
     }
 
     pub(crate) async fn prover_network_client(&self) -> Result<ProverNetworkClient<Channel>> {
-        let channel = grpc::configure_endpoint(&self.rpc_url)?.connect().await?;
-        Ok(ProverNetworkClient::new(channel))
+        self.with_retry(
+            || async {
+                let channel = grpc::configure_endpoint(&self.rpc_url)?.connect().await?;
+                Ok(ProverNetworkClient::new(channel))
+            },
+            "creating network client",
+        )
+        .await
     }
 
     pub(crate) async fn artifact_store_client(&self) -> Result<ArtifactStoreClient<Channel>> {
-        let channel = grpc::configure_endpoint(&self.rpc_url)?.connect().await?;
-        Ok(ArtifactStoreClient::new(channel))
+        self.with_retry(
+            || async {
+                let channel = grpc::configure_endpoint(&self.rpc_url)?.connect().await?;
+                Ok(ArtifactStoreClient::new(channel))
+            },
+            "creating artifact client",
+        )
+        .await
     }
 
     pub(crate) async fn create_artifact_with_content<T: Serialize + Send + Sync>(


### PR DESCRIPTION
Fixes this error that can occur during client creation:

> thread 'tokio-runtime-worker' panicked at script/src/main.rs:309:77:
failed to generate compressed proof: transport error
Caused by:
0: dns error: failed to lookup address information: nodename nor servname provided, or not known
1: dns error: failed to lookup address information: nodename nor servname provided, or not known
2: failed to lookup address information: nodename nor servname provided, or not known
note: run with RUST_BACKTRACE=1 environment variable to display a backtrace
Error: JoinError::Panic(Id(52), "failed to generate compressed proof: transport error\n\nCaused by:\n   0: dns error: failed to lookup address information: nodename nor servname provided, or not known\n   1: dns error: failed to lookup address information: nodename nor servname provided, or not known\n   2: failed to lookup address information: nodename nor servname provided, or not known", ...)


We just need to add retrying to client creation / connection.