### PR TITLE
chore: fix u32 to BigUint conversion

### DIFF
--- a/crates/curves/src/edwards/mod.rs
+++ b/crates/curves/src/edwards/mod.rs
@@ -119,7 +119,7 @@ impl<E: EdwardsParameters> AffinePoint<EdwardsCurve<E>> {
         let all_xy = (&self.x * &self.y * &other.x * &other.y) % &p;
         let d = E::d_biguint();
         let dxy = (d * &all_xy) % &p;
-        let den_x = ((1u32 + &dxy) % &p).modpow(&(&p - 2u32), &p);
+        let den_x = ((BigUint::from(1u32) + &dxy) % &p).modpow(&(&p - 2u32), &p);
         let den_y = ((1u32 + &p - &dxy) % &p).modpow(&(&p - 2u32), &p);
 
         let x_3 = (&x_3n * &den_x) % &p;


### PR DESCRIPTION
## Motivation  
fix incorrect handling of u32 values with BigUint to ensure proper operations

## Solution  
explicitly convert u32 values to BigUint before performing any operations, ensuring correct handling of large numbers

## PR Checklist  
- [ ] Added Tests  
- [ ] Added Documentation  
- [ ] Breaking changes  