### PR TITLE
chore: fix operand formatting in `Instruction` struct

### DIFF
--- a/crates/core/executor/src/instruction.rs
+++ b/crates/core/executor/src/instruction.rs
@@ -140,12 +140,12 @@ impl Debug for Instruction {
         let mnemonic = self.opcode.mnemonic();
         let op_a_formatted = format!("%x{}", self.op_a);
         let op_b_formatted = if self.imm_b || self.opcode == Opcode::AUIPC {
-            format!("{}", self.op_b as i32)
+            format!("{}", self.op_b)
         } else {
-            format!("%x{}", self.op_b)
+            format!("{:#x}", self.op_b)
         };
         let op_c_formatted =
-            if self.imm_c { format!("{}", self.op_c as i32) } else { format!("%x{}", self.op_c) };
+            if self.imm_c { format!("{}", self.op_c) } else { format!("{:#x}", self.op_c) };
 
         let width = 10;
         write!(


### PR DESCRIPTION
## Motivation  
The formatting of operands `op_b` and `op_c` in the `Instruction` struct was incorrect, using `%x{}` for hexadecimal values and converting unsigned operands (`u32`) to `i32`, which could lead to errors.

## Solution  
Fixed the hexadecimal formatting by using `{:#x}` instead of `%x{}`. Removed the unnecessary conversion of unsigned operands (`u32`) to `i32`, ensuring correct handling of values using `format!("{}", self.op_b)` and `format!("{}", self.op_c)`.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes