### PR TITLE
perf: Optimize clk bumping in native executor

### DIFF
--- a/crates/core/executor/src/minimal/arch/x86_64/mod.rs
+++ b/crates/core/executor/src/minimal/arch/x86_64/mod.rs
@@ -462,7 +462,7 @@ impl MinimalTranspiler {
         // For each load, we want to trace the value at the address as well as the previous clock
         // at that address.
         if self.tracing() {
-            backend.trace_mem_value(rs1.into(), imm);
+            backend.trace_mem_value(rs1.into(), imm, instruction.opcode != Opcode::LD);
         }
 
         match instruction.opcode {
@@ -487,7 +487,7 @@ impl MinimalTranspiler {
         // For stores, its the same logic as a load, we want the last known clk and value at the
         // address.
         if self.tracing() {
-            backend.trace_mem_value(rs2.into(), imm);
+            backend.trace_mem_value(rs2.into(), imm, instruction.opcode != Opcode::SD);
         }
 
         // Note: We switch around rs1 and rs2 operaneds to align with the executor.

--- a/crates/core/executor/src/minimal/arch/x86_64/tests.rs
+++ b/crates/core/executor/src/minimal/arch/x86_64/tests.rs
@@ -1,7 +1,7 @@
 use memmap2::MmapMut;
 use sp1_jit::{
     memory::AnonymousMemory, trace_capacity, ComputeInstructions, JitContext, MemoryInstructions,
-    RiscOperand, RiscRegister, RiscvTranspiler, SystemInstructions,
+    RiscOperand, RiscRegister, RiscvTranspiler, SystemInstructions, TraceCollector,
 };
 
 // Import the actual sp1_ecall_handler from the minimal executor
@@ -37,12 +37,14 @@ fn test_write_syscall_to_public_values() {
 
     // Store some data at address 0x10
     backend.add(RiscRegister::X1, RiscOperand::Immediate(0x12345678), RiscOperand::Immediate(0));
+    backend.trace_mem_value(RiscRegister::X0, 0x10, true);
     backend.sw(RiscRegister::X0, RiscRegister::X1, 0x10);
     backend.add(
         RiscRegister::X1,
         RiscOperand::Immediate(0x9ABCDEF0u32 as i32),
         RiscOperand::Immediate(0),
     );
+    backend.trace_mem_value(RiscRegister::X0, 0x14, true);
     backend.sw(RiscRegister::X0, RiscRegister::X1, 0x14);
 
     // Set up WRITE syscall for public values
@@ -92,6 +94,7 @@ fn test_write_syscall_to_hint() {
         RiscOperand::Immediate(0xDEADBEEFu32 as i32),
         RiscOperand::Immediate(0),
     );
+    backend.trace_mem_value(RiscRegister::X0, 0x10, true);
     backend.sw(RiscRegister::X0, RiscRegister::X1, 0x10);
 
     // Set up WRITE syscall for hint buffer

--- a/crates/core/jit/src/backends/debug.rs
+++ b/crates/core/jit/src/backends/debug.rs
@@ -723,8 +723,8 @@ impl<B: RiscvTranspiler> TraceCollector for DebugBackend<B> {
         self.backend.trace_clk_start();
     }
 
-    fn trace_mem_value(&mut self, rs1: RiscRegister, imm: u64) {
-        self.backend.trace_mem_value(rs1, imm);
+    fn trace_mem_value(&mut self, rs1: RiscRegister, imm: u64, emit_offset: bool) {
+        self.backend.trace_mem_value(rs1, imm, emit_offset);
     }
 
     fn trace_pc_start(&mut self) {

--- a/crates/core/jit/src/backends/x86/instruction_impl.rs
+++ b/crates/core/jit/src/backends/x86/instruction_impl.rs
@@ -784,9 +784,6 @@ impl ControlFlowInstructions for TranspilerBackend {
         // Store the current PC + 4 into the destination register.
         self.emit_risc_register_store(TEMP_A, Some(next_pc), rd);
 
-        // Adjust the PC store in the context by the immediate.
-        self.update_pc(TEMP_B, target_pc);
-
         // Add the base amount of cycles for the instruction.
         self.bump_clk();
 
@@ -804,16 +801,18 @@ impl ControlFlowInstructions for TranspilerBackend {
         // ------------------------------------
         let jump_target = self.reg_values.get(&rs1).map(|rs1_imm| rs1_imm.wrapping_add(imm));
 
-        // ------------------------------------
-        // 2. Update PC value
-        // ------------------------------------
-        self.emit_risc_operand_load(rs1.into(), TEMP_A);
-        dynasm! {
-            self;
-            .arch x64;
+        if jump_target.is_none() {
+            // ------------------------------------
+            // 2. Update PC value if we don't have it at transpile time.
+            // ------------------------------------
+            self.emit_risc_operand_load(rs1.into(), TEMP_A);
+            dynasm! {
+                self;
+                .arch x64;
 
-            add Rq(TEMP_A), imm as i32;
-            mov QWORD [Rq(CONTEXT) + PC_OFFSET], Rq(TEMP_A)
+                add Rq(TEMP_A), imm as i32;
+                mov QWORD [Rq(CONTEXT) + PC_OFFSET], Rq(TEMP_A)
+            }
         }
 
         // ------------------------------------
@@ -855,7 +854,6 @@ impl ControlFlowInstructions for TranspilerBackend {
         // Branched:
         // 0. Bump the pc by the immediate.
         // ------------------------------------
-        self.update_pc(Rq::RAX as u8, branched_target);
         self.end_branch(Some(branched_target));
 
         dynasm! {
@@ -870,7 +868,6 @@ impl ControlFlowInstructions for TranspilerBackend {
         // ------------------------------------
         // 1. Bump the pc by 4
         // ------------------------------------
-        self.update_pc(Rq::RAX as u8, not_branched_target);
         self.end_branch(Some(not_branched_target));
     }
 
@@ -900,7 +897,6 @@ impl ControlFlowInstructions for TranspilerBackend {
         // Branched:
         // 0. Bump the pc by the immediate.
         // ------------------------------------
-        self.update_pc(Rq::RAX as u8, branched_target);
         self.end_branch(Some(branched_target));
 
         dynasm! {
@@ -915,7 +911,6 @@ impl ControlFlowInstructions for TranspilerBackend {
         // ------------------------------------
         // 1. Bump the pc by 4
         // ------------------------------------
-        self.update_pc(Rq::RAX as u8, not_branched_target);
         self.end_branch(Some(not_branched_target));
     }
 
@@ -944,7 +939,6 @@ impl ControlFlowInstructions for TranspilerBackend {
         // Branched:
         // 0. Bump the pc by the immediate.
         // ------------------------------------
-        self.update_pc(Rq::RAX as u8, branched_target);
         self.end_branch(Some(branched_target));
 
         dynasm! {
@@ -959,7 +953,6 @@ impl ControlFlowInstructions for TranspilerBackend {
         // ------------------------------------
         // 1. Bump the pc by 4
         // ------------------------------------
-        self.update_pc(Rq::RAX as u8, not_branched_target);
         self.end_branch(Some(not_branched_target));
     }
 
@@ -990,7 +983,6 @@ impl ControlFlowInstructions for TranspilerBackend {
         // Branched:
         // 0. Bump the pc by the immediate.
         // ------------------------------------
-        self.update_pc(Rq::RAX as u8, branched_target);
         self.end_branch(Some(branched_target));
 
         dynasm! {
@@ -1005,7 +997,6 @@ impl ControlFlowInstructions for TranspilerBackend {
         // ------------------------------------
         // 1. Bump the pc by 4
         // ------------------------------------
-        self.update_pc(Rq::RAX as u8, not_branched_target);
         self.end_branch(Some(not_branched_target));
     }
 
@@ -1032,7 +1023,6 @@ impl ControlFlowInstructions for TranspilerBackend {
         // Branched:
         // 0. Bump the pc by the immediate.
         // ------------------------------------
-        self.update_pc(Rq::RAX as u8, branched_target);
         self.end_branch(Some(branched_target));
 
         dynasm! {
@@ -1047,7 +1037,6 @@ impl ControlFlowInstructions for TranspilerBackend {
         // ------------------------------------
         // 1. Bump the pc by 4
         // ------------------------------------
-        self.update_pc(Rq::RAX as u8, not_branched_target);
         self.end_branch(Some(not_branched_target));
     }
 
@@ -1074,7 +1063,6 @@ impl ControlFlowInstructions for TranspilerBackend {
         // Branched:
         // 0. Bump the pc by the immediate.
         // ------------------------------------
-        self.update_pc(Rq::RAX as u8, branched_target);
         self.end_branch(Some(branched_target));
 
         dynasm! {
@@ -1089,7 +1077,6 @@ impl ControlFlowInstructions for TranspilerBackend {
         // ------------------------------------
         // 1. Bump the pc by 4
         // ------------------------------------
-        self.update_pc(Rq::RAX as u8, not_branched_target);
         self.end_branch(Some(not_branched_target));
     }
 }

--- a/crates/core/jit/src/backends/x86/instruction_impl.rs
+++ b/crates/core/jit/src/backends/x86/instruction_impl.rs
@@ -1098,43 +1098,50 @@ impl MemoryInstructions for TranspilerBackend {
     fn lb(&mut self, rd: RiscRegister, rs1: RiscRegister, imm: u64) {
         self.may_early_exit = true;
 
-        // ------------------------------------
-        // Load in the base address and the phy sical memory pointer.
-        // ------------------------------------
-        self.emit_risc_operand_load(rs1.into(), TEMP_A);
+        if !self.tracing() {
+            // ------------------------------------
+            // Load in the base address and the phy sical memory pointer.
+            // ------------------------------------
+            self.emit_risc_operand_load(rs1.into(), TEMP_A);
+
+            dynasm! {
+                self;
+                .arch x64;
+
+                // ------------------------------------
+                // Add the immediate to the base address
+                // Scaled to account for the entry size.
+                //
+                // TEMP_A = rs1 + imm = addr
+                // ------------------------------------
+                add Rq(TEMP_A), imm as i32;
+
+                // ------------------------------------
+                // Store the intra-word offset.
+                // ------------------------------------
+                mov rax, Rq(TEMP_A);
+                and rax, 7;
+
+                // ------------------------------------
+                // Align to the start of the word.
+                //
+                // Scale to account for the entry size.
+                // ------------------------------------
+                and Rq(TEMP_A), -8;
+                shl Rq(TEMP_A), 1;
+
+                // ------------------------------------
+                // Add the risc32 byte offset to the physical memory pointer
+                //
+                // TEMP_A = addr + physical_memory_pointer
+                // ------------------------------------
+                add Rq(TEMP_A), Rq(MEMORY_PTR)
+            }
+        }
 
         dynasm! {
             self;
             .arch x64;
-
-            // ------------------------------------
-            // Add the immediate to the base address
-            // Scaled to account for the entry size.
-            //
-            // TEMP_A = rs1 + imm = addr
-            // ------------------------------------
-            add Rq(TEMP_A), imm as i32;
-
-            // ------------------------------------
-            // Store the intra-word offset.
-            // ------------------------------------
-            mov rax, Rq(TEMP_A);
-            and rax, 7;
-
-            // ------------------------------------
-            // Align to the start of the word.
-            //
-            // Scale to account for the entry size.
-            // ------------------------------------
-            and Rq(TEMP_A), -8;
-            shl Rq(TEMP_A), 1;
-
-            // ------------------------------------
-            // Add the risc32 byte offset to the physical memory pointer
-            //
-            // TEMP_A = addr + physical_memory_pointer
-            // ------------------------------------
-            add Rq(TEMP_A), Rq(MEMORY_PTR);
 
             // ------------------------------------
             // 4. Load byte → sign-extend to 32 bits
@@ -1154,43 +1161,50 @@ impl MemoryInstructions for TranspilerBackend {
     fn lbu(&mut self, rd: RiscRegister, rs1: RiscRegister, imm: u64) {
         self.may_early_exit = true;
 
-        // ------------------------------------
-        // Load in the base address
-        // and the physical memory pointer.
-        // ------------------------------------
-        self.emit_risc_operand_load(rs1.into(), TEMP_A);
+        if !self.tracing() {
+            // ------------------------------------
+            // Load in the base address
+            // and the physical memory pointer.
+            // ------------------------------------
+            self.emit_risc_operand_load(rs1.into(), TEMP_A);
+
+            dynasm! {
+                self;
+                .arch x64;
+
+                // ------------------------------------
+                // Add the immediate to the base address
+                //
+                // TEMP_A = rs1 + imm = addr
+                // ------------------------------------
+                add Rq(TEMP_A), imm as i32;
+
+                // ------------------------------------
+                // Store the intra-word offset.
+                // ------------------------------------
+                mov rax, Rq(TEMP_A);
+                and rax, 7;
+
+                // ------------------------------------
+                // Align to the start of the word.
+                //
+                // Scale to account for the entry size.
+                // ------------------------------------
+                and Rq(TEMP_A), -8;
+                shl Rq(TEMP_A), 1;
+
+                // ------------------------------------
+                // Add the risc32 byte offset to the physical memory pointer
+                //
+                // TEMP_A = addr + physical_memory_pointer
+                // ------------------------------------
+                add Rq(TEMP_A), Rq(MEMORY_PTR)
+            }
+        }
 
         dynasm! {
             self;
             .arch x64;
-
-            // ------------------------------------
-            // Add the immediate to the base address
-            //
-            // TEMP_A = rs1 + imm = addr
-            // ------------------------------------
-            add Rq(TEMP_A), imm as i32;
-
-            // ------------------------------------
-            // Store the intra-word offset.
-            // ------------------------------------
-            mov rax, Rq(TEMP_A);
-            and rax, 7;
-
-            // ------------------------------------
-            // Align to the start of the word.
-            //
-            // Scale to account for the entry size.
-            // ------------------------------------
-            and Rq(TEMP_A), -8;
-            shl Rq(TEMP_A), 1;
-
-            // ------------------------------------
-            // Add the risc32 byte offset to the physical memory pointer
-            //
-            // TEMP_A = addr + physical_memory_pointer
-            // ------------------------------------
-            add Rq(TEMP_A), Rq(MEMORY_PTR);
 
             // ------------------------------------
             // Load byte → zero-extend to 32 bits
@@ -1204,43 +1218,50 @@ impl MemoryInstructions for TranspilerBackend {
     fn lh(&mut self, rd: RiscRegister, rs1: RiscRegister, imm: u64) {
         self.may_early_exit = true;
 
-        // ------------------------------------
-        // Load in the base address
-        // and the physical memory pointer.
-        // ------------------------------------
-        self.emit_risc_operand_load(rs1.into(), TEMP_A);
+        if !self.tracing() {
+            // ------------------------------------
+            // Load in the base address
+            // and the physical memory pointer.
+            // ------------------------------------
+            self.emit_risc_operand_load(rs1.into(), TEMP_A);
+
+            dynasm! {
+                self;
+                .arch x64;
+
+                // ------------------------------------
+                // Add the immediate to the base address
+                //
+                // TEMP_A = rs1 + imm = addr
+                // ------------------------------------
+                add Rq(TEMP_A), imm as i32;
+
+                 // ------------------------------------
+                // Store the intra-word offset.
+                // ------------------------------------
+                mov rax, Rq(TEMP_A);
+                and rax, 7;
+
+                // ------------------------------------
+                // Align to the start of the word.
+                //
+                // Scale to account for the entry size.
+                // ------------------------------------
+                and Rq(TEMP_A), -8;
+                shl Rq(TEMP_A), 1;
+
+                // ------------------------------------
+                // Add the risc32 byte offset to the physical memory pointer
+                //
+                // TEMP_A = addr + physical_memory_pointer
+                // ------------------------------------
+                add Rq(TEMP_A), Rq(MEMORY_PTR)
+            }
+        }
 
         dynasm! {
             self;
             .arch x64;
-
-            // ------------------------------------
-            // Add the immediate to the base address
-            //
-            // TEMP_A = rs1 + imm = addr
-            // ------------------------------------
-            add Rq(TEMP_A), imm as i32;
-
-             // ------------------------------------
-            // Store the intra-word offset.
-            // ------------------------------------
-            mov rax, Rq(TEMP_A);
-            and rax, 7;
-
-            // ------------------------------------
-            // Align to the start of the word.
-            //
-            // Scale to account for the entry size.
-            // ------------------------------------
-            and Rq(TEMP_A), -8;
-            shl Rq(TEMP_A), 1;
-
-            // ------------------------------------
-            // Add the risc32 byte offset to the physical memory pointer
-            //
-            // TEMP_A = addr + physical_memory_pointer
-            // ------------------------------------
-            add Rq(TEMP_A), Rq(MEMORY_PTR);
 
             // ------------------------------------
             // Load half-word → sign-extend to 32 bits
@@ -1254,43 +1275,50 @@ impl MemoryInstructions for TranspilerBackend {
     fn lhu(&mut self, rd: RiscRegister, rs1: RiscRegister, imm: u64) {
         self.may_early_exit = true;
 
-        // ------------------------------------
-        //  Load in the base address
-        //  and the physical memory pointer.
-        // ------------------------------------
-        self.emit_risc_operand_load(rs1.into(), TEMP_A);
+        if !self.tracing() {
+            // ------------------------------------
+            //  Load in the base address
+            //  and the physical memory pointer.
+            // ------------------------------------
+            self.emit_risc_operand_load(rs1.into(), TEMP_A);
+
+            dynasm! {
+                self;
+                .arch x64;
+
+                // ------------------------------------
+                // Add the immediate to the base address
+                //
+                // TEMP_A = rs1 + imm = addr
+                // ------------------------------------
+                add Rq(TEMP_A), imm as i32;
+
+                // ------------------------------------
+                // Store the intra-word offset.
+                // ------------------------------------
+                mov rax, Rq(TEMP_A);
+                and rax, 7;
+
+                // ------------------------------------
+                // Align to the start of the word.
+                //
+                // Scale to account for the entry size.
+                // ------------------------------------
+                and Rq(TEMP_A), -8;
+                shl Rq(TEMP_A), 1;
+
+                // ------------------------------------
+                // Add the risc32 byte offset to the physical memory pointer
+                //
+                // TEMP_A = addr + physical_memory_pointer
+                // ------------------------------------
+                add Rq(TEMP_A), Rq(MEMORY_PTR)
+            }
+        }
 
         dynasm! {
             self;
             .arch x64;
-
-            // ------------------------------------
-            // Add the immediate to the base address
-            //
-            // TEMP_A = rs1 + imm = addr
-            // ------------------------------------
-            add Rq(TEMP_A), imm as i32;
-
-            // ------------------------------------
-            // Store the intra-word offset.
-            // ------------------------------------
-            mov rax, Rq(TEMP_A);
-            and rax, 7;
-
-            // ------------------------------------
-            // Align to the start of the word.
-            //
-            // Scale to account for the entry size.
-            // ------------------------------------
-            and Rq(TEMP_A), -8;
-            shl Rq(TEMP_A), 1;
-
-            // ------------------------------------
-            // Add the risc32 byte offset to the physical memory pointer
-            //
-            // TEMP_A = addr + physical_memory_pointer
-            // ------------------------------------
-            add Rq(TEMP_A), Rq(MEMORY_PTR);
 
             // ------------------------------------
             // Load 16 bits, zero-extend to 32 bits
@@ -1304,43 +1332,50 @@ impl MemoryInstructions for TranspilerBackend {
     fn lw(&mut self, rd: RiscRegister, rs1: RiscRegister, imm: u64) {
         self.may_early_exit = true;
 
-        // ------------------------------------
-        // Load the base address into TEMP_A
-        // and physical memory pointer into TEMP_B
-        // ------------------------------------
-        self.emit_risc_operand_load(rs1.into(), TEMP_A);
+        if !self.tracing() {
+            // ------------------------------------
+            // Load the base address into TEMP_A
+            // and physical memory pointer into TEMP_B
+            // ------------------------------------
+            self.emit_risc_operand_load(rs1.into(), TEMP_A);
+
+            dynasm! {
+                self;
+                .arch x64;
+
+                // ------------------------------------
+                // Add the immediate to the base address
+                //
+                // TEMP_A = rs1 + imm = addr
+                // ------------------------------------
+                add Rq(TEMP_A), imm as i32;
+
+                // ------------------------------------
+                // Store the intra-word offset.
+                // ------------------------------------
+                mov rax, Rq(TEMP_A);
+                and rax, 7;
+
+                // ------------------------------------
+                // Align to the start of the word.
+                //
+                // Scale to account for the entry size.
+                // ------------------------------------
+                and Rq(TEMP_A), -8;
+                shl Rq(TEMP_A), 1;
+
+                // ------------------------------------
+                // 3. Add the risc32 byte offset to the physical memory pointer
+                //
+                // TEMP_A = addr + physical_memory_pointer
+                // ------------------------------------
+                add Rq(TEMP_A), Rq(MEMORY_PTR)
+            }
+        }
 
         dynasm! {
             self;
             .arch x64;
-
-            // ------------------------------------
-            // Add the immediate to the base address
-            //
-            // TEMP_A = rs1 + imm = addr
-            // ------------------------------------
-            add Rq(TEMP_A), imm as i32;
-
-            // ------------------------------------
-            // Store the intra-word offset.
-            // ------------------------------------
-            mov rax, Rq(TEMP_A);
-            and rax, 7;
-
-            // ------------------------------------
-            // Align to the start of the word.
-            //
-            // Scale to account for the entry size.
-            // ------------------------------------
-            and Rq(TEMP_A), -8;
-            shl Rq(TEMP_A), 1;
-
-            // ------------------------------------
-            // 3. Add the risc32 byte offset to the physical memory pointer
-            //
-            // TEMP_A = addr + physical_memory_pointer
-            // ------------------------------------
-            add Rq(TEMP_A), Rq(MEMORY_PTR);
 
             // ------------------------------------
             // 4. Load the word from physical memory into TEMP_A (sign-extended to 64-bit)
@@ -1357,43 +1392,50 @@ impl MemoryInstructions for TranspilerBackend {
     fn lwu(&mut self, rd: RiscRegister, rs1: RiscRegister, imm: u64) {
         self.may_early_exit = true;
 
-        // ------------------------------------
-        // Load the base address into TEMP_A
-        // and physical memory pointer into TEMP_B
-        // ------------------------------------
-        self.emit_risc_operand_load(rs1.into(), TEMP_A);
+        if !self.tracing() {
+            // ------------------------------------
+            // Load the base address into TEMP_A
+            // and physical memory pointer into TEMP_B
+            // ------------------------------------
+            self.emit_risc_operand_load(rs1.into(), TEMP_A);
+
+            dynasm! {
+                self;
+                .arch x64;
+
+                // ------------------------------------
+                // Add the immediate to the base address
+                //
+                // TEMP_A = rs1 + imm = addr
+                // ------------------------------------
+                add Rq(TEMP_A), imm as i32;
+
+                // ------------------------------------
+                // Store the intra-word offset.
+                // ------------------------------------
+                mov rax, Rq(TEMP_A);
+                and rax, 7;
+
+                // ------------------------------------
+                // Align to the start of the word.
+                //
+                // Scale to account for the entry size.
+                // ------------------------------------
+                and Rq(TEMP_A), -8;
+                shl Rq(TEMP_A), 1;
+
+                // ------------------------------------
+                // 3. Add the risc32 byte offset to the physical memory pointer
+                //
+                // TEMP_A = addr + physical_memory_pointer
+                // ------------------------------------
+                add Rq(TEMP_A), Rq(MEMORY_PTR)
+            }
+        }
 
         dynasm! {
             self;
             .arch x64;
-
-            // ------------------------------------
-            // Add the immediate to the base address
-            //
-            // TEMP_A = rs1 + imm = addr
-            // ------------------------------------
-            add Rq(TEMP_A), imm as i32;
-
-            // ------------------------------------
-            // Store the intra-word offset.
-            // ------------------------------------
-            mov rax, Rq(TEMP_A);
-            and rax, 7;
-
-            // ------------------------------------
-            // Align to the start of the word.
-            //
-            // Scale to account for the entry size.
-            // ------------------------------------
-            and Rq(TEMP_A), -8;
-            shl Rq(TEMP_A), 1;
-
-            // ------------------------------------
-            // 3. Add the risc32 byte offset to the physical memory pointer
-            //
-            // TEMP_A = addr + physical_memory_pointer
-            // ------------------------------------
-            add Rq(TEMP_A), Rq(MEMORY_PTR);
 
             // ------------------------------------
             // 4. Load the word from physical memory into TEMP_B (zero-extended to 64-bit)
@@ -1410,36 +1452,43 @@ impl MemoryInstructions for TranspilerBackend {
     fn ld(&mut self, rd: RiscRegister, rs1: RiscRegister, imm: u64) {
         self.may_early_exit = true;
 
-        // ------------------------------------
-        // 1. Load the base address into TEMP_A
-        // and physical memory pointer into TEMP_B
-        // ------------------------------------
-        self.emit_risc_operand_load(rs1.into(), TEMP_A);
+        if !self.tracing() {
+            // ------------------------------------
+            // 1. Load the base address into TEMP_A
+            // and physical memory pointer into TEMP_B
+            // ------------------------------------
+            self.emit_risc_operand_load(rs1.into(), TEMP_A);
+
+            dynasm! {
+                self;
+                .arch x64;
+
+                // ------------------------------------
+                //  Add the immediate to the base address
+                //
+                // TEMP_A = rs1 + imm = addr
+                // ------------------------------------
+                add Rq(TEMP_A), imm as i32;
+
+                // ------------------------------------
+                // Scale to account for the entry size.
+                //
+                // Assume the addr is properly aligned.
+                // ------------------------------------
+                shl Rq(TEMP_A), 1;
+
+                // ------------------------------------
+                // Add the risc byte offset to the physical memory pointer
+                //
+                // TEMP_A = addr + physical_memory_pointer
+                // ------------------------------------
+                add Rq(TEMP_A), Rq(MEMORY_PTR)
+            }
+        }
 
         dynasm! {
             self;
             .arch x64;
-
-            // ------------------------------------
-            //  Add the immediate to the base address
-            //
-            // TEMP_A = rs1 + imm = addr
-            // ------------------------------------
-            add Rq(TEMP_A), imm as i32;
-
-            // ------------------------------------
-            // Scale to account for the entry size.
-            //
-            // Assume the addr is properly aligned.
-            // ------------------------------------
-            shl Rq(TEMP_A), 1;
-
-            // ------------------------------------
-            // Add the risc byte offset to the physical memory pointer
-            //
-            // TEMP_A = addr + physical_memory_pointer
-            // ------------------------------------
-            add Rq(TEMP_A), Rq(MEMORY_PTR);
 
             // ------------------------------------
             // Load the word from physical memory into TEMP_A
@@ -1456,39 +1505,41 @@ impl MemoryInstructions for TranspilerBackend {
     fn sb(&mut self, rs1: RiscRegister, rs2: RiscRegister, imm: u64) {
         self.may_early_exit = true;
 
-        // ------------------------------------
-        // Load the base address into TEMP_A
-        // and physical memory pointer into TEMP_B
-        // ------------------------------------
-        self.emit_risc_operand_load(rs1.into(), TEMP_A);
+        if !self.tracing() {
+            // ------------------------------------
+            // Load the base address into TEMP_A
+            // and physical memory pointer into TEMP_B
+            // ------------------------------------
+            self.emit_risc_operand_load(rs1.into(), TEMP_A);
 
-        dynasm! {
-            self;
-            .arch x64;
+            dynasm! {
+                self;
+                .arch x64;
 
-            // ------------------------------------
-            // Add the immediate to the base address
-            // ------------------------------------
-            add Rq(TEMP_A), imm as i32;
+                // ------------------------------------
+                // Add the immediate to the base address
+                // ------------------------------------
+                add Rq(TEMP_A), imm as i32;
 
-            // ------------------------------------
-            // Store the intra-word offset.
-            // ------------------------------------
-            mov rax, Rq(TEMP_A);
-            and rax, 7;
+                // ------------------------------------
+                // Store the intra-word offset.
+                // ------------------------------------
+                mov rax, Rq(TEMP_A);
+                and rax, 7;
 
-            // ------------------------------------
-            // Align to the start of the word.
-            //
-            // Scale to account for the entry size.
-            // ------------------------------------
-            and Rq(TEMP_A), -8;
-            shl Rq(TEMP_A), 1;
+                // ------------------------------------
+                // Align to the start of the word.
+                //
+                // Scale to account for the entry size.
+                // ------------------------------------
+                and Rq(TEMP_A), -8;
+                shl Rq(TEMP_A), 1;
 
-            // ------------------------------------
-            // Add the risc32 byte offset to the physical memory pointer
-            // ------------------------------------
-            add Rq(TEMP_A), Rq(MEMORY_PTR)
+                // ------------------------------------
+                // Add the risc32 byte offset to the physical memory pointer
+                // ------------------------------------
+                add Rq(TEMP_A), Rq(MEMORY_PTR)
+            }
         }
 
         // ------------------------------------
@@ -1510,38 +1561,40 @@ impl MemoryInstructions for TranspilerBackend {
     fn sh(&mut self, rs1: RiscRegister, rs2: RiscRegister, imm: u64) {
         self.may_early_exit = true;
 
-        // ------------------------------------
-        // Load the base address into TEMP_A
-        // and physical memory pointer into TEMP_B
-        // ------------------------------------
-        self.emit_risc_operand_load(rs1.into(), TEMP_A);
+        if !self.tracing() {
+            // ------------------------------------
+            // Load the base address into TEMP_A
+            // and physical memory pointer into TEMP_B
+            // ------------------------------------
+            self.emit_risc_operand_load(rs1.into(), TEMP_A);
 
-        dynasm! {
-            self;
-            .arch x64;
+            dynasm! {
+                self;
+                .arch x64;
 
-            // ------------------------------------
-            // Add the immediate to the base address
-            // ------------------------------------
-            add Rq(TEMP_A), imm as i32;
+                // ------------------------------------
+                // Add the immediate to the base address
+                // ------------------------------------
+                add Rq(TEMP_A), imm as i32;
 
-            // ------------------------------------
-            // Store the intra-word offset.
-            // ------------------------------------
-            mov rax, Rq(TEMP_A);
-            and rax, 7;
+                // ------------------------------------
+                // Store the intra-word offset.
+                // ------------------------------------
+                mov rax, Rq(TEMP_A);
+                and rax, 7;
 
-            // ------------------------------------
-            // Align to the start of the word.
-            // Scale to account for the entry size.
-            // ------------------------------------
-            and Rq(TEMP_A), -8;
-            shl Rq(TEMP_A), 1;
+                // ------------------------------------
+                // Align to the start of the word.
+                // Scale to account for the entry size.
+                // ------------------------------------
+                and Rq(TEMP_A), -8;
+                shl Rq(TEMP_A), 1;
 
-            // ------------------------------------
-            // Add the risc32 byte offset to the physical memory pointer
-            // ------------------------------------
-            add Rq(TEMP_A), Rq(MEMORY_PTR)
+                // ------------------------------------
+                // Add the risc32 byte offset to the physical memory pointer
+                // ------------------------------------
+                add Rq(TEMP_A), Rq(MEMORY_PTR)
+            }
         }
 
         // ------------------------------------
@@ -1563,38 +1616,40 @@ impl MemoryInstructions for TranspilerBackend {
     fn sw(&mut self, rs1: RiscRegister, rs2: RiscRegister, imm: u64) {
         self.may_early_exit = true;
 
-        // ------------------------------------
-        // Load the base address into TEMP_A
-        // and physical memory pointer into TEMP_B
-        // ------------------------------------
-        self.emit_risc_operand_load(rs1.into(), TEMP_A);
+        if !self.tracing() {
+            // ------------------------------------
+            // Load the base address into TEMP_A
+            // and physical memory pointer into TEMP_B
+            // ------------------------------------
+            self.emit_risc_operand_load(rs1.into(), TEMP_A);
 
-        dynasm! {
-            self;
-            .arch x64;
+            dynasm! {
+                self;
+                .arch x64;
 
-            // ------------------------------------
-            // Add the immediate to the base address
-            // ------------------------------------
-            add Rq(TEMP_A), imm as i32;
+                // ------------------------------------
+                // Add the immediate to the base address
+                // ------------------------------------
+                add Rq(TEMP_A), imm as i32;
 
-            // ------------------------------------
-            // Store the intra-word offset.
-            // ------------------------------------
-            mov rax, Rq(TEMP_A);
-            and rax, 7;
+                // ------------------------------------
+                // Store the intra-word offset.
+                // ------------------------------------
+                mov rax, Rq(TEMP_A);
+                and rax, 7;
 
-            // ------------------------------------
-            // Align to the start of the word.
-            // Scale to account for the entry size.
-            // ------------------------------------
-            and Rq(TEMP_A), -8;
-            shl Rq(TEMP_A), 1;
+                // ------------------------------------
+                // Align to the start of the word.
+                // Scale to account for the entry size.
+                // ------------------------------------
+                and Rq(TEMP_A), -8;
+                shl Rq(TEMP_A), 1;
 
-            // ------------------------------------
-            // Add the risc32 byte offset to the physical memory pointer
-            // ------------------------------------
-            add Rq(TEMP_A), Rq(MEMORY_PTR)
+                // ------------------------------------
+                // Add the risc32 byte offset to the physical memory pointer
+                // ------------------------------------
+                add Rq(TEMP_A), Rq(MEMORY_PTR)
+            }
         }
 
         // ------------------------------------
@@ -1616,32 +1671,34 @@ impl MemoryInstructions for TranspilerBackend {
     fn sd(&mut self, rs1: RiscRegister, rs2: RiscRegister, imm: u64) {
         self.may_early_exit = true;
 
-        // ------------------------------------
-        // Load the base address into TEMP_A
-        // and physical memory pointer into TEMP_B
-        // ------------------------------------
-        self.emit_risc_operand_load(rs1.into(), TEMP_A);
+        if !self.tracing() {
+            // ------------------------------------
+            // Load the base address into TEMP_A
+            // and physical memory pointer into TEMP_B
+            // ------------------------------------
+            self.emit_risc_operand_load(rs1.into(), TEMP_A);
 
-        dynasm! {
-            self;
-            .arch x64;
+            dynasm! {
+                self;
+                .arch x64;
 
-            // ------------------------------------
-            // Add the immediate to the base address
-            // ------------------------------------
-            add Rq(TEMP_A), imm as i32;
+                // ------------------------------------
+                // Add the immediate to the base address
+                // ------------------------------------
+                add Rq(TEMP_A), imm as i32;
 
-            // ------------------------------------
-            // Scale to account for the entry size.
-            //
-            // Assume the addr is properly aligned.
-            // ------------------------------------
-            shl Rq(TEMP_A), 1;
+                // ------------------------------------
+                // Scale to account for the entry size.
+                //
+                // Assume the addr is properly aligned.
+                // ------------------------------------
+                shl Rq(TEMP_A), 1;
 
-            // ------------------------------------
-            // 3. Add the risc32 byte offset to the physical memory pointer
-            // ------------------------------------
-            add Rq(TEMP_A), Rq(MEMORY_PTR)
+                // ------------------------------------
+                // 3. Add the risc32 byte offset to the physical memory pointer
+                // ------------------------------------
+                add Rq(TEMP_A), Rq(MEMORY_PTR)
+            }
         }
 
         // ------------------------------------

--- a/crates/core/jit/src/backends/x86/mod.rs
+++ b/crates/core/jit/src/backends/x86/mod.rs
@@ -80,11 +80,11 @@ const LOCAL_CLK: u8 = Rq::RSI as u8;
 
 /// The saved stack pointer, used during external function calls.
 ///
-/// When not making external function calls, clock is hoisted to
-/// this register.
+/// When not making external function calls, we hoist unconstrained
+/// flag to this register.
 ///
 /// Callee-saved register.
-const CLOCK_OR_SAVED_STACK_PTR: u8 = Rq::R15 as u8;
+const UNCONSTRAINED_OR_SAVED_STACK_PTR: u8 = Rq::R15 as u8;
 
 /// The offset of the pc in the JitContext.
 const PC_OFFSET: i32 = offset_of!(JitContext, pc) as i32;
@@ -253,8 +253,7 @@ impl TraceCollector for TranspilerBackend {
             .arch x64;
 
             // Check if were in unconstrained mode.
-            mov rcx, QWORD [Rq(CONTEXT) + IS_UNCONSTRAINED_OFFSET];
-            cmp rcx, 1;
+            cmp Rq(UNCONSTRAINED_OR_SAVED_STACK_PTR), 1;
             je >done
         }
 
@@ -286,9 +285,10 @@ impl TraceCollector for TranspilerBackend {
             // ------------------------------------
             movdqu xmm15, [Rq(TEMP_A)];
             movdqu [Rq(TAIL_START)], xmm15;
-            mov rdx, Rq(CLOCK_OR_SAVED_STACK_PTR);
-            add rdx, Rq(LOCAL_CLK);
-            add rdx, 1;
+            // Load last committed clk
+            mov rdx, QWORD [Rq(CONTEXT) + CLK_OFFSET];
+            // Add local clk in current JIT execution batch, and 1 for memory write
+            lea rdx, [Rq(LOCAL_CLK) + rdx + 1];
             mov [Rq(TEMP_A)], rdx;
 
             // ------------------------------------
@@ -350,7 +350,10 @@ impl TranspilerBackend {
 
     #[inline]
     fn clk_bump_shifts(&self) -> i8 {
-        assert!(self.clk_bump > 0 && (self.clk_bump & (self.clk_bump - 1)) == 0, "clk_bump must be a power of 2!");
+        assert!(
+            self.clk_bump > 0 && (self.clk_bump & (self.clk_bump - 1)) == 0,
+            "clk_bump must be a power of 2!"
+        );
         self.clk_bump.trailing_zeros() as i8
     }
 
@@ -415,7 +418,7 @@ impl TranspilerBackend {
             push Rq(CONTEXT);
             push Rq(JUMP_TABLE);
             push Rq(TRACE_BUF);
-            push Rq(CLOCK_OR_SAVED_STACK_PTR);
+            push Rq(UNCONSTRAINED_OR_SAVED_STACK_PTR);
 
             // Save some useful pointers to non-volatile registers so we can use them in ASM easily.
             mov Rq(JUMP_TABLE), [rdi + jump_table_offset];
@@ -483,7 +486,7 @@ impl TranspilerBackend {
             .arch x64;
 
             // Restore the callee saved registers.
-            pop Rq(CLOCK_OR_SAVED_STACK_PTR);
+            pop Rq(UNCONSTRAINED_OR_SAVED_STACK_PTR);
             pop Rq(TRACE_BUF);
             pop Rq(JUMP_TABLE);
             pop Rq(CONTEXT);
@@ -695,7 +698,7 @@ impl TranspilerBackend {
             .arch x64;
 
             // Save the original stack pointer
-            mov Rq(CLOCK_OR_SAVED_STACK_PTR), rsp;
+            mov Rq(UNCONSTRAINED_OR_SAVED_STACK_PTR), rsp;
 
             // Align the stack to 16 bytes for the call
             lea rsp, [rsp - 8]; // sub 8 from the rsp
@@ -708,7 +711,7 @@ impl TranspilerBackend {
             call rax;
 
             // Restore the original stack pointer
-            mov rsp, Rq(CLOCK_OR_SAVED_STACK_PTR)
+            mov rsp, Rq(UNCONSTRAINED_OR_SAVED_STACK_PTR)
         }
 
         if self.tracing() {
@@ -770,7 +773,7 @@ impl TranspilerBackend {
             .arch x64;
 
             // Load clk from memory to register
-            mov Rq(CLOCK_OR_SAVED_STACK_PTR), QWORD [Rq(CONTEXT) + CLK_OFFSET];
+            mov Rq(UNCONSTRAINED_OR_SAVED_STACK_PTR), QWORD [Rq(CONTEXT) + IS_UNCONSTRAINED_OFFSET];
             // Setup local clk
             xor Rq(LOCAL_CLK), Rq(LOCAL_CLK)
         }
@@ -785,15 +788,13 @@ impl TranspilerBackend {
             .arch x64;
 
             // Commit local clk first
-            add Rq(CLOCK_OR_SAVED_STACK_PTR), Rq(LOCAL_CLK);
-            // Save clk back to memory
-            mov QWORD [Rq(CONTEXT) + CLK_OFFSET], Rq(CLOCK_OR_SAVED_STACK_PTR);
+            add QWORD [Rq(CONTEXT) + CLK_OFFSET], Rq(LOCAL_CLK);
 
             // Convert local clk to global_clk form
             shr Rq(LOCAL_CLK), clk_bump_shifts;
 
             // Load is_unconstrained (8-bit) into TEMP_A with zero extension
-            mov Rq(TEMP_A), QWORD [Rq(CONTEXT) + IS_UNCONSTRAINED_OFFSET];
+            // mov Rq(TEMP_A), QWORD [Rq(CONTEXT) + IS_UNCONSTRAINED_OFFSET];
 
             // ------------------------------------
             // Add to global_clk based on is_unconstrained:
@@ -802,9 +803,9 @@ impl TranspilerBackend {
             // ------------------------------------
             //
             // Note that is_unconstrained can only be altered in ecalls. In
-            // JIT execution, it remains a constant.
+            // each JIT execution batch, it remains a constant.
             xor eax, eax;
-            test Rq(TEMP_A), Rq(TEMP_A);
+            test Rq(UNCONSTRAINED_OR_SAVED_STACK_PTR), Rq(UNCONSTRAINED_OR_SAVED_STACK_PTR);
             cmovnz Rq(LOCAL_CLK), rax;
 
             // Add the inverted value to global_clk

--- a/crates/core/jit/src/backends/x86/mod.rs
+++ b/crates/core/jit/src/backends/x86/mod.rs
@@ -244,23 +244,26 @@ impl TraceCollector for TranspilerBackend {
     }
 
     /// Write the value at [rs1 + imm] into the trace buffer.
-    fn trace_mem_value(&mut self, rs1: RiscRegister, imm: u64) {
+    fn trace_mem_value(&mut self, rs1: RiscRegister, imm: u64, emit_offset: bool) {
         // Load the value, assumed to be of a memory read, into TEMP_A.
         self.emit_risc_operand_load(rs1.into(), TEMP_A);
-
-        dynasm! {
-            self;
-            .arch x64;
-
-            // Check if were in unconstrained mode.
-            cmp Rq(UNCONSTRAINED_OR_SAVED_STACK_PTR), 1;
-            je >done
-        }
-
         // ------------------------------------
         // Compute the address to load from.
         // ------------------------------------
         do_opt_imm_var!(self, add, TEMP_A, imm);
+
+        if emit_offset {
+            dynasm! {
+                self;
+                .arch x64;
+
+                // ------------------------------------
+                // Store the intra-word offset.
+                // ------------------------------------
+                mov rax, Rq(TEMP_A);
+                and rax, 7
+            }
+        }
 
         dynasm! {
             self;
@@ -276,6 +279,10 @@ impl TraceCollector for TranspilerBackend {
             // physical memory pointer.
             // ------------------------------------
             lea Rq(TEMP_A), [Rq(MEMORY_PTR) + Rq(TEMP_A) * 2];
+
+            // Check if were in unconstrained mode.
+            cmp Rq(UNCONSTRAINED_OR_SAVED_STACK_PTR), 1;
+            je >done;
 
             // ------------------------------------
             // Load the clk & word from the memory entry into the tail.
@@ -298,6 +305,12 @@ impl TraceCollector for TranspilerBackend {
             add Rq(TAIL_START), 16;
 
             done:
+
+            // When tracing is done, the following registers
+            // contain useful values for memory operations:
+            //
+            // * TEMP_A holds address of MemValue entry
+            // * rax holds intra-word offset (when emit_offset is true)
         }
     }
 

--- a/crates/core/jit/src/backends/x86/mod.rs
+++ b/crates/core/jit/src/backends/x86/mod.rs
@@ -458,7 +458,7 @@ impl TranspilerBackend {
         self.hoist_clock();
 
         // Its possible that enter back into the function with a non-zero PC.
-        self.jump_to_pc();
+        self.load_and_jump_to_pc();
     }
 
     /// Restore all the registers callee-saved registers we clobbered
@@ -840,7 +840,7 @@ impl TranspilerBackend {
         }
     }
 
-    /// Update pc value
+    /// Write pc value back to JitContext
     #[inline]
     fn update_pc(&mut self, temp_reg: u8, pc: u64) {
         do_load_imm_var!(self, temp_reg, pc);
@@ -871,11 +871,19 @@ impl TranspilerBackend {
         Some(label)
     }
 
+    /// Loads PC from JitContext, then looks up jump table,
+    /// executes a jump.
+    #[inline]
+    fn load_and_jump_to_pc(&mut self) {
+        self.load_pc_into_register(TEMP_A);
+        self.jump_to_pc();
+    }
+
     /// Looks up into the jump table and executes a jump.
+    /// This method assumes that PC is in TEMP_A. If you are
+    /// not sure, you should use `load_and_jump_to_pc`.
     #[inline]
     fn jump_to_pc(&mut self) {
-        self.load_pc_into_register(TEMP_A);
-
         let pc_base = self.pc_base as i32;
         dynasm! {
             self;
@@ -938,7 +946,15 @@ impl TranspilerBackend {
             }
         }
         if !handled {
-            self.jump_to_pc();
+            // If a target is not available, we fall back to the old path:
+            // update PC, and query jump table.
+            if let Some(target_pc) = jump_target {
+                // This saves a pair of memory store / load operation on PC.
+                do_load_imm_var!(self, TEMP_A, target_pc);
+                self.jump_to_pc();
+            } else {
+                self.load_and_jump_to_pc();
+            }
         }
     }
 }

--- a/crates/core/jit/src/backends/x86/mod.rs
+++ b/crates/core/jit/src/backends/x86/mod.rs
@@ -70,10 +70,13 @@ const JUMP_TABLE: u8 = Rq::R13 as u8;
 /// Callee-saved register.
 const TRACE_BUF: u8 = Rq::R14 as u8;
 
-/// The global clk value.
+/// The local clk value. Local clock represents an internal clock
+/// used by the JIT. This way JIT can bumps local clock in one instruction,
+/// at boundary between JIT code and Rust code, we use local clock
+/// to update both clk and global_clk.
 ///
-/// Callee-saved register.
-const GLOBAL_CLK: u8 = Rq::RSI as u8;
+/// Caller-saved register.
+const LOCAL_CLK: u8 = Rq::RSI as u8;
 
 /// The saved stack pointer, used during external function calls.
 ///
@@ -97,6 +100,9 @@ const MEMORY_PTR_OFFSET: i32 = offset_of!(JitContext, memory) as i32;
 
 /// The offset of the registers in the JitContext.
 const REGISTERS_OFFSET: i32 = offset_of!(JitContext, registers) as i32;
+
+/// The offset of the is_unconstrained flag in the JitContext.
+const IS_UNCONSTRAINED_OFFSET: i32 = offset_of!(JitContext, is_unconstrained) as i32;
 
 /// The offset of `num_mem_reads` in TraceChunkHeader.
 const NUM_MEM_READS_OFFSET: i32 = offset_of!(TraceChunkHeader, num_mem_reads) as i32;
@@ -239,8 +245,6 @@ impl TraceCollector for TranspilerBackend {
 
     /// Write the value at [rs1 + imm] into the trace buffer.
     fn trace_mem_value(&mut self, rs1: RiscRegister, imm: u64) {
-        const IS_UNCONSTRAINED_OFFSET: i32 = offset_of!(JitContext, is_unconstrained) as i32;
-
         // Load the value, assumed to be of a memory read, into TEMP_A.
         self.emit_risc_operand_load(rs1.into(), TEMP_A);
 
@@ -283,6 +287,7 @@ impl TraceCollector for TranspilerBackend {
             movdqu xmm15, [Rq(TEMP_A)];
             movdqu [Rq(TAIL_START)], xmm15;
             mov rdx, Rq(CLOCK_OR_SAVED_STACK_PTR);
+            add rdx, Rq(LOCAL_CLK);
             add rdx, 1;
             mov [Rq(TEMP_A)], rdx;
 
@@ -341,6 +346,12 @@ impl TraceCollector for TranspilerBackend {
 impl TranspilerBackend {
     fn tracing(&self) -> bool {
         self.max_trace_size > 0
+    }
+
+    #[inline]
+    fn clk_bump_shifts(&self) -> i8 {
+        assert!(self.clk_bump > 0 && (self.clk_bump & (self.clk_bump - 1)) == 0, "clk_bump must be a power of 2!");
+        self.clk_bump.trailing_zeros() as i8
     }
 
     fn exit_if_trace_exceeds(&mut self, max_trace_size: u64) {
@@ -754,27 +765,50 @@ impl TranspilerBackend {
 
     #[inline]
     fn hoist_clock(&mut self) {
-        let global_clk_offset = offset_of!(JitContext, global_clk) as i32;
-
         dynasm! {
             self;
             .arch x64;
 
+            // Load clk from memory to register
             mov Rq(CLOCK_OR_SAVED_STACK_PTR), QWORD [Rq(CONTEXT) + CLK_OFFSET];
-            mov Rq(GLOBAL_CLK), QWORD [Rq(CONTEXT) + global_clk_offset]
+            // Setup local clk
+            xor Rq(LOCAL_CLK), Rq(LOCAL_CLK)
         }
     }
 
     #[inline]
     fn write_back_clock(&mut self) {
-        let global_clk_offset = offset_of!(JitContext, global_clk) as i32;
+        let clk_bump_shifts = self.clk_bump_shifts();
 
         dynasm! {
             self;
             .arch x64;
 
+            // Commit local clk first
+            add Rq(CLOCK_OR_SAVED_STACK_PTR), Rq(LOCAL_CLK);
+            // Save clk back to memory
             mov QWORD [Rq(CONTEXT) + CLK_OFFSET], Rq(CLOCK_OR_SAVED_STACK_PTR);
-            mov QWORD [Rq(CONTEXT) + global_clk_offset], Rq(GLOBAL_CLK)
+
+            // Convert local clk to global_clk form
+            shr Rq(LOCAL_CLK), clk_bump_shifts;
+
+            // Load is_unconstrained (8-bit) into TEMP_A with zero extension
+            mov Rq(TEMP_A), QWORD [Rq(CONTEXT) + IS_UNCONSTRAINED_OFFSET];
+
+            // ------------------------------------
+            // Add to global_clk based on is_unconstrained:
+            // - If is_unconstrained == 0, add 1 per bumped clk
+            // - If is_unconstrained == 1, add 0
+            // ------------------------------------
+            //
+            // Note that is_unconstrained can only be altered in ecalls. In
+            // JIT execution, it remains a constant.
+            xor eax, eax;
+            test Rq(TEMP_A), Rq(TEMP_A);
+            cmovnz Rq(LOCAL_CLK), rax;
+
+            // Add the inverted value to global_clk
+            add QWORD [Rq(CONTEXT) + GLOBAL_CLK_OFFSET], Rq(LOCAL_CLK)
         }
     }
 
@@ -849,7 +883,6 @@ impl TranspilerBackend {
     }
 
     fn bump_clk(&mut self) {
-        let is_unconstrained_offset = offset_of!(JitContext, is_unconstrained) as i32;
         let clk_bump = self.clk_bump as i32;
 
         dynasm! {
@@ -859,22 +892,7 @@ impl TranspilerBackend {
             // ------------------------------------
             // Add the amount to the clk field in the context.
             // ------------------------------------
-            add Rq(CLOCK_OR_SAVED_STACK_PTR), clk_bump;
-
-            // ------------------------------------
-            // Add to global_clk based on is_unconstrained:
-            // - If is_unconstrained == 0, add 1
-            // - If is_unconstrained == 1, add 0
-            // ------------------------------------
-
-            // Load is_unconstrained (8-bit) into TEMP_A with zero extension
-            mov Rq(TEMP_A), QWORD [Rq(CONTEXT) + is_unconstrained_offset];
-
-            // XOR with 1 to invert: 0 -> 1, 1 -> 0
-            xor Rq(TEMP_A), 1;
-
-            // Add the inverted value to global_clk
-            add Rq(GLOBAL_CLK), Rq(TEMP_A)
+            add Rq(LOCAL_CLK), clk_bump
         }
     }
 

--- a/crates/core/jit/src/backends/x86/tests.rs
+++ b/crates/core/jit/src/backends/x86/tests.rs
@@ -2,7 +2,7 @@ use super::TranspilerBackend;
 use crate::{
     memory::AnonymousMemory, trace_capacity, ComputeInstructions, ControlFlowInstructions,
     Debuggable, JitContext, JitFunction, MemoryInstructions, MinimalTrace, RiscOperand,
-    RiscRegister, RiscvTranspiler, TraceChunkRaw,
+    RiscRegister, RiscvTranspiler, TraceChunkRaw, TraceCollector,
 };
 use memmap2::MmapMut;
 
@@ -1105,6 +1105,7 @@ mod memory {
         let mut backend = new_backend();
 
         backend.start_instr();
+        backend.trace_mem_value(RiscRegister::X1, 0, true);
         backend.lw(RiscRegister::X1, RiscRegister::X1, 0);
         backend.inspect_register(RiscRegister::X1, assert_register_is!(5));
 
@@ -1116,6 +1117,7 @@ mod memory {
         let mut backend = new_backend();
 
         backend.start_instr();
+        backend.trace_mem_value(RiscRegister::X1, 0, true);
         backend.lb(RiscRegister::X1, RiscRegister::X1, 0); // LB x1, 0(x1)
         backend.inspect_register(RiscRegister::X1, assert_register_is!(0xFFFFFFFFFFFFFF80)); // −128 sign-extended
 
@@ -1128,6 +1130,7 @@ mod memory {
         let mut backend = new_backend();
 
         backend.start_instr();
+        backend.trace_mem_value(RiscRegister::X1, 0, true);
         backend.lbu(RiscRegister::X1, RiscRegister::X1, 0); // LBU x1, 0(x1)
         backend.inspect_register(RiscRegister::X1, assert_register_is!(0x00000080)); // 128 zero-extended
 
@@ -1139,6 +1142,7 @@ mod memory {
         let mut backend = new_backend();
 
         backend.start_instr();
+        backend.trace_mem_value(RiscRegister::X1, 0, true);
         backend.lh(RiscRegister::X1, RiscRegister::X1, 0); // LH x1, 0(x1)
         backend.inspect_register(RiscRegister::X1, assert_register_is!(0xFFFFFFFFFFFF8000)); // −32768 sign-extended
 
@@ -1151,6 +1155,7 @@ mod memory {
         let mut backend = new_backend();
 
         backend.start_instr();
+        backend.trace_mem_value(RiscRegister::X1, 0, true);
         backend.lhu(RiscRegister::X1, RiscRegister::X1, 0); // LHU x1, 0(x1)
         backend.inspect_register(RiscRegister::X1, assert_register_is!(0x00008000)); // 32768 zero-extended
 
@@ -1167,6 +1172,7 @@ mod memory {
 
         // Store 5 into memory[0]
         backend.start_instr();
+        backend.trace_mem_value(RiscRegister::X0, 0, true);
         backend.sw(RiscRegister::X0, RiscRegister::X1, 0); // SW: m(rs1 + imm) = rs2
 
         run_test_and_check_memory(backend, |memory| {
@@ -1185,6 +1191,7 @@ mod memory {
 
         // SH: store 16-bit value at address 0
         backend.start_instr();
+        backend.trace_mem_value(RiscRegister::X0, 0, true);
         backend.sh(RiscRegister::X0, RiscRegister::X1, 0);
 
         run_test_and_check_memory(backend, |memory| {
@@ -1203,6 +1210,7 @@ mod memory {
 
         // SB: store 8-bit value at address 0
         backend.start_instr();
+        backend.trace_mem_value(RiscRegister::X0, 0, true);
         backend.sb(RiscRegister::X0, RiscRegister::X1, 0);
 
         run_test_and_check_memory(backend, |memory| {
@@ -1219,6 +1227,7 @@ mod memory {
         let mut backend = new_backend();
 
         backend.start_instr();
+        backend.trace_mem_value(RiscRegister::X2, 0, true);
         backend.lhu(RiscRegister::X2, RiscRegister::X1, 0); // X1 == 0 by default
         backend.inspect_register(RiscRegister::X2, assert_register_is!(0x00001234));
 
@@ -1232,6 +1241,7 @@ mod memory {
         let mut backend = new_backend();
 
         backend.start_instr();
+        backend.trace_mem_value(RiscRegister::X3, 2, true);
         backend.lhu(RiscRegister::X3, RiscRegister::X1, 2); // imm = 2 => second half-word
         backend.inspect_register(RiscRegister::X3, assert_register_is!(0x0000ABCD));
 
@@ -1244,6 +1254,7 @@ mod memory {
         let mut backend = new_backend();
 
         backend.start_instr();
+        backend.trace_mem_value(RiscRegister::X1, 0, true);
         backend.lhu(RiscRegister::X1, RiscRegister::X1, 0);
         backend.inspect_register(RiscRegister::X1, assert_register_is!(0x00008000));
 
@@ -1256,6 +1267,7 @@ mod memory {
         let mut backend = new_backend();
 
         backend.start_instr();
+        backend.trace_mem_value(RiscRegister::X2, 0, true);
         backend.lh(RiscRegister::X2, RiscRegister::X1, 0);
         backend.inspect_register(RiscRegister::X2, assert_register_is!(0xFFFFFFFFFFFFF234));
 
@@ -1268,6 +1280,7 @@ mod memory {
         let mut backend = new_backend();
 
         backend.start_instr();
+        backend.trace_mem_value(RiscRegister::X3, 2, true);
         backend.lh(RiscRegister::X3, RiscRegister::X1, 2);
         backend.inspect_register(RiscRegister::X3, assert_register_is!(0xFFFFFFFFFFFF8000));
 
@@ -1300,6 +1313,7 @@ mod memory {
         let mut backend = new_backend();
 
         backend.start_instr();
+        backend.trace_mem_value(RiscRegister::X1, 0, false);
         backend.ld(RiscRegister::X1, RiscRegister::X0, 0);
         backend.inspect_register(RiscRegister::X1, assert_register_is!(0xDEADBEEFCAFEBABE));
 
@@ -1313,6 +1327,7 @@ mod memory {
         backend.start_instr();
         // Load base address 8 into X2
         backend.add(RiscRegister::X2, RiscOperand::Immediate(8), RiscOperand::Immediate(0));
+        backend.trace_mem_value(RiscRegister::X2, 8, false);
         // Load doubleword from address X2 + 8 (= 16)
         backend.ld(RiscRegister::X1, RiscRegister::X2, 8);
         backend.inspect_register(RiscRegister::X1, assert_register_is!(0x1234567890ABCDEF));
@@ -1341,6 +1356,7 @@ mod memory {
             RiscOperand::Register(RiscRegister::X1),
             RiscOperand::Immediate(0x76543210u32 as i32),
         );
+        backend.trace_mem_value(RiscRegister::X0, 0, false);
         backend.sd(RiscRegister::X0, RiscRegister::X1, 0);
 
         run_test_and_check_memory(backend, |memory| {
@@ -1362,6 +1378,7 @@ mod memory {
             RiscOperand::Immediate(0x12345678),
             RiscOperand::Immediate(0x12345678),
         );
+        backend.trace_mem_value(RiscRegister::X2, 16, false);
         backend.sd(RiscRegister::X2, RiscRegister::X1, 16);
 
         run_test_and_check_memory(backend, |memory| {
@@ -1375,6 +1392,7 @@ mod memory {
         let mut backend = new_backend();
 
         backend.start_instr();
+        backend.trace_mem_value(RiscRegister::X0, 0, true);
         // LWU loads 32-bit value and zero-extends to 64 bits
         backend.lwu(RiscRegister::X1, RiscRegister::X0, 0);
         backend.inspect_register(RiscRegister::X1, assert_register_is!(0x00000000FFFFFFFF));
@@ -1389,6 +1407,7 @@ mod memory {
         backend.start_instr();
         // Set base address
         backend.add(RiscRegister::X2, RiscOperand::Immediate(4), RiscOperand::Immediate(0));
+        backend.trace_mem_value(RiscRegister::X2, 4, true);
         // Load unsigned word from X2 + 4 (= 8)
         backend.lwu(RiscRegister::X1, RiscRegister::X2, 4);
         backend.inspect_register(RiscRegister::X1, assert_register_is!(0x0000000080000000));
@@ -1401,11 +1420,13 @@ mod memory {
         let mut backend = new_backend();
 
         backend.start_instr();
+        backend.trace_mem_value(RiscRegister::X0, 0, true);
         // LW sign-extends negative values
         backend.lw(RiscRegister::X1, RiscRegister::X0, 0);
         backend.inspect_register(RiscRegister::X1, assert_register_is!(0xFFFFFFFF80000000));
 
         // LWU zero-extends the same value
+        backend.trace_mem_value(RiscRegister::X0, 0, true);
         backend.lwu(RiscRegister::X2, RiscRegister::X0, 0);
         backend.inspect_register(RiscRegister::X2, assert_register_is!(0x0000000080000000));
 
@@ -1466,18 +1487,20 @@ mod trace {
 
         // Do a store into addr = 0, and trace it.
         backend.add(RiscRegister::X1, RiscOperand::Immediate(5), RiscOperand::Immediate(0));
+        backend.trace_mem_value(RiscRegister::X0, 0, true);
         backend.sw(RiscRegister::X0, RiscRegister::X1, 0);
-        backend.trace_mem_value(RiscRegister::X0, 0);
+        backend.trace_mem_value(RiscRegister::X0, 0, false);
 
         // Do a store into addr = 8, and trace it.
         backend.add(RiscRegister::X2, RiscOperand::Immediate(10), RiscOperand::Immediate(0));
+        backend.trace_mem_value(RiscRegister::X0, 8, true);
         backend.sw(RiscRegister::X0, RiscRegister::X2, 8);
 
         // Bump the clk by 8.
         backend.bump_clk();
-        backend.trace_mem_value(RiscRegister::X0, 8);
+        backend.trace_mem_value(RiscRegister::X0, 8, false);
         // The last trace call should have bumped the clk by 8.
-        backend.trace_mem_value(RiscRegister::X0, 8);
+        backend.trace_mem_value(RiscRegister::X0, 8, false);
 
         backend.call_extern_fn(some_precompile);
 
@@ -1496,22 +1519,25 @@ mod trace {
         assert_eq!(registers[1], 5);
         assert_eq!(registers[2], 10);
         assert_eq!(pc, 103);
-        assert_eq!(mem_reads, 5);
+        assert_eq!(mem_reads, 7);
 
         let mem_reads = trace.mem_reads().collect::<Vec<_>>();
 
         // Check the values.
-        assert_eq!(mem_reads[0].value, 5);
-        assert_eq!(mem_reads[1].value, 10);
-        assert_eq!(mem_reads[2].value, 10);
-        assert_eq!(mem_reads[3].value, 15);
-        assert_eq!(mem_reads[4].value, 20);
+        assert_eq!(mem_reads[0].value, 0);
+        assert_eq!(mem_reads[1].value, 5);
+        assert_eq!(mem_reads[2].value, 0);
+        assert_eq!(mem_reads[3].value, 10);
+        assert_eq!(mem_reads[4].value, 10);
+        assert_eq!(mem_reads[5].value, 15);
+        assert_eq!(mem_reads[6].value, 20);
 
         // Check the clks.
-        assert_eq!(mem_reads[0].clk, 0);
-        assert_eq!(mem_reads[1].clk, 0);
-        assert_eq!(mem_reads[2].clk, 10);
-        assert_eq!(mem_reads[3].clk, 5);
+        assert_eq!(mem_reads[1].clk, 2);
+        assert_eq!(mem_reads[2].clk, 0);
+        assert_eq!(mem_reads[3].clk, 2);
         assert_eq!(mem_reads[4].clk, 10);
+        assert_eq!(mem_reads[5].clk, 5);
+        assert_eq!(mem_reads[6].clk, 10);
     }
 }

--- a/crates/core/jit/src/lib.rs
+++ b/crates/core/jit/src/lib.rs
@@ -148,7 +148,7 @@ pub trait TraceCollector {
     fn trace_registers(&mut self);
 
     /// Write the value located at rs1 + imm into the trace buf.
-    fn trace_mem_value(&mut self, rs1: RiscRegister, imm: u64);
+    fn trace_mem_value(&mut self, rs1: RiscRegister, imm: u64, emit_offset: bool);
 
     /// Write the start pc of the trace chunk.
     fn trace_pc_start(&mut self);


### PR DESCRIPTION
This change introduces a new `local clk` in native executor JIT code. For each RISC-V instruction, native executor can only bump `local clk` in one x86_64 instruction. The values in `local clk` is then commited back to both `clk` and `global_clk` at the boundary between JIT code and Rust code.

For each JIT execution batch, `is_unconstrained` is a constant, only ecall can change it. When handling ecall, we will have to commit JIT running states and call into Rust code. This means:

* In each JIT execution batch, `global_clk` will either be bumped with the number of instructions, or not bumped at all. There is no behavior changes from one instruction to the next.
* We can also hoist `is_unconstrained` as a constant register value.

On top of #2658 and #2681, this change brings noticeable speedups. Testing on AWS m8a.xlarge machine:

For non-tracing mode:

```
|           | before      | after       |
|-----------|-------------|-------------|
| secp256k1 | 1400.57 Mhz | 1592.91 Mhz |
| keccak    | 1810.81 Mhz | 1933.13 Mhz |
| ed25519   | 1304.25 Mhz | 1429.22 Mhz |
```

~~For tracing mode:~~

```
Ignore this one, see below.

|           | before      | after       |
|-----------|-------------|-------------|
| secp256k1 | 959.18 Mhz  | 1167.51 Mhz |
| keccak    | 1351.05 Mhz | 1346.62 Mhz |
| ed25519   | 731.14 Mhz  | 785.52 Mhz  |
```

**Update**: I just noticed that something is off with my ed25519 tests. The test input I use is too small(1500 ed25519 verifications, completes in ~1.5 seconds), so that initialization cost affects speeds. I rerun the benchmark on a larger test input(20000 ed25519 verifications, completes in ~13 seconds), tracing mode result is actually:

```
|           | before      | after       | % of non-tracing mode |
|-----------|-------------|-------------|-----------------------|
| secp256k1 | 959.18 Mhz  | 1240.51 Mhz | 77.87%                |
| keccak    | 1351.05 Mhz | 1419.47 Mhz | 73.42%                |
| ed25519   | 1011.11 Mhz | 1178.77 Mhz | 82.47%                |
```

For non-tracing mode, the speed stays the same as the smaller test.