### PR TITLE
fix: add `-D__ILP32__` in zkvm only

### DIFF
--- a/crates/build/src/command/docker.rs
+++ b/crates/build/src/command/docker.rs
@@ -149,7 +149,7 @@ pub(crate) fn create_docker_command(
         "-e".to_string(),
         format!("RUSTC={}", rustc_bin.display()),
         "-e".to_string(),
-        "CFLAGS=-D__ILP32__".to_string(),
+        "CFLAGS_riscv32im_succinct_zkvm_elf=-D__ILP32__".to_string(),
         "--entrypoint".to_string(),
         "".to_string(),
         image,

--- a/crates/build/src/command/local.rs
+++ b/crates/build/src/command/local.rs
@@ -29,7 +29,7 @@ pub(crate) fn create_local_command(
 
     // the following flag is added to avoid build failure on ring:
     // https://github.com/briansmith/ring/blob/bcf68dd27a071ff1947b6327d4c6bde526e24b60/include/ring-core/target.h#L47
-    command.env("CFLAGS", "-D__ILP32__");
+    command.env("CFLAGS_riscv32im_succinct_zkvm_elf", "-D__ILP32__");
 
     let parsed_version = {
         let output = Command::new("rustc")


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

The `CFLAG` `-D__ILP32__` has been added in #2185 to allow zkVM programs that depends on `ring` to build, but the flag is also active during the build script compilation (that not occurs inside the zkVM), leading to build errors.

## Solution

Use the `CFLAGS` variant that include the `riscv32im_succinct_zkvm_elf` target in order to add `-D__ILP32__` only when needed.

Closes #2274