### PR TITLE
Remove debug-assertions flag from Rust compilation flags

### DIFF
--- a/.github/workflows/docker-gnark.yml
+++ b/.github/workflows/docker-gnark.yml
@@ -47,7 +47,7 @@ jobs:
         env:
           SP1_GNARK_IMAGE: sp1-gnark
           RUST_LOG: info
-          RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0 -C target-cpu=native
+          RUSTFLAGS: -Copt-level=3 -Coverflow-checks=y -Cdebuginfo=0 -C target-cpu=native
           RUST_BACKTRACE: 1   
         with:
           command: test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
           command: test
           args: --release -p sp1-sdk --features native-gnark -- test_e2e_groth16_plonk --nocapture
         env:
-          RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0 -C target-cpu=native
+          RUSTFLAGS: -Copt-level=3 -Coverflow-checks=y -Cdebuginfo=0 -C target-cpu=native
           RUST_BACKTRACE: 1
 
   groth16-docker:
@@ -94,7 +94,7 @@ jobs:
           command: test
           args: --release -p sp1-sdk -- test_e2e_prove_groth16 --nocapture
         env:
-          RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0 -C target-cpu=native
+          RUSTFLAGS: -Copt-level=3 -Coverflow-checks=y -Cdebuginfo=0 -C target-cpu=native
           RUST_BACKTRACE: 1
 
   plonk:
@@ -134,7 +134,7 @@ jobs:
           command: test
           args: --release -p sp1-sdk --features native-gnark -- test_e2e_prove_plonk --nocapture
         env:
-          RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0 -C target-cpu=native
+          RUSTFLAGS: -Copt-level=3 -Coverflow-checks=y -Cdebuginfo=0 -C target-cpu=native
           RUST_BACKTRACE: 1
 
   plonk-docker:
@@ -174,7 +174,7 @@ jobs:
           command: test
           args: --release -p sp1-sdk -- test_e2e_prove_plonk --nocapture
         env:
-          RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0 -C target-cpu=native
+          RUSTFLAGS: -Copt-level=3 -Coverflow-checks=y -Cdebuginfo=0 -C target-cpu=native
           RUST_BACKTRACE: 1
 
   check-branch:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -61,7 +61,7 @@ jobs:
           command: test
           args: --release --features native-gnark --workspace --exclude sp1-verifier
         env:
-          RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0 -C target-cpu=native
+          RUSTFLAGS: -Copt-level=3 -Coverflow-checks=y -Cdebuginfo=0 -C target-cpu=native
           RUST_BACKTRACE: 1
           SP1_DEV: 1
 
@@ -105,7 +105,7 @@ jobs:
           command: test
           args: --release --features native-gnark --workspace --exclude sp1-verifier
         env:
-          RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0 -C target-cpu=native
+          RUSTFLAGS: -Copt-level=3 -Coverflow-checks=y -Cdebuginfo=0 -C target-cpu=native
           RUST_BACKTRACE: 1
           SP1_DEV: 1
 


### PR DESCRIPTION
This PR removes the `-Cdebug-assertions` flag from RUSTFLAGS environment variable across all workflow files. This change helps to:

- Improve performance by removing runtime assertion checks
- Maintain consistent behavior between debug and release builds
- Reduce potential false positives in tests

The flag was removed from the following files:
- .github/workflows/docker-gnark.yml
- .github/workflows/main.yml
- .github/workflows/pr.yml