### PR TITLE
fix(sp1up): correct openssl warning message in install script

### DIFF
--- a/sp1up/install
+++ b/sp1up/install
@@ -54,7 +54,7 @@ fi
 
 # Warn MacOS users that they may need to manually install openssl via Homebrew:
 if [[ "$OSTYPE" =~ ^darwin ]] && [[ ! -f /usr/local/opt/openssl/lib/libssl.3.dylib && ! -f /opt/homebrew/opt/openssl/lib/libssl.3.dylib ]]; then
-    echo && echo "warning: libusb not found. You may need to install it manually on MacOS via Homebrew (brew install openssl)."
+    echo && echo "warning: openssl not found. You may need to install it manually on MacOS via Homebrew (brew install openssl)."
 fi
 
 echo && echo "✅ Installation complete!"


### PR DESCRIPTION
## Motivation

While trying to run my sp1up install script on my Mac, I was sort of losing it because I didn't have OpenSSL. The script performs two separate checks for required libraries under macOS: the first one is right to give a warning about missing libusb, but the second one (for OpenSSL) is wrong in copying the libusb warning. 

## Solution

This pull request corrects the sp1up install script so the OpenSSL check will print the correct warning message. The message has been revised to:

> "warning: openssl not found. You may need to install it manually on MacOS via Homebrew (brew install openssl)."

This fix should prevent mac users from being confused and spare others the frustration I had to endure.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes