### PR TITLE
chore: bump sdk to v5.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7371,7 +7371,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-sdk"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6884,7 +6884,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-build"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -6896,7 +6896,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cli"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -6925,7 +6925,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -6952,7 +6952,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sp1-curves",
- "sp1-primitives 5.2.1",
+ "sp1-primitives 5.2.2",
  "sp1-stark",
  "sp1-zkvm",
  "strum",
@@ -6968,7 +6968,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-machine"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "bincode",
  "cbindgen",
@@ -7007,7 +7007,7 @@ dependencies = [
  "sp1-core-executor",
  "sp1-curves",
  "sp1-derive",
- "sp1-primitives 5.2.1",
+ "sp1-primitives 5.2.2",
  "sp1-stark",
  "sp1-zkvm",
  "static_assertions",
@@ -7026,7 +7026,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cuda"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "bincode",
  "ctrlc",
@@ -7044,7 +7044,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -7059,14 +7059,14 @@ dependencies = [
  "rug",
  "serde",
  "snowbridge-amcl",
- "sp1-primitives 5.2.1",
+ "sp1-primitives 5.2.2",
  "sp1-stark",
  "typenum",
 ]
 
 [[package]]
 name = "sp1-derive"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -7074,7 +7074,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-eval"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -7092,7 +7092,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-helper"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "sp1-build",
 ]
@@ -7111,17 +7111,17 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "bincode",
  "elliptic-curve",
  "serde",
- "sp1-primitives 5.2.1",
+ "sp1-primitives 5.2.2",
 ]
 
 [[package]]
 name = "sp1-perf"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "bincode",
  "clap",
@@ -7161,7 +7161,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "bincode",
  "blake3",
@@ -7179,7 +7179,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -7208,7 +7208,7 @@ dependencies = [
  "sha2 0.10.9",
  "sp1-core-executor",
  "sp1-core-machine",
- "sp1-primitives 5.2.1",
+ "sp1-primitives 5.2.2",
  "sp1-recursion-circuit",
  "sp1-recursion-compiler",
  "sp1-recursion-core",
@@ -7224,7 +7224,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-circuit"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "ff 0.13.1",
  "hashbrown 0.14.5",
@@ -7250,7 +7250,7 @@ dependencies = [
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-derive",
- "sp1-primitives 5.2.1",
+ "sp1-primitives 5.2.2",
  "sp1-recursion-compiler",
  "sp1-recursion-core",
  "sp1-recursion-gnark-ffi",
@@ -7262,7 +7262,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-compiler"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "backtrace",
  "criterion",
@@ -7277,7 +7277,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "sp1-core-machine",
- "sp1-primitives 5.2.1",
+ "sp1-primitives 5.2.2",
  "sp1-recursion-core",
  "sp1-recursion-derive",
  "sp1-stark",
@@ -7287,7 +7287,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-core"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "backtrace",
  "cbindgen",
@@ -7319,7 +7319,7 @@ dependencies = [
  "smallvec",
  "sp1-core-machine",
  "sp1-derive",
- "sp1-primitives 5.2.1",
+ "sp1-primitives 5.2.2",
  "sp1-stark",
  "static_assertions",
  "thiserror 1.0.69",
@@ -7330,7 +7330,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-derive"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -7338,7 +7338,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-cli"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "bincode",
  "clap",
@@ -7347,7 +7347,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-ffi"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -7406,7 +7406,7 @@ dependencies = [
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-cuda",
- "sp1-primitives 5.2.1",
+ "sp1-primitives 5.2.2",
  "sp1-prover",
  "sp1-stark",
  "strum",
@@ -7424,7 +7424,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-stark"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "arrayref",
  "hashbrown 0.14.5",
@@ -7448,7 +7448,7 @@ dependencies = [
  "rayon-scan",
  "serde",
  "sp1-derive",
- "sp1-primitives 5.2.1",
+ "sp1-primitives 5.2.2",
  "sp1-zkvm",
  "strum",
  "sysinfo",
@@ -7457,7 +7457,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-verifier"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -7477,7 +7477,7 @@ dependencies = [
  "rstest",
  "serial_test",
  "sha2 0.10.9",
- "sp1-primitives 5.2.1",
+ "sp1-primitives 5.2.2",
  "sp1-recursion-core",
  "sp1-sdk",
  "sp1-stark",
@@ -7488,7 +7488,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "blake3",
  "cfg-if",
@@ -7502,8 +7502,8 @@ dependencies = [
  "p3-field",
  "rand 0.8.5",
  "sha2 0.10.9",
- "sp1-lib 5.2.1",
- "sp1-primitives 5.2.1",
+ "sp1-lib 5.2.2",
+ "sp1-primitives 5.2.2",
 ]
 
 [[package]]
@@ -7840,7 +7840,7 @@ dependencies = [
 
 [[package]]
 name = "test-artifacts"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "sp1-build",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "5.2.1"
+version = "5.2.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/succinctlabs/sp1"
@@ -49,27 +49,27 @@ debug-assertions = true
 
 [workspace.dependencies]
 # sp1
-sp1-build = { path = "crates/build", version = "5.2.1" }
-sp1-cli = { path = "crates/cli", version = "5.2.1", default-features = false }
-sp1-core-machine = { path = "crates/core/machine", version = "5.2.1", default-features = false }
-sp1-core-executor = { path = "crates/core/executor", version = "5.2.1" }
-sp1-curves = { path = "crates/curves", version = "5.2.1" }
-sp1-derive = { path = "crates/derive", version = "5.2.1" }
-sp1-eval = { path = "crates/eval", version = "5.2.1" }
-sp1-helper = { path = "crates/helper", version = "5.2.1", default-features = false }
-sp1-primitives = { path = "crates/primitives", version = "5.2.1" }
-sp1-prover = { path = "crates/prover", version = "5.2.1" }
-sp1-recursion-compiler = { path = "crates/recursion/compiler", version = "5.2.1" }
-sp1-recursion-core = { path = "crates/recursion/core", version = "5.2.1", default-features = false }
-sp1-recursion-derive = { path = "crates/recursion/derive", version = "5.2.1", default-features = false }
-sp1-recursion-gnark-ffi = { path = "crates/recursion/gnark-ffi", version = "5.2.1", default-features = false }
-sp1-recursion-circuit = { path = "crates/recursion/circuit", version = "5.2.1", default-features = false }
-sp1-sdk = { path = "crates/sdk", version = "5.2.1" }
-sp1-cuda = { path = "crates/cuda", version = "5.2.1" }
-sp1-stark = { path = "crates/stark", version = "5.2.1" }
-sp1-lib = { path = "crates/zkvm/lib", version = "5.2.1", default-features = false }
-sp1-zkvm = { path = "crates/zkvm/entrypoint", version = "5.2.1", default-features = false }
-sp1-verifier = { path = "crates/verifier", version = "5.2.1", default-features = false }
+sp1-build = { path = "crates/build", version = "5.2.2" }
+sp1-cli = { path = "crates/cli", version = "5.2.2", default-features = false }
+sp1-core-machine = { path = "crates/core/machine", version = "5.2.2", default-features = false }
+sp1-core-executor = { path = "crates/core/executor", version = "5.2.2" }
+sp1-curves = { path = "crates/curves", version = "5.2.2" }
+sp1-derive = { path = "crates/derive", version = "5.2.2" }
+sp1-eval = { path = "crates/eval", version = "5.2.2" }
+sp1-helper = { path = "crates/helper", version = "5.2.2", default-features = false }
+sp1-primitives = { path = "crates/primitives", version = "5.2.2" }
+sp1-prover = { path = "crates/prover", version = "5.2.2" }
+sp1-recursion-compiler = { path = "crates/recursion/compiler", version = "5.2.2" }
+sp1-recursion-core = { path = "crates/recursion/core", version = "5.2.2", default-features = false }
+sp1-recursion-derive = { path = "crates/recursion/derive", version = "5.2.2", default-features = false }
+sp1-recursion-gnark-ffi = { path = "crates/recursion/gnark-ffi", version = "5.2.2", default-features = false }
+sp1-recursion-circuit = { path = "crates/recursion/circuit", version = "5.2.2", default-features = false }
+sp1-sdk = { path = "crates/sdk", version = "5.2.2" }
+sp1-cuda = { path = "crates/cuda", version = "5.2.2" }
+sp1-stark = { path = "crates/stark", version = "5.2.2" }
+sp1-lib = { path = "crates/zkvm/lib", version = "5.2.2", default-features = false }
+sp1-zkvm = { path = "crates/zkvm/entrypoint", version = "5.2.2", default-features = false }
+sp1-verifier = { path = "crates/verifier", version = "5.2.2", default-features = false }
 
 # For testing.
 test-artifacts = { path = "crates/test-artifacts" }

--- a/crates/core/executor/src/lib.rs
+++ b/crates/core/executor/src/lib.rs
@@ -58,6 +58,8 @@ pub use report::*;
 pub use state::*;
 pub use utils::*;
 
+pub use sp1_stark::SP1ReduceProof;
+
 /// Used for testing.
 #[cfg(test)]
 pub mod programs {

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sp1-sdk"
 description = "SP1 is a performant, 100% open-source, contributor-friendly zkVM."
 readme = "../../README.md"
-version = { workspace = true }
+version = "5.2.2"
 edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sp1-sdk"
 description = "SP1 is a performant, 100% open-source, contributor-friendly zkVM."
 readme = "../../README.md"
-version = "5.2.2"
+version = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }

--- a/crates/test-artifacts/programs/Cargo.lock
+++ b/crates/test-artifacts/programs/Cargo.lock
@@ -346,7 +346,7 @@ version = "1.1.0"
 dependencies = [
  "common-test-utils",
  "sp1-curves",
- "sp1-lib 5.2.1",
+ "sp1-lib 5.2.2",
  "sp1-zkvm",
 ]
 
@@ -389,7 +389,7 @@ name = "bls12381-mul-test"
 version = "1.1.0"
 dependencies = [
  "sp1-derive",
- "sp1-lib 5.2.1",
+ "sp1-lib 5.2.2",
  "sp1-zkvm",
 ]
 
@@ -399,7 +399,7 @@ version = "1.1.0"
 dependencies = [
  "common-test-utils",
  "sp1-curves",
- "sp1-lib 5.2.1",
+ "sp1-lib 5.2.2",
  "sp1-zkvm",
 ]
 
@@ -442,7 +442,7 @@ name = "bn254-mul-test"
 version = "1.1.0"
 dependencies = [
  "sp1-derive",
- "sp1-lib 5.2.1",
+ "sp1-lib 5.2.2",
  "sp1-zkvm",
 ]
 
@@ -512,7 +512,7 @@ name = "common-test-utils"
 version = "1.1.0"
 dependencies = [
  "num-bigint",
- "sp1-lib 5.2.1",
+ "sp1-lib 5.2.2",
 ]
 
 [[package]]
@@ -2347,7 +2347,7 @@ version = "1.1.0"
 dependencies = [
  "common-test-utils",
  "sp1-curves",
- "sp1-lib 5.2.1",
+ "sp1-lib 5.2.2",
  "sp1-zkvm",
 ]
 
@@ -2383,7 +2383,7 @@ dependencies = [
  "num",
  "p256",
  "sp1-curves",
- "sp1-lib 5.2.1",
+ "sp1-lib 5.2.2",
  "sp1-zkvm",
 ]
 
@@ -2404,7 +2404,7 @@ dependencies = [
  "num",
  "p256",
  "sp1-curves",
- "sp1-lib 5.2.1",
+ "sp1-lib 5.2.2",
  "sp1-zkvm",
 ]
 
@@ -2619,7 +2619,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -2639,7 +2639,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-derive"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -2657,7 +2657,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "bincode",
  "elliptic-curve",
@@ -2667,7 +2667,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "bincode",
  "blake3",
@@ -2685,7 +2685,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-stark"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "arrayref",
  "hashbrown 0.14.5",
@@ -2717,7 +2717,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "cfg-if",
  "getrandom 0.2.16",
@@ -2728,7 +2728,7 @@ dependencies = [
  "p3-field",
  "rand 0.8.5",
  "sha2 0.10.9",
- "sp1-lib 5.2.1",
+ "sp1-lib 5.2.2",
  "sp1-primitives",
 ]
 

--- a/crates/test-artifacts/programs/fibonacci-blake3/Cargo.lock
+++ b/crates/test-artifacts/programs/fibonacci-blake3/Cargo.lock
@@ -446,7 +446,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sp1-lib"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "bincode",
  "serde",
@@ -455,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "bincode",
  "blake3",
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "blake3",
  "cfg-if",

--- a/crates/verifier/guest-verify-programs/Cargo.lock
+++ b/crates/verifier/guest-verify-programs/Cargo.lock
@@ -597,40 +597,22 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 [[package]]
 name = "sp1-lib"
 version = "5.2.1"
-dependencies = [
- "bincode",
- "serde",
- "sp1-primitives 5.2.1",
-]
-
-[[package]]
-name = "sp1-lib"
-version = "5.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e1fe81b6f87134f9170cb642f948ae41e0ee1cd3785e0cb665add5b67106d1a"
 dependencies = [
  "bincode",
  "elliptic-curve",
  "serde",
- "sp1-primitives 5.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp1-primitives 5.2.1",
 ]
 
 [[package]]
-name = "sp1-primitives"
-version = "5.2.1"
+name = "sp1-lib"
+version = "5.2.2"
 dependencies = [
  "bincode",
- "blake3",
- "cfg-if",
- "hex",
- "lazy_static",
- "num-bigint",
- "p3-baby-bear",
- "p3-field",
- "p3-poseidon2",
- "p3-symmetric",
  "serde",
- "sha2",
+ "sp1-primitives 5.2.2",
 ]
 
 [[package]]
@@ -654,8 +636,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp1-primitives"
+version = "5.2.2"
+dependencies = [
+ "bincode",
+ "blake3",
+ "cfg-if",
+ "hex",
+ "lazy_static",
+ "num-bigint",
+ "p3-baby-bear",
+ "p3-field",
+ "p3-poseidon2",
+ "p3-symmetric",
+ "serde",
+ "sha2",
+]
+
+[[package]]
 name = "sp1-verifier"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "blake3",
  "cfg-if",
@@ -668,7 +668,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "blake3",
  "cfg-if",
@@ -678,8 +678,8 @@ dependencies = [
  "libm",
  "rand",
  "sha2",
- "sp1-lib 5.2.1",
- "sp1-primitives 5.2.1",
+ "sp1-lib 5.2.2",
+ "sp1-primitives 5.2.2",
 ]
 
 [[package]]
@@ -702,7 +702,7 @@ dependencies = [
  "num-bigint",
  "rand",
  "rustc-hex",
- "sp1-lib 5.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp1-lib 5.2.1",
 ]
 
 [[package]]

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1281,7 +1281,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "lazy_static",
  "lazycell",
  "log",
@@ -4638,7 +4638,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -5833,7 +5833,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-build"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -5845,7 +5845,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -5882,7 +5882,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-machine"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "bincode",
  "cbindgen",
@@ -5936,7 +5936,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cuda"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "bincode",
  "ctrlc",
@@ -5951,7 +5951,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -5971,7 +5971,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-derive"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -5979,7 +5979,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "bincode",
  "elliptic-curve",
@@ -5989,7 +5989,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "bincode",
  "blake3",
@@ -6007,7 +6007,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6050,7 +6050,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-circuit"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "hashbrown 0.14.5",
  "itertools 0.13.0",
@@ -6083,7 +6083,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-compiler"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "backtrace",
  "itertools 0.13.0",
@@ -6103,7 +6103,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-core"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "backtrace",
  "cbindgen",
@@ -6144,7 +6144,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-derive"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -6152,7 +6152,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-ffi"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6176,7 +6176,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-sdk"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "alloy-primitives 1.1.2",
  "alloy-signer",
@@ -6227,7 +6227,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-stark"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "arrayref",
  "hashbrown 0.14.5",
@@ -6259,7 +6259,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-verifier"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "blake3",
  "cfg-if",
@@ -6272,7 +6272,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "cfg-if",
  "critical-section",

--- a/patch-testing/Cargo.lock
+++ b/patch-testing/Cargo.lock
@@ -5195,7 +5195,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-sdk"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "alloy-sol-types",
  "anyhow",

--- a/patch-testing/Cargo.lock
+++ b/patch-testing/Cargo.lock
@@ -4852,7 +4852,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-build"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -4864,7 +4864,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -4901,7 +4901,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-machine"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "bincode",
  "cbindgen",
@@ -4955,7 +4955,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cuda"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "bincode",
  "ctrlc",
@@ -4970,7 +4970,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -4990,7 +4990,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-derive"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -4998,7 +4998,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "bincode",
  "elliptic-curve",
@@ -5008,7 +5008,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "bincode",
  "blake3",
@@ -5026,7 +5026,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -5069,7 +5069,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-circuit"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "hashbrown 0.14.5",
  "itertools 0.13.0",
@@ -5102,7 +5102,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-compiler"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "backtrace",
  "itertools 0.13.0",
@@ -5122,7 +5122,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-core"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "backtrace",
  "cbindgen",
@@ -5163,7 +5163,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-derive"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -5171,7 +5171,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-ffi"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -5235,7 +5235,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-stark"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "arrayref",
  "hashbrown 0.14.5",
@@ -5292,7 +5292,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "cfg-if",
  "getrandom 0.2.16",

--- a/patch-testing/secp256k1/program-v0.29.1/Cargo.lock
+++ b/patch-testing/secp256k1/program-v0.29.1/Cargo.lock
@@ -640,7 +640,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "bincode",
  "elliptic-curve",
@@ -650,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "bincode",
  "blake3",
@@ -668,7 +668,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "cfg-if",
  "getrandom 0.2.15",

--- a/patch-testing/secp256k1/program-v0.30.0/Cargo.lock
+++ b/patch-testing/secp256k1/program-v0.30.0/Cargo.lock
@@ -667,7 +667,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "bincode",
  "elliptic-curve",
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "bincode",
  "blake3",
@@ -695,7 +695,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "cfg-if",
  "getrandom 0.2.15",


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

We need a `sp1-sdk` release to make private proving available.

I also added back SP1ReduceProof in sp1-core-executor as it was removed in #2450, but needed [in hokulea](https://github.com/Layr-Labs/hokulea/blob/2dae748c69d7ace01ab1c1ff471e87449371893d/canoe/sp1-cc/host/src/lib.rs#L99)
