### PR TITLE
fix: prevent possible panic from copy_from_slice in HashableKey::bytes32_raw

### DIFF
--- a/crates/prover/src/types.rs
+++ b/crates/prover/src/types.rs
@@ -67,7 +67,8 @@ pub trait HashableKey {
         let vkey_digest_bn254 = self.hash_bn254();
         let vkey_bytes = vkey_digest_bn254.as_canonical_biguint().to_bytes_be();
         let mut result = [0u8; 32];
-        result[1..].copy_from_slice(&vkey_bytes);
+        let start = result.len() - vkey_bytes.len();
+        result[start..].copy_from_slice(&vkey_bytes);
         result
     }
 


### PR DESCRIPTION

## Motivation

```rust
let vkey_bytes = vkey_digest_bn254.as_canonical_biguint().to_bytes_be();
...
result[1..].copy_from_slice(&vkey_bytes);
```

It's not guaranteed that `vkey_bytes` has 31 bytes.
If it has 30 bytes, or less, `.copy_from_slice` will panic.

## Solution

Use the correct offset.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes