### PR TITLE
feat: allow to retrieve cycle count from a network proof

### DIFF
--- a/crates/sdk/src/network/prover.rs
+++ b/crates/sdk/src/network/prover.rs
@@ -193,6 +193,27 @@ impl NetworkProver {
         Ok((status, maybe_proof))
     }
 
+    /// Gets the cycle count of a proof request, if avaliable.
+    ///
+    /// # Details
+    /// * `request_id`: The request ID to get the status of.
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// use sp1_sdk::{network::B256, ProverClient};
+    ///
+    /// tokio_test::block_on(async {
+    ///     let request_id = B256::from_slice(&vec![1u8; 32]);
+    ///     let client = ProverClient::builder().network().build();
+    ///     let cycles = client.get_proof_cycles(request_id).await.unwrap();
+    /// })
+    /// ```
+    pub async fn get_proof_cycles(&self, request_id: B256) -> Result<Option<u64>> {
+        let request = self.client.get_proof_request_details(request_id, None).await?;
+
+        Ok(request.request.and_then(|r| r.cycles))
+    }
+
     /// Gets the status of a proof request with handling for timeouts and unfulfillable requests.
     ///
     /// Returns the proof if it is fulfilled and the fulfillment status. Handles statuses indicating


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Sometimes, for benchmarking purpose, it's useful to have access to the cycle count of proof being executed on the prover network.

## Solution

Adds a `get_proof_cycles()` fn on `NetworkProver`.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes