### PR TITLE
chore: improve error message for rv32im_costs.json loading failure

### DIFF
--- a/crates/core/machine/src/shape/mod.rs
+++ b/crates/core/machine/src/shape/mod.rs
@@ -524,7 +524,8 @@ impl<F: PrimeField32> Default for CoreShapeConfig<F> {
                     ShapeCluster::new(x.into_iter().map(|(k, v)| (k, vec![Some(v)])).collect())
                 })
                 .collect(),
-            costs: serde_json::from_str(include_str!("rv32im_costs.json")).unwrap(),
+            costs: serde_json::from_str(include_str!("rv32im_costs.json"))
+                .expect("Failed to load rv32im_costs.json file. Verify that `git config core.symlinks` is not set to false."),
             _data: PhantomData,
         }
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

When building SP1 from a repo cloned when the git config setting `core.symlinks` is set to false, the `rv32im_costs.json` file (that is a symlink) can't be loaded.

## Solution

Adding an hint of the root cause in the error message.

Closes #2170

