### PR TITLE
Remove strategy.fail-fast from check-verifier-no-std job (no matrix)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -327,8 +327,6 @@ jobs:
     name: Check Verifier `no_std`
     runs-on: [runs-on, runner=16cpu-linux-x64, disk=large, "run-id=${{ github.run_id }}"]
     timeout-minutes: 10
-    strategy:
-      fail-fast: false
     steps:
       - name: Checkout Actions Repository
         uses: actions/checkout@v4


### PR DESCRIPTION
The check-verifier-no-std job in .github/workflows/pr.yml used a `strategy.fail-fast: false` block without defining a matrix. In GitHub Actions, the `strategy` key (and its `fail-fast` option) is only valid when a `matrix` is present. Using `strategy` without a matrix causes a workflow syntax error and prevents the workflow from running.

This commit removes the unnecessary `strategy` block from the check-verifier-no-std job, making the workflow valid and ensuring it runs as expected.

Reference: https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs
