### PR TITLE
Improve error handling in `insert` function and add test for memory instructions

### DIFF
--- a/crates/core/executor/src/memory.rs
+++ b/crates/core/executor/src/memory.rs
@@ -407,7 +407,7 @@ impl<'a, V: Copy> VacantEntry<'a, V> {
     pub fn insert(self, value: V) -> &'a mut V {
         // By construction, the slot in the page is `None`.
         *self.entry = Some(value);
-        self.entry.as_mut().unwrap()
+        self.entry.as_mut().expect("entry should be Some(value) after insertion")
     }
 }
 

--- a/crates/core/machine/src/lib.rs
+++ b/crates/core/machine/src/lib.rs
@@ -167,3 +167,14 @@ pub mod programs {
         }
     }
 }
+#[cfg(test)]
+mod memory_tests {
+    use super::*;
+
+    #[test]
+    fn test_simple_memory_program_instruction_count() {
+        let program = simple_memory_program();
+        assert_eq!(program.instructions.len(), 34);
+    }
+}
+test: add basic check for instruction count in simple_memory_program


### PR DESCRIPTION
## Motivation

The `insert` method previously used `.unwrap()` after assigning `Some(value)` to `self.entry`. Although this works under the assumption that `self.entry` is always `Some` at that point, replacing `.unwrap()` with `.expect()` allows us to provide a more descriptive error message in case of unexpected behavior. This improves the debugging experience and aligns with best practices in Rust codebases by avoiding silent panics.

In addition to this, a unit test has been added to `lib.rs` to validate the expected instruction count in the `simple_memory_program`. This helps improve test coverage and ensures the logic behind memory instruction generation behaves as intended.

## Solution

- Replaced `unwrap()` with `expect("entry should be Some(value) after insertion")` in `insert()` method inside `memory.rs`.
- Added a basic unit test named `test_simple_memory_program_instruction_count()` in `lib.rs` under a new `memory_tests` module, verifying that the instruction count matches expected behavior (`34` instructions).

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
