### PR TITLE
docs: Update SP1 Book documentation link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ If you have reviewed existing documentation and still have questions, or you are
 *opening a discussion**. This repository comes with a discussions board where you can also ask for help. Click the "
 Discussions" tab at the top.
 
-As SP1 is still in heavy development, the documentation can be a bit scattered. The [SP1 Book](https://succinctlabs.github.io/sp1/) is our
+As SP1 is still in heavy development, the documentation can be a bit scattered. The [SP1 Book](https://docs.succinct.xyz/docs/sp1/introduction) is our
 current best-effort attempt at keeping up-to-date information.
 
 ### Submitting a bug report


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
Updates the SP1 Book link from https://succinctlabs.github.io/sp1/ to https://docs.succinct.xyz/docs/sp1/introduction to reflect the new documentation location.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

