### PR TITLE
chore: update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/docker-gnark.yml
+++ b/.github/workflows/docker-gnark.yml
@@ -30,7 +30,7 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup CI
         uses: ./.github/actions/setup

--- a/.github/workflows/docker-publish-gnark.yml
+++ b/.github/workflows/docker-publish-gnark.yml
@@ -27,7 +27,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Docker BuildX
         uses: docker/setup-buildx-action@v3
       - name: Log into registry ${{ env.REGISTRY }}
@@ -55,7 +55,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Docker BuildX
         uses: docker/setup-buildx-action@v3
       - name: Log into registry ${{ env.REGISTRY }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - name: Checkout repository
         id: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Docker BuildX
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/executor-suite.yml
+++ b/.github/workflows/executor-suite.yml
@@ -35,13 +35,13 @@ jobs:
       ]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup CI
         uses: ./.github/actions/setup
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_S3 }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_S3 }}
@@ -85,13 +85,13 @@ jobs:
       ]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup CI
         uses: ./.github/actions/setup
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_S3 }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_S3 }}
@@ -135,13 +135,13 @@ jobs:
       ]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup CI
         uses: ./.github/actions/setup
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_S3 }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_S3 }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup CI
         uses: ./.github/actions/setup
@@ -74,7 +74,7 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup CI
         uses: ./.github/actions/setup
@@ -114,7 +114,7 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup CI
         uses: ./.github/actions/setup
@@ -154,7 +154,7 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup CI
         uses: ./.github/actions/setup
@@ -200,7 +200,7 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup CI
         uses: ./.github/actions/setup
@@ -242,7 +242,7 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup CI
         uses: ./.github/actions/setup
@@ -280,7 +280,7 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup CI
         uses: ./.github/actions/setup
@@ -323,7 +323,7 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup CI
         uses: ./.github/actions/setup
@@ -352,7 +352,7 @@ jobs:
   #     CARGO_NET_GIT_FETCH_WITH_CLI: "true"
   #   steps:
   #     - name: Checkout sources
-  #       uses: actions/checkout@v4
+  #       uses: actions/checkout@v6
 
   #     - name: Setup CI
   #       uses: ./.github/actions/setup

--- a/.github/workflows/patch-testing-cycles.yml
+++ b/.github/workflows/patch-testing-cycles.yml
@@ -15,7 +15,7 @@ jobs:
       issues: write
     steps:
       - name: "Checkout sources"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v6"
         with:
           fetch-depth: 0  
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -37,7 +37,7 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup CI
         uses: ./.github/actions/setup
@@ -100,7 +100,7 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup CI
         uses: ./.github/actions/setup
@@ -163,7 +163,7 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup CI
         uses: ./.github/actions/setup
@@ -197,7 +197,7 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup CI
         uses: ./.github/actions/setup
@@ -236,7 +236,7 @@ jobs:
       RUSTFLAGS: "--cfg sp1_debug_constraints"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup CI
         uses: ./.github/actions/setup
@@ -276,7 +276,7 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup CI
         uses: ./.github/actions/setup
@@ -324,7 +324,7 @@ jobs:
   #     CARGO_NET_GIT_FETCH_WITH_CLI: "true"
   #   steps:
   #     - name: Checkout sources
-  #       uses: actions/checkout@v4
+  #       uses: actions/checkout@v6
 
   #     - name: Setup CI
   #       uses: ./.github/actions/setup
@@ -364,7 +364,7 @@ jobs:
   #     fail-fast: false
   #   steps:
   #     - name: Checkout Actions Repository
-  #       uses: actions/checkout@v4
+  #       uses: actions/checkout@v6
   
   #     - name: Install Rust toolchain
   #       uses: dtolnay/rust-toolchain@stable
@@ -395,7 +395,7 @@ jobs:
   #     CARGO_NET_GIT_FETCH_WITH_CLI: "true"
   #   steps:
   #     - name: "Checkout sources"
-  #       uses: "actions/checkout@v4"
+  #       uses: "actions/checkout@v6"
 
   #     - name: Setup CI
   #       uses: ./.github/actions/setup
@@ -428,7 +428,7 @@ jobs:
   #   runs-on: [runs-on, runner=16cpu-linux-x64, disk=large, "run-id=${{ github.run_id }}"]
   #   steps:
   #     - name: "Checkout sources"
-  #       uses: "actions/checkout@v4"
+  #       uses: "actions/checkout@v6"
 
   #     - name: "Setup CI"
   #       uses: ./.github/actions/setup
@@ -455,7 +455,7 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup CI
         uses: ./.github/actions/setup
@@ -512,7 +512,7 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup CI
         uses: ./.github/actions/setup

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Install Rust toolchain

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       release_name: ${{ steps.release_info.outputs.release_name }}
       changelog: ${{ steps.build_changelog.outputs.changelog }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -107,7 +107,7 @@ jobs:
           #   platform: win32
           #   arch: amd64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # Install rust and go
       - name: Install rust
@@ -236,7 +236,7 @@ jobs:
             arch: x86_64
     steps:
       # Note: We need to checkout the repo in order to upload artifacts to the release.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}
 
@@ -312,7 +312,7 @@ jobs:
     needs: [sp1-gpu-server-release, cargo-prove-release, prepare]
     if: ${{ success() && inputs.prerelease != true }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set latest release
         env:
@@ -342,7 +342,7 @@ jobs:
     runs-on: "${{ matrix.runner }}"
     steps:
       - name: "Checkout source code"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v6"
 
       - name: "Install SP1"
         run: |
@@ -395,7 +395,7 @@ jobs:
     needs: [sp1-gpu-server-release, cargo-prove-release, prepare]
     if: failure()
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # todo remove this and use GH cli to create the issue
       - uses: JasonEtco/create-an-issue@v2
@@ -414,7 +414,7 @@ jobs:
     needs: [sp1-gpu-server-release, cargo-prove-release, prepare]
     if: failure()
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Delete failed release
         env:

--- a/.github/workflows/suite.yml
+++ b/.github/workflows/suite.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Checkout sources
         if: steps.sp1-perf-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup CI
         if: steps.sp1-perf-cache.outputs.cache-hit != 'true'
@@ -105,7 +105,7 @@ jobs:
 
       - name: Checkout sources
         if: steps.sp1-perf-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup CI
         if: steps.sp1-perf-cache.outputs.cache-hit != 'true'
@@ -182,7 +182,7 @@ jobs:
 
       - name: Checkout sources
         if: steps.sp1-gpu-server-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup CI
         if: steps.sp1-gpu-server-cache.outputs.cache-hit != 'true'
@@ -223,7 +223,7 @@ jobs:
           key: ${{ needs.build-sp1-perf-avx512.outputs.cache-key }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_S3 }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_S3 }}
@@ -308,7 +308,7 @@ jobs:
           nvidia-smi
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_S3 }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_S3 }}
@@ -363,7 +363,7 @@ jobs:
           key: ${{ needs.build-sp1-perf-avx512.outputs.cache-key }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_S3 }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_S3 }}

--- a/.github/workflows/toolchain-ec2.yml
+++ b/.github/workflows/toolchain-ec2.yml
@@ -42,7 +42,7 @@ jobs:
       # - ec2:DescribeInstances
       # - ec2:DescribeInstanceStatus
       - name: "Configure AWS credentials"
-        uses: "aws-actions/configure-aws-credentials@v1"
+        uses: "aws-actions/configure-aws-credentials@v4"
         with:
           aws-access-key-id: "${{ secrets.AWS_ACCESS_KEY_ID }}"
           aws-secret-access-key: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
@@ -82,7 +82,7 @@ jobs:
           fi
 
       - name: "Checkout"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v6"
 
       - name: "Install Rust"
         run: |
@@ -119,7 +119,7 @@ jobs:
 
     steps:
       - name: "Configure AWS credentials"
-        uses: "aws-actions/configure-aws-credentials@v1"
+        uses: "aws-actions/configure-aws-credentials@v4"
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Changes in the PR:
+ actions/checkout: v4 -> v6
+ aws-actions/configure-aws-credentials: v1 -> v4

This fixes the EC2 runner failures where the PAT couldn't register
self-hosted runners due to outdated action versions.