### PR TITLE
feat: add iOS-specific TLS configuration for gRPC clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3346,7 +3346,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.5",
 ]
 
 [[package]]
@@ -5295,7 +5295,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.5",
 ]
 
 [[package]]
@@ -8343,6 +8343,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -8871,6 +8872,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.5",
 ]
 
 [[package]]

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -63,7 +63,6 @@ sp1-primitives = { workspace = true }
 sp1-prover-types = { workspace = true }
 sp1-recursion-gnark-ffi = { workspace = true }
 itertools = { workspace = true }
-tonic = { workspace = true, features = ["tls", "tls-roots"], optional = true }
 aws-config = { workspace = true, optional = true }
 aws-sdk-kms = { workspace = true, optional = true }
 rustls = { workspace = true, features = ["ring"], optional = true }
@@ -82,6 +81,11 @@ sha2 = { workspace = true }
 k256 = { workspace = true, features = ["serde"] } # Signing
 eventsource-stream = { workspace = true }         # SSE Extenstion for reqwest
 
+[target.'cfg(target_os = "ios")'.dependencies]
+tonic = { workspace = true, features = ["tls", "tls-webpki-roots"], optional = true }
+[target.'cfg(not(target_os = "ios"))'.dependencies]
+tonic = { workspace = true, features = ["tls", "tls-roots"], optional = true }
+
 [dev-dependencies]
 test-artifacts = { path = "../test-artifacts" }
 tokio = { workspace = true, features = ["macros", "rt"] }
@@ -91,7 +95,7 @@ rstest = { workspace = true }
 [features]
 default = []
 native-gnark = ["sp1-prover/native-gnark"]
-# TODO: Once alloy has a 1.* release, we can likely remove this feature flag, as there will be less 
+# TODO: Once alloy has a 1.* release, we can likely remove this feature flag, as there will be less
 # dependency resolution issues.
 network = [
   "dep:prost",

--- a/crates/sdk/src/network/grpc.rs
+++ b/crates/sdk/src/network/grpc.rs
@@ -16,6 +16,9 @@ pub fn configure_endpoint(addr: &str) -> Result<Endpoint, Error> {
 
     // Configure TLS if using HTTPS.
     if addr.starts_with("https://") {
+        #[cfg(target_os = "ios")]
+        let tls_config = ClientTlsConfig::new().with_webpki_roots();
+        #[cfg(not(target_os = "ios"))]
         let tls_config = ClientTlsConfig::new().with_enabled_roots();
         endpoint = endpoint.tls_config(tls_config)?;
     }

--- a/crates/sdk/src/prover/prove.rs
+++ b/crates/sdk/src/prover/prove.rs
@@ -16,6 +16,14 @@ pub struct SP1ProvingKey {
     pub(crate) elf: Elf,
 }
 
+impl SP1ProvingKey {
+    /// Creates a new `SP1ProvingKey` from a verifying key and ELF.
+    #[must_use]
+    pub fn new(vk: SP1VerifyingKey, elf: Elf) -> Self {
+        Self { vk, elf }
+    }
+}
+
 impl ProvingKey for SP1ProvingKey {
     fn verifying_key(&self) -> &SP1VerifyingKey {
         &self.vk


### PR DESCRIPTION
On iOS, native OS certificate roots are unavailable, causing gRPC TLS connections to fail. This PR fixes connectivity by using webpki bundled roots (`with_webpki_roots`) when targeting iOS, while keeping native roots on all other platforms.

Also adds a public `SP1ProvingKey::new` to allow construction a pk fron a vk and a ELF: On iOS I want to avoid `setup()`, so I (de)serialize the vk.