### PR TITLE
chore: fix duplicates in Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6952,7 +6952,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sp1-curves",
- "sp1-primitives 5.2.2",
+ "sp1-primitives",
  "sp1-stark",
  "sp1-zkvm",
  "strum",
@@ -7007,7 +7007,7 @@ dependencies = [
  "sp1-core-executor",
  "sp1-curves",
  "sp1-derive",
- "sp1-primitives 5.2.2",
+ "sp1-primitives",
  "sp1-stark",
  "sp1-zkvm",
  "static_assertions",
@@ -7059,7 +7059,7 @@ dependencies = [
  "rug",
  "serde",
  "snowbridge-amcl",
- "sp1-primitives 5.2.2",
+ "sp1-primitives",
  "sp1-stark",
  "typenum",
 ]
@@ -7099,24 +7099,12 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03046db52868c1b60e8acffa0777ef6dc11ec1bbbb10b9eb612a871f69c8d3f6"
-dependencies = [
- "bincode",
- "elliptic-curve",
- "serde",
- "sp1-primitives 5.0.0",
-]
-
-[[package]]
-name = "sp1-lib"
 version = "5.2.2"
 dependencies = [
  "bincode",
  "elliptic-curve",
  "serde",
- "sp1-primitives 5.2.2",
+ "sp1-primitives",
 ]
 
 [[package]]
@@ -7137,26 +7125,6 @@ dependencies = [
  "test-artifacts",
  "time 0.3.41",
  "tracing",
-]
-
-[[package]]
-name = "sp1-primitives"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6939d6b2f63e54e5fbd208a0293027608f22511741b62fe32b6f67f6c144e0c0"
-dependencies = [
- "bincode",
- "blake3",
- "cfg-if",
- "hex",
- "lazy_static",
- "num-bigint 0.4.6",
- "p3-baby-bear",
- "p3-field",
- "p3-poseidon2",
- "p3-symmetric",
- "serde",
- "sha2 0.10.9",
 ]
 
 [[package]]
@@ -7208,7 +7176,7 @@ dependencies = [
  "sha2 0.10.9",
  "sp1-core-executor",
  "sp1-core-machine",
- "sp1-primitives 5.2.2",
+ "sp1-primitives",
  "sp1-recursion-circuit",
  "sp1-recursion-compiler",
  "sp1-recursion-core",
@@ -7250,7 +7218,7 @@ dependencies = [
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-derive",
- "sp1-primitives 5.2.2",
+ "sp1-primitives",
  "sp1-recursion-compiler",
  "sp1-recursion-core",
  "sp1-recursion-gnark-ffi",
@@ -7277,7 +7245,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "sp1-core-machine",
- "sp1-primitives 5.2.2",
+ "sp1-primitives",
  "sp1-recursion-core",
  "sp1-recursion-derive",
  "sp1-stark",
@@ -7319,7 +7287,7 @@ dependencies = [
  "smallvec",
  "sp1-core-machine",
  "sp1-derive",
- "sp1-primitives 5.2.2",
+ "sp1-primitives",
  "sp1-stark",
  "static_assertions",
  "thiserror 1.0.69",
@@ -7406,7 +7374,7 @@ dependencies = [
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-cuda",
- "sp1-primitives 5.2.2",
+ "sp1-primitives",
  "sp1-prover",
  "sp1-stark",
  "strum",
@@ -7448,7 +7416,7 @@ dependencies = [
  "rayon-scan",
  "serde",
  "sp1-derive",
- "sp1-primitives 5.2.2",
+ "sp1-primitives",
  "sp1-zkvm",
  "strum",
  "sysinfo",
@@ -7477,7 +7445,7 @@ dependencies = [
  "rstest",
  "serial_test",
  "sha2 0.10.9",
- "sp1-primitives 5.2.2",
+ "sp1-primitives",
  "sp1-recursion-core",
  "sp1-sdk",
  "sp1-stark",
@@ -7502,8 +7470,8 @@ dependencies = [
  "p3-field",
  "rand 0.8.5",
  "sha2 0.10.9",
- "sp1-lib 5.2.2",
- "sp1-primitives 5.2.2",
+ "sp1-lib",
+ "sp1-primitives",
 ]
 
 [[package]]
@@ -7667,7 +7635,7 @@ dependencies = [
  "num-bigint 0.4.6",
  "rand 0.8.5",
  "rustc-hex",
- "sp1-lib 5.0.0",
+ "sp1-lib",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,3 +117,6 @@ default.extend-ignore-words-re = ["(?i)groth", "TRE"]
 
 [workspace.lints.clippy]
 print_stdout = "deny"
+
+[patch.crates-io]
+sp1-lib = { path = "crates/zkvm/lib" }

--- a/crates/verifier/guest-verify-programs/Cargo.lock
+++ b/crates/verifier/guest-verify-programs/Cargo.lock
@@ -596,43 +596,12 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sp1-lib"
-version = "5.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e1fe81b6f87134f9170cb642f948ae41e0ee1cd3785e0cb665add5b67106d1a"
+version = "5.2.2"
 dependencies = [
  "bincode",
  "elliptic-curve",
  "serde",
- "sp1-primitives 5.2.1",
-]
-
-[[package]]
-name = "sp1-lib"
-version = "5.2.2"
-dependencies = [
- "bincode",
- "serde",
- "sp1-primitives 5.2.2",
-]
-
-[[package]]
-name = "sp1-primitives"
-version = "5.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dddd8d022840c1c500e0d7f82e9b9cf080b7dabd469f06b394010e6a594f692b"
-dependencies = [
- "bincode",
- "blake3",
- "cfg-if",
- "hex",
- "lazy_static",
- "num-bigint",
- "p3-baby-bear",
- "p3-field",
- "p3-poseidon2",
- "p3-symmetric",
- "serde",
- "sha2",
+ "sp1-primitives",
 ]
 
 [[package]]
@@ -678,8 +647,8 @@ dependencies = [
  "libm",
  "rand",
  "sha2",
- "sp1-lib 5.2.2",
- "sp1-primitives 5.2.2",
+ "sp1-lib",
+ "sp1-primitives",
 ]
 
 [[package]]
@@ -702,7 +671,7 @@ dependencies = [
  "num-bigint",
  "rand",
  "rustc-hex",
- "sp1-lib 5.2.1",
+ "sp1-lib",
 ]
 
 [[package]]

--- a/crates/verifier/guest-verify-programs/Cargo.toml
+++ b/crates/verifier/guest-verify-programs/Cargo.toml
@@ -37,3 +37,6 @@ sp1-verifier = { path = "../" }
 
 [features]
 blake3 = ["sp1-zkvm/blake3"]
+
+[patch.crates-io]
+sp1-lib = { path = "../../zkvm/lib" }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Duplicate `sp1-lib` and `sp1-primitives` either from the workspace and crates.io caused issues when releasing SP1 v5.2.2.

## Solution

Add a patch for `sp1-lib` to always take from the workspace.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes