### PR TITLE
fix(network): validate fulfillment strategy in request path

### DIFF
--- a/crates/sdk/src/network/prover.rs
+++ b/crates/sdk/src/network/prover.rs
@@ -575,6 +575,9 @@ impl NetworkProver {
         treasury: Option<Address>,
         max_price_per_pgu: Option<u64>,
     ) -> Result<B256> {
+        super::validation::validate_strategy_compatibility(self.network_mode(), strategy)
+            .map_err(|e| anyhow::anyhow!("{}", e))?;
+
         let vk_hash = self.register_program(&pk.vk, &pk.elf).await?;
         let (cycle_limit, gas_limit, public_values_hash) =
             self.get_execution_limits(cycle_limit, gas_limit, &pk.elf, stdin, skip_simulation)?;


### PR DESCRIPTION
## Motivation

missing validation in request async

request_async() in crates/sdk/src/network/prove.rs does not validate strategy compatibility, while run_async() does.
Location: 
NetworkProveBuilder::request_async() calls self.prover.request_proof_impl(...) directly without prior validation, unlike NetworkProveBuilder::run_async() which calls validation::validate_strategy_compatibility(...) first (prove.rs, lines 649-653 vs. 590-610).

## Solution

Centralize fulfillment strategy vs. network mode validation in NetworkProver::request_proof_impl()

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes