### PR TITLE
optimize: improve performance in words_to_bytes_le utility function

### DIFF
--- a/crates/zkvm/lib/src/utils.rs
+++ b/crates/zkvm/lib/src/utils.rs
@@ -121,7 +121,11 @@ pub enum MulAssignError {
 
 /// Converts a slice of words to a byte array in little endian.
 pub fn words_to_bytes_le(words: &[u32]) -> Vec<u8> {
-    words.iter().flat_map(|word| word.to_le_bytes().to_vec()).collect::<Vec<_>>()
+    let mut result = Vec::with_capacity(words.len() * 4);
+    for word in words {
+        result.extend_from_slice(&word.to_le_bytes());
+    }
+    result
 }
 
 /// Converts a byte array in little endian to a slice of words.


### PR DESCRIPTION
optimize: improve performance in words_to_bytes_le utility function

This optimization improves the performance of the words_to_bytes_le function by:
- Pre-allocating the result vector with exact capacity needed
- Eliminating unnecessary allocations for each word conversion
- Reducing memory usage by avoiding intermediate vectors
- Maintaining identical functionality with more efficient implementation

The changes should result in better performance particularly for large inputs where multiple allocations would have been costly.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes