### PR TITLE
fix(edwards): correct y-coordinate sign in Edwards addition

### DIFF
--- a/crates/curves/src/edwards/mod.rs
+++ b/crates/curves/src/edwards/mod.rs
@@ -114,7 +114,7 @@ impl<E: EdwardsParameters> AffinePoint<EdwardsCurve<E>> {
     ) -> AffinePoint<EdwardsCurve<E>> {
         let p = <E as EllipticCurveParameters>::BaseField::modulus();
         let x_3n = (&self.x * &other.y + &self.y * &other.x) % &p;
-        let y_3n = (&self.y * &other.y + &self.x * &other.x) % &p;
+        let y_3n = (&self.y * &other.y - &self.x * &other.x) % &p;
 
         let all_xy = (&self.x * &self.y * &other.x * &other.y) % &p;
         let d = E::d_biguint();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Untwisted Edwards curves defined by x^2 + y^2 = 1 + d * x^2 * y^2 have the usual group‐law addition formulas:

x3 = (x1y2 + y1x2) / (1 + d * x1 * x2 * y1 * y2) y3 = (y1y2 - x1x2) / (1 - d * x1 * x2 * y1 * y2)

The current implementation of the Edwards addition function in `ed_add()` includes a plus sign in the \( y \)‐numerator, which does not agree with the above formula so some arithmetic will give the wrong results.

## Solution

This PR corrects the sign in the \( y \)-coordinate numerator to:

```rust
(&self.y * &other.y - &self.x * &other.x) % &p
```

which aligns with the canonical Edwards addition law. The denominators remain unaffected, according to the canonical untwisted Edwards curve formulas.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes