### PR TITLE
chore(ci): upgrade checkout to v5

### DIFF
--- a/.github/workflows/docker-gnark.yml
+++ b/.github/workflows/docker-gnark.yml
@@ -29,7 +29,7 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup CI
         uses: ./.github/actions/setup

--- a/.github/workflows/docker-publish-gnark.yml
+++ b/.github/workflows/docker-publish-gnark.yml
@@ -27,7 +27,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up Docker BuildX
         uses: docker/setup-buildx-action@v3
       - name: Log into registry ${{ env.REGISTRY }}
@@ -55,7 +55,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up Docker BuildX
         uses: docker/setup-buildx-action@v3
       - name: Log into registry ${{ env.REGISTRY }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - name: Checkout repository
         id: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Docker BuildX
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/executor-suite.yml
+++ b/.github/workflows/executor-suite.yml
@@ -35,7 +35,7 @@ jobs:
       ]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup CI
         uses: ./.github/actions/setup
@@ -87,7 +87,7 @@ jobs:
       ]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup CI
         uses: ./.github/actions/setup
@@ -139,7 +139,7 @@ jobs:
       ]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup CI
         uses: ./.github/actions/setup

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup CI
         uses: ./.github/actions/setup
@@ -74,7 +74,7 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup CI
         uses: ./.github/actions/setup
@@ -114,7 +114,7 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup CI
         uses: ./.github/actions/setup
@@ -154,7 +154,7 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup CI
         uses: ./.github/actions/setup
@@ -200,7 +200,7 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup CI
         uses: ./.github/actions/setup
@@ -242,7 +242,7 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup CI
         uses: ./.github/actions/setup
@@ -280,7 +280,7 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup CI
         uses: ./.github/actions/setup
@@ -323,7 +323,7 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup CI
         uses: ./.github/actions/setup
@@ -352,7 +352,7 @@ jobs:
   #     CARGO_NET_GIT_FETCH_WITH_CLI: "true"
   #   steps:
   #     - name: Checkout sources
-  #       uses: actions/checkout@v4
+  #       uses: actions/checkout@v5
 
   #     - name: Setup CI
   #       uses: ./.github/actions/setup

--- a/.github/workflows/patch-testing-cycles.yml
+++ b/.github/workflows/patch-testing-cycles.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: [runs-on, runner=16cpu-linux-x64, disk=large, "run-id=${{ github.run_id }}"]
     steps:
       - name: "Checkout sources"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v5"
         with:
           fetch-depth: 0  
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,7 +35,7 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup CI
         uses: ./.github/actions/setup
@@ -79,7 +79,7 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup CI
         uses: ./.github/actions/setup
@@ -123,7 +123,7 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup CI
         uses: ./.github/actions/setup
@@ -159,7 +159,7 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup CI
         uses: ./.github/actions/setup
@@ -205,7 +205,7 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup CI
         uses: ./.github/actions/setup
@@ -244,7 +244,7 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup CI
         uses: ./.github/actions/setup
@@ -291,7 +291,7 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup CI
         uses: ./.github/actions/setup
@@ -331,7 +331,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout Actions Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
   
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -361,7 +361,7 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - name: "Checkout sources"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v5"
 
       - name: Setup CI
         uses: ./.github/actions/setup
@@ -391,7 +391,7 @@ jobs:
     runs-on: [runs-on, runner=16cpu-linux-x64, disk=large, "run-id=${{ github.run_id }}"]
     steps:
       - name: "Checkout sources"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v5"
 
       - name: "Setup CI"
         uses: ./.github/actions/setup

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Install Rust toolchain

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       release_name: ${{ steps.release_info.outputs.release_name }}
       changelog: ${{ steps.build_changelog.outputs.changelog }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -96,7 +96,7 @@ jobs:
           #   platform: win32
           #   arch: amd64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Install rust and go
       - name: Install rust
@@ -197,7 +197,7 @@ jobs:
     needs: [release, prepare]
     if: success()
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set latest release
         env:
@@ -227,7 +227,7 @@ jobs:
     runs-on: "${{ matrix.runner }}"
     steps:
       - name: "Checkout source code"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v5"
 
       - name: "Install SP1"
         run: |
@@ -280,7 +280,7 @@ jobs:
     needs: [prepare, release]
     if: failure()
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # todo remove this and use GH cli to create the issue
       - uses: JasonEtco/create-an-issue@v2
@@ -299,7 +299,7 @@ jobs:
     needs: [prepare, release]
     if: failure()
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Delete failed release
         env:

--- a/.github/workflows/suite.yml
+++ b/.github/workflows/suite.yml
@@ -39,7 +39,7 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup CI
         uses: ./.github/actions/setup
@@ -100,7 +100,7 @@ jobs:
       ]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup CI
         uses: ./.github/actions/setup
@@ -160,7 +160,7 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup CI
         uses: ./.github/actions/setup

--- a/.github/workflows/toolchain-ec2.yml
+++ b/.github/workflows/toolchain-ec2.yml
@@ -82,7 +82,7 @@ jobs:
           fi
 
       - name: "Checkout"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v5"
 
       - name: "Install Rust"
         run: |


### PR DESCRIPTION
Node 24 compatibility: switch all jobs to actions/checkout@v5. Requires runner v2.327.1+. Pure maintenance, behavior unchanged.

Ref: https://github.com/actions/checkout/releases/tag/v5.0.0