### PR TITLE
Fix workspace parent directory check in Docker build command

### DIFF
--- a/crates/build/src/command/docker.rs
+++ b/crates/build/src/command/docker.rs
@@ -46,10 +46,10 @@ pub(crate) fn create_docker_command(
         .unwrap_or_else(|| program_metadata.workspace_root.clone());
 
     // Ensure the workspace directory is parent of the program
-    if !program_metadata.workspace_root.starts_with(workspace_root) {
+    if !canonicalized_program_dir.starts_with(workspace_root) {
         eprintln!(
             "Workspace root ({}) must be a parent of the program directory ({}).",
-            workspace_root, program_metadata.workspace_root
+            workspace_root, canonicalized_program_dir
         );
         exit(1);
     }


### PR DESCRIPTION
Previously, the code checked whether the workspace root from cargo metadata was a subdirectory of the user-specified workspace directory. This logic was incorrect, as it did not actually verify that the program directory being built was inside the workspace. As a result, the check could pass even if the program was outside the workspace, or fail for valid configurations, leading to potential build errors or unexpected behavior when mounting directories in Docker.
This commit fixes the logic by ensuring that the canonicalized program directory is a subdirectory of the workspace root. The error message was also updated to accurately reflect the directories being compared. With this change, Docker builds will only proceed if the program is truly located within the specified workspace, preventing misconfigurations and potential build failures due to incorrect directory relationships.