### PR TITLE
chore: remove protobuf-comiler to Dockerfile.build dep

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -21,7 +21,7 @@ RUN cargo run --bin cargo-prove -- prove install-toolchain && rm -rf /root/sp1
 
 FROM ubuntu:24.04@sha256:e3f92abc0967a6c19d0dfa2d55838833e947b9d74edbcb0113e48535ad4be12a as final
 
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates clang gcc libssl-dev pkg-config protobuf-compiler \
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates clang gcc libssl-dev pkg-config \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /root/.cargo /root/.cargo


### PR DESCRIPTION
Reverting changes from #2193, since it was too ad hoc to celestia support in op-succinct.
Chose to remove protobuf dep from celestia program.