### PR TITLE
feat: cargo-prove informative error for non standard cargo target dir

### DIFF
--- a/crates/build/src/command/docker.rs
+++ b/crates/build/src/command/docker.rs
@@ -76,7 +76,13 @@ pub(crate) fn create_docker_command(
 
     // Get the target directory for the ELF in the context of the Docker container.
     let relative_target_dir =
-        (program_metadata.target_directory).strip_prefix(workspace_root).unwrap();
+        program_metadata.target_directory.strip_prefix(workspace_root).with_context(|| {
+            format!(
+                "Cargo target directory ({}) must be a child of the workspace directory ({}).\n\
+                 This can happen if CARGO_TARGET_DIR is set to a location outside the workspace.",
+                program_metadata.target_directory, workspace_root
+            )
+        })?;
     let target_dir = format!(
         "/root/program/{}/{}/{}",
         relative_target_dir,


### PR DESCRIPTION
## Motivation
When running cargo prove in docker with a CARGO_TARGET_DIR that is not a child of the current workspace, cargo prove currently fails without any clear indication of why. This is confusing.

## Solution
This change adds a clear error message that should allow users encountering this issue to rectify the problem by simply modifying their CARGO_TARGET_DIR, without having to dig into the code.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes