### PR TITLE
perf: avoid byte lookup work and allocation in generate_trace

### DIFF
--- a/crates/core/machine/src/alu/bitwise/mod.rs
+++ b/crates/core/machine/src/alu/bitwise/mod.rs
@@ -77,8 +77,7 @@ impl<F: PrimeField32> MachineAir<F> for BitwiseChip {
             .map(|event| {
                 let mut row = [F::zero(); NUM_BITWISE_COLS];
                 let cols: &mut BitwiseCols<F> = row.as_mut_slice().borrow_mut();
-                let mut blu = Vec::new();
-                self.event_to_row(event, cols, &mut blu);
+                self.event_to_row_no_blu(event, cols);
                 row
             })
             .collect::<Vec<_>>();
@@ -128,6 +127,20 @@ impl<F: PrimeField32> MachineAir<F> for BitwiseChip {
 }
 
 impl BitwiseChip {
+    /// Create a row from an event without emitting byte lookup events.
+    fn event_to_row_no_blu<F: PrimeField>(&self, event: &AluEvent, cols: &mut BitwiseCols<F>) {
+        cols.pc = F::from_canonical_u32(event.pc);
+
+        cols.a = Word::from(event.a);
+        cols.b = Word::from(event.b);
+        cols.c = Word::from(event.c);
+        cols.op_a_not_0 = F::from_bool(!event.op_a_0);
+
+        cols.is_xor = F::from_bool(event.opcode == Opcode::XOR);
+        cols.is_or = F::from_bool(event.opcode == Opcode::OR);
+        cols.is_and = F::from_bool(event.opcode == Opcode::AND);
+    }
+
     /// Create a row from an event.
     fn event_to_row<F: PrimeField>(
         &self,


### PR DESCRIPTION
This change introduces event_to_row_no_blu to populate BitwiseCols without emitting byte lookup events and switches generate_trace to use it. Previously, generate_trace allocated a Vec per event and event_to_row performed to_le_bytes and per-byte iterations to push ByteLookupEvent items that were immediately dropped. Byte lookup dependencies are already generated in generate_dependencies via a HashMap aggregation, so this work in generate_trace was redundant. The refactor preserves functionality, reduces allocations and CPU overhead during trace building, and confines byte lookup emission to the dependency-generation phase where it is actually consumed.