### PR TITLE
feat(prover): Use reqwest to download vkeys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2773,20 +2773,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
-name = "downloader"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac1e888d6830712d565b2f3a974be3200be9296bc1b03db8251a4cbf18a4a34"
-dependencies = [
- "digest 0.10.7",
- "futures",
- "rand 0.8.5",
- "reqwest",
- "thiserror 1.0.69",
- "tokio",
-]
-
-[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5875,6 +5861,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes 1.10.1",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2 0.4.10",
@@ -7153,7 +7140,6 @@ dependencies = [
  "bincode",
  "clap",
  "dirs",
- "downloader",
  "enum-map",
  "eyre",
  "hashbrown 0.14.5",
@@ -7170,6 +7156,7 @@ dependencies = [
  "p3-symmetric",
  "p3-util",
  "rayon",
+ "reqwest",
  "serde",
  "serde_json",
  "serial_test",

--- a/crates/prover/Cargo.toml
+++ b/crates/prover/Cargo.toml
@@ -47,9 +47,9 @@ hashbrown = { workspace = true, features = ["inline-more"] }
 enum-map = { version = "2.7.3" }
 
 [build-dependencies]
-downloader = { version = "0.2", default-features = false, features = [
+reqwest = { version = "0.12", default-features = false, features = [
   "rustls-tls",
-  "verify",
+  "blocking",
 ] }
 sha2 = { version = "0.10" }
 hex = "0.4"


### PR DESCRIPTION
The patch uses the `reqwest` crate rather than `downloader` to build `sp1-prover`.

See https://github.com/succinctlabs/sp1/issues/2506 for context.