### PR TITLE
feat: support compressed gnark groth16 proof

### DIFF
--- a/crates/verifier/src/groth16/converter.rs
+++ b/crates/verifier/src/groth16/converter.rs
@@ -16,29 +16,34 @@ use super::error::Groth16Error;
 ///
 /// The byte slice is represented as 2 uncompressed g1 points, and one uncompressed g2 point,
 /// as outputted from Gnark.
-pub(crate) fn load_groth16_proof_from_bytes(
+pub(crate) fn load_groth16_proof_from_bytes(buffer: &[u8]) -> Result<Groth16Proof, Groth16Error> {
+    if buffer.len() < GROTH16_PROOF_LENGTH {
+        return Err(Groth16Error::GeneralError(Error::InvalidData));
+    }
+    let (ar, bs, krs) = (
+        uncompressed_bytes_to_g1_point(&buffer[..64])?,
+        uncompressed_bytes_to_g2_point(&buffer[64..192])?,
+        uncompressed_bytes_to_g1_point(&buffer[192..256])?,
+    );
+
+    Ok(Groth16Proof { ar, bs, krs })
+}
+
+/// Load the compressed Groth16 proof from the given byte slice.
+///
+/// The byte slice is represented as 2 compressed g1 points, and one compressed g2 point,
+/// as outputted from Gnark.
+pub(crate) fn load_compressed_groth16_proof_from_bytes(
     buffer: &[u8],
-    compressed: bool,
 ) -> Result<Groth16Proof, Groth16Error> {
-    let (ar, bs, krs) = if compressed {
-        if buffer.len() < GROTH16_PROOF_LENGTH / 2 {
-            return Err(Groth16Error::GeneralError(Error::InvalidData));
-        }
-        (
-            unchecked_compressed_x_to_g1_point(&buffer[..32])?,
-            unchecked_compressed_x_to_g2_point(&buffer[32..96])?,
-            unchecked_compressed_x_to_g1_point(&buffer[96..128])?,
-        )
-    } else {
-        if buffer.len() < GROTH16_PROOF_LENGTH {
-            return Err(Groth16Error::GeneralError(Error::InvalidData));
-        }
-        (
-            uncompressed_bytes_to_g1_point(&buffer[..64])?,
-            uncompressed_bytes_to_g2_point(&buffer[64..192])?,
-            uncompressed_bytes_to_g1_point(&buffer[192..256])?,
-        )
-    };
+    if buffer.len() < GROTH16_PROOF_LENGTH / 2 {
+        return Err(Groth16Error::GeneralError(Error::InvalidData));
+    }
+    let (ar, bs, krs) = (
+        unchecked_compressed_x_to_g1_point(&buffer[..32])?,
+        unchecked_compressed_x_to_g2_point(&buffer[32..96])?,
+        unchecked_compressed_x_to_g1_point(&buffer[96..128])?,
+    );
 
     Ok(Groth16Proof { ar, bs, krs })
 }

--- a/crates/verifier/src/groth16/mod.rs
+++ b/crates/verifier/src/groth16/mod.rs
@@ -149,7 +149,7 @@ impl Groth16Verifier {
     /// [`verify`] checks. If you have a complete proof with the prefix, use [`verify`] instead.
     pub fn verify_compressed_gnark_proof(
         proof: &[u8],
-        public_inputs: &[u8; 32],
+        public_inputs: &[[u8; 32]],
         groth16_vk: &[u8],
     ) -> Result<(), Groth16Error> {
         let proof = load_compressed_groth16_proof_from_bytes(proof)?;

--- a/crates/verifier/src/groth16/mod.rs
+++ b/crates/verifier/src/groth16/mod.rs
@@ -76,16 +76,18 @@ impl Groth16Verifier {
             &proof[VK_HASH_PREFIX_LENGTH..],
             &[sp1_vkey_hash, hash_public_inputs(sp1_public_inputs)],
             groth16_vk,
+            false,
         )
         .is_ok()
         {
-            return Ok(())
+            return Ok(());
         }
 
         Self::verify_gnark_proof(
             &proof[VK_HASH_PREFIX_LENGTH..],
             &[sp1_vkey_hash, hash_public_inputs_with_fn(sp1_public_inputs, blake3_hash)],
             groth16_vk,
+            false,
         )
     }
 
@@ -114,8 +116,9 @@ impl Groth16Verifier {
         proof: &[u8],
         public_inputs: &[[u8; 32]],
         groth16_vk: &[u8],
+        proof_compressed: bool,
     ) -> Result<(), Groth16Error> {
-        let proof = load_groth16_proof_from_bytes(proof)?;
+        let proof = load_groth16_proof_from_bytes(proof, proof_compressed)?;
         let groth16_vk = load_groth16_verifying_key_from_bytes(groth16_vk)?;
 
         let public_inputs =

--- a/crates/verifier/src/groth16/mod.rs
+++ b/crates/verifier/src/groth16/mod.rs
@@ -3,7 +3,10 @@ pub mod error;
 mod verify;
 
 use bn::Fr;
-pub(crate) use converter::{load_groth16_proof_from_bytes, load_groth16_verifying_key_from_bytes};
+pub(crate) use converter::{
+    load_compressed_groth16_proof_from_bytes, load_groth16_proof_from_bytes,
+    load_groth16_verifying_key_from_bytes,
+};
 pub(crate) use verify::*;
 
 use error::Groth16Error;
@@ -76,7 +79,6 @@ impl Groth16Verifier {
             &proof[VK_HASH_PREFIX_LENGTH..],
             &[sp1_vkey_hash, hash_public_inputs(sp1_public_inputs)],
             groth16_vk,
-            false,
         )
         .is_ok()
         {
@@ -87,7 +89,6 @@ impl Groth16Verifier {
             &proof[VK_HASH_PREFIX_LENGTH..],
             &[sp1_vkey_hash, hash_public_inputs_with_fn(sp1_public_inputs, blake3_hash)],
             groth16_vk,
-            false,
         )
     }
 
@@ -101,7 +102,7 @@ impl Groth16Verifier {
     ///
     /// * `proof` - The raw Groth16 proof bytes (without the 4-byte vkey hash prefix)
     /// * `public_inputs` - The public inputs to the circuit
-    /// * `groth16_vk` - The Groth16 verifying key bytes
+    /// * `groth16_vk` - The compressed Groth16 verifying key bytes
     ///
     /// # Returns
     ///
@@ -116,9 +117,42 @@ impl Groth16Verifier {
         proof: &[u8],
         public_inputs: &[[u8; 32]],
         groth16_vk: &[u8],
-        proof_compressed: bool,
     ) -> Result<(), Groth16Error> {
-        let proof = load_groth16_proof_from_bytes(proof, proof_compressed)?;
+        let proof = load_groth16_proof_from_bytes(proof)?;
+        let groth16_vk = load_groth16_verifying_key_from_bytes(groth16_vk)?;
+
+        let public_inputs =
+            public_inputs.iter().map(|input| Fr::from_slice(input).unwrap()).collect::<Vec<_>>();
+        verify_groth16_algebraic(&groth16_vk, &proof, &public_inputs)
+    }
+
+    /// Verifies a compressed Gnark Groth16 proof using raw byte inputs.
+    ///
+    /// WARNING: if you're verifying an SP1 proof, you should use [`verify`] instead.
+    /// This is a lower-level verification method that works directly with raw bytes rather than
+    /// the SP1 SDK's data structures.
+    ///
+    /// # Arguments
+    ///
+    /// * `proof` - The raw compressed Groth16 proof bytes (without the 4-byte vkey hash prefix)
+    /// * `public_inputs` - The public inputs to the circuit
+    /// * `groth16_vk` - The compressed Groth16 verifying key bytes
+    ///
+    /// # Returns
+    ///
+    /// A [`Result`] containing unit `()` if the proof is valid,
+    /// or a [`Groth16Error`] if verification fails.
+    ///
+    /// # Note
+    ///
+    /// This method expects the raw proof bytes without the 4-byte vkey hash prefix that
+    /// [`verify`] checks. If you have a complete proof with the prefix, use [`verify`] instead.
+    pub fn verify_compressed_gnark_proof(
+        proof: &[u8],
+        public_inputs: &[u8; 32],
+        groth16_vk: &[u8],
+    ) -> Result<(), Groth16Error> {
+        let proof = load_compressed_groth16_proof_from_bytes(proof)?;
         let groth16_vk = load_groth16_verifying_key_from_bytes(groth16_vk)?;
 
         let public_inputs =


### PR DESCRIPTION
Hey, SP1 team. For the purpose of reducing on-chain cost, we had to use compressed gnark groth16 proof, and verify it within SP1 VM. In this case, we have to enable loading compressed gnark groth16 proof. Thank you