### PR TITLE
fix: dev clippy

### DIFF
--- a/.claude/skills/ci-clippy/SKILL.md
+++ b/.claude/skills/ci-clippy/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: ci-clippy
+description: Run the CI clippy and fmt checks (matching the GitHub Actions lint job) and fix any issues found.
+allowed-tools: Read, Grep, Glob, Bash, Edit
+---
+
+# Run CI Clippy & Fix Issues
+
+Run the same clippy and formatting checks as the CI lint job in `.github/workflows/pr.yml`, then fix any errors.
+
+## Steps
+
+1. Run formatting check:
+```
+cargo fmt --all -- --check
+```
+
+2. Run clippy with the CI flags:
+```
+cargo clippy --all-features --all-targets -- -D warnings -A incomplete-features
+```
+
+3. If either command reports errors, fix them:
+   - For fmt issues: run `cargo fmt --all` or manually fix formatting
+   - For clippy errors: read the relevant source files, understand the issue, and apply the minimal fix
+   - Re-run the failing check to confirm the fix
+
+4. Repeat until both commands pass cleanly.
+
+## Notes
+
+- Warnings from `clippy.toml` about unreachable types (e.g. `slop_koala_bear::*`) are informational and not errors.
+- `test-artifacts` build script warnings ("Skipping build due to clippy invocation") are expected.
+- The clippy command can take 4-5 minutes on a full rebuild. Use `--timeout 600000` when running via Bash.

--- a/crates/verifier/src/converter.rs
+++ b/crates/verifier/src/converter.rs
@@ -47,7 +47,7 @@ pub fn compress_g2_point_to_x(g2: &AffineG2) -> Result<[u8; 64], Error> {
 ///
 /// If this Fq element is part of a compressed point, the flag that indicates the sign of the
 /// y coordinate is also returned.
-pub fn deserialize_with_flags(buf: &[u8]) -> Result<(Fq, CompressedPointFlag), Error> {
+pub(crate) fn deserialize_with_flags(buf: &[u8]) -> Result<(Fq, CompressedPointFlag), Error> {
     if buf.len() != 32 {
         return Err(Error::InvalidXLength);
     };


### PR DESCRIPTION
## Summary
- Changed `pub fn deserialize_with_flags` to `pub(crate) fn deserialize_with_flags` in `crates/verifier/src/converter.rs` — the function returns `CompressedPointFlag` which is `pub(crate)`, so the function's visibility must match to satisfy the `private_interfaces` lint (`-D warnings` in CI).
- Added a `ci-clippy` Claude skill for running the CI lint checks.

## Test plan
- [x] `cargo clippy --all-features --all-targets -- -D warnings -A incomplete-features` passes
- [x] `cargo fmt --all -- --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)