### PR TITLE
chore: bump SP1 to v5.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6871,7 +6871,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-build"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -6883,7 +6883,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cli"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -6912,7 +6912,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -6955,7 +6955,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-machine"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "bincode",
  "cbindgen",
@@ -7013,7 +7013,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cuda"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "bincode",
  "ctrlc",
@@ -7031,7 +7031,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -7053,7 +7053,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-derive"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -7061,7 +7061,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-eval"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "anyhow",
  "bincode",
@@ -7079,14 +7079,14 @@ dependencies = [
 
 [[package]]
 name = "sp1-helper"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "sp1-build",
 ]
 
 [[package]]
 name = "sp1-lib"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "bincode",
  "elliptic-curve",
@@ -7096,7 +7096,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-perf"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "bincode",
  "clap",
@@ -7116,7 +7116,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "bincode",
  "blake3",
@@ -7134,7 +7134,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "anyhow",
  "bincode",
@@ -7179,7 +7179,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-circuit"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "ff 0.13.1",
  "hashbrown 0.14.5",
@@ -7217,7 +7217,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-compiler"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "backtrace",
  "criterion",
@@ -7242,7 +7242,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-core"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "backtrace",
  "cbindgen",
@@ -7285,7 +7285,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-derive"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -7293,7 +7293,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-cli"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "bincode",
  "clap",
@@ -7302,7 +7302,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-ffi"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "anyhow",
  "bincode",
@@ -7326,7 +7326,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-sdk"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -7379,7 +7379,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-stark"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "arrayref",
  "hashbrown 0.14.5",
@@ -7412,7 +7412,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-verifier"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -7443,7 +7443,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "blake3",
  "cfg-if",
@@ -7795,7 +7795,7 @@ dependencies = [
 
 [[package]]
 name = "test-artifacts"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "sp1-build",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "5.2.3"
+version = "5.2.4"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/succinctlabs/sp1"
@@ -49,27 +49,27 @@ debug-assertions = true
 
 [workspace.dependencies]
 # sp1
-sp1-build = { path = "crates/build", version = "5.2.3" }
-sp1-cli = { path = "crates/cli", version = "5.2.3", default-features = false }
-sp1-core-machine = { path = "crates/core/machine", version = "5.2.3", default-features = false }
-sp1-core-executor = { path = "crates/core/executor", version = "5.2.3" }
-sp1-curves = { path = "crates/curves", version = "5.2.3" }
-sp1-derive = { path = "crates/derive", version = "5.2.3" }
-sp1-eval = { path = "crates/eval", version = "5.2.3" }
-sp1-helper = { path = "crates/helper", version = "5.2.3", default-features = false }
-sp1-primitives = { path = "crates/primitives", version = "5.2.3" }
-sp1-prover = { path = "crates/prover", version = "5.2.3" }
-sp1-recursion-compiler = { path = "crates/recursion/compiler", version = "5.2.3" }
-sp1-recursion-core = { path = "crates/recursion/core", version = "5.2.3", default-features = false }
-sp1-recursion-derive = { path = "crates/recursion/derive", version = "5.2.3", default-features = false }
-sp1-recursion-gnark-ffi = { path = "crates/recursion/gnark-ffi", version = "5.2.3", default-features = false }
-sp1-recursion-circuit = { path = "crates/recursion/circuit", version = "5.2.3", default-features = false }
-sp1-sdk = { path = "crates/sdk", version = "5.2.3" }
-sp1-cuda = { path = "crates/cuda", version = "5.2.3" }
-sp1-stark = { path = "crates/stark", version = "5.2.3" }
-sp1-lib = { path = "crates/zkvm/lib", version = "5.2.3", default-features = false }
-sp1-zkvm = { path = "crates/zkvm/entrypoint", version = "5.2.3", default-features = false }
-sp1-verifier = { path = "crates/verifier", version = "5.2.3", default-features = false }
+sp1-build = { path = "crates/build", version = "5.2.4" }
+sp1-cli = { path = "crates/cli", version = "5.2.4", default-features = false }
+sp1-core-machine = { path = "crates/core/machine", version = "5.2.4", default-features = false }
+sp1-core-executor = { path = "crates/core/executor", version = "5.2.4" }
+sp1-curves = { path = "crates/curves", version = "5.2.4" }
+sp1-derive = { path = "crates/derive", version = "5.2.4" }
+sp1-eval = { path = "crates/eval", version = "5.2.4" }
+sp1-helper = { path = "crates/helper", version = "5.2.4", default-features = false }
+sp1-primitives = { path = "crates/primitives", version = "5.2.4" }
+sp1-prover = { path = "crates/prover", version = "5.2.4" }
+sp1-recursion-compiler = { path = "crates/recursion/compiler", version = "5.2.4" }
+sp1-recursion-core = { path = "crates/recursion/core", version = "5.2.4", default-features = false }
+sp1-recursion-derive = { path = "crates/recursion/derive", version = "5.2.4", default-features = false }
+sp1-recursion-gnark-ffi = { path = "crates/recursion/gnark-ffi", version = "5.2.4", default-features = false }
+sp1-recursion-circuit = { path = "crates/recursion/circuit", version = "5.2.4", default-features = false }
+sp1-sdk = { path = "crates/sdk", version = "5.2.4" }
+sp1-cuda = { path = "crates/cuda", version = "5.2.4" }
+sp1-stark = { path = "crates/stark", version = "5.2.4" }
+sp1-lib = { path = "crates/zkvm/lib", version = "5.2.4", default-features = false }
+sp1-zkvm = { path = "crates/zkvm/entrypoint", version = "5.2.4", default-features = false }
+sp1-verifier = { path = "crates/verifier", version = "5.2.4", default-features = false }
 
 # For testing.
 test-artifacts = { path = "crates/test-artifacts" }

--- a/crates/prover/Cargo.toml
+++ b/crates/prover/Cargo.toml
@@ -11,21 +11,22 @@ categories = { workspace = true }
 exclude = ["src/vk_map.bin"]
 
 [dependencies]
-p3-matrix = { workspace = true }
 sp1-recursion-compiler = { workspace = true }
 sp1-recursion-core = { workspace = true, default-features = true }
 sp1-recursion-circuit = { workspace = true }
 sp1-recursion-gnark-ffi = { workspace = true }
 sp1-core-machine = { workspace = true, default-features = true }
 sp1-stark = { workspace = true }
-p3-symmetric = { workspace = true }
 sp1-core-executor = { workspace = true }
 sp1-primitives = { workspace = true }
+sp1-verifier = { workspace = true }
 p3-field = { workspace = true }
 p3-challenger = { workspace = true }
 p3-baby-bear = { workspace = true }
 p3-bn254-fr = { workspace = true }
 p3-commit = { workspace = true }
+p3-matrix = { workspace = true }
+p3-symmetric = { workspace = true }
 p3-util = { workspace = true }
 bincode = "1.3.3"
 serde = { workspace = true, features = ["derive", "rc"] }

--- a/crates/test-artifacts/programs/Cargo.lock
+++ b/crates/test-artifacts/programs/Cargo.lock
@@ -346,7 +346,7 @@ version = "1.1.0"
 dependencies = [
  "common-test-utils",
  "sp1-curves",
- "sp1-lib 5.2.3",
+ "sp1-lib 5.2.4",
  "sp1-zkvm",
 ]
 
@@ -389,7 +389,7 @@ name = "bls12381-mul-test"
 version = "1.1.0"
 dependencies = [
  "sp1-derive",
- "sp1-lib 5.2.3",
+ "sp1-lib 5.2.4",
  "sp1-zkvm",
 ]
 
@@ -399,7 +399,7 @@ version = "1.1.0"
 dependencies = [
  "common-test-utils",
  "sp1-curves",
- "sp1-lib 5.2.3",
+ "sp1-lib 5.2.4",
  "sp1-zkvm",
 ]
 
@@ -442,7 +442,7 @@ name = "bn254-mul-test"
 version = "1.1.0"
 dependencies = [
  "sp1-derive",
- "sp1-lib 5.2.3",
+ "sp1-lib 5.2.4",
  "sp1-zkvm",
 ]
 
@@ -512,7 +512,7 @@ name = "common-test-utils"
 version = "1.1.0"
 dependencies = [
  "num-bigint",
- "sp1-lib 5.2.3",
+ "sp1-lib 5.2.4",
 ]
 
 [[package]]
@@ -2347,7 +2347,7 @@ version = "1.1.0"
 dependencies = [
  "common-test-utils",
  "sp1-curves",
- "sp1-lib 5.2.3",
+ "sp1-lib 5.2.4",
  "sp1-zkvm",
 ]
 
@@ -2383,7 +2383,7 @@ dependencies = [
  "num",
  "p256",
  "sp1-curves",
- "sp1-lib 5.2.3",
+ "sp1-lib 5.2.4",
  "sp1-zkvm",
 ]
 
@@ -2404,7 +2404,7 @@ dependencies = [
  "num",
  "p256",
  "sp1-curves",
- "sp1-lib 5.2.3",
+ "sp1-lib 5.2.4",
  "sp1-zkvm",
 ]
 
@@ -2619,7 +2619,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -2639,7 +2639,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-derive"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -2657,7 +2657,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "bincode",
  "elliptic-curve",
@@ -2667,7 +2667,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "bincode",
  "blake3",
@@ -2685,7 +2685,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-stark"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "arrayref",
  "hashbrown 0.14.5",
@@ -2717,7 +2717,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "cfg-if",
  "getrandom 0.2.16",
@@ -2728,7 +2728,7 @@ dependencies = [
  "p3-field",
  "rand 0.8.5",
  "sha2 0.10.9",
- "sp1-lib 5.2.3",
+ "sp1-lib 5.2.4",
  "sp1-primitives",
 ]
 

--- a/crates/test-artifacts/programs/fibonacci-blake3/Cargo.lock
+++ b/crates/test-artifacts/programs/fibonacci-blake3/Cargo.lock
@@ -446,7 +446,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sp1-lib"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "bincode",
  "serde",
@@ -455,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "bincode",
  "blake3",
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "blake3",
  "cfg-if",

--- a/crates/verifier/guest-verify-programs/Cargo.lock
+++ b/crates/verifier/guest-verify-programs/Cargo.lock
@@ -596,7 +596,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sp1-lib"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "bincode",
  "elliptic-curve",
@@ -606,7 +606,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "bincode",
  "blake3",
@@ -624,7 +624,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-verifier"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "blake3",
  "cfg-if",
@@ -637,7 +637,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "blake3",
  "cfg-if",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -2266,20 +2266,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
-name = "downloader"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac1e888d6830712d565b2f3a974be3200be9296bc1b03db8251a4cbf18a4a34"
-dependencies = [
- "digest 0.10.7",
- "futures",
- "rand 0.8.5",
- "reqwest",
- "thiserror 1.0.69",
- "tokio",
-]
-
-[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4985,6 +4971,7 @@ checksum = "e98ff6b0dbbe4d5a37318f433d4fc82babd21631f194d370409ceb2e40b2f0b5"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "http 1.3.1",
@@ -5833,7 +5820,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-build"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -5845,7 +5832,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -5882,7 +5869,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-machine"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "bincode",
  "cbindgen",
@@ -5936,7 +5923,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cuda"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "bincode",
  "ctrlc",
@@ -5951,7 +5938,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -5971,7 +5958,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-derive"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -5979,7 +5966,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "bincode",
  "elliptic-curve",
@@ -5989,7 +5976,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "bincode",
  "blake3",
@@ -6007,13 +5994,12 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "anyhow",
  "bincode",
  "clap",
  "dirs",
- "downloader",
  "enum-map",
  "eyre",
  "hashbrown 0.14.5",
@@ -6030,6 +6016,7 @@ dependencies = [
  "p3-symmetric",
  "p3-util",
  "rayon",
+ "reqwest",
  "serde",
  "serde_json",
  "serial_test",
@@ -6042,6 +6029,7 @@ dependencies = [
  "sp1-recursion-core",
  "sp1-recursion-gnark-ffi",
  "sp1-stark",
+ "sp1-verifier",
  "thiserror 1.0.69",
  "tracing",
  "tracing-appender",
@@ -6050,7 +6038,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-circuit"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "hashbrown 0.14.5",
  "itertools 0.13.0",
@@ -6083,7 +6071,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-compiler"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "backtrace",
  "itertools 0.13.0",
@@ -6103,7 +6091,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-core"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "backtrace",
  "cbindgen",
@@ -6144,7 +6132,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-derive"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -6152,7 +6140,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-ffi"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6176,7 +6164,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-sdk"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "alloy-primitives 1.1.2",
  "alloy-signer",
@@ -6227,7 +6215,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-stark"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "arrayref",
  "hashbrown 0.14.5",
@@ -6259,7 +6247,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-verifier"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "blake3",
  "cfg-if",
@@ -6272,7 +6260,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "cfg-if",
  "critical-section",

--- a/patch-testing/Cargo.lock
+++ b/patch-testing/Cargo.lock
@@ -1245,20 +1245,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
-name = "downloader"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac1e888d6830712d565b2f3a974be3200be9296bc1b03db8251a4cbf18a4a34"
-dependencies = [
- "digest 0.10.7",
- "futures",
- "rand 0.8.5",
- "reqwest",
- "thiserror 1.0.69",
- "tokio",
-]
-
-[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3548,7 +3534,9 @@ dependencies = [
  "base64",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "h2",
  "http",
  "http-body",
@@ -4194,7 +4182,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-build"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -4206,7 +4194,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -4243,7 +4231,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-machine"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "bincode",
  "cbindgen",
@@ -4297,7 +4285,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cuda"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "bincode",
  "ctrlc",
@@ -4312,7 +4300,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -4332,7 +4320,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-derive"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -4340,7 +4328,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "bincode",
  "elliptic-curve",
@@ -4350,7 +4338,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "bincode",
  "blake3",
@@ -4368,13 +4356,12 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "anyhow",
  "bincode",
  "clap",
  "dirs",
- "downloader",
  "enum-map",
  "eyre",
  "hashbrown 0.14.5",
@@ -4391,6 +4378,7 @@ dependencies = [
  "p3-symmetric",
  "p3-util",
  "rayon",
+ "reqwest",
  "serde",
  "serde_json",
  "serial_test",
@@ -4403,6 +4391,7 @@ dependencies = [
  "sp1-recursion-core",
  "sp1-recursion-gnark-ffi",
  "sp1-stark",
+ "sp1-verifier",
  "thiserror 1.0.69",
  "tracing",
  "tracing-appender",
@@ -4411,7 +4400,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-circuit"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "hashbrown 0.14.5",
  "itertools 0.13.0",
@@ -4444,7 +4433,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-compiler"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "backtrace",
  "itertools 0.13.0",
@@ -4464,7 +4453,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-core"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "backtrace",
  "cbindgen",
@@ -4505,7 +4494,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-derive"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -4513,7 +4502,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-ffi"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4537,7 +4526,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-sdk"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "alloy-sol-types",
  "anyhow",
@@ -4571,7 +4560,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-stark"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "arrayref",
  "hashbrown 0.14.5",
@@ -4627,8 +4616,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp1-verifier"
+version = "5.2.4"
+dependencies = [
+ "blake3",
+ "cfg-if",
+ "hex",
+ "lazy_static",
+ "sha2 0.10.9",
+ "substrate-bn-succinct",
+ "thiserror 2.0.16",
+]
+
+[[package]]
 name = "sp1-zkvm"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "cfg-if",
  "getrandom 0.2.16",
@@ -4726,6 +4728,23 @@ dependencies = [
 name = "substrate-bn"
 version = "0.6.0"
 source = "git+https://github.com/sp1-patches/bn?tag=patch-0.6.0-sp1-5.0.0#e0d67f219b2ad6a1887e3275b7ba09ada4b1afb6"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "cfg-if",
+ "crunchy",
+ "lazy_static",
+ "num-bigint 0.4.6",
+ "rand 0.8.5",
+ "rustc-hex",
+ "sp1-lib",
+]
+
+[[package]]
+name = "substrate-bn-succinct"
+version = "0.6.0-v5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ba32f1b74728f92887c3ad17c42bf82998eb52c9091018f35294e9cd388b0c8"
 dependencies = [
  "bytemuck",
  "byteorder",

--- a/patch-testing/secp256k1/program-v0.29.1/Cargo.lock
+++ b/patch-testing/secp256k1/program-v0.29.1/Cargo.lock
@@ -640,7 +640,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "bincode",
  "elliptic-curve",
@@ -650,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "bincode",
  "blake3",
@@ -668,7 +668,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "cfg-if",
  "getrandom 0.2.15",

--- a/patch-testing/secp256k1/program-v0.30.0/Cargo.lock
+++ b/patch-testing/secp256k1/program-v0.30.0/Cargo.lock
@@ -667,7 +667,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "bincode",
  "elliptic-curve",
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "bincode",
  "blake3",
@@ -695,7 +695,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "5.2.3"
+version = "5.2.4"
 dependencies = [
  "cfg-if",
  "getrandom 0.2.15",


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

A new release is needed with #2515

## Solution

* Bump SP1 to v5.2.4
* Add `sp1-verifier` as dep of `sp1-prover` as release-plz don't order releases correctly when there is only a dev dependency

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes