### PR TITLE
feat: disallow SP1 to be ran in debug

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -149,7 +149,7 @@ jobs:
           command: test
           args: --release --package sp1-verifier
         env:
-          RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0 -C target-cpu=native
+          RUSTFLAGS: -Copt-level=3 -Coverflow-checks=y -Cdebuginfo=0 -C target-cpu=native
           RUST_BACKTRACE: 1
 
       - name: Run cargo test with Blake3 PV hashing
@@ -158,7 +158,7 @@ jobs:
           command: test
           args: --release --package sp1-verifier -F blake3
         env:
-          RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0 -C target-cpu=native
+          RUSTFLAGS: -Copt-level=3 -Coverflow-checks=y -Cdebuginfo=0 -C target-cpu=native
           RUST_BACKTRACE: 1
 
   lint:

--- a/crates/sdk/src/env/mod.rs
+++ b/crates/sdk/src/env/mod.rs
@@ -19,6 +19,7 @@ use crate::network::builder::NetworkProverBuilder;
 use crate::{
     cpu::{execute::CpuExecuteBuilder, CpuProver},
     cuda::CudaProver,
+    utils::check_release_build,
     SP1ProofMode, SP1ProofWithPublicValues,
 };
 
@@ -49,8 +50,12 @@ impl EnvProver {
 
         let prover: Box<dyn Prover<CpuProverComponents>> = match mode.as_str() {
             "mock" => Box::new(CpuProver::mock()),
-            "cpu" => Box::new(CpuProver::new()),
+            "cpu" => {
+                check_release_build();
+                Box::new(CpuProver::new())
+            },
             "cuda" => {
+                check_release_build();
                 Box::new(CudaProver::new(SP1Prover::new(), None))
             }
             "network" => {

--- a/crates/sdk/src/utils.rs
+++ b/crates/sdk/src/utils.rs
@@ -40,5 +40,5 @@ pub(crate) fn block_on<T>(fut: impl std::future::Future<Output = T>) -> T {
 /// will be performant, which is important for benchmarking.
 pub(crate) fn check_release_build() {
     #[cfg(debug_assertions)]
-    panic!("sp1-sdk must be built in release mode. please compile with the --release flag.");
+    panic!("sp1-sdk must be built in release mode, please compile with the --release flag.");
 }

--- a/crates/sdk/src/utils.rs
+++ b/crates/sdk/src/utils.rs
@@ -35,3 +35,10 @@ pub(crate) fn block_on<T>(fut: impl std::future::Future<Output = T>) -> T {
         rt.block_on(fut)
     }
 }
+
+/// Forbid `sp1-sdk` to be compiled in debug to avoid teams doing benchmarks and forget to build in
+/// release seeing degraded performances.
+pub(crate) fn check_release_build() {
+    #[cfg(debug_assertions)]
+    panic!("sp1-sdk must be built in release mode. please compile with the --release flag.");
+}

--- a/crates/sdk/src/utils.rs
+++ b/crates/sdk/src/utils.rs
@@ -36,8 +36,8 @@ pub(crate) fn block_on<T>(fut: impl std::future::Future<Output = T>) -> T {
     }
 }
 
-/// Forbid `sp1-sdk` to be compiled in debug to avoid teams doing benchmarks and forget to build in
-/// release seeing degraded performances.
+/// Check that SP1 SDK was built in release mode. Ensures that the prover and executor
+/// will be performant, which is important for benchmarking.
 pub(crate) fn check_release_build() {
     #[cfg(debug_assertions)]
     panic!("sp1-sdk must be built in release mode. please compile with the --release flag.");


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Teams that run benchmarks might forget the release flag and see degraded performance. To avoid that, we want to disallow provers to be ran in debug in CPU and Cuda mode.

## Solution

Panics when the CPU and Cuda provers are instantiated if `sp1-sdk` is build in debug. It's not an issue with the network prover as progams are executed on a remote cluster.