### PR TITLE
Add test for instruction count in simple_memory_program

### DIFF
--- a/crates/core/machine/src/lib.rs
+++ b/crates/core/machine/src/lib.rs
@@ -167,3 +167,14 @@ pub mod programs {
         }
     }
 }
+#[cfg(test)]
+mod memory_tests {
+    use super::*;
+
+    #[test]
+    fn test_simple_memory_program_instruction_count() {
+        let program = simple_memory_program();
+        assert_eq!(program.instructions.len(), 34);
+    }
+}
+test: add basic check for instruction count in simple_memory_program


### PR DESCRIPTION
Added a simple unit test to verify that `simple_memory_program()` returns 34 instructions. This ensures future changes don’t break the expected instruction structure.

## Motivation

This test was added to prevent regressions in the instruction layout of the `simple_memory_program()`. If someone modifies the program logic in the future and accidentally removes or adds an instruction, this test will immediately catch the discrepancy.

## Solution

A unit test named `test_simple_memory_program_instruction_count` was introduced. It asserts that the number of instructions returned by the `simple_memory_program()` function is exactly 34. This is a simple yet effective way to preserve the integrity of the program's structure.

## PR Checklist

- [x] Added Tests  
- [ ] Added Documentation  
- [ ] Breaking changes
