### PR TITLE
feat: introduce `WarningLevel`

### DIFF
--- a/crates/build/src/build.rs
+++ b/crates/build/src/build.rs
@@ -6,7 +6,7 @@ use cargo_metadata::camino::Utf8PathBuf;
 use crate::{
     command::{docker::create_docker_command, local::create_local_command, utils::execute_command},
     utils::{cargo_rerun_if_changed, current_datetime},
-    BuildArgs, BUILD_TARGET, HELPER_TARGET_SUBDIR,
+    BuildArgs, WarningLevel, BUILD_TARGET, HELPER_TARGET_SUBDIR,
 };
 
 /// Build a program with the specified [`BuildArgs`]. The `program_dir` is specified as an argument
@@ -129,7 +129,7 @@ pub(crate) fn build_program_internal(path: &str, args: Option<BuildArgs>) {
     }
 
     // Build the program with the given arguments.
-    let path_output = if let Some(args) = args {
+    let path_output = if let Some(args) = &args {
         execute_build_program(&args, Some(program_dir.to_path_buf()))
     } else {
         execute_build_program(&BuildArgs::default(), Some(program_dir.to_path_buf()))
@@ -138,7 +138,9 @@ pub(crate) fn build_program_internal(path: &str, args: Option<BuildArgs>) {
         panic!("Failed to build SP1 program: {}.", err);
     }
 
-    println!("cargo:warning={} built at {}", root_package_name, current_datetime());
+    if args.map(|args| matches!(args.warning_level, WarningLevel::All)).unwrap_or(true) {
+        println!("cargo:warning={} built at {}", root_package_name, current_datetime());
+    }
 }
 
 /// Collects the list of targets that would be built and their output ELF file paths.

--- a/crates/build/src/command/docker.rs
+++ b/crates/build/src/command/docker.rs
@@ -6,7 +6,7 @@ use std::{
 use anyhow::{Context, Result};
 use cargo_metadata::camino::Utf8PathBuf;
 
-use crate::BuildArgs;
+use crate::{BuildArgs, WarningLevel};
 
 use super::utils::{get_program_build_args, get_rust_compiler_flags};
 
@@ -100,7 +100,9 @@ pub(crate) fn create_docker_command(
         let stdout_string =
             String::from_utf8(output.stdout).expect("Can't parse rustc --version stdout");
 
-        println!("cargo:warning=docker: rustc +succinct --version: {:?}", stdout_string);
+        if matches!(args.warning_level, WarningLevel::All) {
+            println!("cargo:warning=docker: rustc +succinct --version: {:?}", stdout_string);
+        }
 
         super::utils::parse_rustc_version(&stdout_string)
     };

--- a/crates/build/src/command/local.rs
+++ b/crates/build/src/command/local.rs
@@ -1,7 +1,6 @@
-use std::path::PathBuf;
-use std::{env, process::Command};
+use std::{env, path::PathBuf, process::Command};
 
-use crate::{BuildArgs, HELPER_TARGET_SUBDIR};
+use crate::{BuildArgs, WarningLevel, HELPER_TARGET_SUBDIR};
 use cargo_metadata::camino::Utf8PathBuf;
 use dirs::home_dir;
 
@@ -46,7 +45,9 @@ pub(crate) fn create_local_command(
         let stdout_string =
             String::from_utf8(output.stdout).expect("Can't parse rustc --version stdout");
 
-        println!("cargo:warning=rustc +succinct --version: {:?}", stdout_string);
+        if matches!(args.warning_level, WarningLevel::All) {
+            println!("cargo:warning=rustc +succinct --version: {:?}", stdout_string);
+        }
 
         super::utils::parse_rustc_version(&stdout_string)
     };

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -5,11 +5,21 @@ use build::build_program_internal;
 pub use build::{execute_build_program, generate_elf_paths};
 pub use command::TOOLCHAIN_NAME;
 
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 
 const DEFAULT_DOCKER_TAG: &str = concat!("v", env!("CARGO_PKG_VERSION"));
 const BUILD_TARGET: &str = "riscv32im-succinct-zkvm-elf";
 const HELPER_TARGET_SUBDIR: &str = "elf-compilation";
+
+/// Controls the warning message verbosity in the build process.
+#[derive(Clone, Copy, ValueEnum, Debug, Default)]
+pub enum WarningLevel {
+    /// Show all warning messages (default).
+    #[default]
+    All,
+    /// Suppress non-essential warnings; show only critical stuff.
+    Minimal,
+}
 
 /// Compile an SP1 program.
 ///
@@ -78,6 +88,9 @@ pub struct BuildArgs {
         help = "The top level directory to be used in the docker invocation."
     )]
     pub workspace_directory: Option<String>,
+
+    #[arg(long, value_enum, default_value = "all", help = "Control warning message verbosity")]
+    pub warning_level: WarningLevel,
 }
 
 // Implement default args to match clap defaults.
@@ -96,6 +109,7 @@ impl Default for BuildArgs {
             locked: false,
             no_default_features: false,
             workspace_directory: None,
+            warning_level: WarningLevel::All,
         }
     }
 }


### PR DESCRIPTION
This commit introduces `WarningLevel` in `BuildArgs` to allow suppressing the non-essential warning messages in the build process. The default value of `WarningLevel` is `All`, i.e., all warning messages are displayed, making the existing behavior unchanged. Users can specify `WarningLevel::Minimal` in `BuildArgs` to skip the non-critical messages mentioned in #2186.

Close https://github.com/succinctlabs/sp1/issues/2186

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes