### PR TITLE
docs(executor): patched crates link

### DIFF
--- a/crates/core/executor/src/syscalls/write.rs
+++ b/crates/core/executor/src/syscalls/write.rs
@@ -133,7 +133,7 @@ impl Syscall for WriteSyscall {
                 panic!(
                     "You are using reserved file descriptor {fd} that is not supported on SP1 versions >= v4.0.0. \
                     Update your patches to the latest versions that are compatible with versions >= v4.0.0. \
-                    See `https://docs.succinct.xyz/docs/sp1/writing-programs/patched-crates` for more information"
+                    See `https://docs.succinct.xyz/docs/sp1/optimizing-programs/precompiles` for more information"
                 );
             }
         } else if fd == FD_PUBLIC_VALUES {


### PR DESCRIPTION
Update the link for the patched crates, which changed with the recent docs re-organization.