### PR TITLE
fix(sdk): Remove dangerous -P flag from tar extraction

### DIFF
--- a/crates/sdk/src/install.rs
+++ b/crates/sdk/src/install.rs
@@ -97,7 +97,7 @@ pub fn install_circuit_artifacts(build_dir: PathBuf, artifacts_type: &str) {
     // Extract the tarball to the build directory.
     let mut res = Command::new("tar")
         .args([
-            "-Pxzf",
+            "-xzf",
             artifacts_tar_gz_file.path().to_str().unwrap(),
             "-C",
             build_dir.to_str().unwrap(),


### PR DESCRIPTION
The use of the `-P` flag in the tar command during SDK installation allows absolute paths in the archive, which could lead to arbitrary file overwrites. This PR removes the flag to prevent this vulnerability.