### PR TITLE
chore: check syscalls in secp256k1_verify test

### DIFF
--- a/patch-testing/secp256k1/src/lib.rs
+++ b/patch-testing/secp256k1/src/lib.rs
@@ -43,7 +43,7 @@ fn test_recover_rand_lte_100(
     }
 }
 
-#[sp1_test::sp1_test("secp256k1_verify")]
+#[sp1_test::sp1_test("secp256k1_verify", syscalls = [SECP256K1_DOUBLE, SECP256K1_ADD])]
 fn test_verify_rand_lte_100(
     stdin: &mut sp1_sdk::SP1Stdin,
 ) -> impl FnOnce(sp1_sdk::SP1PublicValues) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Check that the `SECP256K1_DOUBLE` and `SECP256K1_ADD` syscalls are actually called.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes