### PR TITLE
feat: stateless proving with Moongate

### DIFF
--- a/crates/cuda/proto/api.proto
+++ b/crates/cuda/proto/api.proto
@@ -6,6 +6,7 @@ service ProverService {
     rpc Setup(SetupRequest) returns (SetupResponse) {}
     rpc Ready(ReadyRequest) returns (ReadyResponse) {}
     rpc ProveCore(ProveCoreRequest) returns (ProveCoreResponse) {}
+    rpc ProveCoreStateless(ProveCoreRequest) returns (ProveCoreResponse) {}
     rpc Compress(CompressRequest) returns (CompressResponse) {}
     rpc Shrink(ShrinkRequest) returns (ShrinkResponse) {}
     rpc Wrap(WrapRequest) returns (WrapResponse) {}

--- a/crates/cuda/src/lib.rs
+++ b/crates/cuda/src/lib.rs
@@ -79,8 +79,7 @@ pub struct ProveCoreRequestPayload {
 /// The payload for the [sp1_prover::SP1Prover::stateless_prove_core] method.
 ///
 /// We use this object to serialize and deserialize the payload from the client to the server.
-/// The ELF is included in the payload to allow to build the program and the pk on the Moongate
-/// server
+/// The proving key is sent in the payload with the request to allow the Moongate server to generate proofs without re-generating the proving key. 
 #[derive(Serialize, Deserialize)]
 pub struct StatelessProveCoreRequestPayload {
     /// The input stream.

--- a/crates/cuda/src/lib.rs
+++ b/crates/cuda/src/lib.rs
@@ -52,7 +52,7 @@ pub struct CudaProverContainer {
 
 /// The payload for the [sp1_prover::SP1Prover::setup] method.
 ///
-/// We use this object to serialize and deserialize the payload from the client to the server.
+/// This object is used to serialize and deserialize the payloads for the Moongate server.
 #[derive(Serialize, Deserialize)]
 pub struct SetupRequestPayload {
     pub elf: Vec<u8>,
@@ -69,7 +69,7 @@ pub struct SetupResponsePayload {
 
 /// The payload for the [sp1_prover::SP1Prover::prove_core] method.
 ///
-/// We use this object to serialize and deserialize the payload from the client to the server.
+/// This object is used to serialize and deserialize the payloads for the Moongate server.
 #[derive(Serialize, Deserialize)]
 pub struct ProveCoreRequestPayload {
     /// The input stream.
@@ -78,8 +78,9 @@ pub struct ProveCoreRequestPayload {
 
 /// The payload for the [sp1_prover::SP1Prover::stateless_prove_core] method.
 ///
-/// We use this object to serialize and deserialize the payload from the client to the server.
-/// The proving key is sent in the payload with the request to allow the Moongate server to generate proofs without re-generating the proving key. 
+/// This object is used to serialize and deserialize the payloads for the Moongate server.
+/// The proving key is sent in the payload with the request to allow the Moongate server to generate
+/// proofs without re-generating the proving key.
 #[derive(Serialize, Deserialize)]
 pub struct StatelessProveCoreRequestPayload {
     /// The input stream.
@@ -90,7 +91,7 @@ pub struct StatelessProveCoreRequestPayload {
 
 /// The payload for the [sp1_prover::SP1Prover::compress] method.
 ///
-/// We use this object to serialize and deserialize the payload from the client to the server.
+/// This object is used to serialize and deserialize the payloads for the Moongate server.
 #[derive(Serialize, Deserialize)]
 pub struct CompressRequestPayload {
     /// The verifying key.
@@ -103,7 +104,7 @@ pub struct CompressRequestPayload {
 
 /// The payload for the [sp1_prover::SP1Prover::shrink] method.
 ///
-/// We use this object to serialize and deserialize the payload from the client to the server.
+/// This object is used to serialize and deserialize the payloads for the Moongate server.
 #[derive(Serialize, Deserialize)]
 pub struct ShrinkRequestPayload {
     pub reduced_proof: SP1ReduceProof<InnerSC>,
@@ -111,7 +112,7 @@ pub struct ShrinkRequestPayload {
 
 /// The payload for the [sp1_prover::SP1Prover::wrap_bn254] method.
 ///
-/// We use this object to serialize and deserialize the payload from the client to the server.
+/// This object is used to serialize and deserialize the payloads for the Moongate server.
 #[derive(Serialize, Deserialize)]
 pub struct WrapRequestPayload {
     pub reduced_proof: SP1ReduceProof<InnerSC>,
@@ -276,10 +277,10 @@ impl SP1CudaProver {
     /// You will need at least 24GB of VRAM to run this method.
     pub fn prove_core_stateless(
         &self,
-        pk: SP1ProvingKey,
+        pk: &SP1ProvingKey,
         stdin: &SP1Stdin,
     ) -> Result<SP1CoreProof, SP1CoreProverError> {
-        let payload = StatelessProveCoreRequestPayload { pk, stdin: stdin.clone() };
+        let payload = StatelessProveCoreRequestPayload { pk: pk.clone(), stdin: stdin.clone() };
         let request =
             crate::proto::api::ProveCoreRequest { data: bincode::serialize(&payload).unwrap() };
         let response = block_on(async { self.client.prove_core_stateless(request).await }).unwrap();

--- a/crates/cuda/src/lib.rs
+++ b/crates/cuda/src/lib.rs
@@ -85,8 +85,8 @@ pub struct ProveCoreRequestPayload {
 pub struct StatelessProveCoreRequestPayload {
     /// The input stream.
     pub stdin: SP1Stdin,
-    /// The ELF.
-    pub elf: Vec<u8>,
+    /// The proving key.
+    pub pk: SP1ProvingKey,
 }
 
 /// The payload for the [sp1_prover::SP1Prover::compress] method.
@@ -277,10 +277,10 @@ impl SP1CudaProver {
     /// You will need at least 24GB of VRAM to run this method.
     pub fn prove_core_stateless(
         &self,
-        elf: Vec<u8>,
+        pk: SP1ProvingKey,
         stdin: &SP1Stdin,
     ) -> Result<SP1CoreProof, SP1CoreProverError> {
-        let payload = StatelessProveCoreRequestPayload { elf, stdin: stdin.clone() };
+        let payload = StatelessProveCoreRequestPayload { pk, stdin: stdin.clone() };
         let request =
             crate::proto::api::ProveCoreRequest { data: bincode::serialize(&payload).unwrap() };
         let response = block_on(async { self.client.prove_core_stateless(request).await }).unwrap();

--- a/crates/cuda/src/proto/api.rs
+++ b/crates/cuda/src/proto/api.rs
@@ -87,6 +87,11 @@ pub trait ProverService {
         ctx: twirp::Context,
         req: ProveCoreRequest,
     ) -> Result<ProveCoreResponse, twirp::TwirpErrorResponse>;
+    async fn prove_core_stateless(
+        &self,
+        ctx: twirp::Context,
+        req: ProveCoreRequest,
+    ) -> Result<ProveCoreResponse, twirp::TwirpErrorResponse>;
     async fn compress(
         &self,
         ctx: twirp::Context,
@@ -128,6 +133,13 @@ where
         req: ProveCoreRequest,
     ) -> Result<ProveCoreResponse, twirp::TwirpErrorResponse> {
         T::prove_core(&*self, ctx, req).await
+    }
+    async fn prove_core_stateless(
+        &self,
+        ctx: twirp::Context,
+        req: ProveCoreRequest,
+    ) -> Result<ProveCoreResponse, twirp::TwirpErrorResponse> {
+        T::prove_core_stateless(&*self, ctx, req).await
     }
     async fn compress(
         &self,
@@ -175,6 +187,12 @@ where
             },
         )
         .route(
+            "/ProveCoreStateless",
+            |api: T, ctx: twirp::Context, req: ProveCoreRequest| async move {
+                api.prove_core_stateless(ctx, req).await
+            },
+        )
+        .route(
             "/Compress",
             |api: T, ctx: twirp::Context, req: CompressRequest| async move {
                 api.compress(ctx, req).await
@@ -208,6 +226,10 @@ pub trait ProverServiceClient: Send + Sync + std::fmt::Debug {
         &self,
         req: ProveCoreRequest,
     ) -> Result<ProveCoreResponse, twirp::ClientError>;
+    async fn prove_core_stateless(
+        &self,
+        req: ProveCoreRequest,
+    ) -> Result<ProveCoreResponse, twirp::ClientError>;
     async fn compress(
         &self,
         req: CompressRequest,
@@ -237,6 +259,12 @@ impl ProverServiceClient for twirp::client::Client {
         req: ProveCoreRequest,
     ) -> Result<ProveCoreResponse, twirp::ClientError> {
         self.request("api.ProverService/ProveCore", req).await
+    }
+    async fn prove_core_stateless(
+        &self,
+        req: ProveCoreRequest,
+    ) -> Result<ProveCoreResponse, twirp::ClientError> {
+        self.request("api.ProverService/ProveCoreStateless", req).await
     }
     async fn compress(
         &self,

--- a/crates/sdk/src/cuda/mod.rs
+++ b/crates/sdk/src/cuda/mod.rs
@@ -88,7 +88,7 @@ impl CudaProver {
         kind: SP1ProofMode,
     ) -> Result<(SP1ProofWithPublicValues, u64)> {
         // Generate the core proof.
-        let proof = self.cuda_prover.prove_core_stateless(pk.elf.clone(), stdin)?;
+        let proof = self.cuda_prover.prove_core_stateless(pk.clone(), stdin)?;
         // TODO: Return the prover gas
         let cycles = proof.cycles;
         if kind == SP1ProofMode::Core {

--- a/crates/sdk/src/cuda/mod.rs
+++ b/crates/sdk/src/cuda/mod.rs
@@ -88,7 +88,7 @@ impl CudaProver {
         kind: SP1ProofMode,
     ) -> Result<(SP1ProofWithPublicValues, u64)> {
         // Generate the core proof.
-        let proof = self.cuda_prover.prove_core(stdin)?;
+        let proof = self.cuda_prover.prove_core_stateless(pk.elf.clone(), stdin)?;
         // TODO: Return the prover gas
         let cycles = proof.cycles;
         if kind == SP1ProofMode::Core {

--- a/crates/sdk/src/cuda/mod.rs
+++ b/crates/sdk/src/cuda/mod.rs
@@ -88,7 +88,7 @@ impl CudaProver {
         kind: SP1ProofMode,
     ) -> Result<(SP1ProofWithPublicValues, u64)> {
         // Generate the core proof.
-        let proof = self.cuda_prover.prove_core_stateless(pk.clone(), stdin)?;
+        let proof = self.cuda_prover.prove_core_stateless(pk, stdin)?;
         // TODO: Return the prover gas
         let cycles = proof.cycles;
         if kind == SP1ProofMode::Core {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

When proving with Cuda, calling `prove()` only work with the last program that was registered with `setup()`.

## Solution

Sends the ELF with each `prove()` request, and lazily call `setup()`on the Moongate server if the program is not already registered. 

Closes #2247, #2180

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes