### PR TITLE
feat: allow to customize embedded Moongate server visible GPU device …

### DIFF
--- a/crates/cuda/Cargo.toml
+++ b/crates/cuda/Cargo.toml
@@ -19,6 +19,7 @@ tokio = { version = "^1.44.2", features = ["full"] }
 tracing = { workspace = true }
 twirp = { package = "twirp-rs", version = "0.13.0-succinct" }
 ctrlc = "3.4.4"
+once_cell = "1.21.3"
 
 [build-dependencies]
 prost-build = { version = "0.13", optional = true }

--- a/crates/cuda/src/lib.rs
+++ b/crates/cuda/src/lib.rs
@@ -240,15 +240,16 @@ impl SP1CudaProver {
             .map_err(|e| format!("Failed to start Docker container: {}. Please check your Docker installation and permissions.", e))?;
 
         // Kill the container on control-c
-        ctrlc::set_handler(move || {
+        // The error returned by set_handler is ignored to avoid panic when the handler has already
+        // been set.
+        let _ = ctrlc::set_handler(move || {
             tracing::debug!("received Ctrl+C, cleaning up...");
             if !cleanup_flag.load(Ordering::SeqCst) {
                 cleanup_container(&cleanup_name);
                 cleanup_flag.store(true, Ordering::SeqCst);
             }
             std::process::exit(0);
-        })
-        .unwrap();
+        });
 
         // Wait a few seconds for the container to start
         std::thread::sleep(Duration::from_secs(2));

--- a/crates/cuda/src/lib.rs
+++ b/crates/cuda/src/lib.rs
@@ -122,12 +122,12 @@ pub struct WrapRequestPayload {
 #[derive(Debug)]
 pub enum MoongateServer {
     External { endpoint: String },
-    Embedded { visible_device_index: Option<u64>, port: Option<u64> },
+    Local { visible_device_index: Option<u64>, port: Option<u64> },
 }
 
 impl Default for MoongateServer {
     fn default() -> Self {
-        Self::Embedded { visible_device_index: None, port: None }
+        Self::Local { visible_device_index: None, port: None }
     }
 }
 
@@ -148,7 +148,7 @@ impl SP1CudaProver {
 
                 SP1CudaProver { client, managed_container: None }
             }
-            MoongateServer::Embedded { visible_device_index, port } => {
+            MoongateServer::Local { visible_device_index, port } => {
                 Self::start_moongate_server(reqwest_middlewares, visible_device_index, port)?
             }
         };

--- a/crates/cuda/src/lib.rs
+++ b/crates/cuda/src/lib.rs
@@ -205,8 +205,7 @@ impl SP1CudaProver {
         let cleanup_name = container_name.clone();
         let cleanup_flag = cleaned_up.clone();
         let port = port.unwrap_or(3000);
-        let gpus =
-            visible_device_index.map(|i| format!("device = {i}")).unwrap_or("all".to_string());
+        let gpus = visible_device_index.map(|i| format!("device={i}")).unwrap_or("all".to_string());
 
         // Check if Docker is available and the user has necessary permissions
         if !Self::check_docker_availability()? {

--- a/crates/cuda/src/lib.rs
+++ b/crates/cuda/src/lib.rs
@@ -254,7 +254,7 @@ impl SP1CudaProver {
         std::thread::sleep(Duration::from_secs(2));
 
         let client = Client::new(
-            Url::parse("http://localhost:3000/twirp/").expect("failed to parse url"),
+            Url::parse(&format!("http://localhost:{port}/twirp/")).expect("failed to parse url"),
             reqwest::Client::new(),
             reqwest_middlewares,
         )

--- a/crates/perf/src/main.rs
+++ b/crates/perf/src/main.rs
@@ -2,7 +2,7 @@ use std::time::{Duration, Instant};
 
 use clap::{command, Parser};
 use rand::Rng;
-use sp1_cuda::SP1CudaProver;
+use sp1_cuda::{MoongateServer, SP1CudaProver};
 use sp1_prover::{components::CpuProverComponents, HashableKey, ProverMode};
 use sp1_sdk::{self, Prover, ProverClient, SP1Context, SP1Prover, SP1Stdin};
 use sp1_stark::SP1ProverOpts;
@@ -136,7 +136,8 @@ fn main() {
             println!("{:?}", result);
         }
         ProverMode::Cuda => {
-            let server = SP1CudaProver::new(None).expect("failed to initialize CUDA prover");
+            let server = SP1CudaProver::new(MoongateServer::default())
+                .expect("failed to initialize CUDA prover");
 
             let context = SP1Context::default();
             let (report, execution_duration) =

--- a/crates/sdk/src/cuda/builder.rs
+++ b/crates/sdk/src/cuda/builder.rs
@@ -29,8 +29,8 @@ impl CudaProverBuilder {
     /// let prover = ProverClient::builder().cuda().server("http://...").build();
     /// ```
     #[must_use]
-    pub fn server(self, endpoint: &str) -> ExternalMoonGateServerCudaProverBuilder {
-        ExternalMoonGateServerCudaProverBuilder { endpoint: endpoint.to_string() }
+    pub fn server(self, endpoint: &str) -> ExternalMoongateServerCudaProverBuilder {
+        ExternalMoongateServerCudaProverBuilder { endpoint: endpoint.to_string() }
     }
 
     /// Allows to customize the embedded Moongate server.
@@ -47,8 +47,8 @@ impl CudaProverBuilder {
     /// let prover = ProverClient::builder().cuda().local().port(3200).build();
     /// ```
     #[must_use]
-    pub fn local(self) -> LocalMoonGateServerCudaProverBuilder {
-        LocalMoonGateServerCudaProverBuilder::default()
+    pub fn local(self) -> LocalMoongateServerCudaProverBuilder {
+        LocalMoongateServerCudaProverBuilder::default()
     }
 
     /// Builds a [`CudaProver`].
@@ -73,11 +73,11 @@ impl CudaProverBuilder {
 /// This is not meant to be used directly. Use [`CudaProverBuilder::server`]
 /// instead.
 #[derive(Debug)]
-pub struct ExternalMoonGateServerCudaProverBuilder {
+pub struct ExternalMoongateServerCudaProverBuilder {
     endpoint: String,
 }
 
-impl ExternalMoonGateServerCudaProverBuilder {
+impl ExternalMoongateServerCudaProverBuilder {
     /// Builds a [`CudaProver`].
     ///
     /// # Details
@@ -100,12 +100,12 @@ impl ExternalMoonGateServerCudaProverBuilder {
 /// This is not meant to be used directly. Use [`CudaProverBuilder::local`]
 /// instead.
 #[derive(Debug, Default)]
-pub struct LocalMoonGateServerCudaProverBuilder {
+pub struct LocalMoongateServerCudaProverBuilder {
     visible_device_index: Option<u64>,
     port: Option<u64>,
 }
 
-impl LocalMoonGateServerCudaProverBuilder {
+impl LocalMoongateServerCudaProverBuilder {
     /// Sets the embedded Moongate server port.
     ///
     /// If not set, the default value is `3000`.

--- a/crates/sdk/src/cuda/builder.rs
+++ b/crates/sdk/src/cuda/builder.rs
@@ -2,6 +2,7 @@
 //!
 //! This module provides a builder for the [`CpuProver`].
 
+use sp1_cuda::MoongateServer;
 use sp1_prover::SP1Prover;
 
 use super::CudaProver;
@@ -11,11 +12,11 @@ use super::CudaProver;
 /// The builder is used to configure the [`CudaProver`] before it is built.
 #[derive(Debug, Default)]
 pub struct CudaProverBuilder {
-    moongate_endpoint: Option<String>,
+    moongate_server: Option<MoongateServer>,
 }
 
 impl CudaProverBuilder {
-    /// Sets the Moongate server endpoint.
+    /// Uses an external Moongate server with the provided endpoint.
     ///
     /// # Details
     /// Run the CUDA prover with the provided endpoint for the Moongate (GPU prover) server.
@@ -25,19 +26,38 @@ impl CudaProverBuilder {
     /// ```rust,no_run
     /// use sp1_sdk::ProverClient;
     ///
-    /// let prover = ProverClient::builder().cuda().with_moongate_endpoint("http://...").build();
+    /// let prover = ProverClient::builder().cuda().with_external_moongate_server("http://...").build();
     /// ```
     #[must_use]
-    pub fn with_moongate_endpoint(mut self, endpoint: &str) -> Self {
-        self.moongate_endpoint = Some(endpoint.to_string());
-        self
+    pub fn with_external_moongate_server(
+        self,
+        endpoint: &str,
+    ) -> ExternalMoonGateServerCudaProverBuilder {
+        ExternalMoonGateServerCudaProverBuilder { endpoint: endpoint.to_string() }
+    }
+
+    /// Allows to customize the embedded Moongate server.
+    ///
+    /// # Details
+    /// The builder returned by this method allow to customize the embedded Moongate server port and
+    /// visible device. It is therefore possible to instantiate multiple [`CudaProver`s], each one
+    /// linked to a different GPU.
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// use sp1_sdk::ProverClient;
+    ///
+    /// let prover = ProverClient::builder().cuda().with_embedded_moongate_server().port(3200).build();
+    /// ```
+    #[must_use]
+    pub fn with_embedded_moongate_server(self) -> EmbeddedMoonGateServerCudaProverBuilder {
+        EmbeddedMoonGateServerCudaProverBuilder::default()
     }
 
     /// Builds a [`CudaProver`].
     ///
     /// # Details
-    /// This method will build a [`CudaProver`] with the given parameters. In particular, it will
-    /// build a mock prover if the `mock` flag is set.
+    /// This method will build a [`CudaProver`] with the given parameters.
     ///
     /// # Example
     /// ```rust,no_run
@@ -47,6 +67,90 @@ impl CudaProverBuilder {
     /// ```
     #[must_use]
     pub fn build(self) -> CudaProver {
-        CudaProver::new(SP1Prover::new(), self.moongate_endpoint)
+        CudaProver::new(SP1Prover::new(), self.moongate_server.unwrap_or_default())
+    }
+}
+
+/// A builder for the [`CudaProver`] with an external Moongate server.
+///
+/// This is not meant to be used directly. Use [`CudaProverBuilder::with_external_moongate_server`]
+/// instead.
+#[derive(Debug)]
+pub struct ExternalMoonGateServerCudaProverBuilder {
+    endpoint: String,
+}
+
+impl ExternalMoonGateServerCudaProverBuilder {
+    /// Builds a [`CudaProver`].
+    ///
+    /// # Details
+    /// This method will build a [`CudaProver`] with the given parameters.
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// use sp1_sdk::ProverClient;
+    ///
+    /// let prover = ProverClient::builder().cuda().with_external_moongate_server("http://...").build();
+    /// ```
+    #[must_use]
+    pub fn build(self) -> CudaProver {
+        CudaProver::new(SP1Prover::new(), MoongateServer::External { endpoint: self.endpoint })
+    }
+}
+
+/// A builder for the [`CudaProver`] with the embedded Moongate server.
+///
+/// This is not meant to be used directly. Use [`CudaProverBuilder::with_embedded_moongate_server`]
+/// instead.
+#[derive(Debug, Default)]
+pub struct EmbeddedMoonGateServerCudaProverBuilder {
+    visible_device_index: Option<u64>,
+    port: Option<u64>,
+}
+
+impl EmbeddedMoonGateServerCudaProverBuilder {
+    /// Sets the embedded Moongate server port.
+    ///
+    /// If not set, the default value is `3000`.
+    #[must_use]
+    pub fn port(mut self, port: u64) -> Self {
+        self.port = Some(port);
+        self
+    }
+
+    /// Sets the embedded Moongate visible device index.
+    ///
+    /// If not set, the default value is `3000`.
+    #[must_use]
+    pub fn visible_device(mut self, index: u64) -> Self {
+        self.visible_device_index = Some(index);
+        self
+    }
+
+    /// Builds a [`CudaProver`].
+    ///
+    /// # Details
+    /// This method will build a [`CudaProver`] with the given parameters.
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// use sp1_sdk::ProverClient;
+    ///
+    /// let prover = ProverClient::builder()
+    ///     .cuda()
+    ///     .with_embedded_moongate_server()
+    ///     .visible_device(2)
+    ///     .port(3002)
+    ///     .build();
+    /// ```
+    #[must_use]
+    pub fn build(self) -> CudaProver {
+        CudaProver::new(
+            SP1Prover::new(),
+            MoongateServer::Embedded {
+                visible_device_index: self.visible_device_index,
+                port: self.port,
+            },
+        )
     }
 }

--- a/crates/sdk/src/cuda/builder.rs
+++ b/crates/sdk/src/cuda/builder.rs
@@ -26,13 +26,10 @@ impl CudaProverBuilder {
     /// ```rust,no_run
     /// use sp1_sdk::ProverClient;
     ///
-    /// let prover = ProverClient::builder().cuda().with_external_moongate_server("http://...").build();
+    /// let prover = ProverClient::builder().cuda().server("http://...").build();
     /// ```
     #[must_use]
-    pub fn with_external_moongate_server(
-        self,
-        endpoint: &str,
-    ) -> ExternalMoonGateServerCudaProverBuilder {
+    pub fn server(self, endpoint: &str) -> ExternalMoonGateServerCudaProverBuilder {
         ExternalMoonGateServerCudaProverBuilder { endpoint: endpoint.to_string() }
     }
 
@@ -47,11 +44,11 @@ impl CudaProverBuilder {
     /// ```rust,no_run
     /// use sp1_sdk::ProverClient;
     ///
-    /// let prover = ProverClient::builder().cuda().with_embedded_moongate_server().port(3200).build();
+    /// let prover = ProverClient::builder().cuda().local().port(3200).build();
     /// ```
     #[must_use]
-    pub fn with_embedded_moongate_server(self) -> EmbeddedMoonGateServerCudaProverBuilder {
-        EmbeddedMoonGateServerCudaProverBuilder::default()
+    pub fn local(self) -> LocalMoonGateServerCudaProverBuilder {
+        LocalMoonGateServerCudaProverBuilder::default()
     }
 
     /// Builds a [`CudaProver`].
@@ -73,7 +70,7 @@ impl CudaProverBuilder {
 
 /// A builder for the [`CudaProver`] with an external Moongate server.
 ///
-/// This is not meant to be used directly. Use [`CudaProverBuilder::with_external_moongate_server`]
+/// This is not meant to be used directly. Use [`CudaProverBuilder::server`]
 /// instead.
 #[derive(Debug)]
 pub struct ExternalMoonGateServerCudaProverBuilder {
@@ -90,7 +87,7 @@ impl ExternalMoonGateServerCudaProverBuilder {
     /// ```rust,no_run
     /// use sp1_sdk::ProverClient;
     ///
-    /// let prover = ProverClient::builder().cuda().with_external_moongate_server("http://...").build();
+    /// let prover = ProverClient::builder().cuda().server("http://...").build();
     /// ```
     #[must_use]
     pub fn build(self) -> CudaProver {
@@ -100,15 +97,15 @@ impl ExternalMoonGateServerCudaProverBuilder {
 
 /// A builder for the [`CudaProver`] with the embedded Moongate server.
 ///
-/// This is not meant to be used directly. Use [`CudaProverBuilder::with_embedded_moongate_server`]
+/// This is not meant to be used directly. Use [`CudaProverBuilder::local`]
 /// instead.
 #[derive(Debug, Default)]
-pub struct EmbeddedMoonGateServerCudaProverBuilder {
+pub struct LocalMoonGateServerCudaProverBuilder {
     visible_device_index: Option<u64>,
     port: Option<u64>,
 }
 
-impl EmbeddedMoonGateServerCudaProverBuilder {
+impl LocalMoonGateServerCudaProverBuilder {
     /// Sets the embedded Moongate server port.
     ///
     /// If not set, the default value is `3000`.
@@ -136,18 +133,13 @@ impl EmbeddedMoonGateServerCudaProverBuilder {
     /// ```rust,no_run
     /// use sp1_sdk::ProverClient;
     ///
-    /// let prover = ProverClient::builder()
-    ///     .cuda()
-    ///     .with_embedded_moongate_server()
-    ///     .visible_device(2)
-    ///     .port(3002)
-    ///     .build();
+    /// let prover = ProverClient::builder().cuda().local().visible_device(2).port(3002).build();
     /// ```
     #[must_use]
     pub fn build(self) -> CudaProver {
         CudaProver::new(
             SP1Prover::new(),
-            MoongateServer::Embedded {
+            MoongateServer::Local {
                 visible_device_index: self.visible_device_index,
                 port: self.port,
             },

--- a/crates/sdk/src/cuda/mod.rs
+++ b/crates/sdk/src/cuda/mod.rs
@@ -9,7 +9,7 @@ use anyhow::Result;
 use prove::CudaProveBuilder;
 use sp1_core_executor::SP1ContextBuilder;
 use sp1_core_machine::io::SP1Stdin;
-use sp1_cuda::SP1CudaProver;
+use sp1_cuda::{MoongateServer, SP1CudaProver};
 use sp1_prover::{components::CpuProverComponents, SP1Prover};
 
 use crate::{
@@ -25,8 +25,8 @@ pub struct CudaProver {
 
 impl CudaProver {
     /// Creates a new [`CudaProver`].
-    pub fn new(prover: SP1Prover, moongate_endpoint: Option<String>) -> Self {
-        let cuda_prover = SP1CudaProver::new(moongate_endpoint);
+    pub fn new(prover: SP1Prover, moongate_server: MoongateServer) -> Self {
+        let cuda_prover = SP1CudaProver::new(moongate_server);
         Self {
             cpu_prover: prover,
             cuda_prover: cuda_prover.expect("Failed to initialize CUDA prover"),
@@ -181,6 +181,6 @@ impl Prover<CpuProverComponents> for CudaProver {
 
 impl Default for CudaProver {
     fn default() -> Self {
-        Self::new(SP1Prover::new(), None)
+        Self::new(SP1Prover::new(), MoongateServer::default())
     }
 }

--- a/crates/sdk/src/env/mod.rs
+++ b/crates/sdk/src/env/mod.rs
@@ -11,6 +11,7 @@ use anyhow::Result;
 use prove::EnvProveBuilder;
 use sp1_core_executor::SP1ContextBuilder;
 use sp1_core_machine::io::SP1Stdin;
+use sp1_cuda::MoongateServer;
 use sp1_prover::{components::CpuProverComponents, SP1Prover, SP1ProvingKey, SP1VerifyingKey};
 
 use super::{Prover, SP1VerificationError};
@@ -56,7 +57,7 @@ impl EnvProver {
             },
             "cuda" => {
                 check_release_build();
-                Box::new(CudaProver::new(SP1Prover::new(), None))
+                Box::new(CudaProver::new(SP1Prover::new(), MoongateServer::default()))
             }
             "network" => {
                 #[cfg(not(feature = "network"))]


### PR DESCRIPTION
…and port

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Moongate uses only the first visible GPU and if we try to instantiate more than one `CudaProver`, the second instance will try to create the Moongate container on the (already used) 3000 port and fail.

## Solution

Allow to parametrize the Moongate container creation with the following:

* Visible device index
* Port

This allow to instantiate multiple `CudaProver`, each one communicating with a different Moongate container.

Closes #2246

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes