### PR TITLE
chore: replace clap with arg in build_recursion_vks.rs

### DIFF
--- a/crates/prover/scripts/build_recursion_vks.rs
+++ b/crates/prover/scripts/build_recursion_vks.rs
@@ -9,19 +9,19 @@ use sp1_prover::{
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
 struct Args {
-    #[clap(short, long)]
+    #[arg(short, long)]
     build_dir: PathBuf,
-    //     #[clap(short, long, default_value_t = false)]
+    //     #[arg(short, long, default_value_t = false)]
     //     dummy: bool,
-    //     #[clap(short, long, default_value_t = REDUCE_BATCH_SIZE)]
+    //     #[arg(short, long, default_value_t = REDUCE_BATCH_SIZE)]
     //     reduce_batch_size: usize,
-    //     #[clap(short, long, default_value_t = 1)]
+    //     #[arg(short, long, default_value_t = 1)]
     //     num_compiler_workers: usize,
-    //     #[clap(short, long, default_value_t = 1)]
+    //     #[arg(short, long, default_value_t = 1)]
     //     num_setup_workers: usize,
-    //     #[clap(short, long)]
+    //     #[arg(short, long)]
     //     start: Option<usize>,
-    //     #[clap(short, long)]
+    //     #[arg(short, long)]
     //     end: Option<usize>,
 }
 


### PR DESCRIPTION
<!-- Thank you for your Pull Request. Please provide a description above and review the requirements below.
Bug fixes and new features should include tests.
Typos / punctuation / trivial PRs are generally not accepted.
Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md
The contributors guide includes instructions for running rustfmt and building the documentation. -->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

This PR refactors `build_recursion_vks.rs` by replacing deprecated `#[clap(...)]` attributes with the updated `#[arg(...)]` syntax from the `clap` crate. It helps keep the codebase up-to-date with current best practices and removes legacy syntax.

## Solution

Replaced 7 instances of `#[clap(...)]` with `#[arg(...)]` to align with the current API of `clap`. No functional changes were made.

## PR Checklist

- [ ] Added Tests  
- [ ] Added Documentation  
- [ ] Breaking changes
