### PR TITLE
chore: remove protobuf-comiler to Dockerfile.build dep

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -21,7 +21,7 @@ RUN cargo run --bin cargo-prove -- prove install-toolchain && rm -rf /root/sp1
 
 FROM ubuntu:24.04@sha256:e3f92abc0967a6c19d0dfa2d55838833e947b9d74edbcb0113e48535ad4be12a as final
 
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates clang gcc libssl-dev pkg-config protobuf-compiler \
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates clang gcc libssl-dev pkg-config \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /root/.cargo /root/.cargo


### PR DESCRIPTION
this pull request updates the `Dockerfile.build` by removing the `protobuf-compiler` package from the list of installed dependencies