### PR TITLE
refactor: use macros to generate assert methods

### DIFF
--- a/crates/recursion/compiler/src/ir/builder.rs
+++ b/crates/recursion/compiler/src/ir/builder.rs
@@ -427,6 +427,14 @@ impl<C: Config> Builder<C> {
     }
 }
 
+impl_typed_assert!(
+    Builder<C>,
+    (assert_var_eq, assert_var_ne, Var<C::N>, SymbolicVar<C::N>, "vars"),
+    (assert_felt_eq, assert_felt_ne, Felt<C::F>, SymbolicFelt<C::F>, "felts"),
+    (assert_usize_eq, assert_usize_ne, Usize<C::N>, SymbolicUsize<C::N>, "usizes"),
+    (assert_ext_eq, assert_ext_ne, Ext<C::F, C::EF>, SymbolicExt<C::F, C::EF>, "exts"),
+);
+
 /// A builder for the DSL that handles if statements.
 #[allow(dead_code)]
 pub struct IfBuilder<'a, C: Config> {


### PR DESCRIPTION
## Motivation

The `Builder<C>` in `crates/recursion/compiler/src/ir/builder.rs` had 8 nearly identical assert methods (~80 lines of duplicated code): `assert_var_eq/ne`, `assert_felt_eq/ne`, `assert_usize_eq/ne`, and `assert_ext_eq/ne`. Each method differed only in types while the implementation logic was identical, violating DRY principles.

## Solution

Introduced a declarative macro `impl_typed_assert!` that generates all assert methods based on type definitions. 

**Stats:** Removed 81 lines of duplicated code, added 39 lines (macro + invocation). Net savings: 42 lines (~35%).

Adding a new typed assert pair now requires 1 line instead of ~20 lines of boilerplate.

No API changes - this is a pure refactoring preserving all method signatures and behavior.

## PR Checklist

- [ ] Added Tests - Not needed (pure refactoring, no behavior changes)
- [ ] Added Documentation - Not needed (docs auto-generated by macro)
- [ ] Breaking changes - No breaking changes