### PR TITLE
Update GitHub Actions to Latest Versions

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -72,7 +72,7 @@ runs:
         aws --version
 
     - name: rust-cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/bin/

--- a/.github/workflows/docker-publish-gnark.yml
+++ b/.github/workflows/docker-publish-gnark.yml
@@ -37,7 +37,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push AMD64 image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile.gnark-ffi
@@ -65,7 +65,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push ARM64 image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile.gnark-ffi


### PR DESCRIPTION
Changes
actions/cache@v3 → actions/cache@v4
docker/build-push-action@v5 → docker/build-push-action@v6

Files Changed
.github/actions/setup/action.yml
.github/workflows/docker-publish-gnark.yml

Release Notes
https://github.com/actions/cache/releases/tag/v4.0.0
https://github.com/docker/build-push-action/releases/tag/v6.0.0

This update improves caching performance and Docker build functionality while ensuring security patches are applied across the workflows.