### PR TITLE
chore: Ubuntu 20.04 retirement

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -232,8 +232,6 @@ jobs:
             runner: "ubuntu-24.04"
           - name: "Ubuntu 22.04 (x86_64)"
             runner: "ubuntu-22.04"
-          - name: "Ubuntu 20.04 (x86_64)"
-            runner: "ubuntu-20.04"
           - name: "macOS Ventura (x86_64)"
             runner: "macos-13"
           - name: "macOS Sonoma (ARM64)"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Ubuntu 20.04 LTS runner will be removed on 2025-04-15.
