### PR TITLE
perf: make test-artifacts optional behind bench feature

### DIFF
--- a/crates/perf/Cargo.toml
+++ b/crates/perf/Cargo.toml
@@ -30,7 +30,7 @@ async-scoped = { workspace = true }
 thiserror = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }
-test-artifacts = { path = "../test-artifacts" }
+test-artifacts = { path = "../test-artifacts", optional = true }
 
 [[bin]]
 name = "sp1-perf"
@@ -45,6 +45,7 @@ name = "sp1-perf-setup"
 path = "src/setup.rs"
 
 [features]
+bench = ["dep:test-artifacts"]
 bigint-rug = ["sp1-core-executor/bigint-rug"]
 native-gnark = ["sp1-sdk/native-gnark"]
 network = ["sp1-sdk/network"]

--- a/crates/perf/src/setup.rs
+++ b/crates/perf/src/setup.rs
@@ -1,6 +1,7 @@
 use std::time::Instant;
 
 use sp1_sdk::{Prover, ProverClient};
+#[cfg(feature = "bench")]
 use test_artifacts::FIBONACCI_ELF;
 
 #[tokio::main]
@@ -12,8 +13,11 @@ async fn main() {
     let init_time = t.elapsed();
     tracing::info!("prover init time: {init_time:?}");
 
-    let t = Instant::now();
-    let _pk = client.setup(FIBONACCI_ELF).await.unwrap();
-    let setup_time = t.elapsed();
-    tracing::info!("setup time: {setup_time:?}");
+    #[cfg(feature = "bench")]
+    {
+        let t = Instant::now();
+        let _pk = client.setup(FIBONACCI_ELF).await.unwrap();
+        let setup_time = t.elapsed();
+        tracing::info!("setup time: {setup_time:?}");
+    }
 }


### PR DESCRIPTION
## Summary

`test-artifacts` pre-builds RISC-V programs using SP1's custom `succinct` Rust toolchain. `sp1-perf-executor` doesn't use it at all, and `sp1-perf-setup` only needs it to time the setup phase with `FIBONACCI_ELF`.

This PR gates the dependency behind an optional `bench` feature so that `sp1-perf-executor` and `sp1-perf-setup` can be built with a standard Rust toolchain in environments where the succinct toolchain isn't available (CI pipelines, external integrations, etc.).

## Changes

- `crates/perf/Cargo.toml`: mark `test-artifacts` as `optional = true`, add `bench = ["dep:test-artifacts"]` feature
- `crates/perf/src/setup.rs`: gate `use test_artifacts::FIBONACCI_ELF` and its usage block with `#[cfg(feature = "bench")]`

## Usage

```bash
# Build sp1-perf-executor or sp1-perf-setup — works with standard Rust toolchain
cargo build --bin sp1-perf-executor
cargo build --bin sp1-perf-setup

# Build sp1-perf-setup with full timing — requires succinct toolchain
cargo build --bin sp1-perf-setup --features bench
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)