### PR TITLE
fix: correct misleading proof verification warning on macOS

### DIFF
--- a/crates/core/executor/src/syscalls/verify.rs
+++ b/crates/core/executor/src/syscalls/verify.rs
@@ -31,8 +31,7 @@ impl Syscall for VerifySyscall {
                 panic!("Not enough proofs were written to the runtime.");
             }
             let (proof, proof_vk) = &rt.state.proof_stream[proof_index].clone();
-            rt.state.proof_stream_ptr += 1;
-
+            
             let vkey_bytes: [u32; 8] = vkey.try_into().unwrap();
             let pv_digest_bytes: [u32; 8] = pv_digest.try_into().unwrap();
             if let Some(verifier) = rt.subproof_verifier {
@@ -45,7 +44,10 @@ impl Syscall for VerifySyscall {
                             e
                         )
                     });
-            } else if rt.state.proof_stream_ptr == 1 {
+                // Only increment the proof stream pointer if verification actually happened
+                rt.state.proof_stream_ptr += 1;
+            } else {
+                // Only log but don't increment proof_stream_ptr when not verifying
                 tracing::info!("Not verifying sub proof during runtime");
             }
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Issue #2289 reports a potentially misleading warning "Not all proofs were read" on macOS (Apple Silicon) that doesn't appear on Ubuntu. 

## Solution

Fixed the issue by only incrementing the proof_stream_ptr counter when verification actually occurs. 

Previously, the counter was always incremented regardless of whether verification happened, causing a mismatch between the number of processed proofs and the counter value.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes