### PR TITLE
perf(eval): remove redundant get_cycles call in run_evaluation

### DIFF
--- a/crates/eval/src/lib.rs
+++ b/crates/eval/src/lib.rs
@@ -7,7 +7,7 @@ use slack_rust::{
     chat::post_message::{post_message, PostMessageRequest},
     http_client::default_client,
 };
-use sp1_prover::{components::SP1ProverComponents, utils::get_cycles, SP1Prover};
+use sp1_prover::{components::SP1ProverComponents, SP1Prover};
 use sp1_sdk::{SP1Context, SP1Stdin};
 use sp1_stark::SP1ProverOpts;
 use std::time::{Duration, Instant};
@@ -169,8 +169,6 @@ fn run_evaluation<C: SP1ProverComponents>(
     stdin: &SP1Stdin,
     opts: SP1ProverOpts,
 ) -> PerformanceReport {
-    let cycles = get_cycles(elf, stdin);
-
     let prover = SP1Prover::<C>::new();
     let (_, pk_d, program, vk) = prover.setup(elf);
 
@@ -186,6 +184,8 @@ fn run_evaluation<C: SP1ProverComponents>(
         Ok(proof) => (true, Some(proof)),
         Err(_) => (false, None),
     };
+
+    let cycles = core_proof_opt.as_ref().map_or(0, |proof| proof.cycles);
 
     let (compress_ok, compress_duration) = if let Some(core_proof) = core_proof_opt {
         let (compress_result, dur) =


### PR DESCRIPTION
## Motivation

[run_evaluation]https://github.com/succinctlabs/sp1/blob/fb566da65f3c0d3936f40fec0bf8d226f951c024/crates/eval/src/lib.rs#L166-L213 called [get_cycles()]https://github.com/succinctlabs/sp1/blob/fb566da65f3c0d3936f40fec0bf8d226f951c024/crates/prover/src/utils.rs#L100-L107 before the actual evaluation pipeline.
This function fully executes the RISC-V program just to obtain the cycle count. The same program is then executed two more times — by [prover.execute()]https://github.com/succinctlabs/sp1/blob/fb566da65f3c0d3936f40fec0bf8d226f951c024/crates/prover/src/lib.rs#L315-L375 and inside [prover.prove_core()]https://github.com/succinctlabs/sp1/blob/fb566da65f3c0d3936f40fec0bf8d226f951c024/crates/core/machine/src/utils/prove.rs#L46-L86 — making `get_cycles` a completely redundant full program emulation.

## Solution

Removed the `get_cycles()` call. The cycle count is now extracted from the `SP1CoreProof.cycles` field returned by `prove_core()`, which already contains the identical value.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes