### PR TITLE
fix: log correct network explorer links

### DIFF
--- a/crates/sdk/src/network/mod.rs
+++ b/crates/sdk/src/network/mod.rs
@@ -25,7 +25,10 @@ pub use crate::network::{
 pub use alloy_primitives::B256;
 pub use error::*;
 
-pub(crate) const DEFAULT_NETWORK_RPC_URL: &str = "https://rpc.production.succinct.xyz/";
+pub(crate) const PRIVATE_NETWORK_RPC_URL: &str = "https://rpc.private.succinct.xyz";
+pub(crate) const PRIVATE_EXPLORER_URL: &str = "https://explorer-private.succinct.xyz";
+pub(crate) const PUBLIC_EXPLORER_URL: &str = "https://explorer.succinct.xyz";
+pub(crate) const DEFAULT_NETWORK_RPC_URL: &str = "https://rpc.production.succinct.xyz";
 pub(crate) const DEFAULT_TEE_SERVER_URL: &str = "https://tee.production.succinct.xyz";
 
 pub(crate) const DEFAULT_TIMEOUT_SECS: u64 = 14400;

--- a/crates/sdk/src/network/prover.rs
+++ b/crates/sdk/src/network/prover.rs
@@ -15,7 +15,7 @@ use crate::{
             ProofMode, ProofRequest,
         },
         Error, DEFAULT_CYCLE_LIMIT, DEFAULT_GAS_LIMIT, DEFAULT_NETWORK_RPC_URL,
-        DEFAULT_TIMEOUT_SECS,
+        DEFAULT_TIMEOUT_SECS, PRIVATE_EXPLORER_URL, PRIVATE_NETWORK_RPC_URL, PUBLIC_EXPLORER_URL,
     },
     prover::verify_proof,
     ProofFromNetwork, Prover, SP1ProofMode, SP1ProofWithPublicValues, SP1ProvingKey,
@@ -339,11 +339,14 @@ impl NetworkProver {
         let request_id = B256::from_slice(&response.body.unwrap().request_id);
         tracing::info!("Created request {} in transaction {:?}", request_id, tx_hash);
 
-        if self.client.rpc_url == DEFAULT_NETWORK_RPC_URL {
-            tracing::info!(
-                "View request status at: https://network.succinct.xyz/request/{}",
-                request_id
-            );
+        let explorer = match self.client.rpc_url.trim_end_matches('/') {
+            DEFAULT_NETWORK_RPC_URL => Some(PUBLIC_EXPLORER_URL),
+            PRIVATE_NETWORK_RPC_URL => Some(PRIVATE_EXPLORER_URL),
+            _ => None,
+        };
+
+        if let Some(base_url) = explorer {
+            tracing::info!("View request status at: {}/request/{}", base_url, request_id);
         }
 
         Ok(request_id)

--- a/patch-testing/Cargo.lock
+++ b/patch-testing/Cargo.lock
@@ -4322,7 +4322,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-sdk"
-version = "5.0.3"
+version = "5.0.4"
 dependencies = [
  "anyhow",
  "async-trait",


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
[network.succinct.xyz](https://network.succinct.xyz/) has been deprecated and replaced with [explorer.succinct.xyz](https://explorer.succinct.xyz/) and [explorer-private.succinct.xyz](https://explorer-private.succinct.xyz/) (used by Succinct customers who need private inputs).

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Display the correct explorer both when the default network RPC is used, and when one is passed by the user.

The log will show this:
```
2025-06-13T22:28:17.263550Z  INFO Requesting proof:
2025-06-13T22:28:17.263580Z  INFO ├─ Cycle limit: 20000000000
2025-06-13T22:28:17.263582Z  INFO ├─ Gas limit: 1000000000
2025-06-13T22:28:17.263583Z  INFO ├─ Proof mode: Compressed
2025-06-13T22:28:17.263584Z  INFO ├─ Strategy: Hosted
2025-06-13T22:28:17.263585Z  INFO ├─ Timeout: 14400 seconds
2025-06-13T22:28:17.263585Z  INFO └─ Circuit version: v5.0.0
2025-06-13T22:28:19.437884Z  INFO Created request 0xe80b074e8e78603e4376aeba5f28fcb65596e7e8acee9097d62f04caafdbfc9b in transaction 0x319464fc0062f6544435257e111c201bef18b3ed19d5ddd4582b1fa8a7dff7a8
2025-06-13T22:28:19.437901Z  INFO View request status at: https://explorer.succinct.xyz/request/0xe80b074e8e78603e4376aeba5f28fcb65596e7e8acee9097d62f04caafdbfc9b
2025-06-13T22:28:19.958433Z  INFO Proof request assigned, proving...
```