### PR TITLE
fix: staging trace buffers for `ShrinkWrap`

### DIFF
--- a/sp1-gpu/crates/prover_components/src/builder.rs
+++ b/sp1-gpu/crates/prover_components/src/builder.rs
@@ -77,13 +77,13 @@ pub async fn cuda_worker_builder(scope: TaskScope) -> SP1WorkerBuilder<SP1CudaPr
 
     let shrink_verifier = SP1CudaProverComponents::shrink_verifier();
     let shrink_prover = Arc::new(
-        new_cuda_prover(shrink_verifier.clone(), SHRINK_TRACE_ALLOCATION, 1, false, scope.clone())
+        new_cuda_prover(shrink_verifier.clone(), SHRINK_TRACE_ALLOCATION, 4, false, scope.clone())
             .await,
     );
 
     let wrap_verifier = SP1CudaProverComponents::wrap_verifier();
     let wrap_prover = Arc::new(
-        new_cuda_prover(wrap_verifier.clone(), WRAP_TRACE_ALLOCATION, 1, false, scope.clone())
+        new_cuda_prover(wrap_verifier.clone(), WRAP_TRACE_ALLOCATION, 4, false, scope.clone())
             .await,
     );
 


### PR DESCRIPTION
The number of trace buffers for shrink and wrap provers on GPU is set to 1, which could cause a starving of the GPUs if they are waiting for tracegen of other tasks. 

This PR changes that to allow for more trace buffers on CPU. 

The long term solution would be to refactor the resource allocation code. 