### PR TITLE
chore(sp1-prover): Remove  unused `build-dependencies`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2503,20 +2503,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
-name = "downloader"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac1e888d6830712d565b2f3a974be3200be9296bc1b03db8251a4cbf18a4a34"
-dependencies = [
- "digest 0.10.7",
- "futures",
- "rand 0.8.5",
- "reqwest",
- "thiserror 1.0.69",
- "tokio",
-]
-
-[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7455,7 +7441,6 @@ dependencies = [
  "bincode",
  "clap",
  "dirs",
- "downloader",
  "either",
  "enum-map",
  "eyre",

--- a/crates/prover/Cargo.toml
+++ b/crates/prover/Cargo.toml
@@ -77,11 +77,6 @@ tempfile = { workspace = true }
 sha2 = { workspace = true }
 hex = { workspace = true }
 
-[build-dependencies]
-downloader = { workspace = true, features = ["rustls-tls", "verify"] }
-sha2 = { workspace = true }
-hex = { workspace = true }
-
 [dev-dependencies]
 test-artifacts = { path = "../test-artifacts" }
 anyhow = { workspace = true }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
The `sp1-prover` crate contains the following section:
```
[build-dependencies]
downloader = { workspace = true, features = ["rustls-tls", "verify"] }
sha2 = { workspace = true }
hex = { workspace = true }
```

However, there is no corresponding `build.rs` file, so this `[build-dependencies]` section is stale.

As a result, all consumers of this crate are forced to pull the `downloader` crate, even though it is not needed and is not widely used. To reduce unnecessary dependencies, I removed the `[build-dependencies]` section.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes