### PR TITLE
feat: introduce `SP1_MOONGATE_SERVER_PORT` env value as port for moongate-server

### DIFF
--- a/crates/cuda/src/lib.rs
+++ b/crates/cuda/src/lib.rs
@@ -132,7 +132,11 @@ pub enum MoongateServer {
 
 impl Default for MoongateServer {
     fn default() -> Self {
-        Self::Local { visible_device_index: None, port: None }
+        let port = std::env::var("SP1_MOONGATE_SERVER_PORT")
+            .ok()
+            .and_then(|port_str| port_str.parse().ok());
+
+        Self::Local { visible_device_index: None, port }
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

In testing sp1 and op-succinct, we found that when using CUDA proving mode, the Moongate server's default port is set to 3000, which can easily cause port conflicts with other services on the machine. Since many proof service implementations do not actively configure this port parameter.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

we could introduce an environment variable to specify the desired port. For example:

```bash
SP1_MOONGATE_SERVER_PORT=13001 SP1_PROVER=cuda RUST_LOG=debug ./target/release/fibonacci-script
```

This will instruct the Moongate server to use port 13001:

```log
2025-08-07T15:42:59.954343Z DEBUG starting new connection: http://localhost:13001/
```

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes