### PR TITLE
baby_bear_poseidon2: preserve ultra-compressed mode across Clone

### DIFF
--- a/crates/stark/src/bb31_poseidon2.rs
+++ b/crates/stark/src/bb31_poseidon2.rs
@@ -249,6 +249,7 @@ pub mod baby_bear_poseidon2 {
     enum BabyBearPoseidon2Type {
         Default,
         Compressed,
+        UltraCompressed,
     }
 
     #[derive(Deserialize)]
@@ -293,7 +294,7 @@ pub mod baby_bear_poseidon2 {
             let dft = Dft {};
             let fri_config = ultra_compressed_fri_config();
             let pcs = Pcs::new(27, dft, val_mmcs, fri_config);
-            Self { pcs, perm, config_type: BabyBearPoseidon2Type::Compressed }
+            Self { pcs, perm, config_type: BabyBearPoseidon2Type::UltraCompressed }
         }
     }
 
@@ -302,6 +303,7 @@ pub mod baby_bear_poseidon2 {
             match self.config_type {
                 BabyBearPoseidon2Type::Default => Self::new(),
                 BabyBearPoseidon2Type::Compressed => Self::compressed(),
+                BabyBearPoseidon2Type::UltraCompressed => Self::ultra_compressed(),
             }
         }
     }


### PR DESCRIPTION
Introduce UltraCompressed to BabyBearPoseidon2Type and set it in ultra_compressed(). Update Clone to return the correct constructor for Default, Compressed, and UltraCompressed so that ultra-compressed configs are not downgraded to compressed upon cloning.