### PR TITLE
build: update cache action to v4

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -68,7 +68,7 @@ runs:
         aws --version
 
     - name: rust-cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/bin/


### PR DESCRIPTION
Node 20 compatibility: switch all jobs to actions/cache@v4. Pure maintenance update, behaviour unchanged.