### PR TITLE
fix: allow to use blake3 to hash PV

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -152,15 +152,6 @@ jobs:
           RUSTFLAGS: -Copt-level=3 -Coverflow-checks=y -Cdebuginfo=0 -C target-cpu=native
           RUST_BACKTRACE: 1
 
-      - name: Run cargo test with Blake3 PV hashing
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release --package sp1-verifier -F blake3
-        env:
-          RUSTFLAGS: -Copt-level=3 -Coverflow-checks=y -Cdebuginfo=0 -C target-cpu=native
-          RUST_BACKTRACE: 1
-
   lint:
     name: Formatting & Clippy
     runs-on: [runs-on, runner=16cpu-linux-x64, disk=large, "run-id=${{ github.run_id }}"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2573,6 +2573,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5074,6 +5080,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "reqwest"
 version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5209,6 +5221,36 @@ dependencies = [
  "downcast-rs",
  "num_enum",
  "paste",
+]
+
+[[package]]
+name = "rstest"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+ "rustc_version 0.4.1",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate 3.3.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version 0.4.1",
+ "syn 2.0.100",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -6508,6 +6550,7 @@ dependencies = [
  "lazy_static",
  "num-bigint 0.4.6",
  "num-traits",
+ "rstest",
  "serial_test",
  "sha2 0.10.8",
  "sp1-sdk",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6207,6 +6207,8 @@ name = "sp1-primitives"
 version = "4.2.0"
 dependencies = [
  "bincode",
+ "blake3",
+ "cfg-if",
  "hex",
  "lazy_static",
  "num-bigint 0.4.6",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ serde = "1.0.204"
 serde_json = "1.0.132"
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
-blake3 = "1.6.1"
+blake3 = { version = "1.6.1", default-features = false }
 
 [workspace.metadata.typos]
 default.extend-ignore-re = [

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -11,6 +11,8 @@ categories = { workspace = true }
 
 [dependencies]
 bincode = "1.3.3"
+blake3 = { workspace = true, optional = true }
+cfg-if = "1.0.0"
 hex = "0.4.3"
 lazy_static = "1.5.0"
 num-bigint = { version = "0.4.6", default-features = false }
@@ -20,6 +22,9 @@ p3-poseidon2 = { workspace = true }
 p3-symmetric = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 sha2 = "0.10.8"
+
+[features]
+blake3 = ["dep:blake3"]
 
 [lints]
 workspace = true

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -11,7 +11,7 @@ categories = { workspace = true }
 
 [dependencies]
 bincode = "1.3.3"
-blake3 = { workspace = true, optional = true }
+blake3 = { workspace = true }
 cfg-if = "1.0.0"
 hex = "0.4.3"
 lazy_static = "1.5.0"
@@ -22,9 +22,6 @@ p3-poseidon2 = { workspace = true }
 p3-symmetric = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 sha2 = "0.10.8"
-
-[features]
-blake3 = ["dep:blake3"]
 
 [lints]
 workspace = true

--- a/crates/primitives/src/io.rs
+++ b/crates/primitives/src/io.rs
@@ -1,6 +1,7 @@
 use crate::types::Buffer;
 use num_bigint::BigUint;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 /// Public values for the prover.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -51,20 +52,34 @@ impl SP1PublicValues {
         self.buffer.write_slice(slice);
     }
 
-    /// Hash the public values.
+    /// Hash the public values using SHA256.
     pub fn hash(&self) -> Vec<u8> {
-        hash(self.buffer.data.as_slice()).to_vec()
+        sha256_hash(self.buffer.data.as_slice())
     }
 
-    /// Hash the public values, mask the top 3 bits and return a BigUint. Matches the implementation
-    /// of `hashPublicValues` in the Solidity verifier.
+    /// Hash the public values using Blake3.
+    pub fn blake3_hash(&self) -> Vec<u8> {
+        blake3_hash(self.buffer.data.as_slice())
+    }
+
+    /// Hash the public values using SHA256, mask the top 3 bits and return a BigUint.
+    /// Matches the implementation of `hashPublicValues` in the Solidity verifier.
     ///
     /// ```solidity
     /// sha256(publicValues) & bytes32(uint256((1 << 253) - 1));
     /// ```
     pub fn hash_bn254(&self) -> BigUint {
+        self.hash_bn254_with_fn(sha256_hash)
+    }
+
+    /// Hash the public values using the provided `hasher` function, mask the top 3 bits and
+    /// return a BigUint.
+    pub fn hash_bn254_with_fn<F>(&self, hasher: F) -> BigUint
+    where
+        F: Fn(&[u8]) -> Vec<u8>,
+    {
         // Hash the public values.
-        let mut hash = hash(self.buffer.data.as_slice());
+        let mut hash = hasher(self.buffer.data.as_slice());
 
         // Mask the top 3 bits.
         hash[0] &= 0b00011111;
@@ -80,19 +95,16 @@ impl AsRef<[u8]> for SP1PublicValues {
     }
 }
 
-fn hash(inputs: &[u8]) -> [u8; 32] {
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "blake3")] {
-            *blake3::hash(inputs).as_bytes()
-        }
-        else {
-            use sha2::{Digest, Sha256};
+/// Hash the input using SHA256.
+pub fn sha256_hash(input: &[u8]) -> Vec<u8> {
+    let mut hasher = Sha256::new();
+    hasher.update(input);
+    hasher.finalize().to_vec()
+}
 
-            let mut hasher = Sha256::new();
-            hasher.update(inputs);
-            hasher.finalize().into()
-        }
-    }
+/// Hash the input using Blake3.
+pub fn blake3_hash(input: &[u8]) -> Vec<u8> {
+    blake3::hash(input).as_bytes().to_vec()
 }
 
 #[cfg(test)]
@@ -109,6 +121,21 @@ mod tests {
         let hash = public_values.hash_bn254();
 
         let expected_hash = "1ce987d0a7fcc2636fe87e69295ba12b1cc46c256b369ae7401c51b805ee91bd";
+        let expected_hash_biguint = BigUint::from_bytes_be(&hex::decode(expected_hash).unwrap());
+
+        assert_eq!(hash, expected_hash_biguint);
+    }
+
+    #[test]
+    fn test_hash_public_values_blake3() {
+        let test_hex = "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
+        let test_bytes = hex::decode(test_hex).unwrap();
+
+        let mut public_values = SP1PublicValues::new();
+        public_values.write_slice(&test_bytes);
+        let hash = public_values.hash_bn254_with_fn(blake3_hash);
+
+        let expected_hash = "1639647ab9e42519f0cbdcf343033482b018c0c1ed48f8367f32381c60913447";
         let expected_hash_biguint = BigUint::from_bytes_be(&hex::decode(expected_hash).unwrap());
 
         assert_eq!(hash, expected_hash_biguint);

--- a/crates/prover/src/verify.rs
+++ b/crates/prover/src/verify.rs
@@ -206,15 +206,15 @@ impl<C: SP1ProverComponents> SP1Prover<C> {
                 return Err(MachineVerificationError::InvalidPublicValues(
                     "last_init_addr_bits != last_finalize_addr_bits_prev",
                 ));
-            } else if !shard_proof.contains_global_memory_init()
-                && public_values.previous_init_addr_bits != public_values.last_init_addr_bits
+            } else if !shard_proof.contains_global_memory_init() &&
+                public_values.previous_init_addr_bits != public_values.last_init_addr_bits
             {
                 return Err(MachineVerificationError::InvalidPublicValues(
                     "previous_init_addr_bits != last_init_addr_bits",
                 ));
-            } else if !shard_proof.contains_global_memory_finalize()
-                && public_values.previous_finalize_addr_bits
-                    != public_values.last_finalize_addr_bits
+            } else if !shard_proof.contains_global_memory_finalize() &&
+                public_values.previous_finalize_addr_bits !=
+                    public_values.last_finalize_addr_bits
             {
                 return Err(MachineVerificationError::InvalidPublicValues(
                     "previous_finalize_addr_bits != last_finalize_addr_bits",
@@ -251,26 +251,26 @@ impl<C: SP1ProverComponents> SP1Prover<C> {
         for shard_proof in proof.0.iter() {
             let public_values: &PublicValues<Word<_>, _> =
                 shard_proof.public_values.as_slice().borrow();
-            if committed_value_digest_prev != zero_committed_value_digest
-                && public_values.committed_value_digest != committed_value_digest_prev
+            if committed_value_digest_prev != zero_committed_value_digest &&
+                public_values.committed_value_digest != committed_value_digest_prev
             {
                 return Err(MachineVerificationError::InvalidPublicValues(
                     "committed_value_digest != committed_value_digest_prev",
                 ));
-            } else if deferred_proofs_digest_prev != zero_deferred_proofs_digest
-                && public_values.deferred_proofs_digest != deferred_proofs_digest_prev
+            } else if deferred_proofs_digest_prev != zero_deferred_proofs_digest &&
+                public_values.deferred_proofs_digest != deferred_proofs_digest_prev
             {
                 return Err(MachineVerificationError::InvalidPublicValues(
                     "deferred_proofs_digest != deferred_proofs_digest_prev",
                 ));
-            } else if !shard_proof.contains_cpu()
-                && public_values.committed_value_digest != committed_value_digest_prev
+            } else if !shard_proof.contains_cpu() &&
+                public_values.committed_value_digest != committed_value_digest_prev
             {
                 return Err(MachineVerificationError::InvalidPublicValues(
                     "committed_value_digest != committed_value_digest_prev",
                 ));
-            } else if !shard_proof.contains_cpu()
-                && public_values.deferred_proofs_digest != deferred_proofs_digest_prev
+            } else if !shard_proof.contains_cpu() &&
+                public_values.deferred_proofs_digest != deferred_proofs_digest_prev
             {
                 return Err(MachineVerificationError::InvalidPublicValues(
                     "deferred_proofs_digest != deferred_proofs_digest_prev",

--- a/crates/prover/src/verify.rs
+++ b/crates/prover/src/verify.rs
@@ -451,13 +451,7 @@ pub fn verify_plonk_bn254_public_inputs(
         return Err(PlonkVerificationError::InvalidVerificationKey.into());
     }
 
-    let sha256_public_values_hash = public_values.hash_bn254();
-    if sha256_public_values_hash != expected_public_values_hash {
-        let blake3_public_values_hash = public_values.hash_bn254_with_fn(blake3_hash);
-        if blake3_public_values_hash != expected_public_values_hash {
-            return Err(Groth16VerificationError::InvalidPublicValues.into());
-        }
-    }
+    verify_public_values(public_values, expected_public_values_hash)?;
 
     Ok(())
 }
@@ -477,6 +471,19 @@ pub fn verify_groth16_bn254_public_inputs(
         return Err(Groth16VerificationError::InvalidVerificationKey.into());
     }
 
+    verify_public_values(public_values, expected_public_values_hash)?;
+
+    Ok(())
+}
+
+// As SHA256 and BLAKE3 are both designed to be collision resistant, it is computationally
+// infeasible to find two distinct inputs, one processed with SHA256 and the other with Blake3,
+// that yield the same hash value. Indeed, this would require breaking both algorithms
+// simultaneously, a task that is beyond current computational capabilities.
+fn verify_public_values(
+    public_values: &SP1PublicValues,
+    expected_public_values_hash: BigUint,
+) -> Result<()> {
     let sha256_public_values_hash = public_values.hash_bn254();
     if sha256_public_values_hash != expected_public_values_hash {
         let blake3_public_values_hash = public_values.hash_bn254_with_fn(blake3_hash);

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -83,6 +83,7 @@ network = [
 ]
 cuda = []
 bigint-rug = ["sp1-core-machine/bigint-rug"]
+blake3 = ["sp1-primitives/blake3"]
 
 profiling = ["sp1-core-executor/profiling"]
 

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -83,7 +83,6 @@ network = [
 ]
 cuda = []
 bigint-rug = ["sp1-core-machine/bigint-rug"]
-blake3 = ["sp1-primitives/blake3"]
 
 profiling = ["sp1-core-executor/profiling"]
 

--- a/crates/sdk/src/prover.rs
+++ b/crates/sdk/src/prover.rs
@@ -85,10 +85,15 @@ pub enum SP1VerificationError {
     Other(anyhow::Error),
 }
 
-// As SHA256 and BLAKE3 are both designed to be collision resistant, it is computationally
-// infeasible to find two distinct inputs, one processed with SHA256 and the other with Blake3,
-// that yield the same hash value. Indeed, this would require breaking both algorithms
-// simultaneously, a task that is beyond current computational capabilities.
+/// In SP1, a proof's public values can either be hashed with SHA2 or Blake3. In SP1 V4, there is no
+/// metadata attached to the proof about which hasher function was used for public values hashing.
+/// Instead, when verifying the proof, the public values are hashed with SHA2 and Blake3, and
+/// if either matches the `expected_public_values_hash`, the verification is successful.
+///
+/// The security for this verification in SP1 V4 derives from the fact that both SHA2 and Blake3 are
+/// designed to be collision resistant. It is computationally infeasible to find an input i1 for
+/// SHA256 and an input i2 for Blake3 that the same hash value. Doing so would require breaking both
+/// algorithms simultaneously.
 pub(crate) fn verify_proof<C: SP1ProverComponents>(
     prover: &SP1Prover<C>,
     version: &str,
@@ -115,10 +120,8 @@ pub(crate) fn verify_proof<C: SP1ProverComponents>(
             // Make sure the committed value digest matches the public values hash.
             // It is computationally infeasible to find two distinct inputs, one processed with
             // SHA256 and the other with Blake3, that yield the same hash value.
-            let sha256_hash = bundle.public_values.hash();
-            let blake3_hash = bundle.public_values.blake3_hash();
-            if committed_value_digest_bytes != sha256_hash &&
-                committed_value_digest_bytes != blake3_hash
+            if committed_value_digest_bytes != bundle.public_values.hash() &&
+                committed_value_digest_bytes != bundle.public_values.blake3_hash()
             {
                 return Err(SP1VerificationError::InvalidPublicValues);
             }
@@ -142,10 +145,8 @@ pub(crate) fn verify_proof<C: SP1ProverComponents>(
             // Make sure the committed value digest matches the public values hash.
             // It is computationally infeasible to find two distinct inputs, one processed with
             // SHA256 and the other with Blake3, that yield the same hash value.
-            let sha256_hash = bundle.public_values.hash();
-            let blake3_hash = bundle.public_values.blake3_hash();
-            if committed_value_digest_bytes != sha256_hash &&
-                committed_value_digest_bytes != blake3_hash
+            if committed_value_digest_bytes != bundle.public_values.hash() &&
+                committed_value_digest_bytes != bundle.public_values.blake3_hash()
             {
                 return Err(SP1VerificationError::InvalidPublicValues);
             }

--- a/crates/sdk/src/prover.rs
+++ b/crates/sdk/src/prover.rs
@@ -115,12 +115,12 @@ pub(crate) fn verify_proof<C: SP1ProverComponents>(
             // Make sure the committed value digest matches the public values hash.
             // It is computationally infeasible to find two distinct inputs, one processed with
             // SHA256 and the other with Blake3, that yield the same hash value.
-            for (a, (sha_b, blake3_b)) in committed_value_digest_bytes.iter().zip_eq(
-                bundle.public_values.hash().into_iter().zip(bundle.public_values.blake3_hash()),
-            ) {
-                if *a != sha_b && *a != blake3_b {
-                    return Err(SP1VerificationError::InvalidPublicValues);
-                }
+            let sha256_hash = bundle.public_values.hash();
+            let blake3_hash = bundle.public_values.blake3_hash();
+            if committed_value_digest_bytes != sha256_hash &&
+                committed_value_digest_bytes != blake3_hash
+            {
+                return Err(SP1VerificationError::InvalidPublicValues);
             }
 
             // Verify the core proof.
@@ -142,12 +142,12 @@ pub(crate) fn verify_proof<C: SP1ProverComponents>(
             // Make sure the committed value digest matches the public values hash.
             // It is computationally infeasible to find two distinct inputs, one processed with
             // SHA256 and the other with Blake3, that yield the same hash value.
-            for (a, (sha_b, blake3_b)) in committed_value_digest_bytes.iter().zip_eq(
-                bundle.public_values.hash().into_iter().zip(bundle.public_values.blake3_hash()),
-            ) {
-                if *a != sha_b && *a != blake3_b {
-                    return Err(SP1VerificationError::InvalidPublicValues);
-                }
+            let sha256_hash = bundle.public_values.hash();
+            let blake3_hash = bundle.public_values.blake3_hash();
+            if committed_value_digest_bytes != sha256_hash &&
+                committed_value_digest_bytes != blake3_hash
+            {
+                return Err(SP1VerificationError::InvalidPublicValues);
             }
 
             prover.verify_compressed(proof, vkey).map_err(SP1VerificationError::Recursion)

--- a/crates/sdk/src/prover.rs
+++ b/crates/sdk/src/prover.rs
@@ -86,7 +86,7 @@ pub enum SP1VerificationError {
 }
 
 // As SHA256 and BLAKE3 are both designed to be collision resistant, it is computationally
-// infeasible to find two distinct inputs—one processed with SHA256 and the other with BLAKE3,
+// infeasible to find two distinct inputs, one processed with SHA256 and the other with Blake3,
 // that yield the same hash value. Indeed, this would require breaking both algorithms
 // simultaneously, a task that is beyond current computational capabilities.
 pub(crate) fn verify_proof<C: SP1ProverComponents>(
@@ -113,6 +113,8 @@ pub(crate) fn verify_proof<C: SP1ProverComponents>(
                 .collect_vec();
 
             // Make sure the committed value digest matches the public values hash.
+            // It is computationally infeasible to find two distinct inputs, one processed with
+            // SHA256 and the other with Blake3, that yield the same hash value.
             for (a, (sha_b, blake3_b)) in committed_value_digest_bytes.iter().zip_eq(
                 bundle.public_values.hash().into_iter().zip(bundle.public_values.blake3_hash()),
             ) {
@@ -138,6 +140,8 @@ pub(crate) fn verify_proof<C: SP1ProverComponents>(
                 .collect_vec();
 
             // Make sure the committed value digest matches the public values hash.
+            // It is computationally infeasible to find two distinct inputs, one processed with
+            // SHA256 and the other with Blake3, that yield the same hash value.
             for (a, (sha_b, blake3_b)) in committed_value_digest_bytes.iter().zip_eq(
                 bundle.public_values.hash().into_iter().zip(bundle.public_values.blake3_hash()),
             ) {

--- a/crates/test-artifacts/programs/Cargo.lock
+++ b/crates/test-artifacts/programs/Cargo.lock
@@ -2531,6 +2531,7 @@ name = "sp1-primitives"
 version = "4.2.0"
 dependencies = [
  "bincode",
+ "cfg-if",
  "hex",
  "lazy_static",
  "num-bigint",

--- a/crates/test-artifacts/programs/Cargo.lock
+++ b/crates/test-artifacts/programs/Cargo.lock
@@ -298,6 +298,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake3"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389a099b34312839e16420d499a9cad9650541715937ffbdd40d36f49e77eeb3"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -515,6 +528,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "convert_case"
@@ -2531,6 +2550,7 @@ name = "sp1-primitives"
 version = "4.2.0"
 dependencies = [
  "bincode",
+ "blake3",
  "cfg-if",
  "hex",
  "lazy_static",

--- a/crates/test-artifacts/programs/fibonacci-blake3/Cargo.lock
+++ b/crates/test-artifacts/programs/fibonacci-blake3/Cargo.lock
@@ -434,6 +434,7 @@ name = "sp1-primitives"
 version = "4.2.0"
 dependencies = [
  "bincode",
+ "blake3",
  "cfg-if",
  "hex",
  "lazy_static",

--- a/crates/test-artifacts/programs/fibonacci-blake3/Cargo.lock
+++ b/crates/test-artifacts/programs/fibonacci-blake3/Cargo.lock
@@ -434,6 +434,7 @@ name = "sp1-primitives"
 version = "4.2.0"
 dependencies = [
  "bincode",
+ "cfg-if",
  "hex",
  "lazy_static",
  "num-bigint",

--- a/crates/verifier/Cargo.toml
+++ b/crates/verifier/Cargo.toml
@@ -15,7 +15,7 @@ sha2 = { version = "0.10.8", default-features = false }
 thiserror = { version = "2", default-features = false }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 lazy_static = { version = "1.5.0", default-features = false }
-blake3 = { workspace = true, optional = true }
+blake3 = { workspace = true }
 cfg-if = "1.0.0"
 
 # arkworks
@@ -32,12 +32,12 @@ num-bigint = "0.4.6"
 num-traits = "0.2.19"
 cfg-if = "1.0.0"
 serial_test = "3.2.0"
+rstest = "0.25.0"
 
 [features]
 default = ["std"]
 std = ["thiserror/std"]
 ark = ["ark-bn254", "ark-serialize", "ark-ff", "ark-groth16", "ark-ec"]
-blake3 = ["dep:blake3"]
 
 [lints]
 workspace = true

--- a/crates/verifier/Cargo.toml
+++ b/crates/verifier/Cargo.toml
@@ -37,7 +37,7 @@ serial_test = "3.2.0"
 default = ["std"]
 std = ["thiserror/std"]
 ark = ["ark-bn254", "ark-serialize", "ark-ff", "ark-groth16", "ark-ec"]
-blake3 = ["dep:blake3", "sp1-sdk/blake3"]
+blake3 = ["dep:blake3"]
 
 [lints]
 workspace = true

--- a/crates/verifier/Cargo.toml
+++ b/crates/verifier/Cargo.toml
@@ -37,7 +37,7 @@ serial_test = "3.2.0"
 default = ["std"]
 std = ["thiserror/std"]
 ark = ["ark-bn254", "ark-serialize", "ark-ff", "ark-groth16", "ark-ec"]
-blake3 = ["dep:blake3"]
+blake3 = ["dep:blake3", "sp1-sdk/blake3"]
 
 [lints]
 workspace = true

--- a/crates/verifier/src/groth16/mod.rs
+++ b/crates/verifier/src/groth16/mod.rs
@@ -72,11 +72,13 @@ impl Groth16Verifier {
 
         // It is computationally infeasible to find two distinct inputs, one processed with
         // SHA256 and the other with Blake3, that yield the same hash value.
-        if let Err(_) = Self::verify_gnark_proof(
+        if Self::verify_gnark_proof(
             &proof[VK_HASH_PREFIX_LENGTH..],
             &[sp1_vkey_hash, hash_public_inputs(sp1_public_inputs)],
             groth16_vk,
-        ) {
+        )
+        .is_err()
+        {
             Self::verify_gnark_proof(
                 &proof[VK_HASH_PREFIX_LENGTH..],
                 &[sp1_vkey_hash, hash_public_inputs_with_fn(sp1_public_inputs, blake3_hash)],

--- a/crates/verifier/src/groth16/mod.rs
+++ b/crates/verifier/src/groth16/mod.rs
@@ -77,16 +77,16 @@ impl Groth16Verifier {
             &[sp1_vkey_hash, hash_public_inputs(sp1_public_inputs)],
             groth16_vk,
         )
-        .is_err()
+        .is_ok()
         {
-            Self::verify_gnark_proof(
-                &proof[VK_HASH_PREFIX_LENGTH..],
-                &[sp1_vkey_hash, hash_public_inputs_with_fn(sp1_public_inputs, blake3_hash)],
-                groth16_vk,
-            )
-        } else {
-            Ok(())
+            return Ok(())
         }
+
+        Self::verify_gnark_proof(
+            &proof[VK_HASH_PREFIX_LENGTH..],
+            &[sp1_vkey_hash, hash_public_inputs_with_fn(sp1_public_inputs, blake3_hash)],
+            groth16_vk,
+        )
     }
 
     /// Verifies a Gnark Groth16 proof using raw byte inputs.

--- a/crates/verifier/src/groth16/mod.rs
+++ b/crates/verifier/src/groth16/mod.rs
@@ -9,7 +9,8 @@ pub(crate) use verify::*;
 use error::Groth16Error;
 
 use crate::{
-    constants::VK_HASH_PREFIX_LENGTH, decode_sp1_vkey_hash, error::Error, hash_public_inputs,
+    blake3_hash, constants::VK_HASH_PREFIX_LENGTH, decode_sp1_vkey_hash, error::Error,
+    hash_public_inputs, hash_public_inputs_with_fn,
 };
 
 use alloc::vec::Vec;
@@ -69,11 +70,21 @@ impl Groth16Verifier {
 
         let sp1_vkey_hash = decode_sp1_vkey_hash(sp1_vkey_hash)?;
 
-        Self::verify_gnark_proof(
+        // It is computationally infeasible to find two distinct inputs, one processed with
+        // SHA256 and the other with Blake3, that yield the same hash value.
+        if let Err(_) = Self::verify_gnark_proof(
             &proof[VK_HASH_PREFIX_LENGTH..],
             &[sp1_vkey_hash, hash_public_inputs(sp1_public_inputs)],
             groth16_vk,
-        )
+        ) {
+            Self::verify_gnark_proof(
+                &proof[VK_HASH_PREFIX_LENGTH..],
+                &[sp1_vkey_hash, hash_public_inputs_with_fn(sp1_public_inputs, blake3_hash)],
+                groth16_vk,
+            )
+        } else {
+            Ok(())
+        }
     }
 
     /// Verifies a Gnark Groth16 proof using raw byte inputs.
@@ -96,7 +107,7 @@ impl Groth16Verifier {
     /// # Note
     ///
     /// This method expects the raw proof bytes without the 4-byte vkey hash prefix that
-    /// [`verify`] checks. If you have a complete proof with the prefix, use [`verify`] instead.    
+    /// [`verify`] checks. If you have a complete proof with the prefix, use [`verify`] instead.
     pub fn verify_gnark_proof(
         proof: &[u8],
         public_inputs: &[[u8; 32]],

--- a/crates/verifier/src/plonk/mod.rs
+++ b/crates/verifier/src/plonk/mod.rs
@@ -77,8 +77,9 @@ impl PlonkVerifier {
 
         let sp1_vkey_hash = decode_sp1_vkey_hash(sp1_vkey_hash)?;
 
-        // It is computationally infeasible to find two distinct inputs, one processed with
-        // SHA256 and the other with Blake3, that yield the same hash value.
+        // First, check if the public values hashed with SHA2 match the expected public values.
+        // If not, try hashing with Blake3. If both fail, return an error. We perform the checks
+        // sequentially to avoid calculating both hashes unless necessary.
         if Self::verify_gnark_proof(
             &proof[VK_HASH_PREFIX_LENGTH..],
             &[sp1_vkey_hash, hash_public_inputs(sp1_public_inputs)],

--- a/crates/verifier/src/plonk/mod.rs
+++ b/crates/verifier/src/plonk/mod.rs
@@ -84,16 +84,16 @@ impl PlonkVerifier {
             &[sp1_vkey_hash, hash_public_inputs(sp1_public_inputs)],
             plonk_vk,
         )
-        .is_err()
+        .is_ok()
         {
-            Self::verify_gnark_proof(
-                &proof[VK_HASH_PREFIX_LENGTH..],
-                &[sp1_vkey_hash, hash_public_inputs_with_fn(sp1_public_inputs, blake3_hash)],
-                plonk_vk,
-            )
-        } else {
-            Ok(())
+            return Ok(())
         }
+
+        Self::verify_gnark_proof(
+            &proof[VK_HASH_PREFIX_LENGTH..],
+            &[sp1_vkey_hash, hash_public_inputs_with_fn(sp1_public_inputs, blake3_hash)],
+            plonk_vk,
+        )
     }
 
     /// Verifies a Gnark PLONK proof using raw byte inputs.

--- a/crates/verifier/src/plonk/mod.rs
+++ b/crates/verifier/src/plonk/mod.rs
@@ -79,11 +79,13 @@ impl PlonkVerifier {
 
         // It is computationally infeasible to find two distinct inputs, one processed with
         // SHA256 and the other with Blake3, that yield the same hash value.
-        if let Err(_) = Self::verify_gnark_proof(
+        if Self::verify_gnark_proof(
             &proof[VK_HASH_PREFIX_LENGTH..],
             &[sp1_vkey_hash, hash_public_inputs(sp1_public_inputs)],
             plonk_vk,
-        ) {
+        )
+        .is_err()
+        {
             Self::verify_gnark_proof(
                 &proof[VK_HASH_PREFIX_LENGTH..],
                 &[sp1_vkey_hash, hash_public_inputs_with_fn(sp1_public_inputs, blake3_hash)],

--- a/crates/verifier/src/tests.rs
+++ b/crates/verifier/src/tests.rs
@@ -1,8 +1,7 @@
 use rstest::rstest;
 use serial_test::serial;
 use sp1_sdk::{install::try_install_circuit_artifacts, HashableKey, ProverClient, SP1Stdin};
-use test_artifacts::FIBONACCI_BLAKE3_ELF;
-use test_artifacts::FIBONACCI_ELF;
+use test_artifacts::{FIBONACCI_BLAKE3_ELF, FIBONACCI_ELF};
 
 use crate::{error::Error, Groth16Error, PlonkError};
 

--- a/crates/verifier/src/tests.rs
+++ b/crates/verifier/src/tests.rs
@@ -14,7 +14,64 @@ use crate::{error::Error, Groth16Error, PlonkError};
 
 #[serial]
 #[test]
+fn test_verify_core() {
+    // Set up the pk and vk.
+    let client = ProverClient::from_env();
+    let (pk, vk) = client.setup(FIBONACCI_ELF);
+
+    // Generate the proof.
+    let sp1_proof_with_public_values = client.prove(&pk, &SP1Stdin::new()).core().run().unwrap();
+
+    // Verify.
+    client.verify(&sp1_proof_with_public_values, &vk).expect("Proof is invalid");
+}
+
+#[serial]
+#[test]
+fn test_verify_compressed() {
+    // Set up the pk and vk.
+    let client = ProverClient::from_env();
+    let (pk, vk) = client.setup(FIBONACCI_ELF);
+
+    // Generate the proof.
+    let sp1_proof_with_public_values =
+        client.prove(&pk, &SP1Stdin::new()).compressed().run().unwrap();
+
+    // Verify.
+    client.verify(&sp1_proof_with_public_values, &vk).expect("Proof is invalid");
+}
+
+#[serial]
+#[test]
 fn test_verify_groth16() {
+    // Set up the pk and vk.
+    let client = ProverClient::from_env();
+    let (pk, vk) = client.setup(FIBONACCI_ELF);
+
+    // Generate the proof.
+    let sp1_proof_with_public_values = client.prove(&pk, &SP1Stdin::new()).groth16().run().unwrap();
+
+    // Verify.
+    client.verify(&sp1_proof_with_public_values, &vk).expect("Proof is invalid");
+}
+
+#[serial]
+#[test]
+fn test_verify_plonk() {
+    // Set up the pk and vk.
+    let client = ProverClient::from_env();
+    let (pk, vk) = client.setup(FIBONACCI_ELF);
+
+    // Generate the proof.
+    let sp1_proof_with_public_values = client.prove(&pk, &SP1Stdin::new()).plonk().run().unwrap();
+
+    // Verify.
+    client.verify(&sp1_proof_with_public_values, &vk).expect("Proof is invalid");
+}
+
+#[serial]
+#[test]
+fn test_groth16_verifier() {
     #[cfg(feature = "blake3")]
     const GROTH16_ELF: &[u8] = include_bytes!("../guest-verify-programs/groth16_verify_blake3");
     #[cfg(not(feature = "blake3"))]
@@ -113,7 +170,7 @@ fn test_verify_invalid_groth16() {
 
 #[serial]
 #[test]
-fn test_verify_plonk() {
+fn test_plonk_verifier() {
     #[cfg(feature = "blake3")]
     const PLONK_ELF: &[u8] = include_bytes!("../guest-verify-programs/plonk_verify_blake3");
     #[cfg(not(feature = "blake3"))]

--- a/crates/verifier/src/tests.rs
+++ b/crates/verifier/src/tests.rs
@@ -1,23 +1,24 @@
+use rstest::rstest;
 use serial_test::serial;
 use sp1_sdk::{install::try_install_circuit_artifacts, HashableKey, ProverClient, SP1Stdin};
-
-cfg_if::cfg_if! {
-    if #[cfg(feature = "blake3")] {
-        use test_artifacts::FIBONACCI_BLAKE3_ELF as FIBONACCI_ELF;
-    }
-    else {
-        use test_artifacts::FIBONACCI_ELF;
-    }
-}
+use test_artifacts::FIBONACCI_BLAKE3_ELF;
+use test_artifacts::FIBONACCI_ELF;
 
 use crate::{error::Error, Groth16Error, PlonkError};
 
+const GROTH16_ELF: &[u8] = include_bytes!("../guest-verify-programs/groth16_verify");
+const GROTH16_BLAKE3_ELF: &[u8] = include_bytes!("../guest-verify-programs/groth16_verify_blake3");
+const PLONK_ELF: &[u8] = include_bytes!("../guest-verify-programs/plonk_verify");
+const PLONK_BLAKE3_ELF: &[u8] = include_bytes!("../guest-verify-programs/plonk_verify_blake3");
+
+#[rstest]
+#[case(FIBONACCI_ELF)]
+#[case(FIBONACCI_BLAKE3_ELF)]
 #[serial]
-#[test]
-fn test_verify_core() {
+fn test_verify_core(#[case] elf: &[u8]) {
     // Set up the pk and vk.
     let client = ProverClient::from_env();
-    let (pk, vk) = client.setup(FIBONACCI_ELF);
+    let (pk, vk) = client.setup(elf);
 
     // Generate the proof.
     let sp1_proof_with_public_values = client.prove(&pk, &SP1Stdin::new()).core().run().unwrap();
@@ -26,12 +27,14 @@ fn test_verify_core() {
     client.verify(&sp1_proof_with_public_values, &vk).expect("Proof is invalid");
 }
 
+#[rstest]
+#[case(FIBONACCI_ELF)]
+#[case(FIBONACCI_BLAKE3_ELF)]
 #[serial]
-#[test]
-fn test_verify_compressed() {
+fn test_verify_compressed(#[case] elf: &[u8]) {
     // Set up the pk and vk.
     let client = ProverClient::from_env();
-    let (pk, vk) = client.setup(FIBONACCI_ELF);
+    let (pk, vk) = client.setup(elf);
 
     // Generate the proof.
     let sp1_proof_with_public_values =
@@ -41,12 +44,14 @@ fn test_verify_compressed() {
     client.verify(&sp1_proof_with_public_values, &vk).expect("Proof is invalid");
 }
 
+#[rstest]
+#[case(FIBONACCI_ELF)]
+#[case(FIBONACCI_BLAKE3_ELF)]
 #[serial]
-#[test]
-fn test_verify_groth16() {
+fn test_verify_groth16(#[case] elf: &[u8]) {
     // Set up the pk and vk.
     let client = ProverClient::from_env();
-    let (pk, vk) = client.setup(FIBONACCI_ELF);
+    let (pk, vk) = client.setup(elf);
 
     // Generate the proof.
     let sp1_proof_with_public_values = client.prove(&pk, &SP1Stdin::new()).groth16().run().unwrap();
@@ -55,12 +60,14 @@ fn test_verify_groth16() {
     client.verify(&sp1_proof_with_public_values, &vk).expect("Proof is invalid");
 }
 
+#[rstest]
+#[case(FIBONACCI_ELF)]
+#[case(FIBONACCI_BLAKE3_ELF)]
 #[serial]
-#[test]
-fn test_verify_plonk() {
+fn test_verify_plonk(#[case] elf: &[u8]) {
     // Set up the pk and vk.
     let client = ProverClient::from_env();
-    let (pk, vk) = client.setup(FIBONACCI_ELF);
+    let (pk, vk) = client.setup(elf);
 
     // Generate the proof.
     let sp1_proof_with_public_values = client.prove(&pk, &SP1Stdin::new()).plonk().run().unwrap();
@@ -69,17 +76,14 @@ fn test_verify_plonk() {
     client.verify(&sp1_proof_with_public_values, &vk).expect("Proof is invalid");
 }
 
+#[rstest]
+#[case(FIBONACCI_ELF, GROTH16_ELF)]
+#[case(FIBONACCI_BLAKE3_ELF, GROTH16_BLAKE3_ELF)]
 #[serial]
-#[test]
-fn test_groth16_verifier() {
-    #[cfg(feature = "blake3")]
-    const GROTH16_ELF: &[u8] = include_bytes!("../guest-verify-programs/groth16_verify_blake3");
-    #[cfg(not(feature = "blake3"))]
-    const GROTH16_ELF: &[u8] = include_bytes!("../guest-verify-programs/groth16_verify");
-
+fn test_groth16_verifier(#[case] elf: &[u8], #[case] groth16_elf: &[u8]) {
     // Set up the pk and vk.
     let client = ProverClient::from_env();
-    let (pk, vk) = client.setup(FIBONACCI_ELF);
+    let (pk, vk) = client.setup(elf);
 
     // Generate the Groth16 proof.
     let sp1_proof_with_public_values = client.prove(&pk, &SP1Stdin::new()).groth16().run().unwrap();
@@ -119,15 +123,17 @@ fn test_groth16_verifier() {
     stdin.write_slice(&public_inputs);
     stdin.write(&vkey_hash);
 
-    let _ = client.execute(GROTH16_ELF, &stdin).run().unwrap();
+    let _ = client.execute(groth16_elf, &stdin).run().unwrap();
 }
 
+#[rstest]
+#[case(FIBONACCI_ELF)]
+#[case(FIBONACCI_BLAKE3_ELF)]
 #[serial]
-#[test]
-fn test_verify_invalid_groth16() {
+fn test_verify_invalid_groth16(#[case] elf: &[u8]) {
     // Set up the pk and vk.
     let client = ProverClient::from_env();
-    let (pk, vk) = client.setup(FIBONACCI_ELF);
+    let (pk, vk) = client.setup(elf);
 
     // Generate the Groth16 proof.
     let sp1_proof_with_public_values = client.prove(&pk, &SP1Stdin::new()).groth16().run().unwrap();
@@ -168,17 +174,14 @@ fn test_verify_invalid_groth16() {
     assert!(matches!(result, Err(Groth16Error::GeneralError(Error::InvalidData))));
 }
 
+#[rstest]
+#[case(FIBONACCI_ELF, PLONK_ELF)]
+#[case(FIBONACCI_BLAKE3_ELF, PLONK_BLAKE3_ELF)]
 #[serial]
-#[test]
-fn test_plonk_verifier() {
-    #[cfg(feature = "blake3")]
-    const PLONK_ELF: &[u8] = include_bytes!("../guest-verify-programs/plonk_verify_blake3");
-    #[cfg(not(feature = "blake3"))]
-    const PLONK_ELF: &[u8] = include_bytes!("../guest-verify-programs/plonk_verify");
-
+fn test_plonk_verifier(#[case] elf: &[u8], #[case] plonk_elf: &[u8]) {
     // Set up the pk and vk.
     let client = ProverClient::from_env();
-    let (pk, vk) = client.setup(FIBONACCI_ELF);
+    let (pk, vk) = client.setup(elf);
 
     // Generate the Plonk proof.
     let sp1_proof_with_public_values = client.prove(&pk, &SP1Stdin::new()).plonk().run().unwrap();
@@ -199,15 +202,17 @@ fn test_plonk_verifier() {
     stdin.write_slice(&public_inputs);
     stdin.write(&vkey_hash);
 
-    let _ = client.execute(PLONK_ELF, &stdin).run().unwrap();
+    let _ = client.execute(plonk_elf, &stdin).run().unwrap();
 }
 
+#[rstest]
+#[case(FIBONACCI_ELF)]
+#[case(FIBONACCI_BLAKE3_ELF)]
 #[serial]
-#[test]
-fn test_verify_invalid_plonk() {
+fn test_verify_invalid_plonk(#[case] elf: &[u8]) {
     // Set up the pk and vk.
     let client = ProverClient::from_env();
-    let (pk, vk) = client.setup(FIBONACCI_ELF);
+    let (pk, vk) = client.setup(elf);
 
     // Generate the Plonk proof.
     let sp1_proof_with_public_values = client.prove(&pk, &SP1Stdin::new()).plonk().run().unwrap();

--- a/patch-testing/Cargo.lock
+++ b/patch-testing/Cargo.lock
@@ -391,6 +391,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake3"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389a099b34312839e16420d499a9cad9650541715937ffbdd40d36f49e77eeb3"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4151,6 +4164,7 @@ name = "sp1-primitives"
 version = "4.2.0"
 dependencies = [
  "bincode",
+ "blake3",
  "cfg-if",
  "hex",
  "lazy_static",

--- a/patch-testing/Cargo.lock
+++ b/patch-testing/Cargo.lock
@@ -4151,6 +4151,7 @@ name = "sp1-primitives"
 version = "4.2.0"
 dependencies = [
  "bincode",
+ "cfg-if",
  "hex",
  "lazy_static",
  "num-bigint 0.4.6",


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

`verify()` fails on proofs when `sp1-zkvm` `blake3` feature is enabled.

## Solution

Remove the `blake3` feature everywhere except in `sp1-zkvm`, and when we want to verify PV, check with both Sha256 and Blake3 hashing.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
