### PR TITLE
fix: Execute program till the end when tracing mode is off.

### DIFF
--- a/crates/core/executor/src/minimal/arch/portable/mod.rs
+++ b/crates/core/executor/src/minimal/arch/portable/mod.rs
@@ -336,7 +336,9 @@ impl MinimalExecutor {
         self.input.push_back(input.to_vec());
     }
 
-    /// Execute the program. Returning a trace chunk if the program has not completed.
+    /// Execute the program. Returning a trace chunk if:
+    /// 1. The program has not completed.
+    /// 2. Tracing mode is on.
     #[allow(clippy::redundant_closure_for_method_calls)]
     pub fn execute_chunk(&mut self) -> Option<TraceChunkRaw> {
         if self.is_done() {
@@ -394,6 +396,13 @@ impl MinimalExecutor {
                     .collect(),
             )
         })
+    }
+
+    /// Run the program till the end.
+    pub fn run_to_end(&mut self) {
+        while !self.is_done() {
+            self.execute_chunk();
+        }
     }
 
     /// Check if the program has halted.

--- a/crates/core/executor/src/minimal/arch/x86_64/mod.rs
+++ b/crates/core/executor/src/minimal/arch/x86_64/mod.rs
@@ -90,7 +90,9 @@ impl MinimalExecutor {
         self.input.push_back(input.to_vec());
     }
 
-    /// Execute the program. Returning a trace chunk if the program has not completed.
+    /// Execute the program. Returning a trace chunk if:
+    /// 1. The program has not completed.
+    /// 2. Tracing mode is on.
     pub fn execute_chunk(&mut self) -> Option<TraceChunkRaw> {
         if !self.input.is_empty() {
             self.compiled.set_input_buffer(std::mem::take(&mut self.input));
@@ -98,6 +100,13 @@ impl MinimalExecutor {
 
         // SAFETY: The backend is assumed to output valid JIT functions.
         unsafe { self.compiled.call() }
+    }
+
+    /// Run the program till the end.
+    pub fn run_to_end(&mut self) {
+        while !self.is_done() {
+            self.execute_chunk();
+        }
     }
 
     /// Get the registers of the JIT function.

--- a/crates/core/executor/src/minimal/tests.rs
+++ b/crates/core/executor/src/minimal/tests.rs
@@ -63,7 +63,7 @@ mod differential_tests {
         let mut native_executor = NativeExecutor::new(program.clone(), false, None);
         let native_time = {
             let start = std::time::Instant::now();
-            while native_executor.execute_chunk().is_some() {}
+            native_executor.run_to_end();
             start.elapsed()
         };
 
@@ -71,7 +71,7 @@ mod differential_tests {
         let mut portable_executor = MinimalExecutor::new(program.clone(), false, None);
         let portable_time = {
             let start = std::time::Instant::now();
-            while portable_executor.execute_chunk().is_some() {}
+            portable_executor.run_to_end();
             start.elapsed()
         };
 
@@ -108,7 +108,7 @@ mod differential_tests {
         for i in 0..5 {
             portable_executor.with_input(&serialize(&vec![i; i]).unwrap());
         }
-        while portable_executor.execute_chunk().is_some() {}
+        portable_executor.run_to_end();
 
         // Run the native x86_64 executor
         let mut native_executor = NativeExecutor::new(program.clone(), false, None);
@@ -116,7 +116,7 @@ mod differential_tests {
         for i in 0..5 {
             native_executor.with_input(&serialize(&vec![i; i]).unwrap());
         }
-        while native_executor.execute_chunk().is_some() {}
+        native_executor.run_to_end();
 
         let (is_equal, report) = compare_states(
             &program,
@@ -268,8 +268,8 @@ mod differential_tests {
             let mut native = NativeExecutor::new(program.clone(), true, None);
             let native_rx = native.new_debug_receiver().expect("Failed to create debug receiver");
 
-            s.spawn(move || while portable.execute_chunk().is_some() {});
-            s.spawn(move || while native.execute_chunk().is_some() {});
+            s.spawn(move || portable.run_to_end());
+            s.spawn(move || native.run_to_end());
             s.spawn(move || {
                 let mut got_prev: Option<debug::State> = None;
                 let mut expected_prev: Option<debug::State> = None;

--- a/crates/core/jit/src/lib.rs
+++ b/crates/core/jit/src/lib.rs
@@ -259,6 +259,11 @@ impl JitFunction {
         })
     }
 
+    /// Return true if tracing mode is enabled
+    pub fn tracing(&self) -> bool {
+        self.trace_buf_size > 0
+    }
+
     /// Write the initial memory image to the JIT memory.
     ///
     /// # Panics
@@ -330,7 +335,7 @@ impl JitFunction {
         // Ensure the memory pointer is aligned to the alignment of the u64.
         let align_offset = self.memory.as_ptr().align_offset(std::mem::align_of::<u64>());
         let mem_ptr = self.memory.as_mut_ptr().add(align_offset);
-        let tracing = self.trace_buf_size > 0;
+        let tracing = self.tracing();
 
         // We want to skip any hints that the previous chunk read.
         let start_hint_lens = self.hints.len();

--- a/crates/core/machine/src/utils/test.rs
+++ b/crates/core/machine/src/utils/test.rs
@@ -28,7 +28,7 @@ pub async fn run_test(
     for buf in &inputs.buffer {
         executor.with_input(buf);
     }
-    while executor.execute_chunk().is_some() {}
+    executor.run_to_end();
     let public_values = SP1PublicValues::from(executor.public_values_stream());
 
     let _ = run_test_core(program, inputs, 21, 22).await?;
@@ -45,7 +45,7 @@ pub async fn run_test_small_trace(
     for buf in &inputs.buffer {
         executor.with_input(buf);
     }
-    while executor.execute_chunk().is_some() {}
+    executor.run_to_end();
     let public_values = SP1PublicValues::from(executor.public_values_stream());
 
     let _ = run_test_core(program, inputs, 20, 23).await?;

--- a/crates/prover/src/utils.rs
+++ b/crates/prover/src/utils.rs
@@ -75,7 +75,7 @@ pub fn get_cycles(elf: &[u8], stdin: &SP1Stdin) -> u64 {
     for buf in &stdin.buffer {
         executor.with_input(buf);
     }
-    while executor.execute_chunk().is_some() {}
+    executor.run_to_end();
     executor.global_clk()
 }
 


### PR DESCRIPTION
When tracing mode is off, MinimalExecutor::execute_chunk will always return None. So we cannot use the return value of execute_chunk to test if a program has terminated. This change introduces a new `run_to_end` method, and fix the code so SP1 correctly identifies termination.
