### PR TITLE
Remove duplicated `assert_bool` call in `IsZeroOperation::eval`

### DIFF
--- a/crates/recursion/core/src/air/is_zero.rs
+++ b/crates/recursion/core/src/air/is_zero.rs
@@ -65,8 +65,6 @@ impl<F: Field> IsZeroOperation<F> {
 
         builder.when(is_real.clone()).assert_eq(is_zero, cols.result);
 
-        builder.when(is_real.clone()).assert_bool(cols.result);
-
         // If the result is 1, then the input is 0.
         builder.when(is_real.clone()).when(cols.result).assert_zero(a.clone());
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

The `builder.when(is_real.clone()).assert_bool(cols.result);` line was duplicated in the `IsZeroOperation::eval` function. Removing the duplicate avoids unnecessary assertions and keeps the code clean.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Deleted the second occurrence of `builder.when(is_real.clone()).assert_bool(cols.result);` in `IsZeroOperation::eval`.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes