### PR TITLE
refactor(test): expand `use` Glob Import in `machine.rs` Tests (TODO Resolved)

### DIFF
--- a/crates/recursion/core/src/machine.rs
+++ b/crates/recursion/core/src/machine.rs
@@ -274,8 +274,12 @@ pub mod tests {
     use sp1_core_machine::utils::run_test_machine;
     use sp1_stark::{baby_bear_poseidon2::BabyBearPoseidon2, StarkGenericConfig};
 
-    // TODO expand glob import
-    use crate::{runtime::instruction as instr, *};
+    use crate::air::Block;
+    use crate::instruction::{Instruction, base_alu, ext_alu, mem, mem_single, mem_ext};
+    use crate::opcode::{BaseAluOpcode, ExtAluOpcode, MemAccessKind};
+    use crate::program::linear_program;
+    use crate::runtime::Runtime;
+    use crate::RecursionProgram;
 
     type SC = BabyBearPoseidon2;
     type F = <SC as StarkGenericConfig>::Val;


### PR DESCRIPTION
This PR **resolves a `TODO`** in `crates/recursion/core/src/machine.rs` by expanding a glob import in the test module.  
Instead of the previous glob import (`use crate::{runtime::instruction as instr, *};`), all necessary symbols are now explicitly imported:

```rust
use crate::instruction::{Instruction, base_alu, ext_alu, mem, mem_single, mem_ext};
use crate::opcode::{BaseAluOpcode, ExtAluOpcode, MemAccessKind};
use crate::program::linear_program;
use crate::runtime::Runtime;
use crate::RecursionProgram;
```

This improves code readability, ensures clarity of used symbols, and follows best practices.

### Motivation

Glob imports in test code can obscure dependencies and hinder maintainability.  
The presence of a `// TODO expand glob import` comment explicitly called for resolving this.  
This PR addresses that request.

### Resolution of TODO

> **This change directly resolves the following TODO in the codebase:**
>
> ```rust
> // TODO expand glob import
> use crate::{runtime::instruction as instr, *};
> ```

