### PR TITLE
fix(gpu): handle channel disconnect gracefully in tracegen

### DIFF
--- a/sp1-gpu/crates/jagged_tracegen/src/lib.rs
+++ b/sp1-gpu/crates/jagged_tracegen/src/lib.rs
@@ -399,8 +399,8 @@ async fn host_preprocessed_tracegen<A: CudaTracegenAir<Felt>>(
                         air.generate_preprocessed_trace_into(&program, slice);
                         let start_pointer = unsafe { base_ptr.add(offset) as usize };
                         // Since it's unbounded, it will only error if the receiver is disconnected.
-                        tx.unbounded_send((air.name().to_string(), start_pointer, height, width))
-                            .unwrap();
+                        // If the receiver dropped (task cancelled), exit gracefully instead of panicking.
+                        let _ = tx.unbounded_send((air.name().to_string(), start_pointer, height, width));
                     }
                 },
             );
@@ -733,8 +733,8 @@ where
                             };
                             air.generate_trace_into(&record, &mut A::Record::default(), slice);
                             let start_pointer = unsafe { base_ptr.add(offset) as usize };
-                            // Since it's unbounded, it will only error if the receiver is disconnected.
-                            tx.unbounded_send((air.name().to_string(), start_pointer, height, width)).unwrap();
+                            // If the receiver dropped (task cancelled), exit gracefully instead of panicking.
+                            let _ = tx.unbounded_send((air.name().to_string(), start_pointer, height, width));
                         },
                     );
                 });

--- a/sp1-gpu/crates/jagged_tracegen/src/lib.rs
+++ b/sp1-gpu/crates/jagged_tracegen/src/lib.rs
@@ -400,7 +400,12 @@ async fn host_preprocessed_tracegen<A: CudaTracegenAir<Felt>>(
                         let start_pointer = unsafe { base_ptr.add(offset) as usize };
                         // Since it's unbounded, it will only error if the receiver is disconnected.
                         // If the receiver dropped (task cancelled), exit gracefully instead of panicking.
-                        let _ = tx.unbounded_send((air.name().to_string(), start_pointer, height, width));
+                        let _ = tx.unbounded_send((
+                            air.name().to_string(),
+                            start_pointer,
+                            height,
+                            width,
+                        ));
                     }
                 },
             );


### PR DESCRIPTION
## Description
 
When the coordinator cancels a proving task mid-execution, the async receiver drops, causing all Rayon sender threads to panic at .unwrap() on unbounded_send. This cascades and kills the GPU worker process:

```
  thread '<unnamed>' (71) panicked at sp1-gpu/crates/jagged_tracegen/src/lib.rs:737:103
  thread '<unnamed>' (73) panicked at sp1-gpu/crates/jagged_tracegen/src/lib.rs:737:103
  thread '<unnamed>' (72) panicked at sp1-gpu/crates/jagged_tracegen/src/lib.rs:737:103
  Rayon: detected unexpected panic; aborting
```

  Replace `.unwrap()` with let `_ =` at both call sites in `jagged_tracegen`. If the receiver is gone, the trace data has no consumer, silently dropping...