### PR TITLE
fix: clippy warning

### DIFF
--- a/crates/core/executor/src/vm.rs
+++ b/crates/core/executor/src/vm.rs
@@ -1,3 +1,6 @@
+#![allow(unknown_lints)]
+#![allow(clippy::manual_checked_ops)]
+
 use crate::{
     events::{MemoryAccessPosition, MemoryReadRecord, MemoryRecord, MemoryWriteRecord},
     vm::{


### PR DESCRIPTION
Allow manual checked div in the `executor/vm.rs` module for predictable codegen