### PR TITLE
Fix: Prevent DoS from Malformed ELF Binaries

### DIFF
--- a/crates/prover/src/build.rs
+++ b/crates/prover/src/build.rs
@@ -157,7 +157,12 @@ pub fn dummy_proof() -> (StarkVerifyingKey<OuterSC>, ShardProof<OuterSC>) {
     let context = SP1Context::default();
 
     tracing::info!("setup elf");
-    let (_, pk_d, program, vk) = prover.setup(elf);
+    let (_, pk_d, program, vk) = match prover.setup(elf) {
+        Ok(res) => res,
+        Err(e) => {
+            panic!("Failed to setup prover: {}", e);
+        }
+    };
 
     tracing::info!("prove core");
     let mut stdin = SP1Stdin::new();

--- a/crates/sdk/src/cpu/mod.rs
+++ b/crates/sdk/src/cpu/mod.rs
@@ -6,7 +6,7 @@ pub mod builder;
 pub mod execute;
 pub mod prove;
 
-use anyhow::Result;
+use anyhow::{Error, Result};
 use execute::CpuExecuteBuilder;
 use prove::CpuProveBuilder;
 use sp1_core_executor::{SP1Context, SP1ContextBuilder};
@@ -210,9 +210,14 @@ impl CpuProver {
 }
 
 impl Prover<CpuProverComponents> for CpuProver {
-    fn setup(&self, elf: &[u8]) -> (SP1ProvingKey, SP1VerifyingKey) {
-        let (pk, _, _, vk) = self.prover.setup(elf);
-        (pk, vk)
+    fn setup(&self, elf: &[u8]) -> Result<(SP1ProvingKey, SP1VerifyingKey), Error> {
+        let (pk, _, _, vk) = match self.prover.setup(elf) {
+            Ok(res) => res,
+            Err(e) => {
+                return Err(Error::msg(format!("Failed to setup prover: {}", e)));
+            }
+        };
+        Ok((pk, vk))
     }
 
     fn inner(&self) -> &SP1Prover<CpuProverComponents> {

--- a/crates/sdk/src/cuda/mod.rs
+++ b/crates/sdk/src/cuda/mod.rs
@@ -5,7 +5,7 @@
 pub mod builder;
 pub mod prove;
 
-use anyhow::Result;
+use anyhow::{Error, Result};
 use prove::CudaProveBuilder;
 use sp1_core_executor::SP1ContextBuilder;
 use sp1_core_machine::io::SP1Stdin;
@@ -160,9 +160,14 @@ impl CudaProver {
 }
 
 impl Prover<CpuProverComponents> for CudaProver {
-    fn setup(&self, elf: &[u8]) -> (SP1ProvingKey, SP1VerifyingKey) {
-        let (pk, vk) = self.cuda_prover.setup(elf).unwrap();
-        (pk, vk)
+    fn setup(&self, elf: &[u8]) -> Result<(SP1ProvingKey, SP1VerifyingKey), Error> {
+        let (pk, vk) = match self.cuda_prover.setup(elf) {
+            Ok(res) => res,
+            Err(e) => {
+                return Err(Error::msg(format!("Failed to setup prover: {}", e)));
+            }
+        };
+        Ok((pk, vk))
     }
 
     fn inner(&self) -> &SP1Prover<CpuProverComponents> {

--- a/crates/sdk/src/env/mod.rs
+++ b/crates/sdk/src/env/mod.rs
@@ -7,7 +7,7 @@ pub mod prove;
 
 use std::env;
 
-use anyhow::Result;
+use anyhow::{Error, Result};
 use prove::EnvProveBuilder;
 use sp1_core_executor::SP1ContextBuilder;
 use sp1_core_machine::io::SP1Stdin;
@@ -160,8 +160,11 @@ impl EnvProver {
     /// Setup a program to be proven and verified by the SP1 RISC-V zkVM by computing the proving
     /// and verifying keys.
     #[must_use]
-    pub fn setup(&self, elf: &[u8]) -> (SP1ProvingKey, SP1VerifyingKey) {
-        self.prover.setup(elf)
+    pub fn setup(&self, elf: &[u8]) -> Result<(SP1ProvingKey, SP1VerifyingKey), Error> {
+        match self.prover.setup(elf) {
+            Ok(res) => Ok(res),
+            Err(e) => Err(Error::msg(format!("Failed to setup prover: {}", e))),
+        }
     }
 }
 
@@ -176,8 +179,11 @@ impl Prover<CpuProverComponents> for EnvProver {
         self.prover.inner()
     }
 
-    fn setup(&self, elf: &[u8]) -> (SP1ProvingKey, SP1VerifyingKey) {
-        self.prover.setup(elf)
+    fn setup(&self, elf: &[u8]) -> Result<(SP1ProvingKey, SP1VerifyingKey), Error> {
+        match self.prover.setup(elf) {
+            Ok(res) => Ok(res),
+            Err(e) => Err(Error::msg(format!("Failed to setup prover: {}", e))),
+        }
     }
 
     fn prove(

--- a/crates/sdk/src/network/prover.rs
+++ b/crates/sdk/src/network/prover.rs
@@ -690,11 +690,11 @@ impl NetworkProver {
                         if let Some(network_error) = e.downcast_ref::<Error>() {
                             if matches!(
                                 network_error,
-                                Error::RequestUnfulfillable { .. } |
-                                    Error::RequestTimedOut { .. } |
-                                    Error::RequestAuctionTimedOut { .. }
-                            ) && strategy == FulfillmentStrategy::Auction &&
-                                whitelist.is_none()
+                                Error::RequestUnfulfillable { .. }
+                                    | Error::RequestTimedOut { .. }
+                                    | Error::RequestAuctionTimedOut { .. }
+                            ) && strategy == FulfillmentStrategy::Auction
+                                && whitelist.is_none()
                             {
                                 tracing::warn!(
                                     "Retrying auction request with fallback whitelist..."
@@ -888,8 +888,11 @@ impl NetworkProver {
 }
 
 impl Prover<CpuProverComponents> for NetworkProver {
-    fn setup(&self, elf: &[u8]) -> (SP1ProvingKey, SP1VerifyingKey) {
-        self.prover.setup(elf)
+    fn setup(&self, elf: &[u8]) -> Result<(SP1ProvingKey, SP1VerifyingKey), anyhow::Error> {
+        match self.prover.setup(elf) {
+            Ok((pk, vk)) => Ok((pk, vk)),
+            Err(e) => Err(anyhow::anyhow!(e)),
+        }
     }
 
     fn inner(&self) -> &SP1Prover {

--- a/crates/sdk/src/prover.rs
+++ b/crates/sdk/src/prover.rs
@@ -4,7 +4,7 @@
 
 use std::borrow::Borrow;
 
-use anyhow::Result;
+use anyhow::{Error, Result};
 use itertools::Itertools;
 use p3_field::PrimeField32;
 use sp1_core_executor::{ExecutionReport, SP1Context};
@@ -32,7 +32,7 @@ pub trait Prover<C: SP1ProverComponents>: Send + Sync {
     }
 
     /// Generate the proving and verifying keys for the given program.
-    fn setup(&self, elf: &[u8]) -> (SP1ProvingKey, SP1VerifyingKey);
+    fn setup(&self, elf: &[u8]) -> Result<(SP1ProvingKey, SP1VerifyingKey), Error>;
 
     /// Executes the program on the given input.
     fn execute(&self, elf: &[u8], stdin: &SP1Stdin) -> Result<(SP1PublicValues, ExecutionReport)> {
@@ -121,8 +121,8 @@ pub(crate) fn verify_proof<C: SP1ProverComponents>(
             // Make sure the committed value digest matches the public values hash.
             // It is computationally infeasible to find two distinct inputs, one processed with
             // SHA256 and the other with Blake3, that yield the same hash value.
-            if committed_value_digest_bytes != bundle.public_values.hash() &&
-                committed_value_digest_bytes != bundle.public_values.blake3_hash()
+            if committed_value_digest_bytes != bundle.public_values.hash()
+                && committed_value_digest_bytes != bundle.public_values.blake3_hash()
             {
                 return Err(SP1VerificationError::InvalidPublicValues);
             }
@@ -146,8 +146,8 @@ pub(crate) fn verify_proof<C: SP1ProverComponents>(
             // Make sure the committed value digest matches the public values hash.
             // It is computationally infeasible to find two distinct inputs, one processed with
             // SHA256 and the other with Blake3, that yield the same hash value.
-            if committed_value_digest_bytes != bundle.public_values.hash() &&
-                committed_value_digest_bytes != bundle.public_values.blake3_hash()
+            if committed_value_digest_bytes != bundle.public_values.hash()
+                && committed_value_digest_bytes != bundle.public_values.blake3_hash()
             {
                 return Err(SP1VerificationError::InvalidPublicValues);
             }


### PR DESCRIPTION
# Fix: Prevent DoS from Malformed ELF Binaries

## Summary

This PR addresses a critical security vulnerability where malformed ELF binaries could cause the SP1 prover to panic, resulting in a Denial of Service (DoS) condition. This issue was discovered during a security audit where the SP1 library was causing DoS on a client's node.

## Problem

The `setup()` method and related functions were using `.unwrap()` calls when parsing ELF binaries and setting up the prover. When a malformed ELF binary was provided, these unwrap calls would cause the application to panic and crash entirely.

### Reproduction

The following code demonstrates the vulnerability with a malformed ELF binary:

```rust
use sp1_sdk::{EnvProver, ProverClient};
use std::sync::OnceLock;

static SP1_PROVER_CLIENT: OnceLock<EnvProver> = OnceLock::new();

fn main() {
    // Malformed ELF binary that triggers the DoS
    let malformed_elf = vec![0xfb, 0x34, 0x00, 0x00, 0x00, 0x00];

    let prover_client = SP1_PROVER_CLIENT.get_or_init(ProverClient::from_env);

    // This call will crash the application
    let (_pk, _vk) = prover_client.setup(&malformed_elf);
}
```

## Changes

### 1. Core Changes - Proper Error Propagation

-   **`crates/prover/src/lib.rs`**: Modified `SP1Prover::setup()` to return `Result` instead of panicking on invalid ELF

    -   Changed return type from tuple to `eyre::Result<(...)>`
    -   Added proper error handling for `Program::from(elf)` calls with descriptive error messages

-   **`crates/prover/src/build.rs`**: Updated `dummy_proof()` to handle setup errors gracefully with panic message

### 2. SDK Layer - Result Type Updates

Updated all SDK prover implementations to propagate errors properly:

-   **`crates/sdk/src/prover.rs`**: Changed trait definition of `Prover::setup()` to return `Result<(SP1ProvingKey, SP1VerifyingKey), Error>`
-   **`crates/sdk/src/cpu/mod.rs`**: Updated `CpuProver::setup()` implementation
-   **`crates/sdk/src/cuda/mod.rs`**: Updated `CudaProver::setup()` implementation
-   **`crates/sdk/src/env/mod.rs`**: Updated `EnvProver::setup()` implementation
-   **`crates/sdk/src/network/prover.rs`**: Updated `NetworkProver::setup()` implementation

### 3. Build Tools

-   **`crates/build/src/lib.rs`**: Updated `vkey()` and `vkeys()` functions to return `Result` and handle setup errors

## Error Messages

The error messages in this PR are functional but may not be ideal for your use case. Error messages currently use generic formats like:

```rust
return Err(eyre::eyre!("Failed to parse ELF into program: {}", e));
```

**Feel free to modify these error messages** to be more specific, user-friendly, or aligned with your project's error handling conventions. The important fix is the proper error propagation rather than panicking.

## Breaking Changes

This is a **breaking change** for any code that calls the `setup()` method, as it now returns a `Result` instead of a tuple. Callers will need to handle the potential error case:

**Before:**

```rust
let (pk, vk) = prover.setup(&elf);
```

**After:**

```rust
let (pk, vk) = prover.setup(&elf)?;
// or
let (pk, vk) = match prover.setup(&elf) {
    Ok(keys) => keys,
    Err(e) => {
        // Handle error appropriately
    }
};
```

## Security Impact

This fix prevents malicious or malformed ELF binaries from crashing applications that use the SP1 SDK. Instead of a panic that brings down the entire process, errors are now properly propagated and can be handled by the calling code, allowing for graceful degradation and proper error logging.

---

_This PR was created based on findings from a security audit where SP1 was integrated into a client's system._
_Made by FuzzingLabs_
