### PR TITLE
feat: set network error as transient

### DIFF
--- a/crates/sdk/src/network/retry.rs
+++ b/crates/sdk/src/network/retry.rs
@@ -101,7 +101,8 @@ where
                             error_msg.contains("transport error") ||
                             error_msg.contains("failed to lookup") ||
                             error_msg.contains("timeout") ||
-                            error_msg.contains("deadline exceeded");
+                            error_msg.contains("deadline exceeded") ||
+                            error_msg.contains("error sending request for url");
 
                         if is_transient {
                             tracing::warn!(


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

A customer had an "error sending request for url" issue during uploading artifacts while proving.

As the error is not marked as transient, the prove request failed.
 
## Solution

Mark errors containing "error sending request for url" as transient.
