### PR TITLE
fix: enforce one-hot operation flags in BaseAlu eval

### DIFF
--- a/crates/recursion/core/src/chips/alu_base.rs
+++ b/crates/recursion/core/src/chips/alu_base.rs
@@ -209,6 +209,10 @@ where
         ) in zip(local.values, prep_local.accesses)
         {
             // Check exactly one flag is enabled.
+            builder.assert_bool(is_add.clone());
+            builder.assert_bool(is_sub.clone());
+            builder.assert_bool(is_mul.clone());
+            builder.assert_bool(is_div.clone());
             let is_real = is_add + is_sub + is_mul + is_div;
             builder.assert_bool(is_real.clone());
 

--- a/crates/recursion/core/src/chips/alu_ext.rs
+++ b/crates/recursion/core/src/chips/alu_ext.rs
@@ -214,6 +214,10 @@ where
             let out = vals.out.as_extension::<AB>();
 
             // Check exactly one flag is enabled.
+            builder.assert_bool(is_add.clone());
+            builder.assert_bool(is_sub.clone());
+            builder.assert_bool(is_mul.clone());
+            builder.assert_bool(is_div.clone());
             let is_real = is_add + is_sub + is_mul + is_div;
             builder.assert_bool(is_real.clone());
 


### PR DESCRIPTION
The problem:
We only checked the Boolean value of the sum of the operation flags (is_add + is_sub + is_mul + is_div), rather than each flag individually. This allowed the prover to set a non-strict one-hot set of flags: for example, to make is_add = a, is_sub = 1 - a when is_real = 1, that is, to activate two flags at once in a linear combination, which violates the semantics of “exactly one operation performed” and could simultaneously attach several when(...) constraints on the same in1/in2/out.

The solution: 
Explicitly assert the Boolean value of each flag and separately check that the sum of the flags is Boolean. As a result, in a real string, exactly one flag is equal to 1, while in padding, all flags are equal to 0; the behavior now corresponds to the intended one-hot logic.