### PR TITLE
Fix Critical Compilation Errors in SP1 Precompile Integration

### DIFF
--- a/crates/core/machine/src/syscall/precompiles/README.md
+++ b/crates/core/machine/src/syscall/precompiles/README.md
@@ -181,8 +181,8 @@ pub fn default_syscall_map() -> HashMap<SyscallCode, Arc<dyn Syscall>> {
     // Other syscall maps...
     syscall_map.insert(
         SyscallCode::CUSTOM_OP,
-        Arch::new(CustomOpChip::new())
-    )
+        Arc::new(CustomOpChip::new())
+    );
 }
 ```
 


### PR DESCRIPTION
### Adding Semicolon in default_syscall_map
In Rust, a semicolon is mandatory to terminate expressions within a function body. Without it, the compiler will throw a syntax error, preventing compilation.
### Replacing Arch::new with Arc::new
Using Arch::new instead of Arc::new causes a compilation error, as Arch is incompatible with the expected type Arc<dyn Syscall>, blocking the registration of the precompile.


