### PR TITLE
fix: broken link in warning message for high cycle count

### DIFF
--- a/crates/prover/src/lib.rs
+++ b/crates/prover/src/lib.rs
@@ -1397,7 +1397,7 @@ impl<C: SP1ProverComponents> SP1Prover<C> {
     fn check_for_high_cycles(cycles: u64) {
         if cycles > 100_000_000 {
             tracing::warn!(
-                "High cycle count detected ({}M cycles). For better performance, consider using the Succinct Prover Network: https://docs.succinct.xyz/docs/sp1/generating-proofs/prover-network",
+                "High cycle count detected ({}M cycles). For better performance, consider using the Succinct Prover Network: https://docs.succinct.xyz/docs/sp1/prover-network/quickstart",
                 cycles / 1_000_000
             );
         }


### PR DESCRIPTION
## Motivation

Hi! The warning message for high cycle counts included an outdated link that no longer points to the correct documentation. This could confuse users trying to find the Prover Network setup guide.

## Solution

Updated the URL in the `tracing::warn!` message to the correct quickstart page for the Succinct Prover Network.

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes