### PR TITLE
fix(`get_proof_status`): Deserialize into `ProofFromNetwork`

### DIFF
--- a/crates/sdk/src/network/prover.rs
+++ b/crates/sdk/src/network/prover.rs
@@ -170,7 +170,10 @@ impl NetworkProver {
         &self,
         request_id: B256,
     ) -> Result<(GetProofRequestStatusResponse, Option<SP1ProofWithPublicValues>)> {
-        self.client.get_proof_request_status(request_id, None).await
+        let (status, maybe_proof): (GetProofRequestStatusResponse, Option<ProofFromNetwork>) =
+            self.client.get_proof_request_status(request_id, None).await?;
+        let maybe_proof = maybe_proof.map(Into::into);
+        Ok((status, maybe_proof))
     }
 
     /// Gets the status of a proof request with handling for timeouts and unfulfillable requests.


### PR DESCRIPTION
## Motivation

Users who use `get_proof_status` on SP1 SDK `4.2.0` encounter a `failed to deserialize proof` issue when calling `get_proof_status`.

This method is uncommonly used (as the default `prove` path calls `process_proof_status`), and the changes in https://github.com/succinctlabs/sp1/pull/2204 forgot to update `get_proof_status` when updating `process_proof_status`.

## Solution

Deserialize into `ProofFromNetwork` in `get_proof_status`, then map into `SP1ProofWithPublicValues`.