### PR TITLE
Fix potential panic in `debug_cumulative_sums` when permutation matrix is empty

### DIFF
--- a/crates/stark/src/debug.rs
+++ b/crates/stark/src/debug.rs
@@ -125,8 +125,15 @@ fn catch_unwind_silent<F: FnOnce() -> R + panic::UnwindSafe, R>(f: F) -> std::th
 ///
 /// Note that this does not actually verify the proof.
 pub fn debug_cumulative_sums<F: Field, EF: ExtensionField<F>>(perms: &[RowMajorMatrix<EF>]) {
-    let sum: EF = perms.iter().map(|perm| *perm.row_slice(perm.height() - 1).last().unwrap()).sum();
-    assert_eq!(sum, EF::zero());
+    let sum: EF = perms.iter().map(|perm| {
+        if perm.width() == 0 || perm.height() == 0 {
+            EF::zero()
+        } else {
+            *perm.row_slice(perm.height() - 1).last().unwrap_or(&EF::zero())
+        }
+    }).sum();
+    
+    assert_eq!(sum, EF::zero(), "Cumulative sum mismatch in debug check");
 }
 
 /// A builder for debugging constraints.


### PR DESCRIPTION
## Motivation

This PR addresses a bug in `debug_cumulative_sums` that can cause a runtime panic when the permutation matrix has no columns (i.e. `width == 0`), such as in chips with no interactions.

Previously, the function used `.last().unwrap()` without checking if the row was empty. This would panic if the row contained no elements, which is possible in practice.

## Solution

- Replaced `.last().unwrap()` with `.last().unwrap_or(&EF::zero())`, making the function robust to empty rows.
- Added an explicit check for both `width == 0` and `height == 0` to safely return `EF::zero()` when the permutation matrix is effectively empty.
- Improved the assertion by adding a helpful error message to `assert_eq!`.

This ensures that the debug logic does not panic on valid edge cases and improves the safety and clarity of the code.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [x] Breaking changes — **No**
- [x] Safe fallback behavior for empty matrices