### PR TITLE
`docker pull` inherits `stderr` and `stdout`, so docker logs are printed

### DIFF
--- a/crates/cuda/src/lib.rs
+++ b/crates/cuda/src/lib.rs
@@ -216,9 +216,15 @@ impl SP1CudaProver {
         }
 
         // Pull the docker image if it's not present
-        if let Err(e) = Command::new("docker").args(["pull", &image_name]).output() {
-            return Err(format!("Failed to pull Docker image: {}. Please check your internet connection and Docker permissions.", e).into());
+        let status = Command::new("docker")
+            .args(&["pull", &image_name])
+            .status()
+            .map_err(|e| format!("Failed to pull Docker image: {}. Please check your internet connection and Docker permissions.", e))?;
+        
+        if !status.success() {
+            return Err(format!("`docker pull` exited with: {}", status).into());
         }
+
 
         // Start the docker container
         let rust_log_level = std::env::var("RUST_LOG").unwrap_or_else(|_| "none".to_string());


### PR DESCRIPTION
## Motivation

Partial fix for #2338 .

## Solution

https://doc.rust-lang.org/std/process/struct.Command.html#method.status
> stdout and stderr are inherited from the parent.

## PR Checklist

- [ ] ~Added Tests~ N/A
- [ ] ~Added Documentation~ N/A
- [ ] ~Breaking changes~ N/A

(lmk if anything else is needed :pray:)