### PR TITLE
Go build config

### DIFF
--- a/crates/recursion/gnark-ffi/build.rs
+++ b/crates/recursion/gnark-ffi/build.rs
@@ -22,10 +22,11 @@ fn main() {
             // Example: SP1_GNARK_FFI_GO_ENVS="CC=clang-cl;CCC_OVERRIDE_OPTIONS=x-dM"
             let go_envs: HashMap<String, String> = match env::var("SP1_GNARK_FFI_GO_ENVS") {
                 Ok(env_str) => env_str.split(';')
-                    .map(|s| (
-                        String::from(s.split_once('=').collect::<Vec<_>>()[0]),
-                        String::from(s.split_once('=').collect::<Vec<_>>()[1])
-                    ))
+                    .map(|s| match s.split_once('=') {
+                        Some((k, v)) => (k.to_string(), v.to_string()),
+                        // A degenerate edge-case of a variable name w/o a value:
+                        None => (s.to_string(), "".to_string()),
+                    })
                     .collect(),
                 Err(_) => HashMap::new(),
             };

--- a/crates/recursion/gnark-ffi/build.rs
+++ b/crates/recursion/gnark-ffi/build.rs
@@ -17,10 +17,16 @@ fn main() {
             let lib_name = "sp1gnark";
             let dest = dest_path.join(format!("lib{lib_name}.a"));
 
-            // Parse custom environment for `go build` command, e.g. to support cross-compilation.
-            // SP1_FFI_ENV_FOR_GO may contain a semi-colon-separated list of name=value pairs.
-            let go_env: HashMap<String, String> = match env::var("SP1_FFI_ENV_FOR_GO") {
-                Ok(env_str) => env_str.split(';').map(|s| (String::from(s.split('=').collect::<Vec<_>>()[0]), String::from(s.split('=').collect::<Vec<_>>()[1]))).collect(),
+            // Parse custom environment for the `go build` command, e.g. to support cross-compilation.
+            // The variable may contain a semi-colon-separated list of name=value pairs.
+            // Example: SP1_GNARK_FFI_GO_ENVS="CC=clang-cl;CCC_OVERRIDE_OPTIONS=x-dM"
+            let go_envs: HashMap<String, String> = match env::var("SP1_GNARK_FFI_GO_ENVS") {
+                Ok(env_str) => env_str.split(';')
+                    .map(|s| (
+                        String::from(s.split('=').collect::<Vec<_>>()[0]),
+                        String::from(s.split('=').collect::<Vec<_>>()[1])
+                    ))
+                    .collect(),
                 Err(_) => HashMap::new(),
             };
 
@@ -30,7 +36,7 @@ fn main() {
             let status = Command::new("go")
                 .current_dir("go")
                 .env("CGO_ENABLED", "1")
-                .envs(go_env)
+                .envs(go_envs)
                 .args([
                     "build",
                     "-tags=debug",

--- a/crates/recursion/gnark-ffi/build.rs
+++ b/crates/recursion/gnark-ffi/build.rs
@@ -23,8 +23,8 @@ fn main() {
             let go_envs: HashMap<String, String> = match env::var("SP1_GNARK_FFI_GO_ENVS") {
                 Ok(env_str) => env_str.split(';')
                     .map(|s| (
-                        String::from(s.split('=').collect::<Vec<_>>()[0]),
-                        String::from(s.split('=').collect::<Vec<_>>()[1])
+                        String::from(s.split_once('=').collect::<Vec<_>>()[0]),
+                        String::from(s.split_once('=').collect::<Vec<_>>()[1])
                     ))
                     .collect(),
                 Err(_) => HashMap::new(),

--- a/crates/recursion/gnark-ffi/build.rs
+++ b/crates/recursion/gnark-ffi/build.rs
@@ -76,8 +76,12 @@ fn main() {
 
             // Static linking doesn't really work on macos, so we need to link some system libs
             if cfg!(target_os = "macos") {
-                println!("cargo:rustc-link-lib=framework=CoreFoundation");
-                println!("cargo:rustc-link-lib=framework=Security");
+                // unless, of course, we're cross-building for another platform,
+                // then we can use an env var to skip this:
+                if env::var("SP1_GNARK_FFI_SKIP_MAC_FRAMEWORKS").is_err() {
+                    println!("cargo:rustc-link-lib=framework=CoreFoundation");
+                    println!("cargo:rustc-link-lib=framework=Security");
+                }
             }
         }
     }


### PR DESCRIPTION
## Motivation

As described at https://github.com/succinctlabs/sp1/issues/2387 , when cross-compiling a project that uses the `sp1` library, it's necessary to configure native compilers/build systems (such as Cargo for most of the Rust code) so that they generate proper target platform binaries, instead of assuming that the compilation is targeting the host system. Generally, with Cargo, this boils down to providing the `--target` command line argument and perhaps setting a few environment variables to point to a target platform C compiler etc.

However, there's a subproject within the `sp1` library called `gnark-ffi` that not only uses Rust, but also compiles a native Go library from its Rust build script, and then generates Rust bindings and actually links against this native library. Since Go needs to produce a native library, when cross-compiling, the Go compiler must also be configured appropriately so that it produces target platform binaries instead of building for the host platform. Normally this is achieved by setting the `GOOS`/`GOARCH` environment variables. However, when building native bindings, which `gnark-ffi` does, more configuration needs to be provided to point Go to the target platform tools. However, the environment variables used for that (e.g. `CC`) sometimes clash with the settings required by the outer Cargo build, making it impossible to build proper Go binaries when cross-compiling.

## Solution

This fix introduces a couple of environment variables that can help configure the inner Go build. Both the variables are optional and don't need to be specified for regular builds. The new variables are:
* `SP1_GNARK_FFI_GO_ENVS` that allows one to pass additional, semi-colon-delimited environment variables to the inner Go build. Example: `SP1_GNARK_FFI_GO_ENVS="CC=clang-cl;CCC_OVERRIDE_OPTIONS=x-dM"` which will pass the `CC` and `CCC_OVERRIDE_OPTIONS` variables to the inner `go build` command when compiling the Go library.
* `SP1_GNARK_FFI_SKIP_MAC_FRAMEWORKS` that allows one to skip linking against native Mac frameworks to allow using a Mac to build for other platforms (e.g. for Windows.) If set, regardless of the value (could be an empty string), then the inner Go build won't link against the Mac frameworks. This is necessary because the `target_os` variable that the build script is using to decide if the frameworks are required seems not to respect cross-compilation settings - it reports 'macos' regardless of the target platform for which a build is performed.

Fixes #2387

## PR Checklist

- [-] Added Tests
- [+] Added Documentation
- [-] Breaking changes