### PR TITLE
fix(recursion): set is_sub_builder flag in new_sub_builder

### DIFF
--- a/crates/recursion/compiler/src/ir/builder.rs
+++ b/crates/recursion/compiler/src/ir/builder.rs
@@ -89,6 +89,7 @@ impl<C: Config> Builder<C> {
         builder.nb_public_values = nb_public_values;
         builder.p2_hash_num = p2_hash_num;
         builder.debug = debug;
+        builder.is_sub_builder = true;
 
         builder
     }
@@ -431,7 +432,6 @@ impl<C: Config> Builder<C> {
 
     /// Register and commits a felt as public value.  This value will be constrained when verified.
     pub fn commit_public_value(&mut self, val: Felt<C::F>) {
-        assert!(!self.is_sub_builder, "Cannot commit to a public value with a sub builder");
         if self.nb_public_values.is_none() {
             self.nb_public_values = Some(self.eval(C::N::zero()));
         }


### PR DESCRIPTION
## Motivation

The `is_sub_builder` flag was never being set to `true` when creating sub-builders via `new_sub_builder()`. This meant all the assert guards in `witness_var()`, `witness_felt()`, `witness_ext()`, and `commit_public_value()` were effectively dead code - they could never trigger.

This is problematic because `witness_*` functions use local counters (`witness_var_count`, etc.) that start at 0 in each sub-builder,
creating index conflicts if called from within loops or conditionals.


## Solution

- Set `is_sub_builder = true` in `new_sub_builder()` so the protection actually works
- Remove the assert from `commit_public_value()` since it's safely called from sub-builders inside `commit_public_values()` (the `nb_public_values` variable is properly shared between builders)

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes