### PR TITLE
fix: use posix_spawn instead of fork for child process

### DIFF
--- a/crates/core/runner/src/native.rs
+++ b/crates/core/runner/src/native.rs
@@ -133,9 +133,7 @@ impl MinimalExecutorRunner {
                 Command::new(crate::binary::get_binary_path()),
                 self.input.memory_limit,
             )
-            .map_err(|e| {
-                ExecutionError::Other(format!("failed to spawn child process: {e}"))
-            })?;
+            .map_err(|e| ExecutionError::Other(format!("failed to spawn child process: {e}")))?;
 
             {
                 let stdin = child.stdin.take().expect("open stdin");

--- a/crates/core/runner/src/native.rs
+++ b/crates/core/runner/src/native.rs
@@ -391,20 +391,22 @@ fn create(input: &Input) -> (SharedMemory, Option<ShmTraceRing>) {
 }
 
 /// Spawns a process with piped I/O and an RSS memory monitor thread.
-/// **Written by Gemini 3**
 fn spawn_restricted(mut cmd: Command, limit_bytes: u64) -> std::io::Result<Child> {
-    // Force pipes for all three standard streams
     cmd.stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::piped());
 
-    // Disable core dumps process-wide. Children inherit this via posix_spawn without
-    // needing pre_exec (which would force Rust to use fork instead of posix_spawn,
-    // causing ENOMEM when the parent has large sparse mmap regions).
-    unsafe {
-        let limit = libc::rlimit { rlim_cur: 0, rlim_max: 0 };
-        libc::setrlimit(libc::RLIMIT_CORE, &limit);
-    }
+    // Disable core dumps for the child by temporarily zeroing RLIMIT_CORE in the
+    // parent (inherited via posix_spawn). Avoids pre_exec which forces fork().
+    let child = unsafe {
+        let mut old_limit: libc::rlimit = std::mem::zeroed();
+        libc::getrlimit(libc::RLIMIT_CORE, &mut old_limit);
 
-    let child = cmd.spawn()?;
+        let zero = libc::rlimit { rlim_cur: 0, rlim_max: 0 };
+        libc::setrlimit(libc::RLIMIT_CORE, &zero);
+        let result = cmd.spawn();
+        libc::setrlimit(libc::RLIMIT_CORE, &old_limit);
+
+        result
+    }?;
     let child_pid = child.id();
 
     // Start the Background Memory Monitor (The Enforcer)

--- a/crates/core/runner/src/native.rs
+++ b/crates/core/runner/src/native.rs
@@ -133,7 +133,9 @@ impl MinimalExecutorRunner {
                 Command::new(crate::binary::get_binary_path()),
                 self.input.memory_limit,
             )
-            .expect("start child proces");
+            .map_err(|e| {
+                ExecutionError::Other(format!("failed to spawn child process: {e}"))
+            })?;
 
             {
                 let stdin = child.stdin.take().expect("open stdin");
@@ -396,29 +398,14 @@ fn spawn_restricted(mut cmd: Command, limit_bytes: u64) -> std::io::Result<Child
     // Force pipes for all three standard streams
     cmd.stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::piped());
 
-    // Disable core dump for the child process for fast exiting, in debugging sessions
-    // you can comment this section out.
+    // Disable core dumps process-wide. Children inherit this via posix_spawn without
+    // needing pre_exec (which would force Rust to use fork instead of posix_spawn,
+    // causing ENOMEM when the parent has large sparse mmap regions).
     unsafe {
-        use std::os::unix::process::CommandExt;
-        cmd.pre_exec(|| {
-            // Create a limit structure with soft and hard limits set to 0
-            let limit = libc::rlimit {
-                rlim_cur: 0, // Soft limit
-                rlim_max: 0, // Hard limit
-            };
-
-            // Call setrlimit to disable core dumps
-            let ret = libc::setrlimit(libc::RLIMIT_CORE, &limit);
-
-            if ret != 0 {
-                // Convert libc error to Rust io::Error
-                return Err(std::io::Error::last_os_error());
-            }
-            Ok(())
-        });
+        let limit = libc::rlimit { rlim_cur: 0, rlim_max: 0 };
+        libc::setrlimit(libc::RLIMIT_CORE, &limit);
     }
 
-    // Spawn the child normally using Rust std
     let child = cmd.spawn()?;
     let child_pid = child.id();
 


### PR DESCRIPTION
## Summary

`spawn_restricted()` uses `.pre_exec()` to disable core dumps, which forces Rust's `Command::spawn()` to use `fork()+exec()` instead of `posix_spawn()`. On glibc ≥ 2.24, `posix_spawn` uses `clone(CLONE_VM|CLONE_VFORK)` which avoids duplicating the parent's virtual address space.

The CPU worker accumulates a ~108 GB private jemalloc arena from previous tasks (e.g., PlonkWrap). When `fork()` is called, the kernel's overcommit heuristic (`vm.overcommit_memory=0`) intermittently rejects the address space duplication, causing `ENOMEM`.