### PR TITLE
fix(workspace): Align internal crate versions with workspace version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace.package]
+# Workspace'in ana versiyonu
 version = "5.0.8"
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -49,26 +50,27 @@ debug-assertions = true
 
 [workspace.dependencies]
 # sp1
-sp1-build = { path = "crates/build", version = "5.0.5" }
-sp1-cli = { path = "crates/cli", version = "5.0.5", default-features = false }
-sp1-core-machine = { path = "crates/core/machine", version = "5.0.5" }
-sp1-core-executor = { path = "crates/core/executor", version = "5.0.5" }
-sp1-curves = { path = "crates/curves", version = "5.0.5" }
-sp1-derive = { path = "crates/derive", version = "5.0.5" }
-sp1-eval = { path = "crates/eval", version = "5.0.5" }
-sp1-helper = { path = "crates/helper", version = "5.0.5", default-features = false }
-sp1-primitives = { path = "crates/primitives", version = "5.0.5" }
-sp1-prover = { path = "crates/prover", version = "5.0.5" }
-sp1-recursion-compiler = { path = "crates/recursion/compiler", version = "5.0.5" }
-sp1-recursion-core = { path = "crates/recursion/core", version = "5.0.5" }
-sp1-recursion-derive = { path = "crates/recursion/derive", version = "5.0.5", default-features = false }
-sp1-recursion-gnark-ffi = { path = "crates/recursion/gnark-ffi", version = "5.0.5", default-features = false }
-sp1-recursion-circuit = { path = "crates/recursion/circuit", version = "5.0.5", default-features = false }
-sp1-sdk = { path = "crates/sdk", version = "5.0.5" }
-sp1-cuda = { path = "crates/cuda", version = "5.0.5" }
-sp1-stark = { path = "crates/stark", version = "5.0.5" }
-sp1-lib = { path = "crates/zkvm/lib", version = "5.0.5", default-features = false }
-sp1-zkvm = { path = "crates/zkvm/entrypoint", version = "5.0.5", default-features = false }
+# DÜZELTME: Tüm sp1-* bağımlılıkları workspace'in ana versiyonu olan 5.0.8'e güncellendi.
+sp1-build = { path = "crates/build", version = "5.0.8" }
+sp1-cli = { path = "crates/cli", version = "5.0.8", default-features = false }
+sp1-core-machine = { path = "crates/core/machine", version = "5.0.8" }
+sp1-core-executor = { path = "crates/core/executor", version = "5.0.8" }
+sp1-curves = { path = "crates/curves", version = "5.0.8" }
+sp1-derive = { path = "crates/derive", version = "5.0.8" }
+sp1-eval = { path = "crates/eval", version = "5.0.8" }
+sp1-helper = { path = "crates/helper", version = "5.0.8", default-features = false }
+sp1-primitives = { path = "crates/primitives", version = "5.0.8" }
+sp1-prover = { path = "crates/prover", version = "5.0.8" }
+sp1-recursion-compiler = { path = "crates/recursion/compiler", version = "5.0.8" }
+sp1-recursion-core = { path = "crates/recursion/core", version = "5.0.8" }
+sp1-recursion-derive = { path = "crates/recursion/derive", version = "5.0.8", default-features = false }
+sp1-recursion-gnark-ffi = { path = "crates/recursion/gnark-ffi", version = "5.0.8", default-features = false }
+sp1-recursion-circuit = { path = "crates/recursion/circuit", version = "5.0.8", default-features = false }
+sp1-sdk = { path = "crates/sdk", version = "5.0.8" }
+sp1-cuda = { path = "crates/cuda", version = "5.0.8" }
+sp1-stark = { path = "crates/stark", version = "5.0.8" }
+sp1-lib = { path = "crates/zkvm/lib", version = "5.0.8", default-features = false }
+sp1-zkvm = { path = "crates/zkvm/entrypoint", version = "5.0.8", default-features = false }
 
 # For testing.
 test-artifacts = { path = "crates/test-artifacts" }


### PR DESCRIPTION
This PR resolves a critical version inconsistency within the main Cargo.toml file.

Problem:

The main workspace package was defined as version 5.0.8, but all internal sp1-* path dependencies were still pinned to 5.0.5. This 
mismatch could lead to several issues, including:

Potential build failures or unexpected behavior with cargo tooling.
The risk of crates using outdated code from their internal dependencies.
Confusion for developers about the project's current and correct version.

Solution:

All sp1-* versions within [workspace.dependencies] have been updated from 5.0.5 to 5.0.8.
This change ensures that all crates in the workspace are consistent with the declared package version, guaranteeing that the project builds with the intended dependencies and maintaining a clean, predictable state.