### PR TITLE
perf(gnark-ffi): speed up plonk proving by caching circuit and keys

### DIFF
--- a/crates/recursion/gnark-ffi/go/sp1/prove_plonk.go
+++ b/crates/recursion/gnark-ffi/go/sp1/prove_plonk.go
@@ -3,61 +3,104 @@ package sp1
 import (
 	"bufio"
 	"encoding/json"
+	"fmt"
 	"os"
+	"sync"
+	"time"
 
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/backend/plonk"
+	"github.com/consensys/gnark/constraint"
 	"github.com/consensys/gnark/frontend"
 )
+
+// Global cache for the constraint system, proving key, and verifying key,
+// similar to prove_groth16.go.
+var globalPlonkMutex sync.RWMutex
+var globalPlonkScs constraint.ConstraintSystem = plonk.NewCS(ecc.BN254)
+var globalPlonkScsInitialized = false
+var globalPlonkPk plonk.ProvingKey = plonk.NewProvingKey(ecc.BN254)
+var globalPlonkPkInitialized = false
+var globalPlonkVk plonk.VerifyingKey = plonk.NewVerifyingKey(ecc.BN254)
+var globalPlonkVkInitialized = false
 
 func ProvePlonk(dataDir string, witnessPath string) Proof {
 	// Sanity check the required arguments have been provided.
 	if dataDir == "" {
 		panic("dataDirStr is required")
 	}
-	os.Setenv("CONSTRAINTS_JSON", dataDir+"/"+constraintsJsonFile)
 
-	// Read the R1CS.
-	scsFile, err := os.Open(dataDir + "/" + plonkCircuitPath)
-	if err != nil {
-		panic(err)
+	start := time.Now()
+	os.Setenv("CONSTRAINTS_JSON", dataDir+"/"+constraintsJsonFile)
+	fmt.Printf("Setting environment variables took %s\n", time.Since(start))
+
+	// Read the R1CS (cached globally after first call). `dataDir` is the path
+	// to the circuit artifacts directory and does not change during the lifetime
+	// of this server, so it is safe to cache these.
+	globalPlonkMutex.Lock()
+	if !globalPlonkScsInitialized {
+		start = time.Now()
+		scsFile, err := os.Open(dataDir + "/" + plonkCircuitPath)
+		if err != nil {
+			panic(err)
+		}
+		scsReader := bufio.NewReaderSize(scsFile, 1024*1024)
+		globalPlonkScs.ReadFrom(scsReader)
+		defer scsFile.Close()
+		globalPlonkScsInitialized = true
+		fmt.Printf("Reading R1CS took %s\n", time.Since(start))
 	}
-	scs := plonk.NewCS(ecc.BN254)
-	scs.ReadFrom(scsFile)
-	defer scsFile.Close()
+	globalPlonkMutex.Unlock()
 
 	// Read the proving key.
-	pkFile, err := os.Open(dataDir + "/" + plonkPkPath)
-	if err != nil {
-		panic(err)
+	globalPlonkMutex.Lock()
+	if !globalPlonkPkInitialized {
+		start = time.Now()
+		pkFile, err := os.Open(dataDir + "/" + plonkPkPath)
+		if err != nil {
+			panic(err)
+		}
+		pkReader := bufio.NewReaderSize(pkFile, 1024*1024)
+		globalPlonkPk.UnsafeReadFrom(pkReader)
+		defer pkFile.Close()
+		globalPlonkPkInitialized = true
+		fmt.Printf("Reading proving key took %s\n", time.Since(start))
 	}
-	pk := plonk.NewProvingKey(ecc.BN254)
-	bufReader := bufio.NewReaderSize(pkFile, 1024*1024)
-	pk.UnsafeReadFrom(bufReader)
-	defer pkFile.Close()
+	globalPlonkMutex.Unlock()
 
 	// Read the verifier key.
-	vkFile, err := os.Open(dataDir + "/" + plonkVkPath)
-	if err != nil {
-		panic(err)
+	globalPlonkMutex.Lock()
+	if !globalPlonkVkInitialized {
+		start = time.Now()
+		vkFile, err := os.Open(dataDir + "/" + plonkVkPath)
+		if err != nil {
+			panic(err)
+		}
+		globalPlonkVk.ReadFrom(vkFile)
+		defer vkFile.Close()
+		globalPlonkVkInitialized = true
+		fmt.Printf("Reading verifying key took %s\n", time.Since(start))
 	}
-	vk := plonk.NewVerifyingKey(ecc.BN254)
-	vk.ReadFrom(vkFile)
-	defer vkFile.Close()
+	globalPlonkMutex.Unlock()
 
+	start = time.Now()
 	// Read the file.
 	data, err := os.ReadFile(witnessPath)
 	if err != nil {
 		panic(err)
 	}
+	fmt.Printf("Reading witness file took %s\n", time.Since(start))
 
+	start = time.Now()
 	// Deserialize the JSON data into a slice of Instruction structs
 	var witnessInput WitnessInput
 	err = json.Unmarshal(data, &witnessInput)
 	if err != nil {
 		panic(err)
 	}
+	fmt.Printf("Deserializing JSON data took %s\n", time.Since(start))
 
+	start = time.Now()
 	// Generate the witness.
 	assignment := NewCircuit(witnessInput)
 	witness, err := frontend.NewWitness(&assignment, ecc.BN254.ScalarField())
@@ -68,18 +111,24 @@ func ProvePlonk(dataDir string, witnessPath string) Proof {
 	if err != nil {
 		panic(err)
 	}
+	fmt.Printf("Generating witness took %s\n", time.Since(start))
 
+	start = time.Now()
 	// Generate the proof.
-	proof, err := plonk.Prove(scs, pk, witness)
+	proof, err := plonk.Prove(globalPlonkScs, globalPlonkPk, witness)
 	if err != nil {
+		fmt.Printf("Error: %v\n", err)
 		panic(err)
 	}
+	fmt.Printf("Generating proof took %s\n", time.Since(start))
 
+	start = time.Now()
 	// Verify proof.
-	err = plonk.Verify(proof, vk, publicWitness)
+	err = plonk.Verify(proof, globalPlonkVk, publicWitness)
 	if err != nil {
 		panic(err)
 	}
+	fmt.Printf("Verifying proof took %s\n", time.Since(start))
 
 	return NewSP1PlonkBn254Proof(&proof, witnessInput)
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Speed up PLONK proving by caching the constraint system, proving key, and verifying key globally, avoiding redundant disk reads on every call.

## Solution

Ported the global caching pattern from `gnark-ffi/go/sp1/prove_groth16.go` to `gnark-ffi/go/sp1/prove_plonk.go`: constraint system, proving key, and verifying key are now loaded once and reused across subsequent calls.

**Known issue**: Both prove_plonk.go and prove_groth16.go share the same mutex + boolean flag locking pattern, which has a potential data race when reading cached globals from concurrent goroutines after initialisation. This should be addressed in a follow-up (e.g. by migrating to sync.Once)

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes