### PR TITLE
Unify precompile event addition for Secp256r1Add with other Weierstrass curves

### DIFF
--- a/crates/core/executor/src/syscalls/precompiles/weierstrass/add.rs
+++ b/crates/core/executor/src/syscalls/precompiles/weierstrass/add.rs
@@ -47,7 +47,7 @@ impl<E: EllipticCurve> Syscall for WeierstrassAddAssignSyscall<E> {
                 syscall_event,
                 PrecompileEvent::Bls12381Add(event),
             ),
-            CurveType::Secp256r1 => rt.record_mut().add_precompile_event(
+            CurveType::Secp256r1 => rt.add_precompile_event(
                 syscall_code,
                 syscall_event,
                 PrecompileEvent::Secp256r1Add(event),


### PR DESCRIPTION
Previously, the addition of the precompile event for the Secp256r1 curve in WeierstrassAddAssignSyscall was performed via a direct call to rt.record_mut().add_precompile_event(...), while for other Weierstrass curves (Secp256k1, Bn254, Bls12381) the method rt.add_precompile_event(...) was used.

This inconsistency could lead to confusion and potential maintenance issues, as rt.add_precompile_event(...) is the standard interface for adding precompile events and includes an internal check for the executor mode (e.g., only adding events in Trace mode). Directly accessing the record bypasses this check and may inadvertently break architectural invariants or introduce subtle bugs if the code is refactored in the future.

This commit replaces the direct call for Secp256r1Add with the unified rt.add_precompile_event(...) method, making the code consistent across all supported Weierstrass curves. This change improves code clarity, maintainability, and ensures that all precompile events are added through the same, safe interface. No functional behavior is changed, but the codebase is now more robust and easier to reason about.