### PR TITLE
feat: support Android TLS in network gRPC client

### DIFF
--- a/crates/core/jit/src/memory.rs
+++ b/crates/core/jit/src/memory.rs
@@ -62,7 +62,7 @@ impl JitResetableMemory for AnonymousMemory {
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn create_anonymous_file(size: usize) -> File {
     let fd = memfd::MemfdOptions::default()
         .create(uuid::Uuid::new_v4().to_string())

--- a/crates/core/jit/src/memory.rs
+++ b/crates/core/jit/src/memory.rs
@@ -72,7 +72,7 @@ fn create_anonymous_file(size: usize) -> File {
     file
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 fn create_anonymous_file(size: usize) -> File {
     use libc::{c_char, c_uint, ftruncate, shm_open, O_CREAT, O_RDWR, S_IRUSR, S_IWUSR};
     use std::io;

--- a/crates/core/jit/src/shm.rs
+++ b/crates/core/jit/src/shm.rs
@@ -2,8 +2,24 @@
 
 use libc::{
     c_uint, c_void, ftruncate, madvise, sem_close, sem_open, sem_post, sem_t, sem_trywait,
-    sem_unlink, sem_wait, shm_open, shm_unlink, MADV_FREE, O_CREAT, O_RDWR, S_IRUSR, S_IWUSR,
+    sem_unlink, sem_wait, MADV_FREE, O_CREAT, O_RDWR, S_IRUSR, S_IWUSR,
 };
+#[cfg(not(target_os = "android"))]
+use libc::{shm_open, shm_unlink};
+
+#[cfg(target_os = "android")]
+unsafe fn shm_open(
+    _name: *const libc::c_char,
+    _oflag: libc::c_int,
+    _mode: libc::c_uint,
+) -> libc::c_int {
+    -1
+}
+
+#[cfg(target_os = "android")]
+unsafe fn shm_unlink(_name: *const libc::c_char) -> libc::c_int {
+    -1
+}
 use memmap2::{Mmap, MmapMut};
 use std::cmp::Reverse;
 use std::collections::BinaryHeap;
@@ -691,7 +707,7 @@ impl Drop for ShmMemory {
             // Ignore errors here (e.g., if it was already unlinked externally)
             if let Ok(c_name) = CString::new(self.name.as_str()) {
                 unsafe {
-                    libc::shm_unlink(c_name.as_ptr());
+                    shm_unlink(c_name.as_ptr());
                 }
             }
         }

--- a/crates/core/jit/src/shm.rs
+++ b/crates/core/jit/src/shm.rs
@@ -105,7 +105,7 @@ impl PosixSemaphore {
 
     fn wait_timeout(&self, timeout: Duration) -> bool {
         unsafe {
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "android"))]
             {
                 let mut ts = libc::timespec { tv_sec: 0, tv_nsec: 0 };
                 libc::clock_gettime(libc::CLOCK_REALTIME, &mut ts);

--- a/crates/core/jit/src/shm.rs
+++ b/crates/core/jit/src/shm.rs
@@ -120,7 +120,7 @@ impl PosixSemaphore {
                 libc::sem_timedwait(self.sem, &ts) == 0
             }
 
-            #[cfg(target_os = "macos")]
+            #[cfg(any(target_os = "macos", target_os = "ios"))]
             {
                 let start = std::time::Instant::now();
                 while start.elapsed() < timeout {

--- a/crates/core/runner/binary/Cargo.toml
+++ b/crates/core/runner/binary/Cargo.toml
@@ -15,10 +15,12 @@ sp1-core-executor = { workspace = true }
 sp1-jit = { workspace = true }
 
 bincode = { workspace = true }
-crash-handler = { workspace = true }
 libc = { workspace = true }
 serde = { workspace = true, features = ["derive", "rc"] }
 tracing-subscriber = { workspace = true, features = ["std", "env-filter"] }
+
+[target.'cfg(sp1_use_native_executor)'.dependencies]
+crash-handler = { workspace = true }
 
 [build-dependencies]
 sp1-core-executor = { workspace = true }

--- a/crates/core/runner/build.rs
+++ b/crates/core/runner/build.rs
@@ -103,6 +103,9 @@ fn main() {
 
     let inner_target_dir = metadata.target_directory.clone().join("sp1-native-bins");
     cmd.env("CARGO_TARGET_DIR", &inner_target_dir);
+    // Clear target-specific rustflags so they don't leak into this host-native binary build.
+    cmd.env_remove("CARGO_ENCODED_RUSTFLAGS");
+    cmd.env_remove("RUSTFLAGS");
 
     let status = cmd.status().expect("Failed to execute cargo build for internal binary");
     if !status.success() {

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -82,9 +82,9 @@ sha2 = { workspace = true }
 k256 = { workspace = true, features = ["serde"] } # Signing
 eventsource-stream = { workspace = true }         # SSE Extenstion for reqwest
 
-[target.'cfg(target_os = "ios")'.dependencies]
+[target.'cfg(any(target_os = "ios", target_os = "android"))'.dependencies]
 tonic = { workspace = true, features = ["tls", "tls-webpki-roots"], optional = true }
-[target.'cfg(not(target_os = "ios"))'.dependencies]
+[target.'cfg(not(any(target_os = "ios", target_os = "android")))'.dependencies]
 tonic = { workspace = true, features = ["tls", "tls-roots"], optional = true }
 
 [dev-dependencies]

--- a/crates/sdk/src/network/grpc.rs
+++ b/crates/sdk/src/network/grpc.rs
@@ -16,9 +16,9 @@ pub fn configure_endpoint(addr: &str) -> Result<Endpoint, Error> {
 
     // Configure TLS if using HTTPS.
     if addr.starts_with("https://") {
-        #[cfg(target_os = "ios")]
+        #[cfg(any(target_os = "ios", target_os = "android"))]
         let tls_config = ClientTlsConfig::new().with_webpki_roots();
-        #[cfg(not(target_os = "ios"))]
+        #[cfg(not(any(target_os = "ios", target_os = "android")))]
         let tls_config = ClientTlsConfig::new().with_enabled_roots();
         endpoint = endpoint.tls_config(tls_config)?;
     }


### PR DESCRIPTION
- Add Android target support to `sp1-jit`, including stubs for `shm_open`/`shm_unlink` (unsupported on Android)
- Add iOS target support to `sp1-jit`
- Support Android TLS in the network gRPC client
- Fix `RUSTFLAGS` clearing when building the host-native runner binary
- Fix crash-handler inclusion to only apply when `sp1_use_native_executor` is enabled