### PR TITLE
Allow option to enable setting the GPU id and port while starting moongate server

### DIFF
--- a/crates/cuda/src/lib.rs
+++ b/crates/cuda/src/lib.rs
@@ -130,6 +130,12 @@ pub enum MoongateServer {
     Local { visible_device_index: Option<u64>, port: Option<u64> },
 }
 
+impl MoongateServer {
+    pub fn new_local_server(visible_device_index: Option<u64>, port: Option<u64>) -> Self {
+        Self::Local { visible_device_index, port }
+    }
+}
+
 impl Default for MoongateServer {
     fn default() -> Self {
         Self::Local { visible_device_index: None, port: None }

--- a/crates/sdk/src/env/mod.rs
+++ b/crates/sdk/src/env/mod.rs
@@ -57,7 +57,23 @@ impl EnvProver {
             },
             "cuda" => {
                 check_release_build();
-                Box::new(CudaProver::new(SP1Prover::new(), MoongateServer::default()))
+                let visible_device_index: Option<u64> = match env::var("SP1_GPU_ID") {
+                    Ok(visible_device_index) => {
+                        let visible_device_index: u64 = visible_device_index.parse().unwrap_or_else(|_| panic!("invalid GPU index value: {visible_device_index}"));
+                        Some(visible_device_index)
+                    },
+                    Err(_) => None,
+                };
+
+                let port : Option<u64> = match env::var("SP1_PORT") {
+                    Ok(port) => {
+                        let port: u64 = port.parse().unwrap_or_else(|_| panic!("invalid device port: {port}"));
+                        Some(port)
+                    },
+                    Err(_) => None,
+                };
+
+                Box::new(CudaProver::new(SP1Prover::new(), MoongateServer::new_local_server(visible_device_index, port)))
             }
             "network" => {
                 #[cfg(not(feature = "network"))]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Currently while utilizaing sp1.
- the moongate server starts on specific port 3000.
- always gpu id 0 is utilized
- the name of the server is static
-->

## Solution

<!--
allowing the setup to do the following
- name is associated with the port passed in the format `sp1-gpu-{port}` using `SP1_PORT`
- option to pass gpu id using `SP1_GPU_ID`
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [x] Breaking changes