### PR TITLE
perf: remove redundant clone in get_recursion_core_inputs

### DIFF
--- a/crates/prover/src/lib.rs
+++ b/crates/prover/src/lib.rs
@@ -1242,7 +1242,7 @@ impl<C: SP1ProverComponents> SP1Prover<C> {
 
             core_inputs.push(SP1RecursionWitnessValues {
                 vk: vk.clone(),
-                shard_proofs: proofs.clone(),
+                shard_proofs: proofs,
                 is_complete,
                 is_first_shard: batch_idx == 0,
                 vk_root: self.recursion_vk_root,


### PR DESCRIPTION
This change removes a redundant clone in get_recursion_core_inputs where a Vec built via to_vec() was cloned again before assignment. The second clone caused an extra allocation and element copy for shard proofs with no change in behavior. Using the moved Vec preserves the original semantics, reduces memory churn, and avoids unnecessary work during recursive input preparation.