### PR TITLE
feat: allow to customize circuits paths

### DIFF
--- a/crates/sdk/src/install.rs
+++ b/crates/sdk/src/install.rs
@@ -22,13 +22,23 @@ pub const CIRCUIT_ARTIFACTS_URL_BASE: &str = "https://sp1-circuits.s3-us-east-2.
 /// The directory where the groth16 circuit artifacts will be stored.
 #[must_use]
 pub fn groth16_circuit_artifacts_dir() -> PathBuf {
-    dirs::home_dir().unwrap().join(".sp1").join("circuits/groth16").join(SP1_CIRCUIT_VERSION)
+    std::env::var("SP1_GROTH16_CIRCUIT_PATH")
+        .map_or_else(
+            |_| dirs::home_dir().unwrap().join(".sp1").join("circuits/groth16"),
+            |path| path.parse().unwrap(),
+        )
+        .join(SP1_CIRCUIT_VERSION)
 }
 
 /// The directory where the plonk circuit artifacts will be stored.
 #[must_use]
 pub fn plonk_circuit_artifacts_dir() -> PathBuf {
-    dirs::home_dir().unwrap().join(".sp1").join("circuits/plonk").join(SP1_CIRCUIT_VERSION)
+    std::env::var("SP1_PLONK_CIRCUIT_PATH")
+        .map_or_else(
+            |_| dirs::home_dir().unwrap().join(".sp1").join("circuits/plonk"),
+            |path| path.parse().unwrap(),
+        )
+        .join(SP1_CIRCUIT_VERSION)
 }
 
 /// Tries to install the groth16 circuit artifacts if they are not already installed.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

PLONK / Groth16 circuits artifact location can't be customized.

This could be beneficial in settings where we deploy the prover as binary artifacts, say when packaging up inside a jar or potentially even in mobile apps.

Closes #2280

## Solution

Adding `SP1_GROTH16_CIRCUIT_PATH` and `SP1_PLONK_CIRCUIT_PATH` env variables that overrides default path if specified.