### PR TITLE
fix: sp1-gpu default image

### DIFF
--- a/crates/cuda/src/lib.rs
+++ b/crates/cuda/src/lib.rs
@@ -204,7 +204,7 @@ impl SP1CudaProver {
         // If the moongate endpoint url hasn't been provided, we start the Docker container
         let container_name = port.map(|p| format!("sp1-gpu-{p}")).unwrap_or("sp1-gpu".to_string());
         let image_name = std::env::var("SP1_GPU_IMAGE")
-            .unwrap_or_else(|_| "public.ecr.aws/succinct-labs/sp1-gpu:dev".to_string());
+            .unwrap_or_else(|_| "public.ecr.aws/succinct-labs/sp1-gpu:8fd1ef7".to_string());
 
         let cleaned_up = Arc::new(AtomicBool::new(false));
         let port = port.unwrap_or(3000);


### PR DESCRIPTION
## Motivation

There is a 5090 bug in the current default sp1-gpu (formerly moongate) image tag.

## Solution

The new default value (`public.ecr.aws/succinct-labs/sp1-gpu:8fd1ef7`) does not have this 5090 bug.