### PR TITLE
feat: warn when used memory is high

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5635,6 +5635,7 @@ dependencies = [
  "static_assertions",
  "strum",
  "strum_macros",
+ "sysinfo",
  "tempfile",
  "test-artifacts",
  "thiserror 1.0.69",

--- a/crates/core/machine/Cargo.toml
+++ b/crates/core/machine/Cargo.toml
@@ -31,6 +31,7 @@ sp1-primitives = { workspace = true }
 
 rayon = "1.10.0"
 rayon-scan = "0.1.1"
+sysinfo = "0.30.13"
 
 amcl = { package = "snowbridge-amcl", version = "1.0.2", default-features = false, features = [
   "bls381",

--- a/crates/verifier/guest-verify-programs/Cargo.lock
+++ b/crates/verifier/guest-verify-programs/Cargo.lock
@@ -3199,6 +3199,7 @@ dependencies = [
  "static_assertions",
  "strum",
  "strum_macros",
+ "sysinfo",
  "tempfile",
  "thiserror 1.0.69",
  "tracing",


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Sometimes proving hangs when the memory is full.

## Solution

Add a warning when used memory is high.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes