### PR TITLE
fix: mainnet default cycle limit

### DIFF
--- a/crates/sdk/src/network/mod.rs
+++ b/crates/sdk/src/network/mod.rs
@@ -29,9 +29,14 @@ cfg_if::cfg_if! {
     if #[cfg(not(feature = "reserved-capacity"))] {
         pub(crate) const PUBLIC_EXPLORER_URL: &str = "https://explorer.mainnet.succinct.xyz";
         pub(crate) const DEFAULT_NETWORK_RPC_URL: &str = "https://rpc.mainnet.succinct.xyz";
+
+        // NOTE: Given the current default gas/cycle limit logic, setting a very large default
+        // cycle limit will avoid stopping execution prematurely when only gas_limit is specified.
+        pub(crate) const DEFAULT_CYCLE_LIMIT: u64 = 1_000_000_000_000;
     } else {
         pub(crate) const PUBLIC_EXPLORER_URL: &str = "https://explorer.reserved.succinct.xyz";
         pub(crate) const DEFAULT_NETWORK_RPC_URL: &str = "https://rpc.production.succinct.xyz";
+        pub(crate) const DEFAULT_CYCLE_LIMIT: u64 = 100_000_000;
     }
 }
 
@@ -40,5 +45,4 @@ pub(crate) const PRIVATE_EXPLORER_URL: &str = "https://explorer-private.succinct
 pub(crate) const DEFAULT_TEE_SERVER_URL: &str = "https://tee.production.succinct.xyz";
 
 pub(crate) const DEFAULT_AUCTION_TIMEOUT_DURATION: Duration = Duration::from_secs(30);
-pub(crate) const DEFAULT_CYCLE_LIMIT: u64 = 100_000_000;
 pub(crate) const DEFAULT_GAS_LIMIT: u64 = 1_000_000_000;


### PR DESCRIPTION
Currently, if cycle_limit is not specified, a default value is used, which can cause “cycle limit exceeded” error if the proof is large enough.

Since mainnet SPN does not use [cycle_limit to calculate request cost](https://github.com/succinctlabs/network-services/blob/j/vapp/bin/rpc/src/network/request_proof.rs#L143), the easiest fix for now is to default to a very high cycle limit in the SDK.