### PR TITLE
chore: succinct toolchain 1.88.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5506,7 +5506,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-build"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -5518,7 +5518,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cli"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -5547,7 +5547,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -5574,7 +5574,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sp1-curves",
- "sp1-primitives 5.0.7",
+ "sp1-primitives 5.0.8",
  "sp1-stark",
  "sp1-zkvm",
  "strum",
@@ -5590,7 +5590,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-machine"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "bincode",
  "cbindgen",
@@ -5629,7 +5629,7 @@ dependencies = [
  "sp1-core-executor",
  "sp1-curves",
  "sp1-derive",
- "sp1-primitives 5.0.7",
+ "sp1-primitives 5.0.8",
  "sp1-stark",
  "sp1-zkvm",
  "static_assertions",
@@ -5649,7 +5649,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cuda"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "bincode",
  "ctrlc",
@@ -5667,7 +5667,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -5682,14 +5682,14 @@ dependencies = [
  "rug",
  "serde",
  "snowbridge-amcl",
- "sp1-primitives 5.0.7",
+ "sp1-primitives 5.0.8",
  "sp1-stark",
  "typenum",
 ]
 
 [[package]]
 name = "sp1-derive"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -5697,7 +5697,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-eval"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "anyhow",
  "bincode",
@@ -5715,7 +5715,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-helper"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "sp1-build",
 ]
@@ -5734,17 +5734,17 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "bincode",
  "elliptic-curve",
  "serde",
- "sp1-primitives 5.0.7",
+ "sp1-primitives 5.0.8",
 ]
 
 [[package]]
 name = "sp1-perf"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "bincode",
  "clap",
@@ -5784,7 +5784,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "bincode",
  "blake3",
@@ -5802,7 +5802,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "anyhow",
  "bincode",
@@ -5831,7 +5831,7 @@ dependencies = [
  "sha2 0.10.9",
  "sp1-core-executor",
  "sp1-core-machine",
- "sp1-primitives 5.0.7",
+ "sp1-primitives 5.0.8",
  "sp1-recursion-circuit",
  "sp1-recursion-compiler",
  "sp1-recursion-core",
@@ -5846,7 +5846,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-circuit"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "ff 0.13.1",
  "hashbrown 0.14.5",
@@ -5872,7 +5872,7 @@ dependencies = [
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-derive",
- "sp1-primitives 5.0.7",
+ "sp1-primitives 5.0.8",
  "sp1-recursion-compiler",
  "sp1-recursion-core",
  "sp1-recursion-gnark-ffi",
@@ -5884,7 +5884,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-compiler"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "backtrace",
  "criterion",
@@ -5899,7 +5899,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "sp1-core-machine",
- "sp1-primitives 5.0.7",
+ "sp1-primitives 5.0.8",
  "sp1-recursion-core",
  "sp1-recursion-derive",
  "sp1-stark",
@@ -5909,7 +5909,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-core"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "backtrace",
  "cbindgen",
@@ -5941,7 +5941,7 @@ dependencies = [
  "smallvec",
  "sp1-core-machine",
  "sp1-derive",
- "sp1-primitives 5.0.7",
+ "sp1-primitives 5.0.8",
  "sp1-stark",
  "static_assertions",
  "thiserror 1.0.69",
@@ -5952,7 +5952,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-derive"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -5960,7 +5960,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-cli"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "bincode",
  "clap",
@@ -5969,7 +5969,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-ffi"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "anyhow",
  "bincode",
@@ -5993,7 +5993,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-sdk"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -6022,7 +6022,7 @@ dependencies = [
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-cuda",
- "sp1-primitives 5.0.7",
+ "sp1-primitives 5.0.8",
  "sp1-prover",
  "sp1-stark",
  "strum",
@@ -6039,7 +6039,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-stark"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "arrayref",
  "hashbrown 0.14.5",
@@ -6063,7 +6063,7 @@ dependencies = [
  "rayon-scan",
  "serde",
  "sp1-derive",
- "sp1-primitives 5.0.7",
+ "sp1-primitives 5.0.8",
  "sp1-zkvm",
  "strum",
  "strum_macros",
@@ -6073,7 +6073,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-verifier"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -6098,7 +6098,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "blake3",
  "cfg-if",
@@ -6112,8 +6112,8 @@ dependencies = [
  "p3-field",
  "rand 0.8.5",
  "sha2 0.10.9",
- "sp1-lib 5.0.7",
- "sp1-primitives 5.0.7",
+ "sp1-lib 5.0.8",
+ "sp1-primitives 5.0.8",
 ]
 
 [[package]]
@@ -6450,7 +6450,7 @@ dependencies = [
 
 [[package]]
 name = "test-artifacts"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "sp1-build",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5506,7 +5506,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-build"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -5518,7 +5518,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cli"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -5547,7 +5547,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -5574,7 +5574,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sp1-curves",
- "sp1-primitives 5.0.5",
+ "sp1-primitives 5.0.7",
  "sp1-stark",
  "sp1-zkvm",
  "strum",
@@ -5590,7 +5590,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-machine"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "bincode",
  "cbindgen",
@@ -5629,7 +5629,7 @@ dependencies = [
  "sp1-core-executor",
  "sp1-curves",
  "sp1-derive",
- "sp1-primitives 5.0.5",
+ "sp1-primitives 5.0.7",
  "sp1-stark",
  "sp1-zkvm",
  "static_assertions",
@@ -5649,7 +5649,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cuda"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "bincode",
  "ctrlc",
@@ -5667,7 +5667,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -5682,14 +5682,14 @@ dependencies = [
  "rug",
  "serde",
  "snowbridge-amcl",
- "sp1-primitives 5.0.5",
+ "sp1-primitives 5.0.7",
  "sp1-stark",
  "typenum",
 ]
 
 [[package]]
 name = "sp1-derive"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -5697,7 +5697,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-eval"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "anyhow",
  "bincode",
@@ -5715,7 +5715,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-helper"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "sp1-build",
 ]
@@ -5734,17 +5734,17 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "bincode",
  "elliptic-curve",
  "serde",
- "sp1-primitives 5.0.5",
+ "sp1-primitives 5.0.7",
 ]
 
 [[package]]
 name = "sp1-perf"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "bincode",
  "clap",
@@ -5784,7 +5784,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "bincode",
  "blake3",
@@ -5802,7 +5802,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "anyhow",
  "bincode",
@@ -5831,7 +5831,7 @@ dependencies = [
  "sha2 0.10.9",
  "sp1-core-executor",
  "sp1-core-machine",
- "sp1-primitives 5.0.5",
+ "sp1-primitives 5.0.7",
  "sp1-recursion-circuit",
  "sp1-recursion-compiler",
  "sp1-recursion-core",
@@ -5846,7 +5846,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-circuit"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "ff 0.13.1",
  "hashbrown 0.14.5",
@@ -5872,7 +5872,7 @@ dependencies = [
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-derive",
- "sp1-primitives 5.0.5",
+ "sp1-primitives 5.0.7",
  "sp1-recursion-compiler",
  "sp1-recursion-core",
  "sp1-recursion-gnark-ffi",
@@ -5884,7 +5884,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-compiler"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "backtrace",
  "criterion",
@@ -5899,7 +5899,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "sp1-core-machine",
- "sp1-primitives 5.0.5",
+ "sp1-primitives 5.0.7",
  "sp1-recursion-core",
  "sp1-recursion-derive",
  "sp1-stark",
@@ -5909,7 +5909,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-core"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "backtrace",
  "cbindgen",
@@ -5941,7 +5941,7 @@ dependencies = [
  "smallvec",
  "sp1-core-machine",
  "sp1-derive",
- "sp1-primitives 5.0.5",
+ "sp1-primitives 5.0.7",
  "sp1-stark",
  "static_assertions",
  "thiserror 1.0.69",
@@ -5952,7 +5952,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-derive"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -5960,7 +5960,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-cli"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "bincode",
  "clap",
@@ -5969,7 +5969,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-ffi"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6022,7 +6022,7 @@ dependencies = [
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-cuda",
- "sp1-primitives 5.0.5",
+ "sp1-primitives 5.0.7",
  "sp1-prover",
  "sp1-stark",
  "strum",
@@ -6039,7 +6039,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-stark"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "arrayref",
  "hashbrown 0.14.5",
@@ -6063,7 +6063,7 @@ dependencies = [
  "rayon-scan",
  "serde",
  "sp1-derive",
- "sp1-primitives 5.0.5",
+ "sp1-primitives 5.0.7",
  "sp1-zkvm",
  "strum",
  "strum_macros",
@@ -6073,7 +6073,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-verifier"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -6098,7 +6098,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "blake3",
  "cfg-if",
@@ -6112,8 +6112,8 @@ dependencies = [
  "p3-field",
  "rand 0.8.5",
  "sha2 0.10.9",
- "sp1-lib 5.0.5",
- "sp1-primitives 5.0.5",
+ "sp1-lib 5.0.7",
+ "sp1-primitives 5.0.7",
 ]
 
 [[package]]
@@ -6450,7 +6450,7 @@ dependencies = [
 
 [[package]]
 name = "test-artifacts"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "sp1-build",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "5.0.5"
+version = "5.0.7"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/succinctlabs/sp1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "5.0.7"
+version = "5.0.8"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/succinctlabs/sp1"

--- a/crates/build/src/build.rs
+++ b/crates/build/src/build.rs
@@ -205,6 +205,6 @@ pub fn generate_elf_paths(
 /// Prints cargo directives setting relevant `SP1_ELF_` environment variables.
 fn print_elf_paths_cargo_directives(target_elf_paths: &[(String, Utf8PathBuf)]) {
     for (target_name, elf_path) in target_elf_paths.iter() {
-        println!("cargo:rustc-env=SP1_ELF_{}={}", target_name, elf_path);
+        println!("cargo:rustc-env=SP1_ELF_{target_name}={elf_path}");
     }
 }

--- a/crates/build/src/build.rs
+++ b/crates/build/src/build.rs
@@ -135,7 +135,7 @@ pub(crate) fn build_program_internal(path: &str, args: Option<BuildArgs>) {
         execute_build_program(&BuildArgs::default(), Some(program_dir.to_path_buf()))
     };
     if let Err(err) = path_output {
-        panic!("Failed to build SP1 program: {}.", err);
+        panic!("Failed to build SP1 program: {err}.");
     }
 
     if args.map(|args| matches!(args.warning_level, WarningLevel::All)).unwrap_or(true) {

--- a/crates/build/src/command/docker.rs
+++ b/crates/build/src/command/docker.rs
@@ -15,7 +15,7 @@ use super::utils::{get_program_build_args, get_rust_compiler_flags};
 fn get_docker_image(tag: &str) -> String {
     std::env::var("SP1_DOCKER_IMAGE").unwrap_or_else(|_| {
         let image_base = "ghcr.io/succinctlabs/sp1";
-        format!("{}:{}", image_base, tag)
+        format!("{image_base}:{tag}")
     })
 }
 
@@ -68,7 +68,7 @@ pub(crate) fn create_docker_command(
 
     // Mount the entire workspace, and set the working directory to the program dir. Note: If the
     // program dir has local dependencies outside of the workspace, building with Docker will fail.
-    let workspace_root_path = format!("{}:/root/program", workspace_root);
+    let workspace_root_path = format!("{workspace_root}:/root/program");
     let program_dir_path = format!(
         "/root/program/{}",
         canonicalized_program_dir.strip_prefix(workspace_root).unwrap()
@@ -102,7 +102,7 @@ pub(crate) fn create_docker_command(
             String::from_utf8(output.stdout).expect("Can't parse rustc --version stdout");
 
         if matches!(args.warning_level, WarningLevel::All) {
-            println!("cargo:warning=docker: rustc +succinct --version: {:?}", stdout_string);
+            println!("cargo:warning=docker: rustc +succinct --version: {stdout_string:?}");
         }
 
         super::utils::parse_rustc_version(&stdout_string)
@@ -122,7 +122,7 @@ pub(crate) fn create_docker_command(
         PathBuf::from(stdout_string.trim()).join("bin/rustc")
     };
 
-    println!("cargo:warning=docker: rustc_bin: {:?}", rustc_bin);
+    println!("cargo:warning=docker: rustc_bin: {rustc_bin:?}");
 
     // When executing the Docker command:
     // 1. Set the target directory to a subdirectory of the program's target directory to avoid

--- a/crates/build/src/command/local.rs
+++ b/crates/build/src/command/local.rs
@@ -50,7 +50,7 @@ pub(crate) fn create_local_command(
             String::from_utf8(output.stdout).expect("Can't parse rustc --version stdout");
 
         if matches!(args.warning_level, WarningLevel::All) {
-            println!("cargo:warning=rustc +succinct --version: {:?}", stdout_string);
+            println!("cargo:warning=rustc +succinct --version: {stdout_string:?}");
         }
 
         super::utils::parse_rustc_version(&stdout_string)

--- a/crates/cli/src/commands/build_toolchain.rs
+++ b/crates/cli/src/commands/build_toolchain.rs
@@ -33,7 +33,7 @@ impl BuildToolchainCmd {
                 let repo_url = match github_access_token {
                     Ok(github_access_token) => {
                         println!("Detected GITHUB_ACCESS_TOKEN, using it to clone rust.");
-                        format!("https://{}@github.com/succinctlabs/rust", github_access_token)
+                        format!("https://{github_access_token}@github.com/succinctlabs/rust")
                     }
                     Err(_) => {
                         println!("No GITHUB_ACCESS_TOKEN detected. If you get throttled by Github, set it to bypass the rate limit.");
@@ -46,7 +46,7 @@ impl BuildToolchainCmd {
                         &repo_url,
                         "--depth=1",
                         "--single-branch",
-                        &format!("--branch={}", LATEST_SUPPORTED_TOOLCHAIN_VERSION_TAG),
+                        &format!("--branch={LATEST_SUPPORTED_TOOLCHAIN_VERSION_TAG}"),
                         "sp1-rust",
                     ])
                     .current_dir(&temp_dir)
@@ -64,7 +64,7 @@ impl BuildToolchainCmd {
         let bootstrap_toml = include_str!("bootstrap.toml");
         let bootstrap_file = rust_dir.join("bootstrap.toml");
         std::fs::write(&bootstrap_file, bootstrap_toml)
-            .with_context(|| format!("while writing configuration to {:?}", bootstrap_file))?;
+            .with_context(|| format!("while writing configuration to {bootstrap_file:?}"))?;
 
         // Work around target sanity check added in
         // rust-lang/rust@09c076810cb7649e5817f316215010d49e78e8d7.
@@ -122,7 +122,7 @@ impl BuildToolchainCmd {
 
         // Compressing toolchain directory to tar.gz.
         let target = get_target();
-        let tar_gz_path = format!("rust-toolchain-{}.tar.gz", target);
+        let tar_gz_path = format!("rust-toolchain-{target}.tar.gz");
         Command::new("tar")
             .args([
                 "--exclude",
@@ -136,7 +136,7 @@ impl BuildToolchainCmd {
                 ".",
             ])
             .run()?;
-        println!("Successfully compressed the toolchain to {}.", tar_gz_path);
+        println!("Successfully compressed the toolchain to {tar_gz_path}.");
 
         Ok(())
     }

--- a/crates/cli/src/commands/install_toolchain.rs
+++ b/crates/cli/src/commands/install_toolchain.rs
@@ -48,8 +48,7 @@ impl InstallToolchainCmd {
                     let mut headers = reqwest::header::HeaderMap::new();
                     headers.insert(
                         reqwest::header::AUTHORIZATION,
-                        reqwest::header::HeaderValue::from_str(&format!("token {}", token))
-                            .unwrap(),
+                        reqwest::header::HeaderValue::from_str(&format!("token {token}")).unwrap(),
                     );
                     headers
                 })
@@ -74,11 +73,11 @@ impl InstallToolchainCmd {
                             entry_name != "toolchains"
                         {
                             if let Err(err) = fs::remove_dir_all(&entry_path) {
-                                println!("Failed to remove directory {:?}: {}", entry_path, err);
+                                println!("Failed to remove directory {entry_path:?}: {err}");
                             }
                         } else if entry_path.is_file() {
                             if let Err(err) = fs::remove_file(&entry_path) {
-                                println!("Failed to remove file {:?}: {}", entry_path, err);
+                                println!("Failed to remove file {entry_path:?}: {err}");
                             }
                         }
                     }
@@ -89,7 +88,7 @@ impl InstallToolchainCmd {
         println!("Successfully cleaned up ~/.sp1 directory.");
         match fs::create_dir_all(&root_dir) {
             Ok(_) => println!("Successfully created ~/.sp1 directory."),
-            Err(err) => println!("Failed to create ~/.sp1 directory: {}", err),
+            Err(err) => println!("Failed to create ~/.sp1 directory: {err}"),
         };
 
         assert!(
@@ -97,7 +96,7 @@ impl InstallToolchainCmd {
             "Unsupported architecture. Please build the toolchain from source."
         );
         let target = get_target();
-        let toolchain_asset_name = format!("rust-toolchain-{}.tar.gz", target);
+        let toolchain_asset_name = format!("rust-toolchain-{target}.tar.gz");
         let toolchain_archive_path = root_dir.join(toolchain_asset_name.clone());
         let toolchain_dir = root_dir.join(&target);
         let rt = tokio::runtime::Runtime::new()?;
@@ -164,7 +163,7 @@ impl InstallToolchainCmd {
 
         // Ensure permissions.
         let bin_dir = new_toolchain_dir.join("bin");
-        let rustlib_bin_dir = new_toolchain_dir.join(format!("lib/rustlib/{}/bin", target));
+        let rustlib_bin_dir = new_toolchain_dir.join(format!("lib/rustlib/{target}/bin"));
         for entry in fs::read_dir(bin_dir)?.chain(fs::read_dir(rustlib_bin_dir)?) {
             let entry = entry?;
             if entry.path().is_file() {

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -10,7 +10,7 @@ pub const RUSTUP_TOOLCHAIN_NAME: &str = "succinct";
 ///
 /// This tag has support for older x86 libc versions (like the one found in Ubuntu 20.04).
 /// This tag has support for the recent Macos and ARM targets.
-pub const LATEST_SUPPORTED_TOOLCHAIN_VERSION_TAG: &str = "succinct-1.87.0";
+pub const LATEST_SUPPORTED_TOOLCHAIN_VERSION_TAG: &str = "succinct-1.88.0";
 
 pub const SP1_VERSION_MESSAGE: &str =
     concat!("sp1", " (", env!("VERGEN_GIT_SHA"), " ", env!("VERGEN_BUILD_TIMESTAMP"), ")");

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -83,14 +83,12 @@ pub async fn get_toolchain_download_url(client: &Client, target: String) -> Stri
         })
         .unwrap_or_else(|| {
             panic!(
-                "No release found for the expected tag: {}",
-                LATEST_SUPPORTED_TOOLCHAIN_VERSION_TAG
+                "No release found for the expected tag: {LATEST_SUPPORTED_TOOLCHAIN_VERSION_TAG}",
             );
         });
 
     let url = format!(
-        "https://github.com/succinctlabs/rust/releases/download/{}/rust-toolchain-{}.tar.gz",
-        LATEST_SUPPORTED_TOOLCHAIN_VERSION_TAG, target
+        "https://github.com/succinctlabs/rust/releases/download/{LATEST_SUPPORTED_TOOLCHAIN_VERSION_TAG}/rust-toolchain-{target}.tar.gz"
     );
 
     url

--- a/crates/core/executor/src/syscalls/write.rs
+++ b/crates/core/executor/src/syscalls/write.rs
@@ -67,7 +67,7 @@ impl Syscall for WriteSyscall {
                                 });
                             }
                             None => {
-                                flush_s.into_iter().for_each(|line| eprintln!("stdout: {}", line));
+                                flush_s.into_iter().for_each(|line| eprintln!("stdout: {line}"));
                             }
                         }
                     }
@@ -88,7 +88,7 @@ impl Syscall for WriteSyscall {
                         });
                     }
                     None => {
-                        flush_s.into_iter().for_each(|line| eprintln!("stderr: {}", line));
+                        flush_s.into_iter().for_each(|line| eprintln!("stderr: {line}"));
                     }
                 }
             }

--- a/crates/core/machine/build.rs
+++ b/crates/core/machine/build.rs
@@ -135,7 +135,7 @@ mod sys {
             }
             Err(cbindgen::Error::ParseSyntaxError { .. }) => {} /* Ignore parse errors so */
             // rust-analyzer can run.
-            Err(e) => panic!("{:?}", e),
+            Err(e) => panic!("{e:?}"),
         }
 
         // Copy the headers to the include directory and symlink them to the fixed include

--- a/crates/core/machine/src/alu/add_sub/mod.rs
+++ b/crates/core/machine/src/alu/add_sub/mod.rs
@@ -501,7 +501,7 @@ mod tests {
 
                 let result =
                     run_malicious_test::<P>(program, stdin, Box::new(malicious_trace_pv_generator));
-                println!("Result for {:?}: {:?}", opcode, result);
+                println!("Result for {opcode:?}: {result:?}");
                 let add_sub_chip_name = chip_name!(AddSubChip, BabyBear);
                 assert!(
                     result.is_err() &&

--- a/crates/core/machine/src/alu/lt/mod.rs
+++ b/crates/core/machine/src/alu/lt/mod.rs
@@ -74,7 +74,7 @@ pub struct LtCols<T> {
 
     /// The result of the intermediate SLTU operation `b_comp < c_comp`.
     pub sltu: T,
-    /// A bollean flag for an intermediate comparison.
+    /// A boolean flag for an intermediate comparison.
     pub is_comp_eq: T,
     /// A boolean flag for comparing the sign bits.
     pub is_sign_eq: T,

--- a/crates/core/machine/src/global/mod.rs
+++ b/crates/core/machine/src/global/mod.rs
@@ -286,7 +286,7 @@ mod tests {
         println!("{:?}", trace.values);
 
         for mem_event in shard.global_memory_finalize_events {
-            println!("{:?}", mem_event);
+            println!("{mem_event:?}");
         }
     }
 }

--- a/crates/core/machine/src/memory/global.rs
+++ b/crates/core/machine/src/memory/global.rs
@@ -461,7 +461,7 @@ mod tests {
         println!("{:?}", trace.values);
 
         for mem_event in shard.global_memory_finalize_events {
-            println!("{:?}", mem_event);
+            println!("{mem_event:?}");
         }
     }
 

--- a/crates/core/machine/src/memory/global.rs
+++ b/crates/core/machine/src/memory/global.rs
@@ -147,7 +147,7 @@ impl<F: PrimeField32> MachineAir<F> for MemoryGlobalChip {
                 cols.is_prev_addr_zero.populate(prev_addr);
                 cols.is_first_comp = F::from_bool(prev_addr != 0);
                 if prev_addr != 0 {
-                    debug_assert!(prev_addr < addr, "prev_addr {} < addr {}", prev_addr, addr);
+                    debug_assert!(prev_addr < addr, "prev_addr {prev_addr} < addr {addr}");
                     let addr_bits: [_; 32] = array::from_fn(|i| (addr >> i) & 1);
                     cols.lt_cols.populate(&previous_addr_bits, &addr_bits);
                 }

--- a/crates/core/machine/src/memory/local.rs
+++ b/crates/core/machine/src/memory/local.rs
@@ -298,7 +298,7 @@ mod tests {
         println!("{:?}", trace.values);
 
         for mem_event in shard.global_memory_finalize_events {
-            println!("{:?}", mem_event);
+            println!("{mem_event:?}");
         }
     }
 

--- a/crates/core/machine/src/operations/field/field_op.rs
+++ b/crates/core/machine/src/operations/field/field_op.rs
@@ -510,7 +510,7 @@ mod tests {
     #[test]
     fn generate_trace() {
         for op in [FieldOperation::Add, FieldOperation::Mul, FieldOperation::Sub].iter() {
-            println!("op: {:?}", op);
+            println!("op: {op:?}");
             let chip: FieldOpChip<Ed25519BaseField> = FieldOpChip::new(*op);
             let shard = ExecutionRecord::default();
             let _: RowMajorMatrix<BabyBear> =
@@ -527,7 +527,7 @@ mod tests {
             [FieldOperation::Add, FieldOperation::Sub, FieldOperation::Mul, FieldOperation::Div]
                 .iter()
         {
-            println!("op: {:?}", op);
+            println!("op: {op:?}");
 
             let mut challenger = config.challenger();
 

--- a/crates/core/machine/src/riscv/mod.rs
+++ b/crates/core/machine/src/riscv/mod.rs
@@ -612,7 +612,7 @@ pub mod tests {
     #[ignore]
     fn write_core_air_costs() {
         let costs = RiscvAir::<BabyBear>::costs();
-        println!("{:?}", costs);
+        println!("{costs:?}");
         // write to file
         // Create directory if it doesn't exist
         let dir = std::path::Path::new("../executor/src/artifacts");

--- a/crates/core/machine/src/shape/mod.rs
+++ b/crates/core/machine/src/shape/mod.rs
@@ -680,7 +680,7 @@ pub mod tests {
         use p3_baby_bear::BabyBear;
         let shape_config = CoreShapeConfig::<BabyBear>::default();
         let num_shapes = shape_config.all_shapes().collect::<HashSet<_>>().len();
-        println!("There are {} core shapes", num_shapes);
+        println!("There are {num_shapes} core shapes");
         assert!(num_shapes < 1 << 24);
     }
 

--- a/crates/core/machine/src/utils/logger.rs
+++ b/crates/core/machine/src/utils/logger.rs
@@ -46,7 +46,7 @@ pub fn setup_logger() {
                     .init();
             }
             _ => {
-                panic!("Invalid logger type: {}", logger_type);
+                panic!("Invalid logger type: {logger_type}");
             }
         };
 

--- a/crates/core/machine/src/utils/mod.rs
+++ b/crates/core/machine/src/utils/mod.rs
@@ -88,7 +88,7 @@ pub fn next_power_of_two(n: usize, fixed_power: Option<usize>) -> usize {
                 );
             }
             if n > padded_nb_rows {
-                panic!("fixed log2 rows is too small: got {}, expected {}", n, padded_nb_rows);
+                panic!("fixed log2 rows is too small: got {n}, expected {padded_nb_rows}");
             }
             padded_nb_rows
         }

--- a/crates/core/machine/src/utils/span.rs
+++ b/crates/core/machine/src/utils/span.rs
@@ -119,7 +119,7 @@ where
         let (width, lines) = sorted_table_lines(instr_cts);
         let lines = lines.map(|(label, count)| format_table_line(&width, &label, count));
 
-        once(format!("{}", name))
+        once(format!("{name}"))
             .chain(
                 children
                     .iter()

--- a/crates/cuda/src/lib.rs
+++ b/crates/cuda/src/lib.rs
@@ -217,7 +217,7 @@ impl SP1CudaProver {
 
         // Pull the docker image if it's not present
         if let Err(e) = Command::new("docker").args(["pull", &image_name]).output() {
-            return Err(format!("Failed to pull Docker image: {}. Please check your internet connection and Docker permissions.", e).into());
+            return Err(format!("Failed to pull Docker image: {e}. Please check your internet connection and Docker permissions.").into());
         }
 
         // Start the docker container
@@ -240,7 +240,7 @@ impl SP1CudaProver {
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit())
             .spawn()
-            .map_err(|e| format!("Failed to start Docker container: {}. Please check your Docker installation and permissions.", e))?;
+            .map_err(|e| format!("Failed to start Docker container: {e}. Please check your Docker installation and permissions."))?;
 
         MOONGATE_CONTAINERS.lock()?.insert(container_name.clone(), cleaned_up.clone());
 
@@ -386,8 +386,7 @@ impl Drop for SP1CudaProver {
 fn cleanup_container(container_name: &str) {
     if let Err(e) = Command::new("docker").args(["rm", "-f", container_name]).output() {
         eprintln!(
-            "Failed to remove container: {}. You may need to manually remove it using 'docker rm -f {}'",
-            e, container_name
+            "Failed to remove container: {e}. You may need to manually remove it using 'docker rm -f {container_name}'"
         );
     }
 }

--- a/crates/cuda/src/lib.rs
+++ b/crates/cuda/src/lib.rs
@@ -204,7 +204,7 @@ impl SP1CudaProver {
         // If the moongate endpoint url hasn't been provided, we start the Docker container
         let container_name = port.map(|p| format!("sp1-gpu-{p}")).unwrap_or("sp1-gpu".to_string());
         let image_name = std::env::var("SP1_GPU_IMAGE")
-            .unwrap_or_else(|_| "public.ecr.aws/succinct-labs/moongate:v5.0.0".to_string());
+            .unwrap_or_else(|_| "public.ecr.aws/succinct-labs/moongate:v5.0.8".to_string());
 
         let cleaned_up = Arc::new(AtomicBool::new(false));
         let port = port.unwrap_or(3000);

--- a/crates/curves/src/weierstrass/secp256k1.rs
+++ b/crates/curves/src/weierstrass/secp256k1.rs
@@ -135,7 +135,7 @@ mod tests {
             let x_2 = (&x * &x) % Secp256k1BaseField::modulus();
             let sqrt = secp256k1_sqrt(&x_2);
 
-            println!("sqrt: {}", sqrt);
+            println!("sqrt: {sqrt}");
 
             let sqrt_2 = (&sqrt * &sqrt) % Secp256k1BaseField::modulus();
 

--- a/crates/eval/CHANGELOG.md
+++ b/crates/eval/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - performance test + add to CI ([#1426](https://github.com/succinctlabs/sp1/pull/1426))
-- restore acknolwedgements
+- restore acknowledgements
 - update tg ([#1214](https://github.com/succinctlabs/sp1/pull/1214))
 - v1.0.1 ([#1165](https://github.com/succinctlabs/sp1/pull/1165))
 - new README img ([#226](https://github.com/succinctlabs/sp1/pull/226))

--- a/crates/eval/src/lib.rs
+++ b/crates/eval/src/lib.rs
@@ -78,7 +78,7 @@ struct EvalArgs {
 pub async fn evaluate_performance<C: SP1ProverComponents>(
     opts: SP1ProverOpts,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    println!("opts: {:?}", opts);
+    println!("opts: {opts:?}");
 
     let args = EvalArgs::parse();
 
@@ -200,13 +200,13 @@ fn run_evaluation<C: SP1ProverComponents>(
 fn format_results(args: &EvalArgs, results: &[PerformanceReport]) -> Vec<String> {
     let mut detail_text = String::new();
     if let Some(branch_name) = &args.branch_name {
-        detail_text.push_str(&format!("*Branch*: {}\n", branch_name));
+        detail_text.push_str(&format!("*Branch*: {branch_name}\n"));
     }
     if let Some(commit_hash) = &args.commit_hash {
         detail_text.push_str(&format!("*Commit*: {}\n", &commit_hash[..8]));
     }
     if let Some(author) = &args.author {
-        detail_text.push_str(&format!("*Author*: {}\n", author));
+        detail_text.push_str(&format!("*Author*: {author}\n"));
     }
 
     let mut table_text = String::new();
@@ -253,9 +253,9 @@ fn format_duration(duration: f64) -> String {
     let seconds = secs % 60;
 
     if minutes > 0 {
-        format!("{}m{}s", minutes, seconds)
+        format!("{minutes}m{seconds}s")
     } else if seconds > 0 {
-        format!("{}s", seconds)
+        format!("{seconds}s")
     } else {
         format!("{}ms", (duration * 1000.0).round() as u64)
     }
@@ -306,13 +306,13 @@ async fn post_to_github_pr(
     message: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let client = Client::new();
-    let base_url = format!("https://api.github.com/repos/{}/{}", owner, repo);
+    let base_url = format!("https://api.github.com/repos/{owner}/{repo}");
 
     // Get all comments on the PR
-    let comments_url = format!("{}/issues/{}/comments", base_url, pr_number);
+    let comments_url = format!("{base_url}/issues/{pr_number}/comments");
     let comments_response = client
         .get(&comments_url)
-        .header("Authorization", format!("token {}", token))
+        .header("Authorization", format!("token {token}"))
         .header("User-Agent", "sp1-perf-bot")
         .send()
         .await?;
@@ -332,7 +332,7 @@ async fn post_to_github_pr(
         let comment_url = existing_comment["url"].as_str().unwrap();
         let response = client
             .patch(comment_url)
-            .header("Authorization", format!("token {}", token))
+            .header("Authorization", format!("token {token}"))
             .header("User-Agent", "sp1-perf-bot")
             .json(&json!({
                 "body": message
@@ -347,7 +347,7 @@ async fn post_to_github_pr(
         // Create a new comment
         let response = client
             .post(&comments_url)
-            .header("Authorization", format!("token {}", token))
+            .header("Authorization", format!("token {token}"))
             .header("User-Agent", "sp1-perf-bot")
             .json(&json!({
                 "body": message
@@ -409,7 +409,7 @@ mod tests {
         let formatted_results = format_results(&args, &dummy_reports);
 
         for line in &formatted_results {
-            println!("{}", line);
+            println!("{line}");
         }
 
         assert_eq!(formatted_results.len(), 3);

--- a/crates/perf/src/main.rs
+++ b/crates/perf/src/main.rs
@@ -133,7 +133,7 @@ fn main() {
                 verify_wrap_duration,
             };
 
-            println!("{:?}", result);
+            println!("{result:?}");
         }
         ProverMode::Cuda => {
             let server = SP1CudaProver::new(MoongateServer::default())
@@ -187,7 +187,7 @@ fn main() {
                 ..Default::default()
             };
 
-            println!("{:?}", result);
+            println!("{result:?}");
         }
         ProverMode::Network => {
             let prover = ProverClient::builder().network().build();

--- a/crates/prover/scripts/find_maximal_shapes.rs
+++ b/crates/prover/scripts/find_maximal_shapes.rs
@@ -129,7 +129,7 @@ fn main() {
             .args([
                 "s3",
                 "cp",
-                &format!("s3://sp1-testing-suite/{}/program.bin", s3_path),
+                &format!("s3://sp1-testing-suite/{s3_path}/program.bin"),
                 "program.bin",
             ])
             .status()
@@ -140,12 +140,7 @@ fn main() {
 
         // Download stdin.bin.
         let status = std::process::Command::new("aws")
-            .args([
-                "s3",
-                "cp",
-                &format!("s3://sp1-testing-suite/{}/stdin.bin", s3_path),
-                "stdin.bin",
-            ])
+            .args(["s3", "cp", &format!("s3://sp1-testing-suite/{s3_path}/stdin.bin"), "stdin.bin"])
             .status()
             .expect("Failed to execute aws s3 cp command for stdin.bin");
         if !status.success() {

--- a/crates/prover/scripts/find_oom_shapes.rs
+++ b/crates/prover/scripts/find_oom_shapes.rs
@@ -40,7 +40,7 @@ fn main() {
             for shape in shapes.iter() {
                 let lde_size = shape.estimate_lde_size(&costs);
                 if lde_size > args.lde_threshold_bytes {
-                    println!("maximal shape: {:?}, lde_size: {}", shape, lde_size);
+                    println!("maximal shape: {shape:?}, lde_size: {lde_size}");
                 }
             }
         }
@@ -57,7 +57,7 @@ fn main() {
         for shape in small_shapes.iter() {
             let lde_size = shape.estimate_lde_size(&costs);
             if lde_size > args.lde_threshold_bytes {
-                println!("small shape: {:?}, lde_size: {}", shape, lde_size);
+                println!("small shape: {shape:?}, lde_size: {lde_size}");
             }
         }
     }

--- a/crates/prover/scripts/find_recursion_shapes.rs
+++ b/crates/prover/scripts/find_recursion_shapes.rs
@@ -157,7 +157,7 @@ fn main() {
         }
     }
 
-    println!("Final compress shape: {:?}", answer);
-    println!("Final compress shape with no precompiles: {:?}", no_precompile_answer);
-    println!("Final shrink shape: {:?}", shrink_shape);
+    println!("Final compress shape: {answer:?}");
+    println!("Final compress shape with no precompiles: {no_precompile_answer:?}");
+    println!("Final shrink shape: {shrink_shape:?}");
 }

--- a/crates/prover/scripts/test_shape_fixing.rs
+++ b/crates/prover/scripts/test_shape_fixing.rs
@@ -47,7 +47,7 @@ fn test_shape_fixing(
         for mut record in records {
             let _ = record.defer();
             let heights = RiscvAir::<BabyBear>::core_heights(&record);
-            println!("heights: {:?}", heights);
+            println!("heights: {heights:?}");
 
             shape_config.fix_shape(&mut record).unwrap();
 
@@ -83,7 +83,7 @@ fn main() {
             .args([
                 "s3",
                 "cp",
-                &format!("s3://sp1-testing-suite/{}/program.bin", s3_path),
+                &format!("s3://sp1-testing-suite/{s3_path}/program.bin"),
                 "program.bin",
             ])
             .status()
@@ -94,12 +94,7 @@ fn main() {
 
         // Download stdin.bin.
         let status = std::process::Command::new("aws")
-            .args([
-                "s3",
-                "cp",
-                &format!("s3://sp1-testing-suite/{}/stdin.bin", s3_path),
-                "stdin.bin",
-            ])
+            .args(["s3", "cp", &format!("s3://sp1-testing-suite/{s3_path}/stdin.bin"), "stdin.bin"])
             .status()
             .expect("Failed to execute aws s3 cp command for stdin.bin");
         if !status.success() {

--- a/crates/prover/src/lib.rs
+++ b/crates/prover/src/lib.rs
@@ -1613,7 +1613,7 @@ pub mod tests {
         );
         let plonk_bn254_proof =
             prover.wrap_plonk_bn254(wrapped_bn254_proof.clone(), &artifacts_dir);
-        println!("{:?}", plonk_bn254_proof);
+        println!("{plonk_bn254_proof:?}");
 
         prover.verify_plonk_bn254(&plonk_bn254_proof, &vk, &public_values, &artifacts_dir)?;
 
@@ -1623,7 +1623,7 @@ pub mod tests {
             &wrapped_bn254_proof.proof,
         );
         let groth16_bn254_proof = prover.wrap_groth16_bn254(wrapped_bn254_proof, &artifacts_dir);
-        println!("{:?}", groth16_bn254_proof);
+        println!("{groth16_bn254_proof:?}");
 
         if verify {
             prover.verify_groth16_bn254(

--- a/crates/prover/src/shapes.rs
+++ b/crates/prover/src/shapes.rs
@@ -207,7 +207,7 @@ pub fn build_vk_map<C: SP1ProverComponents + 'static>(
                 let panic_tx = panic_tx.clone();
                 s.spawn(move || {
                     while let Ok((i, shape)) = shape_rx.lock().unwrap().recv() {
-                        eprintln!("shape: {:?}", shape);
+                        eprintln!("shape: {shape:?}");
                         let is_shrink = matches!(shape, SP1CompressProgramShape::Shrink(_));
                         let prover = prover.clone();
                         let shape_clone = shape.clone();

--- a/crates/recursion/circuit/src/challenger.rs
+++ b/crates/recursion/circuit/src/challenger.rs
@@ -468,9 +468,9 @@ pub(crate) mod tests {
         challenger.observe(F::two());
         challenger.observe(F::two());
         let result: F = challenger.sample();
-        println!("expected result: {}", result);
+        println!("expected result: {result}");
         let result_ef: EF = challenger.sample_ext_element();
-        println!("expected result_ef: {}", result_ef);
+        println!("expected result_ef: {result_ef}");
 
         let mut builder = AsmBuilder::<F, EF>::default();
 
@@ -515,16 +515,16 @@ pub(crate) mod tests {
         let commit = Hash::from([N::two()]);
         challenger.observe(commit);
         let result: F = challenger.sample();
-        println!("expected result: {}", result);
+        println!("expected result: {result}");
         let result_ef: EF = challenger.sample_ext_element();
-        println!("expected result_ef: {}", result_ef);
+        println!("expected result_ef: {result_ef}");
         let mut bits = challenger.sample_bits(30);
         let mut bits_vec = vec![];
         for _ in 0..30 {
             bits_vec.push(bits % 2);
             bits >>= 1;
         }
-        println!("expected bits: {:?}", bits_vec);
+        println!("expected bits: {bits_vec:?}");
 
         let mut builder = Builder::<C>::default();
 

--- a/crates/recursion/circuit/src/utils.rs
+++ b/crates/recursion/circuit/src/utils.rs
@@ -142,7 +142,7 @@ pub(crate) mod tests {
         proof_wide_span.exit();
 
         if let Err(e) = result {
-            panic!("Verification failed: {:?}", e);
+            panic!("Verification failed: {e:?}");
         }
     }
 

--- a/crates/recursion/compiler/src/circuit/compiler.rs
+++ b/crates/recursion/compiler/src/circuit/compiler.rs
@@ -64,13 +64,13 @@ where
     pub fn read_vaddr_internal(&mut self, vaddr: usize, increment_mult: bool) -> Address<C::F> {
         use vec_map::Entry;
         match self.virtual_to_physical.entry(vaddr) {
-            Entry::Vacant(_) => panic!("expected entry: virtual_physical[{:?}]", vaddr),
+            Entry::Vacant(_) => panic!("expected entry: virtual_physical[{vaddr:?}]"),
             Entry::Occupied(entry) => {
                 if increment_mult {
                     // This is a read, so we increment the mult.
                     match self.addr_to_mult.get_mut(entry.get().as_usize()) {
                         Some(mult) => *mult += C::F::one(),
-                        None => panic!("expected entry: virtual_physical[{:?}]", vaddr),
+                        None => panic!("expected entry: virtual_physical[{vaddr:?}]"),
                     }
                 }
                 *entry.into_mut()
@@ -934,7 +934,7 @@ mod tests {
         let (pk, vk) = wide_machine.setup(&program);
         let result = run_test_machine(vec![record.clone()], wide_machine, pk, vk);
         if let Err(e) = result {
-            panic!("Verification failed: {:?}", e);
+            panic!("Verification failed: {e:?}");
         }
 
         // Run with the poseidon2 skinny chip.
@@ -944,7 +944,7 @@ mod tests {
         let (pk, vk) = skinny_machine.setup(&program);
         let result = run_test_machine(vec![record.clone()], skinny_machine, pk, vk);
         if let Err(e) = result {
-            panic!("Verification failed: {:?}", e);
+            panic!("Verification failed: {e:?}");
         }
     }
 
@@ -1004,7 +1004,7 @@ mod tests {
             F::from_canonical_u32(3),
         ];
         let expected = hasher.hash_iter(input);
-        println!("{:?}", expected);
+        println!("{expected:?}");
 
         let mut builder = AsmBuilder::<F, EF>::default();
         let input_felts: [Felt<_>; 26] = input.map(|x| builder.eval(x));
@@ -1176,8 +1176,8 @@ mod tests {
             runtime.record
         });
 
-        let input_str_fs = input_fs.into_iter().map(|elt| format!("{}", elt));
-        let input_str_efs = input_efs.into_iter().map(|elt| format!("{:?}", elt));
+        let input_str_fs = input_fs.into_iter().map(|elt| format!("{elt}"));
+        let input_str_efs = input_efs.into_iter().map(|elt| format!("{elt:?}"));
         let input_strs = input_str_fs.chain(input_str_efs);
 
         for (input_str, line) in zip(input_strs, buf.lines()) {

--- a/crates/recursion/compiler/src/circuit/mod.rs
+++ b/crates/recursion/compiler/src/circuit/mod.rs
@@ -99,7 +99,7 @@ mod tests {
         match runtime.run() {
             Err(RuntimeError::EmptyWitnessStream) => (),
             Ok(_) => panic!("should not succeed"),
-            Err(x) => panic!("should not yield error variant: {}", x),
+            Err(x) => panic!("should not yield error variant: {x}"),
         }
     }
 }

--- a/crates/recursion/compiler/src/constraints/mod.rs
+++ b/crates/recursion/compiler/src/constraints/mod.rs
@@ -27,7 +27,7 @@ impl<C: Config + Debug> ConstraintCompiler<C> {
     pub fn alloc_id(&mut self) -> String {
         let id = self.allocator;
         self.allocator += 1;
-        format!("backend{}", id)
+        format!("backend{id}")
     }
 
     /// Allocates a variable in the constraint system.
@@ -408,7 +408,7 @@ impl<C: Config + Debug> ConstraintCompiler<C> {
                     }
                 }
                 DslIr::DebugBacktrace(_) => {}
-                _ => panic!("unsupported {:?}", instruction),
+                _ => panic!("unsupported {instruction:?}"),
             };
         }
     }

--- a/crates/recursion/core/build.rs
+++ b/crates/recursion/core/build.rs
@@ -49,7 +49,7 @@ mod sys {
                     break dir;
                 }
                 if !dir.pop() {
-                    panic!("OUT_DIR does not have parent called \"target\": {:?}", out_dir);
+                    panic!("OUT_DIR does not have parent called \"target\": {out_dir:?}");
                 }
             }
         };
@@ -155,7 +155,7 @@ mod sys {
             }
             Err(cbindgen::Error::ParseSyntaxError { .. }) => {} /* Ignore parse errors so */
             // rust-analyzer can run.
-            Err(e) => panic!("{:?}", e),
+            Err(e) => panic!("{e:?}"),
         }
 
         // Copy the headers to the include directory and symlink them to the fixed include

--- a/crates/recursion/core/src/chips/poseidon2_skinny/mod.rs
+++ b/crates/recursion/core/src/chips/poseidon2_skinny/mod.rs
@@ -144,7 +144,7 @@ pub(crate) mod tests {
         let (pk_9, vk_9) = machine_deg_9.setup(&program);
         let result_deg_9 = run_test_machine(vec![runtime.record], machine_deg_9, pk_9, vk_9);
         if let Err(e) = result_deg_9 {
-            panic!("Verification failed: {:?}", e);
+            panic!("Verification failed: {e:?}");
         }
     }
 }

--- a/crates/recursion/core/src/chips/poseidon2_skinny/trace.rs
+++ b/crates/recursion/core/src/chips/poseidon2_skinny/trace.rs
@@ -26,7 +26,7 @@ impl<F: PrimeField32, const DEGREE: usize> MachineAir<F> for Poseidon2SkinnyChip
     type Program = crate::RecursionProgram<F>;
 
     fn name(&self) -> String {
-        format!("Poseidon2SkinnyDeg{}", DEGREE)
+        format!("Poseidon2SkinnyDeg{DEGREE}")
     }
 
     fn generate_dependencies(&self, _: &Self::Record, _: &mut Self::Record) {

--- a/crates/recursion/core/src/chips/poseidon2_wide/air.rs
+++ b/crates/recursion/core/src/chips/poseidon2_wide/air.rs
@@ -22,7 +22,7 @@ impl<F, const DEGREE: usize> BaseAir<F> for Poseidon2WideChip<DEGREE> {
         } else if DEGREE == 9 || DEGREE == 17 {
             NUM_POSEIDON2_DEGREE9_COLS
         } else {
-            panic!("Unsupported degree: {}", DEGREE);
+            panic!("Unsupported degree: {DEGREE}");
         }
     }
 }

--- a/crates/recursion/core/src/chips/poseidon2_wide/mod.rs
+++ b/crates/recursion/core/src/chips/poseidon2_wide/mod.rs
@@ -109,7 +109,7 @@ pub(crate) mod tests {
         let result_deg_3 =
             run_test_machine(vec![runtime.record.clone()], machine_deg_3, pk_3, vk_3);
         if let Err(e) = result_deg_3 {
-            panic!("Verification failed: {:?}", e);
+            panic!("Verification failed: {e:?}");
         }
 
         let config = SC::new();
@@ -117,7 +117,7 @@ pub(crate) mod tests {
         let (pk_9, vk_9) = machine_deg_9.setup(&program);
         let result_deg_9 = run_test_machine(vec![runtime.record], machine_deg_9, pk_9, vk_9);
         if let Err(e) = result_deg_9 {
-            panic!("Verification failed: {:?}", e);
+            panic!("Verification failed: {e:?}");
         }
     }
 }

--- a/crates/recursion/core/src/chips/poseidon2_wide/trace.rs
+++ b/crates/recursion/core/src/chips/poseidon2_wide/trace.rs
@@ -21,7 +21,7 @@ impl<F: PrimeField32, const DEGREE: usize> MachineAir<F> for Poseidon2WideChip<D
     type Program = crate::RecursionProgram<F>;
 
     fn name(&self) -> String {
-        format!("Poseidon2WideDeg{}", DEGREE)
+        format!("Poseidon2WideDeg{DEGREE}")
     }
 
     fn generate_dependencies(&self, _: &Self::Record, _: &mut Self::Record) {

--- a/crates/recursion/core/src/shape.rs
+++ b/crates/recursion/core/src/shape.rs
@@ -75,7 +75,7 @@ impl<F: PrimeField32 + BinomiallyExtendable<D>, const DEGREE: usize>
             let shape = RecursionShape { inner: shape };
             *program.shape_mut() = Some(shape);
         } else {
-            panic!("no shape found for heights: {:?}", heights);
+            panic!("no shape found for heights: {heights:?}");
         }
     }
 

--- a/crates/recursion/gnark-ffi/build.rs
+++ b/crates/recursion/gnark-ffi/build.rs
@@ -15,7 +15,7 @@ fn main() {
             let out_dir = env::var("OUT_DIR").unwrap();
             let dest_path = PathBuf::from(&out_dir);
             let lib_name = "sp1gnark";
-            let dest = dest_path.join(format!("lib{}.a", lib_name));
+            let dest = dest_path.join(format!("lib{lib_name}.a"));
 
             println!("Building Go library at {}", dest.display());
 
@@ -43,7 +43,7 @@ fn main() {
             std::fs::copy(header_src, header_dest).unwrap();
 
             // Generate bindings using bindgen
-            let header_path = dest_path.join(format!("lib{}.h", lib_name));
+            let header_path = dest_path.join(format!("lib{lib_name}.h"));
             let bindings = bindgen::Builder::default()
                 .header(header_path.to_str().unwrap())
                 .generate()
@@ -57,7 +57,7 @@ fn main() {
 
             // Link the Go library
             println!("cargo:rustc-link-search=native={}", dest_path.display());
-            println!("cargo:rustc-link-lib=static={}", lib_name);
+            println!("cargo:rustc-link-lib=static={lib_name}");
 
             // Static linking doesn't really work on macos, so we need to link some system libs
             if cfg!(target_os = "macos") {

--- a/crates/recursion/gnark-ffi/src/ffi/docker.rs
+++ b/crates/recursion/gnark-ffi/src/ffi/docker.rs
@@ -32,7 +32,7 @@ fn assert_docker() {
 
 fn get_docker_image() -> String {
     std::env::var("SP1_GNARK_IMAGE")
-        .unwrap_or_else(|_| format!("ghcr.io/succinctlabs/sp1-gnark:{}", SP1_CIRCUIT_VERSION))
+        .unwrap_or_else(|_| format!("ghcr.io/succinctlabs/sp1-gnark:{SP1_CIRCUIT_VERSION}"))
 }
 
 /// Calls `docker run` with the given arguments and bind mounts.
@@ -44,7 +44,7 @@ fn call_docker(args: &[&str], mounts: &[(&str, &str)]) -> Result<()> {
     let mut cmd = Command::new("docker");
     cmd.args(["run", "--rm"]);
     for (src, dest) in mounts {
-        cmd.arg("-v").arg(format!("{}:{}", src, dest));
+        cmd.arg("-v").arg(format!("{src}:{dest}"));
     }
     cmd.arg(get_docker_image());
     cmd.args(args);

--- a/crates/recursion/gnark-ffi/src/ffi/native.rs
+++ b/crates/recursion/gnark-ffi/src/ffi/native.rs
@@ -265,7 +265,7 @@ mod tests {
         let perm = inner_perm();
         let zeros = [BabyBear::zero(); 16];
         let result = perm.permute(zeros);
-        println!("{:?}", result);
+        println!("{result:?}");
         super::test_babybear_poseidon2();
     }
 }

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sp1-sdk"
 description = "SP1 is a performant, 100% open-source, contributor-friendly zkVM."
 readme = "../../README.md"
-version = "5.0.7"
+version = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }

--- a/crates/sdk/src/env/mod.rs
+++ b/crates/sdk/src/env/mod.rs
@@ -3,7 +3,7 @@
 //! A prover that can execute programs and generate proofs with a different implementation based on
 //! the value of certain environment variables.
 
-mod prove;
+pub mod prove;
 
 use std::env;
 
@@ -106,7 +106,7 @@ impl EnvProver {
         }
     }
 
-    /// Creates a new [`EnvProve`] for proving a program on the CPU.
+    /// Creates a new [`EnvProveBuilder`] for proving a program on the CPU.
     ///
     /// # Details
     /// The builder is used for only the [`crate::cpu::CpuProver`] client type.

--- a/crates/sdk/src/env/prove.rs
+++ b/crates/sdk/src/env/prove.rs
@@ -1,3 +1,7 @@
+//! # Env Proving
+//!
+//! This module provides a builder for proving a program.
+
 use anyhow::Result;
 use sp1_core_machine::io::SP1Stdin;
 use sp1_prover::{components::CpuProverComponents, SP1ProvingKey};
@@ -31,6 +35,7 @@ impl EnvProveBuilder<'_> {
     /// let (pk, vk) = client.setup(elf);
     /// let builder = client.prove(&pk, &stdin).core().run();
     /// ```
+    #[must_use]
     pub fn core(mut self) -> Self {
         self.mode = SP1ProofMode::Core;
         self
@@ -54,6 +59,7 @@ impl EnvProveBuilder<'_> {
     /// let (pk, vk) = client.setup(elf);
     /// let builder = client.prove(&pk, &stdin).compressed().run();
     /// ```
+    #[must_use]
     pub fn compressed(mut self) -> Self {
         self.mode = SP1ProofMode::Compressed;
         self
@@ -78,6 +84,7 @@ impl EnvProveBuilder<'_> {
     /// let (pk, vk) = client.setup(elf);
     /// let builder = client.prove(&pk, &stdin).plonk().run();
     /// ```
+    #[must_use]
     pub fn plonk(mut self) -> Self {
         self.mode = SP1ProofMode::Plonk;
         self
@@ -100,6 +107,7 @@ impl EnvProveBuilder<'_> {
     /// let (pk, vk) = client.setup(elf);
     /// let builder = client.prove(&pk, &stdin).groth16().run();
     /// ```
+    #[must_use]
     pub fn groth16(mut self) -> Self {
         self.mode = SP1ProofMode::Groth16;
         self
@@ -121,6 +129,7 @@ impl EnvProveBuilder<'_> {
     /// let (pk, vk) = client.setup(elf);
     /// let builder = client.prove(&pk, &stdin).mode(SP1ProofMode::Groth16).run();
     /// ```
+    #[must_use]
     pub fn mode(mut self, mode: SP1ProofMode) -> Self {
         self.mode = mode;
         self

--- a/crates/stark/src/septic_curve.rs
+++ b/crates/stark/src/septic_curve.rs
@@ -289,7 +289,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
+    #[ignore = "TODO"]
     fn test_simple_bench() {
         const D: u32 = 1 << 16;
         let mut vec = Vec::with_capacity(D as usize);
@@ -329,7 +329,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
+    #[ignore = "TODO"]
     fn test_parallel_bench() {
         const D: u32 = 1 << 20;
         let mut vec = Vec::with_capacity(D as usize);

--- a/crates/test-artifacts/programs/Cargo.lock
+++ b/crates/test-artifacts/programs/Cargo.lock
@@ -346,7 +346,7 @@ version = "1.1.0"
 dependencies = [
  "common-test-utils",
  "sp1-curves",
- "sp1-lib 5.0.5",
+ "sp1-lib 5.0.7",
  "sp1-zkvm",
 ]
 
@@ -389,7 +389,7 @@ name = "bls12381-mul-test"
 version = "1.1.0"
 dependencies = [
  "sp1-derive",
- "sp1-lib 5.0.5",
+ "sp1-lib 5.0.7",
  "sp1-zkvm",
 ]
 
@@ -399,7 +399,7 @@ version = "1.1.0"
 dependencies = [
  "common-test-utils",
  "sp1-curves",
- "sp1-lib 5.0.5",
+ "sp1-lib 5.0.7",
  "sp1-zkvm",
 ]
 
@@ -442,7 +442,7 @@ name = "bn254-mul-test"
 version = "1.1.0"
 dependencies = [
  "sp1-derive",
- "sp1-lib 5.0.5",
+ "sp1-lib 5.0.7",
  "sp1-zkvm",
 ]
 
@@ -512,7 +512,7 @@ name = "common-test-utils"
 version = "1.1.0"
 dependencies = [
  "num-bigint",
- "sp1-lib 5.0.5",
+ "sp1-lib 5.0.7",
 ]
 
 [[package]]
@@ -2347,7 +2347,7 @@ version = "1.1.0"
 dependencies = [
  "common-test-utils",
  "sp1-curves",
- "sp1-lib 5.0.5",
+ "sp1-lib 5.0.7",
  "sp1-zkvm",
 ]
 
@@ -2383,7 +2383,7 @@ dependencies = [
  "num",
  "p256",
  "sp1-curves",
- "sp1-lib 5.0.5",
+ "sp1-lib 5.0.7",
  "sp1-zkvm",
 ]
 
@@ -2404,7 +2404,7 @@ dependencies = [
  "num",
  "p256",
  "sp1-curves",
- "sp1-lib 5.0.5",
+ "sp1-lib 5.0.7",
  "sp1-zkvm",
 ]
 
@@ -2619,7 +2619,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -2639,7 +2639,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-derive"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -2657,7 +2657,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "bincode",
  "elliptic-curve",
@@ -2667,7 +2667,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "bincode",
  "blake3",
@@ -2685,7 +2685,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-stark"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "arrayref",
  "hashbrown 0.14.5",
@@ -2718,7 +2718,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "cfg-if",
  "getrandom 0.2.16",
@@ -2729,7 +2729,7 @@ dependencies = [
  "p3-field",
  "rand 0.8.5",
  "sha2 0.10.9",
- "sp1-lib 5.0.5",
+ "sp1-lib 5.0.7",
  "sp1-primitives",
 ]
 

--- a/crates/test-artifacts/programs/Cargo.lock
+++ b/crates/test-artifacts/programs/Cargo.lock
@@ -346,7 +346,7 @@ version = "1.1.0"
 dependencies = [
  "common-test-utils",
  "sp1-curves",
- "sp1-lib 5.0.7",
+ "sp1-lib 5.0.8",
  "sp1-zkvm",
 ]
 
@@ -389,7 +389,7 @@ name = "bls12381-mul-test"
 version = "1.1.0"
 dependencies = [
  "sp1-derive",
- "sp1-lib 5.0.7",
+ "sp1-lib 5.0.8",
  "sp1-zkvm",
 ]
 
@@ -399,7 +399,7 @@ version = "1.1.0"
 dependencies = [
  "common-test-utils",
  "sp1-curves",
- "sp1-lib 5.0.7",
+ "sp1-lib 5.0.8",
  "sp1-zkvm",
 ]
 
@@ -442,7 +442,7 @@ name = "bn254-mul-test"
 version = "1.1.0"
 dependencies = [
  "sp1-derive",
- "sp1-lib 5.0.7",
+ "sp1-lib 5.0.8",
  "sp1-zkvm",
 ]
 
@@ -512,7 +512,7 @@ name = "common-test-utils"
 version = "1.1.0"
 dependencies = [
  "num-bigint",
- "sp1-lib 5.0.7",
+ "sp1-lib 5.0.8",
 ]
 
 [[package]]
@@ -2347,7 +2347,7 @@ version = "1.1.0"
 dependencies = [
  "common-test-utils",
  "sp1-curves",
- "sp1-lib 5.0.7",
+ "sp1-lib 5.0.8",
  "sp1-zkvm",
 ]
 
@@ -2383,7 +2383,7 @@ dependencies = [
  "num",
  "p256",
  "sp1-curves",
- "sp1-lib 5.0.7",
+ "sp1-lib 5.0.8",
  "sp1-zkvm",
 ]
 
@@ -2404,7 +2404,7 @@ dependencies = [
  "num",
  "p256",
  "sp1-curves",
- "sp1-lib 5.0.7",
+ "sp1-lib 5.0.8",
  "sp1-zkvm",
 ]
 
@@ -2619,7 +2619,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -2639,7 +2639,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-derive"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -2657,7 +2657,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "bincode",
  "elliptic-curve",
@@ -2667,7 +2667,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "bincode",
  "blake3",
@@ -2685,7 +2685,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-stark"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "arrayref",
  "hashbrown 0.14.5",
@@ -2718,7 +2718,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "cfg-if",
  "getrandom 0.2.16",
@@ -2729,7 +2729,7 @@ dependencies = [
  "p3-field",
  "rand 0.8.5",
  "sha2 0.10.9",
- "sp1-lib 5.0.7",
+ "sp1-lib 5.0.8",
  "sp1-primitives",
 ]
 

--- a/crates/test-artifacts/programs/fibonacci-blake3/Cargo.lock
+++ b/crates/test-artifacts/programs/fibonacci-blake3/Cargo.lock
@@ -446,7 +446,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sp1-lib"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "bincode",
  "serde",
@@ -455,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "bincode",
  "blake3",
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "blake3",
  "cfg-if",

--- a/crates/test-artifacts/programs/fibonacci-blake3/Cargo.lock
+++ b/crates/test-artifacts/programs/fibonacci-blake3/Cargo.lock
@@ -446,7 +446,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sp1-lib"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "bincode",
  "serde",
@@ -455,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "bincode",
  "blake3",
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "blake3",
  "cfg-if",

--- a/crates/verifier/guest-verify-programs/Cargo.lock
+++ b/crates/verifier/guest-verify-programs/Cargo.lock
@@ -3107,7 +3107,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-build"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -3119,7 +3119,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -3142,7 +3142,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sp1-curves",
- "sp1-primitives 5.0.5",
+ "sp1-primitives 5.0.7",
  "sp1-stark",
  "strum",
  "strum_macros",
@@ -3156,7 +3156,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-machine"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "bincode",
  "cbindgen",
@@ -3194,7 +3194,7 @@ dependencies = [
  "sp1-core-executor",
  "sp1-curves",
  "sp1-derive",
- "sp1-primitives 5.0.5",
+ "sp1-primitives 5.0.7",
  "sp1-stark",
  "static_assertions",
  "strum",
@@ -3211,7 +3211,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -3224,14 +3224,14 @@ dependencies = [
  "p3-field",
  "serde",
  "snowbridge-amcl",
- "sp1-primitives 5.0.5",
+ "sp1-primitives 5.0.7",
  "sp1-stark",
  "typenum",
 ]
 
 [[package]]
 name = "sp1-derive"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3251,11 +3251,11 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "bincode",
  "serde",
- "sp1-primitives 5.0.5",
+ "sp1-primitives 5.0.7",
 ]
 
 [[package]]
@@ -3280,7 +3280,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "bincode",
  "blake3",
@@ -3298,7 +3298,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3327,7 +3327,7 @@ dependencies = [
  "sha2",
  "sp1-core-executor",
  "sp1-core-machine",
- "sp1-primitives 5.0.5",
+ "sp1-primitives 5.0.7",
  "sp1-recursion-circuit",
  "sp1-recursion-compiler",
  "sp1-recursion-core",
@@ -3341,7 +3341,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-circuit"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "hashbrown 0.14.5",
  "itertools 0.13.0",
@@ -3364,7 +3364,7 @@ dependencies = [
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-derive",
- "sp1-primitives 5.0.5",
+ "sp1-primitives 5.0.7",
  "sp1-recursion-compiler",
  "sp1-recursion-core",
  "sp1-recursion-gnark-ffi",
@@ -3374,7 +3374,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-compiler"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "backtrace",
  "itertools 0.13.0",
@@ -3384,7 +3384,7 @@ dependencies = [
  "p3-symmetric",
  "serde",
  "sp1-core-machine",
- "sp1-primitives 5.0.5",
+ "sp1-primitives 5.0.7",
  "sp1-recursion-core",
  "sp1-recursion-derive",
  "sp1-stark",
@@ -3394,7 +3394,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-core"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "backtrace",
  "cbindgen",
@@ -3424,7 +3424,7 @@ dependencies = [
  "serde",
  "sp1-core-machine",
  "sp1-derive",
- "sp1-primitives 5.0.5",
+ "sp1-primitives 5.0.7",
  "sp1-stark",
  "static_assertions",
  "thiserror 1.0.69",
@@ -3435,7 +3435,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-derive"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3443,7 +3443,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-ffi"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3467,7 +3467,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-stark"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "arrayref",
  "hashbrown 0.14.5",
@@ -3491,7 +3491,7 @@ dependencies = [
  "rayon-scan",
  "serde",
  "sp1-derive",
- "sp1-primitives 5.0.5",
+ "sp1-primitives 5.0.7",
  "strum",
  "strum_macros",
  "sysinfo",
@@ -3500,7 +3500,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-verifier"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "blake3",
  "cfg-if",
@@ -3514,7 +3514,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "blake3",
  "cfg-if",
@@ -3524,8 +3524,8 @@ dependencies = [
  "libm",
  "rand 0.8.5",
  "sha2",
- "sp1-lib 5.0.5",
- "sp1-primitives 5.0.5",
+ "sp1-lib 5.0.7",
+ "sp1-primitives 5.0.7",
 ]
 
 [[package]]

--- a/crates/verifier/guest-verify-programs/Cargo.lock
+++ b/crates/verifier/guest-verify-programs/Cargo.lock
@@ -3107,7 +3107,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-build"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -3119,7 +3119,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -3142,7 +3142,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sp1-curves",
- "sp1-primitives 5.0.7",
+ "sp1-primitives 5.0.8",
  "sp1-stark",
  "strum",
  "strum_macros",
@@ -3156,7 +3156,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-machine"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "bincode",
  "cbindgen",
@@ -3194,7 +3194,7 @@ dependencies = [
  "sp1-core-executor",
  "sp1-curves",
  "sp1-derive",
- "sp1-primitives 5.0.7",
+ "sp1-primitives 5.0.8",
  "sp1-stark",
  "static_assertions",
  "strum",
@@ -3211,7 +3211,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -3224,14 +3224,14 @@ dependencies = [
  "p3-field",
  "serde",
  "snowbridge-amcl",
- "sp1-primitives 5.0.7",
+ "sp1-primitives 5.0.8",
  "sp1-stark",
  "typenum",
 ]
 
 [[package]]
 name = "sp1-derive"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3251,11 +3251,11 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "bincode",
  "serde",
- "sp1-primitives 5.0.7",
+ "sp1-primitives 5.0.8",
 ]
 
 [[package]]
@@ -3280,7 +3280,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "bincode",
  "blake3",
@@ -3298,7 +3298,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3327,7 +3327,7 @@ dependencies = [
  "sha2",
  "sp1-core-executor",
  "sp1-core-machine",
- "sp1-primitives 5.0.7",
+ "sp1-primitives 5.0.8",
  "sp1-recursion-circuit",
  "sp1-recursion-compiler",
  "sp1-recursion-core",
@@ -3341,7 +3341,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-circuit"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "hashbrown 0.14.5",
  "itertools 0.13.0",
@@ -3364,7 +3364,7 @@ dependencies = [
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-derive",
- "sp1-primitives 5.0.7",
+ "sp1-primitives 5.0.8",
  "sp1-recursion-compiler",
  "sp1-recursion-core",
  "sp1-recursion-gnark-ffi",
@@ -3374,7 +3374,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-compiler"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "backtrace",
  "itertools 0.13.0",
@@ -3384,7 +3384,7 @@ dependencies = [
  "p3-symmetric",
  "serde",
  "sp1-core-machine",
- "sp1-primitives 5.0.7",
+ "sp1-primitives 5.0.8",
  "sp1-recursion-core",
  "sp1-recursion-derive",
  "sp1-stark",
@@ -3394,7 +3394,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-core"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "backtrace",
  "cbindgen",
@@ -3424,7 +3424,7 @@ dependencies = [
  "serde",
  "sp1-core-machine",
  "sp1-derive",
- "sp1-primitives 5.0.7",
+ "sp1-primitives 5.0.8",
  "sp1-stark",
  "static_assertions",
  "thiserror 1.0.69",
@@ -3435,7 +3435,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-derive"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3443,7 +3443,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-ffi"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3467,7 +3467,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-stark"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "arrayref",
  "hashbrown 0.14.5",
@@ -3491,7 +3491,7 @@ dependencies = [
  "rayon-scan",
  "serde",
  "sp1-derive",
- "sp1-primitives 5.0.7",
+ "sp1-primitives 5.0.8",
  "strum",
  "strum_macros",
  "sysinfo",
@@ -3500,7 +3500,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-verifier"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "blake3",
  "cfg-if",
@@ -3514,7 +3514,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "blake3",
  "cfg-if",
@@ -3524,8 +3524,8 @@ dependencies = [
  "libm",
  "rand 0.8.5",
  "sha2",
- "sp1-lib 5.0.7",
- "sp1-primitives 5.0.7",
+ "sp1-lib 5.0.8",
+ "sp1-primitives 5.0.8",
 ]
 
 [[package]]

--- a/patch-testing/Cargo.lock
+++ b/patch-testing/Cargo.lock
@@ -3985,7 +3985,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-build"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -3997,7 +3997,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -4034,7 +4034,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-machine"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "bincode",
  "cbindgen",
@@ -4089,7 +4089,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cuda"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "bincode",
  "ctrlc",
@@ -4104,7 +4104,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -4124,7 +4124,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-derive"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -4132,7 +4132,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "bincode",
  "elliptic-curve",
@@ -4142,7 +4142,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "bincode",
  "blake3",
@@ -4160,7 +4160,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4203,7 +4203,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-circuit"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "hashbrown 0.14.5",
  "itertools 0.13.0",
@@ -4236,7 +4236,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-compiler"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "backtrace",
  "itertools 0.13.0",
@@ -4256,7 +4256,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-core"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "backtrace",
  "cbindgen",
@@ -4297,7 +4297,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-derive"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -4305,7 +4305,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-ffi"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4364,7 +4364,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-stark"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "arrayref",
  "hashbrown 0.14.5",
@@ -4422,7 +4422,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "cfg-if",
  "getrandom 0.2.15",

--- a/patch-testing/Cargo.lock
+++ b/patch-testing/Cargo.lock
@@ -3985,7 +3985,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-build"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -3997,7 +3997,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -4034,7 +4034,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-machine"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "bincode",
  "cbindgen",
@@ -4089,7 +4089,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cuda"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "bincode",
  "ctrlc",
@@ -4104,7 +4104,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -4124,7 +4124,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-derive"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -4132,7 +4132,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "bincode",
  "elliptic-curve",
@@ -4142,7 +4142,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "bincode",
  "blake3",
@@ -4160,7 +4160,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4203,7 +4203,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-circuit"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "hashbrown 0.14.5",
  "itertools 0.13.0",
@@ -4236,7 +4236,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-compiler"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "backtrace",
  "itertools 0.13.0",
@@ -4256,7 +4256,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-core"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "backtrace",
  "cbindgen",
@@ -4297,7 +4297,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-derive"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -4305,7 +4305,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-ffi"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4329,7 +4329,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-sdk"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4364,7 +4364,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-stark"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "arrayref",
  "hashbrown 0.14.5",
@@ -4422,7 +4422,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "cfg-if",
  "getrandom 0.2.15",

--- a/patch-testing/secp256k1/program-v0.29.1/Cargo.lock
+++ b/patch-testing/secp256k1/program-v0.29.1/Cargo.lock
@@ -640,7 +640,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "bincode",
  "elliptic-curve",
@@ -650,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "bincode",
  "blake3",
@@ -668,7 +668,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "cfg-if",
  "getrandom 0.2.15",

--- a/patch-testing/secp256k1/program-v0.29.1/Cargo.lock
+++ b/patch-testing/secp256k1/program-v0.29.1/Cargo.lock
@@ -640,7 +640,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "bincode",
  "elliptic-curve",
@@ -650,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "bincode",
  "blake3",
@@ -668,7 +668,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "cfg-if",
  "getrandom 0.2.15",

--- a/patch-testing/secp256k1/program-v0.30.0/Cargo.lock
+++ b/patch-testing/secp256k1/program-v0.30.0/Cargo.lock
@@ -667,7 +667,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "bincode",
  "elliptic-curve",
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "bincode",
  "blake3",
@@ -695,7 +695,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "5.0.5"
+version = "5.0.7"
 dependencies = [
  "cfg-if",
  "getrandom 0.2.15",

--- a/patch-testing/secp256k1/program-v0.30.0/Cargo.lock
+++ b/patch-testing/secp256k1/program-v0.30.0/Cargo.lock
@@ -667,7 +667,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "bincode",
  "elliptic-curve",
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "bincode",
  "blake3",
@@ -695,7 +695,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "cfg-if",
  "getrandom 0.2.15",

--- a/patch-testing/sp1-test-macro/src/attr.rs
+++ b/patch-testing/sp1-test-macro/src/attr.rs
@@ -90,9 +90,7 @@ impl AttrOption {
 impl Parse for AttrOptions {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         if input.is_empty() {
-            return Err(
-                input.error("No attribute options provided, expected at least an ELF name.")
-            );
+            return Err(input.error("No attribute options provided, expected at least an ELF name."));
         }
 
         let mut options = AttrOptions::new();
@@ -148,8 +146,6 @@ fn parse_option(input: &ParseStream) -> syn::Result<(Span, AttrOption)> {
 
             Ok((ident.span(), AttrOption::Syscalls(vec_syscalls)))
         }
-        _ => {
-            Err(syn::Error::new(ident.span(), format!("Found Unknown attribute option {}", ident)))
-        }
+        _ => Err(syn::Error::new(ident.span(), format!("Found Unknown attribute option {ident}"))),
     }
 }

--- a/patch-testing/sp1-test-macro/src/lib.rs
+++ b/patch-testing/sp1-test-macro/src/lib.rs
@@ -166,7 +166,7 @@ pub fn sp1_test(attr: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     let maybe_prove_test = if options.prove() {
-        let prove_name = syn::Ident::new(&format!("{}_prove", test_name), test_name.span());
+        let prove_name = syn::Ident::new(&format!("{test_name}_prove"), test_name.span());
 
         let prove_fn = quote! {
             #[cfg(feature = "prove")]
@@ -199,7 +199,7 @@ pub fn sp1_test(attr: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     let gpu_prove = if options.gpu() {
-        let gpu_prove_name = syn::Ident::new(&format!("{}_gpu_prove", test_name), test_name.span());
+        let gpu_prove_name = syn::Ident::new(&format!("{test_name}_gpu_prove"), test_name.span());
 
         Some(quote! {
             #[cfg(feature = "gpu")]

--- a/patch-testing/sp1-test/bin/post_to_github.rs
+++ b/patch-testing/sp1-test/bin/post_to_github.rs
@@ -1,5 +1,7 @@
-use sp1_test::utils::{post_to_github_pr_sync, pretty_comparison};
-use sp1_test::BenchEntry;
+use sp1_test::{
+    utils::{post_to_github_pr_sync, pretty_comparison},
+    BenchEntry,
+};
 
 pub fn main() {
     let old_cycle_stats = std::fs::read_to_string("old_cycle_stats.json").unwrap();
@@ -10,7 +12,7 @@ pub fn main() {
 
     let comparison = pretty_comparison(old_cycle_stats, new_cycle_stats).unwrap();
 
-    println!("{}", comparison);
+    println!("{comparison}");
 
     let pr_number = std::env::var("PR_NUMBER").unwrap();
     let token = std::env::var("GITHUB_TOKEN").unwrap();

--- a/patch-testing/sp1-test/src/utils.rs
+++ b/patch-testing/sp1-test/src/utils.rs
@@ -1,8 +1,7 @@
 use crate::BenchEntry;
 use reqwest::Client;
 use serde_json::json;
-use std::collections::HashMap;
-use std::fmt::Write;
+use std::{collections::HashMap, fmt::Write};
 
 pub fn post_to_github_pr_sync(
     owner: &str,
@@ -25,13 +24,13 @@ pub async fn post_to_github_pr(
     message: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let client = Client::new();
-    let base_url = format!("https://api.github.com/repos/{}/{}", owner, repo);
+    let base_url = format!("https://api.github.com/repos/{owner}/{repo}");
 
     // Get all comments on the PR.
-    let comments_url = format!("{}/issues/{}/comments", base_url, pr_number);
+    let comments_url = format!("{base_url}/issues/{pr_number}/comments");
     let comments_response = client
         .get(&comments_url)
-        .header("Authorization", format!("token {}", token))
+        .header("Authorization", format!("token {token}",))
         .header("User-Agent", "sp1-perf-bot")
         .send()
         .await?;
@@ -51,7 +50,7 @@ pub async fn post_to_github_pr(
         let comment_url = existing_comment["url"].as_str().unwrap();
         let response = client
             .patch(comment_url)
-            .header("Authorization", format!("token {}", token))
+            .header("Authorization", format!("token {token}"))
             .header("User-Agent", "sp1-perf-bot")
             .json(&json!({
                 "body": message
@@ -66,7 +65,7 @@ pub async fn post_to_github_pr(
         // Create a new comment.
         let response = client
             .post(&comments_url)
-            .header("Authorization", format!("token {}", token))
+            .header("Authorization", format!("token {token}"))
             .header("User-Agent", "sp1-perf-bot")
             .json(&json!({
                 "body": message


### PR DESCRIPTION
## Solution

In this PR:

* Point succinct Rust toolchain to `succinct-1.88.0` tag
* Bump version to 5.0.7
* Fixed all `clippy::uninlined-format-args` warnings

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes