### PR TITLE
fix(cuda): Send PK in prove_core request (#2247)

### DIFF
--- a/crates/cuda/src/lib.rs
+++ b/crates/cuda/src/lib.rs
@@ -72,6 +72,8 @@ pub struct SetupResponsePayload {
 /// We use this object to serialize and deserialize the payload from the client to the server.
 #[derive(Serialize, Deserialize)]
 pub struct ProveCoreRequestPayload {
+    /// The proving key.
+    pub pk: SP1ProvingKey,
     /// The input stream.
     pub stdin: SP1Stdin,
 }
@@ -250,8 +252,8 @@ impl SP1CudaProver {
     /// Executes the [sp1_prover::SP1Prover::prove_core] method inside the container.
     ///
     /// You will need at least 24GB of VRAM to run this method.
-    pub fn prove_core(&self, stdin: &SP1Stdin) -> Result<SP1CoreProof, SP1CoreProverError> {
-        let payload = ProveCoreRequestPayload { stdin: stdin.clone() };
+    pub fn prove_core(&self, pk: &SP1ProvingKey, stdin: &SP1Stdin) -> Result<SP1CoreProof, SP1CoreProverError> {
+        let payload = ProveCoreRequestPayload { pk: pk.clone(), stdin: stdin.clone() };
         let request =
             crate::proto::api::ProveCoreRequest { data: bincode::serialize(&payload).unwrap() };
         let response = block_on(async { self.client.prove_core(request).await }).unwrap();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

This PR addresses issue #2247, where CUDA proving fails when using a deserialized proving key (PK) without a preceding `client.setup()` call in the same session. The error `TwirpError(TwirpErrorResponse { code: Internal, msg: "proving key not provided", meta: {} })` occurs because the remote CUDA prover service (`moongate`) likely requires initialization associated with the PK, which normally happens during the `setup` call. Calling `prove_core` directly with a deserialized PK skips this remote initialization.

The current workaround involves calling `setup()`, discarding the result, and then calling `prove()` with the deserialized PK, which introduces unnecessary overhead.

## Solution

This PR modifies the client-side CUDA prover (`SP1CudaProver` in `crates/cuda/src/lib.rs`) to send the proving key directly within the `prove_core` request payload.

1.  **`ProveCoreRequestPayload` struct:** Added a `pk: SP1ProvingKey` field to include the proving key in the request sent to the remote service.
2.  **`prove_core` method:**
    *   Updated the method signature to accept `pk: &SP1ProvingKey` as an argument.
    *   Modified the method body to populate the `pk` field in the `ProveCoreRequestPayload`.

This change allows the remote `moongate` service (once updated accordingly) to receive and use the specific proving key required for the `prove_core` operation directly from the request, eliminating the dependency on prior `setup()` calls within the same session for PK initialization.

**Note:** This PR only contains the client-side changes. Corresponding changes are required in the `moongate` server implementation to accept and utilize the `pk` from the `ProveCoreRequestPayload`.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [x] Breaking changes:
    - The public function signature of `SP1CudaProver::prove_core` has changed. It now requires an additional `pk: &SP1ProvingKey` argument:
        ```diff
        - pub fn prove_core(&self, stdin: &SP1Stdin) -> Result<SP1CoreProof, SP1CoreProverError>
        + pub fn prove_core(&self, pk: &SP1ProvingKey, stdin: &SP1Stdin) -> Result<SP1CoreProof, SP1CoreProverError>
        ```
    - The structure of `ProveCoreRequestPayload` has changed, adding a `pk` field. This affects the serialization format used for communication with the remote prover service.
    - This change requires a corresponding update in the remote `moongate` prover service to handle the modified request payload and utilize the provided `pk`. Without the server-side update, calls to `prove_core` will likely fail.