### PR TITLE
fix typo kalos.md

### DIFF
--- a/audits/kalos.md
+++ b/audits/kalos.md
@@ -70,7 +70,7 @@ The computation of `is_external_layer` is incorrect. The range of the iteration 
         .sum::<AB::Expr>();
 
     // Second half of the external rounds.
-    is_external_layer += (rounds_p_end..rounds_p + rounds_f)
+    is_external_layer += (rounds_p_end..2 + rounds_p + rounds_f)
         .map(|i| local.rounds[i].into())
         .sum::<AB::Expr>();
 ```


### PR DESCRIPTION
is_external_layer += (rounds_p_end..rounds_p + rounds_f) need fix to:
is_external_layer += (rounds_p_end..2 + rounds_p + rounds_f)

This PR fixes an error in the computation of `is_external_layer`.  
Previously, the second half of the external rounds was computed over an incorrect range:

```rust
is_external_layer += (rounds_p_end..rounds_p + rounds_f)
    .map(|i| local.rounds[i].into())
    .sum::<AB::Expr>();

The correct range should account for an additional offset of 2, matching the intended 24-round cycle behavior:
is_external_layer += (rounds_p_end..2 + rounds_p + rounds_f)
    .map(|i| local.rounds[i].into())
    .sum::<AB::Expr>();
