### PR TITLE
fix: Further WHIR audit fixes (chiefly consistency checks in WhirProofShape construction)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6081,6 +6081,7 @@ version = "6.1.0"
 dependencies = [
  "serde",
  "slop-algebra",
+ "slop-koala-bear",
  "thiserror 1.0.69",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6163,10 +6163,12 @@ name = "slop-challenger"
 version = "6.1.0"
 dependencies = [
  "futures",
+ "num-bigint 0.4.6",
  "p3-challenger",
  "serde",
  "slop-algebra",
  "slop-symmetric",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -6501,6 +6503,7 @@ dependencies = [
  "derive-where",
  "futures",
  "itertools 0.14.0",
+ "num-bigint 0.4.6",
  "rand 0.8.5",
  "rayon",
  "serde",

--- a/crates/hypercube/src/logup_gkr/prover.rs
+++ b/crates/hypercube/src/logup_gkr/prover.rs
@@ -149,8 +149,12 @@ impl<GC: IopCtx, SC: ShardContext<GC>> GkrProverImpl<GC, SC> {
         let host_numerator = numerator.to_host().unwrap();
         let host_denominator = denominator.to_host().unwrap();
 
-        challenger.observe_variable_length_extension_slice(host_numerator.guts().as_slice());
-        challenger.observe_variable_length_extension_slice(host_denominator.guts().as_slice());
+        challenger
+            .observe_variable_length_extension_slice(host_numerator.guts().as_slice())
+            .unwrap();
+        challenger
+            .observe_variable_length_extension_slice(host_denominator.guts().as_slice())
+            .unwrap();
         let output_host =
             LogUpGkrOutput { numerator: host_numerator, denominator: host_denominator };
 
@@ -201,9 +205,11 @@ impl<GC: IopCtx, SC: ShardContext<GC>> GkrProverImpl<GC, SC> {
             };
             // Observe the openings.
             if let Some(prep_eval) = openings.preprocessed_trace_evaluations.as_ref() {
-                challenger.observe_variable_length_extension_slice(prep_eval);
+                challenger.observe_variable_length_extension_slice(prep_eval).unwrap();
             }
-            challenger.observe_variable_length_extension_slice(&openings.main_trace_evaluations);
+            challenger
+                .observe_variable_length_extension_slice(&openings.main_trace_evaluations)
+                .unwrap();
 
             chip_evaluations.insert(name.to_string(), openings);
         }

--- a/crates/hypercube/src/logup_gkr/verifier.rs
+++ b/crates/hypercube/src/logup_gkr/verifier.rs
@@ -7,6 +7,7 @@ use itertools::Itertools;
 use slop_air::BaseAir;
 use slop_algebra::AbstractField;
 use slop_challenger::GrindingChallenger;
+use slop_challenger::USizeOutOfFieldBounds;
 use slop_challenger::{CanObserve, FieldChallenger, IopCtx, VariableLengthChallenger};
 use slop_multilinear::{
     full_geq, partial_lagrange_blocking, Mle, MleEval, MultilinearPcsChallenger, Point,
@@ -63,6 +64,9 @@ pub enum LogupGkrVerificationError<EF> {
     /// The public values verification failed.
     #[error("public values verification failed")]
     InvalidPublicValues,
+    /// A variable length slice observation can produce this error.
+    #[error("slice length out of field bounds")]
+    SliceLengthOutOfFieldBounds(#[from] USizeOutOfFieldBounds),
 }
 
 /// Verifier for `LogUp` GKR.
@@ -157,8 +161,8 @@ impl<GC: IopCtx, SC: ShardContext<GC>> LogUpGkrVerifier<GC, SC> {
         }
 
         // Observe the output claims.
-        challenger.observe_variable_length_extension_slice(numerator.guts().as_slice());
-        challenger.observe_variable_length_extension_slice(denominator.guts().as_slice());
+        challenger.observe_variable_length_extension_slice(numerator.guts().as_slice())?;
+        challenger.observe_variable_length_extension_slice(denominator.guts().as_slice())?;
 
         if denominator.guts().as_slice().iter().any(slop_algebra::Field::is_zero) {
             return Err(LogupGkrVerificationError::ZeroDenominator);
@@ -277,14 +281,14 @@ impl<GC: IopCtx, SC: ShardContext<GC>> LogUpGkrVerifier<GC, SC> {
         {
             // Observe the opening
             if let Some(prep_eval) = openings.preprocessed_trace_evaluations.as_ref() {
-                challenger.observe_variable_length_extension_slice(prep_eval);
+                challenger.observe_variable_length_extension_slice(prep_eval)?;
                 if prep_eval.evaluations().sizes() != [chip.air.preprocessed_width()] {
                     return Err(LogupGkrVerificationError::InvalidShape);
                 }
             } else if chip.air.preprocessed_width() != 0 {
                 return Err(LogupGkrVerificationError::InvalidShape);
             }
-            challenger.observe_variable_length_extension_slice(&openings.main_trace_evaluations);
+            challenger.observe_variable_length_extension_slice(&openings.main_trace_evaluations)?;
             if openings.main_trace_evaluations.evaluations().sizes() != [chip.air.width()] {
                 return Err(LogupGkrVerificationError::InvalidShape);
             }

--- a/crates/hypercube/src/prover/shard.rs
+++ b/crates/hypercube/src/prover/shard.rs
@@ -622,8 +622,8 @@ impl<GC: IopCtx, SC: ShardContext<GC>, C: DefaultJaggedProver<GC, SC::Config>>
                 let (preprocessed_evals, main_evals) = evals.split_at(air.preprocessed_width());
 
                 // Observe the openings
-                challenger.observe_variable_length_extension_slice(preprocessed_evals);
-                challenger.observe_variable_length_extension_slice(main_evals);
+                challenger.observe_variable_length_extension_slice(preprocessed_evals).unwrap();
+                challenger.observe_variable_length_extension_slice(main_evals).unwrap();
 
                 let preprocessed = AirOpenedValues { local: preprocessed_evals.to_vec() };
 

--- a/crates/hypercube/src/verifier/shard.rs
+++ b/crates/hypercube/src/verifier/shard.rs
@@ -780,7 +780,7 @@ where
     /// Create a shard verifier from basefold parameters.
     #[must_use]
     pub fn from_config(
-        config: &WhirProofShape<GC::F>,
+        config: &WhirProofShape<GC::F, GC::EF>,
         max_log_row_count: usize,
         machine: Machine<GC::F, A>,
         num_expected_commitments: usize,

--- a/crates/hypercube/src/verifier/shard.rs
+++ b/crates/hypercube/src/verifier/shard.rs
@@ -15,7 +15,9 @@ use std::{
 use itertools::Itertools;
 use slop_air::{Air, BaseAir};
 use slop_algebra::{AbstractField, PrimeField32, TwoAdicField};
-use slop_challenger::{CanObserve, FieldChallenger, IopCtx, VariableLengthChallenger};
+use slop_challenger::{
+    CanObserve, FieldChallenger, IopCtx, USizeOutOfFieldBounds, VariableLengthChallenger,
+};
 use slop_commit::Rounds;
 use slop_jagged::{JaggedPcsVerifier, JaggedPcsVerifierError};
 use slop_matrix::dense::RowMajorMatrixView;
@@ -115,6 +117,9 @@ pub enum ShardVerifierError<EF, PcsError> {
     /// The height is larger than `1 << max_log_row_count`.
     #[error("height is larger than maximum possible value")]
     HeightTooLarge,
+    /// Observing variable length slices can produce this error.
+    #[error("slice length out of field bounds")]
+    SliceLengthOutOfFieldBounds(#[from] USizeOutOfFieldBounds),
 }
 
 /// Derive the error type from the jagged config.
@@ -425,8 +430,8 @@ where {
         let len = shard_chips.len();
         challenger.observe(GC::F::from_canonical_usize(len));
         for (_, opening) in opened_values.chips.iter() {
-            challenger.observe_variable_length_extension_slice(&opening.preprocessed.local);
-            challenger.observe_variable_length_extension_slice(&opening.main.local);
+            challenger.observe_variable_length_extension_slice(&opening.preprocessed.local)?;
+            challenger.observe_variable_length_extension_slice(&opening.main.local)?;
         }
 
         Ok(())

--- a/crates/recursion/circuit/src/basefold/whir.rs
+++ b/crates/recursion/circuit/src/basefold/whir.rs
@@ -26,7 +26,7 @@ use sp1_recursion_compiler::{
 
 #[derive(Clone)]
 pub struct RecursiveWhirVerifier<C: CircuitConfig, SC: SP1FieldConfigVariable<C>> {
-    config: WhirProofShape<SP1Field>,
+    config: WhirProofShape<SP1Field, SP1ExtensionField>,
     _config: PhantomData<(C, SC)>,
 }
 
@@ -34,19 +34,18 @@ pub fn write_round_config_to_challenger<
     C: CircuitConfig,
     SC: SP1FieldConfigVariable<C, F = SP1Field>,
 >(
-    round_param: RoundConfig,
+    round_param: &RoundConfig,
     challenger: &mut SC::FriChallengerVariable,
     builder: &mut Builder<C>,
 ) {
-    let RoundConfig {
+    let &RoundConfig {
         folding_factor,
         evaluation_domain_log_size,
         queries_pow_bits,
-        pow_bits,
+        ref pow_bits,
         num_queries,
         ood_samples,
-        log_inv_rate,
-    } = round_param.clone();
+    } = round_param;
 
     let folding_factor_felt: Felt<_> =
         builder.constant(<SC as IopCtx>::F::from_canonical_usize(folding_factor));
@@ -61,8 +60,8 @@ pub fn write_round_config_to_challenger<
     challenger.observe(builder, queries_pow_bits_felt);
 
     let pow_bits_felt: Vec<Felt<_>> = pow_bits
-        .into_iter()
-        .map(|b| builder.constant(<SC as IopCtx>::F::from_canonical_usize(b)))
+        .iter()
+        .map(|b| builder.constant(<SC as IopCtx>::F::from_canonical_usize(*b)))
         .collect();
     challenger.observe_variable_length_slice(builder, &pow_bits_felt);
 
@@ -73,88 +72,70 @@ pub fn write_round_config_to_challenger<
     let ood_samples_felt: Felt<_> =
         builder.constant(<SC as IopCtx>::F::from_canonical_usize(ood_samples));
     challenger.observe(builder, ood_samples_felt);
-
-    let log_inv_rate_felt: Felt<_> =
-        builder.constant(<SC as IopCtx>::F::from_canonical_usize(log_inv_rate));
-    challenger.observe(builder, log_inv_rate_felt);
 }
 
 fn write_whir_config_to_challenger<
     C: CircuitConfig,
     SC: SP1FieldConfigVariable<C, F = SP1Field>,
 >(
-    config: WhirProofShape<SP1Field>,
+    config: WhirProofShape<SP1Field, SP1ExtensionField>,
     challenger: &mut SC::FriChallengerVariable,
     builder: &mut Builder<C>,
 ) {
-    let WhirProofShape {
-        domain_generator,
-        starting_ood_samples,
-        starting_log_inv_rate,
-        starting_interleaved_log_height,
-        starting_domain_log_size,
-        starting_folding_pow_bits,
-        round_parameters,
-        final_poly_log_degree,
-        final_queries,
-        final_pow_bits,
-        final_folding_pow_bits,
-    } = config.clone();
-
-    let domain_generator_felt: Felt<_> = builder.constant(domain_generator);
-    challenger.observe(builder, domain_generator_felt);
-
     let starting_ood_samples_felt: Felt<_> =
-        builder.constant(<SC as IopCtx>::F::from_canonical_usize(starting_ood_samples));
+        builder.constant(<SC as IopCtx>::F::from_canonical_usize(config.starting_ood_samples()));
     challenger.observe(builder, starting_ood_samples_felt);
 
     let starting_log_inv_rate_felt: Felt<_> =
-        builder.constant(<SC as IopCtx>::F::from_canonical_usize(starting_log_inv_rate));
+        builder.constant(<SC as IopCtx>::F::from_canonical_usize(config.starting_log_inv_rate()));
     challenger.observe(builder, starting_log_inv_rate_felt);
 
-    let starting_interleaved_log_height_felt: Felt<_> =
-        builder.constant(<SC as IopCtx>::F::from_canonical_usize(starting_interleaved_log_height));
+    let starting_interleaved_log_height_felt: Felt<_> = builder.constant(
+        <SC as IopCtx>::F::from_canonical_usize(config.starting_interleaved_log_height()),
+    );
     challenger.observe(builder, starting_interleaved_log_height_felt);
 
-    let starting_domain_log_size_felt: Felt<_> =
-        builder.constant(<SC as IopCtx>::F::from_canonical_usize(starting_domain_log_size));
-    challenger.observe(builder, starting_domain_log_size_felt);
-
-    let starting_folding_pow_bits_felt: Vec<Felt<_>> = starting_folding_pow_bits
-        .into_iter()
-        .map(|b| builder.constant(<SC as IopCtx>::F::from_canonical_usize(b)))
+    let starting_folding_pow_bits_felt: Vec<Felt<_>> = config
+        .starting_folding_pow_bits()
+        .iter()
+        .map(|b| builder.constant(<SC as IopCtx>::F::from_canonical_usize(*b)))
         .collect();
     challenger.observe_variable_length_slice(builder, &starting_folding_pow_bits_felt);
 
-    for round_param in round_parameters {
+    let len_felt: Felt<_> =
+        builder.constant(<SC as IopCtx>::F::from_canonical_usize(config.round_parameters().len()));
+    challenger.observe(builder, len_felt);
+    for round_param in config.round_parameters() {
         write_round_config_to_challenger::<C, SC>(round_param, challenger, builder);
     }
 
-    let final_poly_log_degree_felt: Felt<_> =
-        builder.constant(<SC as IopCtx>::F::from_canonical_usize(final_poly_log_degree));
-    challenger.observe(builder, final_poly_log_degree_felt);
-
     let final_queries_felt: Felt<_> =
-        builder.constant(<SC as IopCtx>::F::from_canonical_usize(final_queries));
+        builder.constant(<SC as IopCtx>::F::from_canonical_usize(config.final_queries()));
     challenger.observe(builder, final_queries_felt);
 
     let final_pow_bits_felt: Felt<_> =
-        builder.constant(<SC as IopCtx>::F::from_canonical_usize(final_pow_bits));
+        builder.constant(<SC as IopCtx>::F::from_canonical_usize(config.final_pow_bits()));
     challenger.observe(builder, final_pow_bits_felt);
 
-    let final_folding_pow_bits_felt: Vec<Felt<_>> = final_folding_pow_bits
-        .into_iter()
-        .map(|b| builder.constant(<SC as IopCtx>::F::from_canonical_usize(b)))
+    let final_folding_pow_bits_felt: Vec<Felt<_>> = config
+        .final_folding_pow_bits()
+        .iter()
+        .map(|b| builder.constant(<SC as IopCtx>::F::from_canonical_usize(*b)))
         .collect();
     challenger.observe_variable_length_slice(builder, &final_folding_pow_bits_felt);
 }
 
 impl<C: CircuitConfig, SC: SP1FieldConfigVariable<C, F = SP1Field>> RecursiveWhirVerifier<C, SC> {
     pub fn new(
-        config: WhirProofShape<SP1Field>,
+        config: WhirProofShape<SP1Field, SP1ExtensionField>,
         builder: &mut Builder<C>,
         challenger: &mut SC::FriChallengerVariable,
+        num_expected_commitments: usize,
     ) -> Self {
+        let num_expected_commitments_felt: Felt<_> =
+            builder.constant(<SC as IopCtx>::F::from_canonical_usize(num_expected_commitments));
+        challenger.observe(builder, num_expected_commitments_felt);
+
         write_whir_config_to_challenger::<C, SC>(config.clone(), challenger, builder);
         Self { config, _config: PhantomData }
     }
@@ -225,10 +206,10 @@ impl<C: CircuitConfig, SC: SP1FieldConfigVariable<C>> RecursiveWhirVerifier<C, S
         proof: &RecursiveWhirProof<C, SC>,
         challenger: &mut SC::FriChallengerVariable,
     ) -> PointAndEval<Ext<SP1Field, SP1ExtensionField>> {
-        let n_rounds = self.config.round_parameters.len();
+        let n_rounds = self.config.round_parameters().len();
 
         let ood_points: Vec<Point<Ext<SP1Field, SP1ExtensionField>>> =
-            (0..self.config.starting_ood_samples)
+            (0..self.config.starting_ood_samples())
                 .map(|_| {
                     (0..num_variables)
                         .map(|_| challenger.sample_ext(builder))
@@ -268,8 +249,8 @@ impl<C: CircuitConfig, SC: SP1FieldConfigVariable<C>> RecursiveWhirVerifier<C, S
             builder,
             &proof.initial_sumcheck_polynomials,
             claimed_sum,
-            num_variables - self.config.starting_interleaved_log_height,
-            &self.config.starting_folding_pow_bits,
+            num_variables - self.config.starting_interleaved_log_height(),
+            self.config.starting_folding_pow_bits(),
             challenger,
         );
 
@@ -282,16 +263,15 @@ impl<C: CircuitConfig, SC: SP1FieldConfigVariable<C>> RecursiveWhirVerifier<C, S
 
         // This is relative to the previous commitment (i.e. prev_commitment has a domain size of
         // this size)
-        let mut domain_size =
-            self.config.starting_interleaved_log_height + self.config.starting_log_inv_rate;
-        let mut generator: Felt<SP1Field> = builder.constant(self.config.domain_generator);
+        let mut domain_size = self.config.starting_domain_log_size();
+        let mut generator: Felt<SP1Field> = builder.constant(self.config.domain_generator());
         let mut prev_commitment = commitment;
 
-        let mut prev_folding_factor = num_variables - self.config.starting_interleaved_log_height;
-        let mut num_variables = self.config.starting_interleaved_log_height;
+        let mut prev_folding_factor = num_variables - self.config.starting_interleaved_log_height();
+        let mut num_variables = self.config.starting_interleaved_log_height();
 
         for round_index in 0..n_rounds {
-            let round_params = &self.config.round_parameters[round_index];
+            let round_params = &self.config.round_parameters()[round_index];
             let new_commitment = &proof.commitments[round_index + 1];
 
             // Observe the round commitments
@@ -475,9 +455,9 @@ impl<C: CircuitConfig, SC: SP1FieldConfigVariable<C>> RecursiveWhirVerifier<C, S
         let final_poly = proof.final_polynomial.clone();
         let final_poly_uv = UnivariatePolynomial::new(IntoSymbolic::<C>::as_symbolic(&final_poly));
 
-        challenger.check_witness(builder, self.config.final_pow_bits, proof.final_pow);
+        challenger.check_witness(builder, self.config.final_pow_bits(), proof.final_pow);
 
-        let final_id_indices = (0..self.config.final_queries)
+        let final_id_indices = (0..self.config.final_queries())
             .map(|_| challenger.sample_bits(builder, domain_size))
             .collect::<Vec<_>>();
         let final_id_values: Vec<Felt<SP1Field>> = final_id_indices
@@ -524,8 +504,8 @@ impl<C: CircuitConfig, SC: SP1FieldConfigVariable<C>> RecursiveWhirVerifier<C, S
             builder,
             &proof.final_sumcheck_polynomials,
             claimed_sum,
-            self.config.final_poly_log_degree,
-            &self.config.final_folding_pow_bits,
+            self.config.final_poly_log_degree(),
+            self.config.final_folding_pow_bits(),
             challenger,
         );
 
@@ -755,10 +735,11 @@ where
 mod tests {
     use rand::{Rng, SeedableRng};
     use slop_basefold::FriConfig;
-    use slop_challenger::IopCtx;
+    use slop_challenger::{CanObserve, IopCtx};
     use slop_dft::p3::Radix2DitParallel;
     use slop_merkle_tree::{FieldMerkleTreeProver, MerkleTreeTcs, Poseidon2KoalaBear16Prover};
     use slop_tensor::Tensor;
+    use slop_whir::UncheckedWhirProofShape;
     use slop_whir::{Prover, Verifier};
     use sp1_core_machine::utils::setup_logger;
     use sp1_hypercube::{prover::simple_prover, MachineProof, MachineVerifier, ShardVerifier};
@@ -788,7 +769,8 @@ mod tests {
     #[tokio::test]
     async fn test_whir() {
         setup_logger();
-        let config = WhirProofShape::default_whir_config();
+        let config = UncheckedWhirProofShape::default_whir_config();
+        let config = WhirProofShape::new(config);
         type C = InnerConfig;
         type SC = SP1GlobalContext;
 
@@ -802,6 +784,7 @@ mod tests {
         let merkle_prover: Poseidon2KoalaBear16Prover = FieldMerkleTreeProver::default();
 
         let prover = Prover::<_, _, _>::new(Radix2DitParallel, merkle_prover, config.clone());
+        challenger_prover.observe(<SC as IopCtx>::F::two());
         config.write_to_challenger::<<SC as IopCtx>::Digest, _>(&mut challenger_prover);
         let merkle_verifier = MerkleTreeTcs::default();
         let verifier =
@@ -844,7 +827,7 @@ mod tests {
         let round_areas = proof
             .initial_merkle_proof
             .iter()
-            .map(|p| p.proof.width << config.starting_interleaved_log_height)
+            .map(|p| p.proof.width << config.starting_interleaved_log_height())
             .collect::<Vec<_>>();
         let (point, value) = verifier
             .verify(
@@ -872,6 +855,7 @@ mod tests {
             config.clone(),
             &mut builder,
             &mut challenger_variable,
+            2,
         );
 
         recursive_verifier.observe_commitment(

--- a/crates/recursion/circuit/src/basefold/whir.rs
+++ b/crates/recursion/circuit/src/basefold/whir.rs
@@ -182,7 +182,7 @@ where
     pub _config: PhantomData<C>,
 }
 
-impl<C: CircuitConfig, SC: SP1FieldConfigVariable<C>> RecursiveWhirVerifier<C, SC> {
+impl<C: CircuitConfig, SC: SP1FieldConfigVariable<C, F = SP1Field>> RecursiveWhirVerifier<C, SC> {
     pub(crate) fn observe_commitment(
         &self,
         builder: &mut Builder<C>,
@@ -201,8 +201,13 @@ impl<C: CircuitConfig, SC: SP1FieldConfigVariable<C>> RecursiveWhirVerifier<C, S
         num_variables: usize,
         proof: &RecursiveWhirProof<C, SC>,
         challenger: &mut SC::FriChallengerVariable,
-    ) -> PointAndEval<Ext<SP1Field, SP1ExtensionField>> {
+    ) -> PointAndEval<Ext<SP1Field, SP1ExtensionField>>
+where {
         let n_rounds = self.config.round_parameters().len();
+        let num_variables_felt: Felt<_> =
+            builder.constant(SC::F::from_canonical_usize(num_variables));
+
+        challenger.observe(builder, num_variables_felt);
 
         let ood_points: Vec<Point<Ext<SP1Field, SP1ExtensionField>>> =
             (0..self.config.starting_ood_samples())

--- a/crates/recursion/circuit/src/basefold/whir.rs
+++ b/crates/recursion/circuit/src/basefold/whir.rs
@@ -34,26 +34,22 @@ pub fn write_round_config_to_challenger<
     C: CircuitConfig,
     SC: SP1FieldConfigVariable<C, F = SP1Field>,
 >(
-    round_param: &RoundConfig,
+    round_param: &RoundConfig<SP1Field>,
     challenger: &mut SC::FriChallengerVariable,
     builder: &mut Builder<C>,
 ) {
     let &RoundConfig {
         folding_factor,
-        evaluation_domain_log_size,
         queries_pow_bits,
         ref pow_bits,
         num_queries,
         ood_samples,
+        ..
     } = round_param;
 
     let folding_factor_felt: Felt<_> =
         builder.constant(<SC as IopCtx>::F::from_canonical_usize(folding_factor));
     challenger.observe(builder, folding_factor_felt);
-
-    let evaluation_domain_log_size_felt: Felt<_> =
-        builder.constant(<SC as IopCtx>::F::from_canonical_usize(evaluation_domain_log_size));
-    challenger.observe(builder, evaluation_domain_log_size_felt);
 
     let queries_pow_bits_felt: Felt<_> =
         builder.constant(<SC as IopCtx>::F::from_canonical_usize(queries_pow_bits));
@@ -442,7 +438,7 @@ impl<C: CircuitConfig, SC: SP1FieldConfigVariable<C>> RecursiveWhirVerifier<C, S
                 .concat(),
             );
 
-            domain_size = round_params.evaluation_domain_log_size;
+            domain_size -= 1;
             prev_commitment = new_commitment;
             prev_folding_factor = round_params.folding_factor;
             generator = builder.eval(IntoSymbolic::<C>::as_symbolic(&generator).square());
@@ -735,7 +731,7 @@ where
 mod tests {
     use rand::{Rng, SeedableRng};
     use slop_basefold::FriConfig;
-    use slop_challenger::{CanObserve, IopCtx};
+    use slop_challenger::{CanObserve, IopCtx, VariableLengthChallenger};
     use slop_dft::p3::Radix2DitParallel;
     use slop_merkle_tree::{FieldMerkleTreeProver, MerkleTreeTcs, Poseidon2KoalaBear16Prover};
     use slop_tensor::Tensor;
@@ -814,8 +810,8 @@ mod tests {
         let eval_claim: EF = polynomial_concat.eval_at(&eval_point)[0];
 
         // Observe all commitments into both challengers.
-        verifier.observe_commitment(&commitments, &mut challenger_prover, 2).unwrap();
-        verifier.observe_commitment(&commitments, &mut challenger_verifier, 2).unwrap();
+        challenger_prover.observe_constant_length_digest_slice(&commitments);
+        challenger_verifier.observe_constant_length_digest_slice(&commitments);
 
         // Prove using prove_trusted_evaluation.
         let prover_datas = vec![prover_data_1, prover_data_2].into_iter().collect();

--- a/crates/recursion/circuit/src/basefold/whir.rs
+++ b/crates/recursion/circuit/src/basefold/whir.rs
@@ -830,14 +830,7 @@ mod tests {
             .map(|p| p.proof.width << config.starting_interleaved_log_height())
             .collect::<Vec<_>>();
         let (point, value) = verifier
-            .verify(
-                &commitments,
-                &round_areas,
-                num_variables,
-                eval_claim,
-                &proof,
-                &mut challenger_verifier,
-            )
+            .verify(&commitments, &round_areas, eval_claim, &proof, &mut challenger_verifier)
             .unwrap();
 
         // Recursive circuit verification.

--- a/crates/test-artifacts/programs/Cargo.lock
+++ b/crates/test-artifacts/programs/Cargo.lock
@@ -2064,7 +2064,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
 dependencies = [
  "memchr",
- "thiserror",
+ "thiserror 2.0.16",
  "ucd-trie",
 ]
 
@@ -2840,10 +2840,12 @@ name = "slop-challenger"
 version = "6.1.0"
 dependencies = [
  "futures",
+ "num-bigint 0.4.6",
  "p3-challenger",
  "serde",
  "slop-algebra",
  "slop-symmetric",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3193,11 +3195,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.16",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]

--- a/crates/test-artifacts/programs/fibonacci-blake3/Cargo.lock
+++ b/crates/test-artifacts/programs/fibonacci-blake3/Cargo.lock
@@ -1074,10 +1074,12 @@ name = "slop-challenger"
 version = "6.1.0"
 dependencies = [
  "futures",
+ "num-bigint 0.4.6",
  "p3-challenger",
  "serde",
  "slop-algebra",
  "slop-symmetric",
+ "thiserror",
 ]
 
 [[package]]
@@ -1221,6 +1223,26 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
 
 [[package]]
 name = "tracing"

--- a/crates/verifier/guest-verify-programs/Cargo.lock
+++ b/crates/verifier/guest-verify-programs/Cargo.lock
@@ -1731,10 +1731,12 @@ name = "slop-challenger"
 version = "6.1.0"
 dependencies = [
  "futures",
+ "num-bigint 0.4.6",
  "p3-challenger",
  "serde",
  "slop-algebra",
  "slop-symmetric",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1981,6 +1983,7 @@ dependencies = [
  "derive-where",
  "futures",
  "itertools 0.14.0",
+ "num-bigint 0.4.6",
  "rand",
  "rayon",
  "serde",

--- a/slop/crates/alloc/Cargo.toml
+++ b/slop/crates/alloc/Cargo.toml
@@ -15,5 +15,8 @@ slop-algebra = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }
 
+[dev-dependencies]
+slop-koala-bear = { workspace = true }
+
 [lints]
 workspace = true

--- a/slop/crates/alloc/src/buffer.rs
+++ b/slop/crates/alloc/src/buffer.rs
@@ -327,7 +327,7 @@ where
     /// unsafe {
     ///     // Initialize all 4 bytes
     ///     buffer.as_mut_ptr().write_bytes(0, 4);
-    ///     
+    ///
     ///     // Now we can safely assume all memory is initialized
     ///     buffer.assume_init();
     /// }
@@ -719,43 +719,6 @@ where
         let cap = original_cap * T::D;
         unsafe { Buffer::from_raw_parts(ptr, len, cap, allocator) }
     }
-
-    /// Reinterprets the buffer's base field elements as extension field elements.
-    ///
-    /// This method consumes the buffer and returns a new buffer where every `D`
-    /// base field elements are reinterpreted as one extension field element,
-    /// where `D` is the degree of the extension.
-    ///
-    /// # Type Parameters
-    ///
-    /// - `T`: The base field type
-    /// - `E`: Must implement `ExtensionField<T>`
-    ///
-    /// # Panics
-    ///
-    /// Panics if the buffer length is not divisible by the extension degree.
-    ///
-    /// # Examples
-    ///
-    /// ```rust,ignore
-    /// // If E is a degree-4 extension over T
-    /// let buffer: Buffer<BaseField> = buffer![b1, b2, b3, b4, b5, b6, b7, b8];
-    /// let ext_buffer: Buffer<ExtField> = buffer.into_extension();
-    /// assert_eq!(ext_buffer.len(), 2); // 8 / 4 = 2
-    /// ```
-    pub fn into_extension<E>(self) -> Buffer<E, A>
-    where
-        T: Field,
-        E: ExtensionField<T>,
-    {
-        let mut buffer = ManuallyDrop::new(self);
-        let (original_ptr, original_len, original_cap, allocator) =
-            (buffer.as_mut_ptr(), buffer.len(), buffer.capacity(), buffer.allocator().clone());
-        let ptr = original_ptr as *mut E;
-        let len = original_len.checked_div(E::D).unwrap();
-        let cap = original_cap.checked_div(E::D).unwrap();
-        unsafe { Buffer::from_raw_parts(ptr, len, cap, allocator) }
-    }
 }
 
 impl<T, A: Backend> HasBackend for Buffer<T, A> {
@@ -1043,6 +1006,37 @@ impl<T> Buffer<T, CpuBackend> {
         let mut vec = Vec::from(take_self);
         vec.insert(index, value);
         *self = Self::from(vec);
+    }
+
+    /// Reinterprets the buffer's base field elements as extension field elements.
+    ///
+    /// This method consumes the buffer and returns a new buffer where every `D`
+    /// base field elements are reinterpreted as one extension field element,
+    /// where `D` is the degree of the extension.
+    ///
+    /// # Type Parameters
+    ///
+    /// - `T`: The base field type
+    /// - `E`: Must implement `ExtensionField<T>`
+    ///
+    /// # Panics
+    ///
+    /// Panics if the buffer length is not divisible by the extension degree.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// // If E is a degree-4 extension over T
+    /// let buffer: Buffer<BaseField> = buffer![b1, b2, b3, b4, b5, b6, b7, b8];
+    /// let ext_buffer: Buffer<ExtField> = buffer.into_extension();
+    /// assert_eq!(ext_buffer.len(), 2); // 8 / 4 = 2
+    /// ```
+    pub fn into_extension<E>(self) -> Buffer<E, CpuBackend>
+    where
+        T: Field,
+        E: ExtensionField<T>,
+    {
+        self.into_vec().chunks_exact(E::D).map(E::from_base_slice).collect()
     }
 }
 

--- a/slop/crates/alloc/src/buffer.rs
+++ b/slop/crates/alloc/src/buffer.rs
@@ -686,39 +686,6 @@ where
 
         Ok(())
     }
-
-    /// Reinterprets the buffer's elements as base field elements.
-    ///
-    /// This method consumes the buffer and returns a new buffer where each
-    /// extension field element is reinterpreted as `D` base field elements,
-    /// where `D` is the degree of the extension.
-    ///
-    /// # Type Parameters
-    ///
-    /// - `E`: The base field type
-    /// - `T`: Must implement `ExtensionField<E>`
-    ///
-    /// # Examples
-    ///
-    /// ```rust,ignore
-    /// // If T is a degree-4 extension over E
-    /// let buffer: Buffer<ExtField> = buffer![ext1, ext2, ext3];
-    /// let base_buffer: Buffer<BaseField> = buffer.flatten_to_base();
-    /// assert_eq!(base_buffer.len(), 12); // 3 * 4 = 12
-    /// ```
-    pub fn flatten_to_base<E>(self) -> Buffer<E, A>
-    where
-        T: ExtensionField<E>,
-        E: Field,
-    {
-        let mut buffer = ManuallyDrop::new(self);
-        let (original_ptr, original_len, original_cap, allocator) =
-            (buffer.as_mut_ptr(), buffer.len(), buffer.capacity(), buffer.allocator().clone());
-        let ptr = original_ptr as *mut E;
-        let len = original_len * T::D;
-        let cap = original_cap * T::D;
-        unsafe { Buffer::from_raw_parts(ptr, len, cap, allocator) }
-    }
 }
 
 impl<T, A: Backend> HasBackend for Buffer<T, A> {
@@ -1037,6 +1004,33 @@ impl<T> Buffer<T, CpuBackend> {
         E: ExtensionField<T>,
     {
         self.into_vec().chunks_exact(E::D).map(E::from_base_slice).collect()
+    }
+
+    /// Reinterprets the buffer's elements as base field elements.
+    ///
+    /// This method consumes the buffer and returns a new buffer where each
+    /// extension field element is reinterpreted as `D` base field elements,
+    /// where `D` is the degree of the extension.
+    ///
+    /// # Type Parameters
+    ///
+    /// - `E`: The base field type
+    /// - `T`: Must implement `ExtensionField<E>`
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// // If T is a degree-4 extension over E
+    /// let buffer: Buffer<ExtField> = buffer![ext1, ext2, ext3];
+    /// let base_buffer: Buffer<BaseField> = buffer.flatten_to_base();
+    /// assert_eq!(base_buffer.len(), 12); // 3 * 4 = 12
+    /// ```
+    pub fn flatten_to_base<E>(self) -> Buffer<E>
+    where
+        T: ExtensionField<E>,
+        E: Field,
+    {
+        self.into_vec().iter().flat_map(T::as_base_slice).copied().collect()
     }
 }
 

--- a/slop/crates/alloc/src/buffer.rs
+++ b/slop/crates/alloc/src/buffer.rs
@@ -1003,7 +1003,10 @@ impl<T> Buffer<T, CpuBackend> {
         T: Field,
         E: ExtensionField<T>,
     {
-        self.into_vec().chunks_exact(E::D).map(E::from_base_slice).collect()
+        let self_vec = self.into_vec();
+        let iter = self_vec.chunks_exact(E::D);
+        assert!(iter.clone().remainder().is_empty());
+        iter.map(E::from_base_slice).collect()
     }
 
     /// Reinterprets the buffer's elements as base field elements.
@@ -1274,6 +1277,9 @@ impl<'de, T: Deserialize<'de>> Deserialize<'de> for Buffer<T, CpuBackend> {
 
 #[cfg(test)]
 mod tests {
+    use slop_algebra::{extension::BinomialExtensionField, AbstractField};
+    use slop_koala_bear::KoalaBear;
+
     use super::*;
 
     #[test]
@@ -1334,5 +1340,14 @@ mod tests {
         assert_eq!(buffer.len(), 11);
         assert_eq!(*buffer[4], 4);
         assert_eq!(*buffer[5], 4);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_into_extension() {
+        let buffer = buffer![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        let felt_buffer =
+            buffer.iter().copied().map(KoalaBear::from_canonical_usize).collect::<Buffer<_>>();
+        let _ = felt_buffer.into_extension::<BinomialExtensionField<KoalaBear, 4>>();
     }
 }

--- a/slop/crates/challenger/Cargo.toml
+++ b/slop/crates/challenger/Cargo.toml
@@ -11,7 +11,9 @@ categories.workspace = true
 
 [dependencies]
 p3-challenger = { workspace = true }
+thiserror = { workspace = true }
 slop-symmetric = { workspace = true }
 slop-algebra = { workspace = true }
 futures = { workspace = true }
 serde = { workspace = true }
+num-bigint = { workspace = true }

--- a/slop/crates/challenger/src/lib.rs
+++ b/slop/crates/challenger/src/lib.rs
@@ -3,11 +3,13 @@ mod synchronize;
 
 use std::fmt::Debug;
 
+use num_bigint::BigUint;
 pub use p3_challenger::*;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use slop_algebra::{ExtensionField, Field, PrimeField32};
 use slop_symmetric::{CryptographicHasher, PseudoCompressionFunction};
 pub use synchronize::*;
+use thiserror::Error;
 
 pub trait FromChallenger<Challenger, A>: Sized {
     fn from_challenger(challenger: &Challenger, backend: &A) -> Self;
@@ -51,18 +53,37 @@ pub trait IopCtx:
     fn default_challenger() -> Self::Challenger;
 }
 
+#[derive(Error, Debug, Clone, Copy, Eq, PartialEq)]
+#[error("usize out of field bounds")]
+pub struct USizeOutOfFieldBounds;
+
 pub trait VariableLengthChallenger<F: Field, Digest: Copy>:
     FieldChallenger<F> + CanObserve<Digest>
 {
-    fn observe_variable_length_slice(&mut self, data: &[F]) {
+    fn observe_variable_length_slice(&mut self, data: &[F]) -> Result<(), USizeOutOfFieldBounds> {
+        let data_len_big_uint = BigUint::from(data.len());
+
+        if data_len_big_uint >= F::order() {
+            return Err(USizeOutOfFieldBounds);
+        }
         self.observe(F::from_canonical_u32(data.len() as u32));
         self.observe_slice(data);
+        Ok(())
     }
-    fn observe_variable_length_extension_slice<EF: ExtensionField<F>>(&mut self, data: &[EF]) {
+    fn observe_variable_length_extension_slice<EF: ExtensionField<F>>(
+        &mut self,
+        data: &[EF],
+    ) -> Result<(), USizeOutOfFieldBounds> {
+        let data_len_big_uint = BigUint::from(data.len());
+
+        if data_len_big_uint >= F::order() {
+            return Err(USizeOutOfFieldBounds);
+        }
         self.observe(F::from_canonical_u32(data.len() as u32));
         for &item in data {
             self.observe_ext_element(item);
         }
+        Ok(())
     }
     fn observe_constant_length_slice(&mut self, data: &[F]) {
         self.observe_slice(data);
@@ -75,9 +96,18 @@ pub trait VariableLengthChallenger<F: Field, Digest: Copy>:
     fn observe_constant_length_digest_slice(&mut self, data: &[Digest]) {
         self.observe_slice(data);
     }
-    fn observe_variable_length_digest_slice(&mut self, data: &[Digest]) {
+    fn observe_variable_length_digest_slice(
+        &mut self,
+        data: &[Digest],
+    ) -> Result<(), USizeOutOfFieldBounds> {
+        let data_len_big_uint = BigUint::from(data.len());
+
+        if data_len_big_uint >= F::order() {
+            return Err(USizeOutOfFieldBounds);
+        }
         self.observe(F::from_canonical_u32(data.len() as u32));
         self.observe_slice(data);
+        Ok(())
     }
 }
 

--- a/slop/crates/challenger/src/lib.rs
+++ b/slop/crates/challenger/src/lib.rs
@@ -66,7 +66,7 @@ pub trait VariableLengthChallenger<F: Field, Digest: Copy>:
         if data_len_big_uint >= F::order() {
             return Err(USizeOutOfFieldBounds);
         }
-        self.observe(F::from_canonical_u32(data.len() as u32));
+        self.observe(F::from_canonical_usize(data.len()));
         self.observe_slice(data);
         Ok(())
     }
@@ -79,7 +79,7 @@ pub trait VariableLengthChallenger<F: Field, Digest: Copy>:
         if data_len_big_uint >= F::order() {
             return Err(USizeOutOfFieldBounds);
         }
-        self.observe(F::from_canonical_u32(data.len() as u32));
+        self.observe(F::from_canonical_usize(data.len()));
         for &item in data {
             self.observe_ext_element(item);
         }
@@ -105,7 +105,7 @@ pub trait VariableLengthChallenger<F: Field, Digest: Copy>:
         if data_len_big_uint >= F::order() {
             return Err(USizeOutOfFieldBounds);
         }
-        self.observe(F::from_canonical_u32(data.len() as u32));
+        self.observe(F::from_canonical_usize(data.len()));
         self.observe_slice(data);
         Ok(())
     }

--- a/slop/crates/tensor/src/inner.rs
+++ b/slop/crates/tensor/src/inner.rs
@@ -236,16 +236,6 @@ impl<T, A: Backend> Tensor<T, A> {
         let data_storage = self.into_buffer().flatten_to_base();
         Tensor { storage: data_storage, dimensions }
     }
-
-    pub fn into_extension<ET: ExtensionField<T>>(self) -> Tensor<ET, A>
-    where
-        T: Field,
-    {
-        let [height, width]: [usize; 2] = self.sizes().try_into().unwrap();
-        let dimensions = Dimensions::try_from([height, width / ET::D]).unwrap();
-        let extension_storage = self.into_buffer().into_extension();
-        Tensor { storage: extension_storage, dimensions }
-    }
 }
 
 impl<T, A: Backend, I: AsRef<[usize]>> Index<I> for Tensor<T, A> {
@@ -352,6 +342,16 @@ impl<T> Tensor<T, CpuBackend> {
     #[inline]
     pub fn as_mut_slice(&mut self) -> &mut [T] {
         &mut self.storage[..]
+    }
+
+    pub fn into_extension<ET: ExtensionField<T>>(self) -> Tensor<ET>
+    where
+        T: Field,
+    {
+        let [height, width]: [usize; 2] = self.sizes().try_into().unwrap();
+        let dimensions = Dimensions::try_from([height, width / ET::D]).unwrap();
+        let extension_storage = self.into_buffer().into_extension();
+        Tensor { storage: extension_storage, dimensions }
     }
 }
 

--- a/slop/crates/tensor/src/inner.rs
+++ b/slop/crates/tensor/src/inner.rs
@@ -226,16 +226,6 @@ impl<T, A: Backend> Tensor<T, A> {
     pub unsafe fn assume_init(&mut self) {
         self.storage.set_len(self.storage.capacity());
     }
-
-    pub fn flatten_to_base<F: Field>(self) -> Tensor<F, A>
-    where
-        T: ExtensionField<F>,
-    {
-        let [height, width]: [usize; 2] = self.sizes().try_into().unwrap();
-        let dimensions = Dimensions::try_from([height, T::D * width]).unwrap();
-        let data_storage = self.into_buffer().flatten_to_base();
-        Tensor { storage: data_storage, dimensions }
-    }
 }
 
 impl<T, A: Backend, I: AsRef<[usize]>> Index<I> for Tensor<T, A> {
@@ -352,6 +342,16 @@ impl<T> Tensor<T, CpuBackend> {
         let dimensions = Dimensions::try_from([height, width / ET::D]).unwrap();
         let extension_storage = self.into_buffer().into_extension();
         Tensor { storage: extension_storage, dimensions }
+    }
+
+    pub fn flatten_to_base<F: Field>(self) -> Tensor<F>
+    where
+        T: ExtensionField<F>,
+    {
+        let [height, width]: [usize; 2] = self.sizes().try_into().unwrap();
+        let dimensions = Dimensions::try_from([height, T::D * width]).unwrap();
+        let data_storage = self.into_buffer().flatten_to_base();
+        Tensor { storage: data_storage, dimensions }
     }
 }
 

--- a/slop/crates/whir/Cargo.toml
+++ b/slop/crates/whir/Cargo.toml
@@ -33,6 +33,7 @@ derive-where = { workspace = true }
 rayon = { workspace = true }
 futures = { workspace = true }
 itertools = { workspace = true }
+num-bigint = { workspace = true }
 
 [dev-dependencies]
 slop-baby-bear = { workspace = true }

--- a/slop/crates/whir/src/config.rs
+++ b/slop/crates/whir/src/config.rs
@@ -1,89 +1,26 @@
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
-use slop_algebra::{Field, TwoAdicField};
+use slop_algebra::{ExtensionField, Field, PrimeField64, TwoAdicField};
 use slop_challenger::VariableLengthChallenger;
 
-/// A fully expanded WHIR configuration.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct WhirProofShape<F> {
-    pub domain_generator: F,
-
-    /// The OOD samples used in the commitment.
+pub struct UncheckedWhirProofShape {
     pub starting_ood_samples: usize,
-
-    /// The rate of the initial RS code used during the protocol.
     pub starting_log_inv_rate: usize,
-
-    /// The initial folding factor.
     pub starting_interleaved_log_height: usize,
-
-    /// The initial domain size
-    pub starting_domain_log_size: usize,
-
-    /// The initial pow bits used in the first fold.
     pub starting_folding_pow_bits: Vec<usize>,
-
-    /// The round-specific parameters.
     pub round_parameters: Vec<RoundConfig>,
-
-    /// Logarithm of the number of coefficients in the final polynomial. (The final polynomial
-    /// technically has degree `2^final_poly_log_degree - 1`.)
-    pub final_poly_log_degree: usize,
-
-    /// Number of queries in the last round
     pub final_queries: usize,
-
-    /// Number of final bits of proof of work (for the queries).
-    pub final_pow_bits: usize,
-
-    /// Number of final bits of proof of work (for the sumcheck).
     pub final_folding_pow_bits: Vec<usize>,
+    pub final_pow_bits: usize,
 }
 
-impl<F: TwoAdicField> WhirProofShape<F> {
-    pub fn default_whir_config() -> Self {
-        let folding_factor = 4;
-        WhirProofShape::<F> {
-            domain_generator: F::two_adic_generator(13),
-            starting_ood_samples: 1,
-            starting_log_inv_rate: 1,
-            starting_interleaved_log_height: 12,
-            starting_domain_log_size: 13,
-            starting_folding_pow_bits: vec![10; folding_factor],
-            round_parameters: vec![
-                RoundConfig {
-                    folding_factor,
-                    evaluation_domain_log_size: 12,
-                    queries_pow_bits: 10,
-                    pow_bits: vec![10; folding_factor],
-                    num_queries: 90,
-                    ood_samples: 1,
-                    log_inv_rate: 4,
-                },
-                RoundConfig {
-                    folding_factor,
-                    evaluation_domain_log_size: 11,
-                    queries_pow_bits: 10,
-                    pow_bits: vec![10; folding_factor],
-                    num_queries: 15,
-                    ood_samples: 1,
-                    log_inv_rate: 7,
-                },
-            ],
-            final_poly_log_degree: 4,
-            final_queries: 10,
-            final_pow_bits: 10,
-            final_folding_pow_bits: vec![10; 8],
-        }
-    }
+impl UncheckedWhirProofShape {
     pub fn big_beautiful_whir_config() -> Self {
         let folding_factor = 4;
-        WhirProofShape::<F> {
-            domain_generator: F::two_adic_generator(21),
+        Self {
             starting_ood_samples: 2,
             starting_log_inv_rate: 1,
             starting_interleaved_log_height: 20,
-            starting_domain_log_size: 21,
             starting_folding_pow_bits: vec![0; 10],
             round_parameters: vec![
                 RoundConfig {
@@ -93,7 +30,6 @@ impl<F: TwoAdicField> WhirProofShape<F> {
                     pow_bits: vec![0; folding_factor],
                     num_queries: 84,
                     ood_samples: 2,
-                    log_inv_rate: 4,
                 },
                 RoundConfig {
                     folding_factor,
@@ -102,7 +38,6 @@ impl<F: TwoAdicField> WhirProofShape<F> {
                     pow_bits: vec![0; folding_factor],
                     num_queries: 21,
                     ood_samples: 2,
-                    log_inv_rate: 7,
                 },
                 RoundConfig {
                     folding_factor,
@@ -111,26 +46,131 @@ impl<F: TwoAdicField> WhirProofShape<F> {
                     pow_bits: vec![0; folding_factor],
                     num_queries: 12,
                     ood_samples: 2,
-                    log_inv_rate: 10,
                 },
             ],
-            final_poly_log_degree: 8,
             final_queries: 9,
-            final_pow_bits: 16,
             final_folding_pow_bits: vec![0; 8],
+            final_pow_bits: 16,
+        }
+    }
+
+    pub fn default_whir_config() -> Self {
+        let folding_factor = 4;
+        Self {
+            starting_ood_samples: 1,
+            starting_log_inv_rate: 1,
+            starting_interleaved_log_height: 12,
+            starting_folding_pow_bits: vec![10; folding_factor],
+            round_parameters: vec![
+                RoundConfig {
+                    folding_factor,
+                    evaluation_domain_log_size: 12,
+                    queries_pow_bits: 10,
+                    pow_bits: vec![10; folding_factor],
+                    num_queries: 90,
+                    ood_samples: 1,
+                },
+                RoundConfig {
+                    folding_factor,
+                    evaluation_domain_log_size: 11,
+                    queries_pow_bits: 10,
+                    pow_bits: vec![10; folding_factor],
+                    num_queries: 15,
+                    ood_samples: 1,
+                },
+            ],
+            final_queries: 10,
+            final_pow_bits: 10,
+            final_folding_pow_bits: vec![10; 8],
         }
     }
 }
-impl<F: Field> WhirProofShape<F> {
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WhirProofShape<F, EF> {
+    /// The OOD samples used in the commitment.
+    starting_ood_samples: usize,
+
+    /// The rate of the initial RS code used during the protocol.
+    starting_log_inv_rate: usize,
+
+    /// The initial folding factor.
+    starting_interleaved_log_height: usize,
+
+    /// The initial pow bits used in the first fold.
+    starting_folding_pow_bits: Vec<usize>,
+
+    /// The round-specific parameters.
+    round_parameters: Vec<RoundConfig>,
+
+    /// Number of queries in the last round
+    final_queries: usize,
+
+    /// Number of final bits of proof of work (for the queries).
+    final_pow_bits: usize,
+
+    /// Number of final bits of proof of work (for the sumcheck).
+    final_folding_pow_bits: Vec<usize>,
+
+    _marker: std::marker::PhantomData<(F, EF)>,
+}
+
+impl<F: TwoAdicField + PrimeField64, EF: ExtensionField<F>> WhirProofShape<F, EF> {
+    pub fn new(config: UncheckedWhirProofShape) -> Self {
+        let starting_domain_log_size =
+            config.starting_interleaved_log_height + config.starting_log_inv_rate;
+
+        assert!(starting_domain_log_size >= config.round_parameters.len(), "each STIR round reduces the domain size by 1, so starting_domain_log_size must be at least round_params.len()");
+        assert!(config.round_parameters.iter().enumerate().all(|(i, param)| param.evaluation_domain_log_size == starting_domain_log_size - i - 1), "each STIR round reduces the domain size by 1, so each round's evaluation_domain_log_size must be equal to starting_domain_log_size - i - 1");
+        assert!(
+            config.starting_interleaved_log_height < (usize::BITS as usize),
+            "starting_interleaved_log_height must be less than usize::BITS"
+        );
+        assert!(
+            starting_domain_log_size < (usize::BITS as usize),
+            "starting_domain_log_size must be less than usize::BITS"
+        );
+        assert!(1 << starting_domain_log_size < F::ORDER_U64);
+
+        assert!(config.starting_folding_pow_bits.iter().all(|&bits| 1 << bits < F::ORDER_U64));
+        assert!(config.final_folding_pow_bits.iter().all(|&bits| 1 << bits < F::ORDER_U64));
+
+        for round_param in &config.round_parameters {
+            assert!(round_param.folding_factor < usize::BITS as usize);
+
+            // Check that the folding factor does not overflow when multiplied by EF::D
+            assert!(!(1usize << round_param.folding_factor).overflowing_mul(EF::D).1);
+
+            assert!(1 << round_param.queries_pow_bits < F::ORDER_U64);
+
+            assert!(round_param.pow_bits.iter().all(|&bits| 1 << bits < F::ORDER_U64));
+        }
+
+        let result = Self {
+            starting_ood_samples: config.starting_ood_samples,
+            starting_log_inv_rate: config.starting_log_inv_rate,
+            starting_interleaved_log_height: config.starting_interleaved_log_height,
+            starting_folding_pow_bits: config.starting_folding_pow_bits,
+            round_parameters: config.round_parameters,
+            final_queries: config.final_queries,
+            final_folding_pow_bits: config.final_folding_pow_bits,
+            final_pow_bits: config.final_pow_bits,
+            _marker: std::marker::PhantomData,
+        };
+
+        assert!(result.check_usizes_bound_by_field_order());
+        assert!(result.final_poly_log_degree() < usize::BITS as usize);
+        result
+    }
+}
+impl<F: TwoAdicField, EF: ExtensionField<F>> WhirProofShape<F, EF> {
     pub fn check_usizes_bound_by_field_order(&self) -> bool {
         let &WhirProofShape {
             starting_ood_samples,
             starting_log_inv_rate,
             starting_interleaved_log_height,
-            starting_domain_log_size,
             ref starting_folding_pow_bits,
             ref round_parameters,
-            final_poly_log_degree,
             final_queries,
             final_pow_bits,
             ref final_folding_pow_bits,
@@ -141,7 +181,7 @@ impl<F: Field> WhirProofShape<F> {
         result &= BigUint::from(starting_ood_samples) <= order;
         result &= BigUint::from(starting_log_inv_rate) <= order;
         result &= BigUint::from(starting_interleaved_log_height) <= order;
-        result &= BigUint::from(starting_domain_log_size) <= order;
+        result &= BigUint::from(self.starting_domain_log_size()) <= order;
         result &= starting_folding_pow_bits.iter().all(|&b| BigUint::from(b) <= order);
         round_parameters.iter().for_each(|rp| {
             let &RoundConfig {
@@ -151,17 +191,15 @@ impl<F: Field> WhirProofShape<F> {
                 ref pow_bits,
                 num_queries,
                 ood_samples,
-                log_inv_rate,
             } = rp;
             result &= BigUint::from(folding_factor) <= order
                 && BigUint::from(evaluation_domain_log_size) <= order
                 && BigUint::from(queries_pow_bits) <= order
                 && pow_bits.iter().all(|&b| BigUint::from(b) <= order)
                 && BigUint::from(num_queries) <= order
-                && BigUint::from(ood_samples) <= order
-                && BigUint::from(log_inv_rate) <= order;
+                && BigUint::from(ood_samples) <= order;
         });
-        result &= BigUint::from(final_poly_log_degree) <= order;
+        result &= BigUint::from(self.final_poly_log_degree()) <= order;
         result &= BigUint::from(final_queries) <= order;
         result &= BigUint::from(final_pow_bits) <= order;
         result &= final_folding_pow_bits.iter().all(|&b| BigUint::from(b) <= order);
@@ -173,23 +211,19 @@ impl<F: Field> WhirProofShape<F> {
     ) {
         assert!(self.check_usizes_bound_by_field_order());
         let &WhirProofShape {
-            domain_generator,
             starting_ood_samples,
             starting_log_inv_rate,
             starting_interleaved_log_height,
-            starting_domain_log_size,
             ref starting_folding_pow_bits,
             ref round_parameters,
-            final_poly_log_degree,
             final_queries,
             final_pow_bits,
             ref final_folding_pow_bits,
+            ..
         } = self;
-        challenger.observe(domain_generator);
         challenger.observe(F::from_canonical_usize(starting_ood_samples));
         challenger.observe(F::from_canonical_usize(starting_log_inv_rate));
         challenger.observe(F::from_canonical_usize(starting_interleaved_log_height));
-        challenger.observe(F::from_canonical_usize(starting_domain_log_size));
         challenger
             .observe_variable_length_slice(
                 &starting_folding_pow_bits
@@ -202,7 +236,6 @@ impl<F: Field> WhirProofShape<F> {
         assert!(BigUint::from(round_parameters.len()) <= F::order());
         challenger.observe(F::from_canonical_usize(round_parameters.len()));
         round_parameters.iter().for_each(|f| f.write_to_challenger(challenger));
-        challenger.observe(F::from_canonical_usize(final_poly_log_degree));
         challenger.observe(F::from_canonical_usize(final_queries));
         challenger.observe(F::from_canonical_usize(final_pow_bits));
         challenger
@@ -214,6 +247,56 @@ impl<F: Field> WhirProofShape<F> {
                     .collect::<Vec<_>>(),
             )
             .unwrap();
+    }
+
+    pub fn domain_generator(&self) -> F
+    where
+        F: TwoAdicField,
+    {
+        F::two_adic_generator(self.starting_domain_log_size())
+    }
+
+    pub fn starting_ood_samples(&self) -> usize {
+        self.starting_ood_samples
+    }
+
+    pub fn starting_log_inv_rate(&self) -> usize {
+        self.starting_log_inv_rate
+    }
+
+    pub fn starting_interleaved_log_height(&self) -> usize {
+        self.starting_interleaved_log_height
+    }
+
+    pub fn starting_domain_log_size(&self) -> usize {
+        self.starting_interleaved_log_height + self.starting_log_inv_rate
+    }
+
+    pub fn starting_folding_pow_bits(&self) -> &[usize] {
+        &self.starting_folding_pow_bits
+    }
+
+    pub fn round_parameters(&self) -> &[RoundConfig] {
+        &self.round_parameters
+    }
+
+    pub fn final_poly_log_degree(&self) -> usize {
+        let num_folded_variables =
+            self.round_parameters.iter().map(|p| p.folding_factor).sum::<usize>();
+
+        self.starting_interleaved_log_height - num_folded_variables
+    }
+
+    pub fn final_queries(&self) -> usize {
+        self.final_queries
+    }
+
+    pub fn final_pow_bits(&self) -> usize {
+        self.final_pow_bits
+    }
+
+    pub fn final_folding_pow_bits(&self) -> &[usize] {
+        &self.final_folding_pow_bits
     }
 }
 /// Round specific configuration
@@ -231,8 +314,6 @@ pub struct RoundConfig {
     pub num_queries: usize,
     /// Number of OOD samples in this round
     pub ood_samples: usize,
-    /// Rate of current RS codeword
-    pub log_inv_rate: usize,
 }
 
 impl RoundConfig {
@@ -250,6 +331,5 @@ impl RoundConfig {
             .unwrap();
         challenger.observe(F::from_canonical_usize(self.num_queries));
         challenger.observe(F::from_canonical_usize(self.ood_samples));
-        challenger.observe(F::from_canonical_usize(self.log_inv_rate));
     }
 }

--- a/slop/crates/whir/src/config.rs
+++ b/slop/crates/whir/src/config.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use slop_algebra::{Field, TwoAdicField};
+use slop_algebra::{Field, PrimeField, PrimeField32, TwoAdicField};
 use slop_challenger::VariableLengthChallenger;
 
 /// A fully expanded WHIR configuration.
@@ -120,11 +120,57 @@ impl<F: TwoAdicField> WhirProofShape<F> {
         }
     }
 }
-impl<F: Field> WhirProofShape<F> {
+impl<F: PrimeField32> WhirProofShape<F> {
+    pub fn check_usizes_bound_by_field_order(&self) -> bool {
+        let &WhirProofShape {
+            starting_ood_samples,
+            starting_log_inv_rate,
+            starting_interleaved_log_height,
+            starting_domain_log_size,
+            ref starting_folding_pow_bits,
+            ref round_parameters,
+            final_poly_log_degree,
+            final_queries,
+            final_pow_bits,
+            ref final_folding_pow_bits,
+            ..
+        } = self;
+        let mut result = true;
+        let order = F::ORDER_U32 as usize;
+        result &= starting_ood_samples <= order;
+        result &= starting_log_inv_rate <= order;
+        result &= starting_interleaved_log_height <= order;
+        result &= starting_domain_log_size <= order;
+        result &= starting_folding_pow_bits.iter().all(|&b| b <= order);
+        round_parameters.iter().for_each(|rp| {
+            let &RoundConfig {
+                folding_factor,
+                evaluation_domain_log_size,
+                queries_pow_bits,
+                ref pow_bits,
+                num_queries,
+                ood_samples,
+                log_inv_rate,
+            } = rp;
+            result &= folding_factor <= order
+                && evaluation_domain_log_size <= order
+                && queries_pow_bits <= order
+                && pow_bits.iter().all(|&b| b <= order)
+                && num_queries <= order
+                && ood_samples <= order
+                && log_inv_rate <= order;
+        });
+        result &= final_poly_log_degree <= order;
+        result &= final_queries <= order;
+        result &= final_pow_bits <= order;
+        result &= final_folding_pow_bits.iter().all(|&b| b <= order);
+        result
+    }
     pub fn write_to_challenger<D: Copy, C: VariableLengthChallenger<F, D>>(
         &self,
         challenger: &mut C,
     ) {
+        assert!(self.check_usizes_bound_by_field_order());
         let &WhirProofShape {
             domain_generator,
             starting_ood_samples,
@@ -150,6 +196,8 @@ impl<F: Field> WhirProofShape<F> {
                 .map(F::from_canonical_usize)
                 .collect::<Vec<_>>(),
         );
+        assert!(round_parameters.len() <= F::ORDER_U32 as usize);
+        challenger.observe(F::from_canonical_usize(round_parameters.len()));
         round_parameters.iter().for_each(|f| f.write_to_challenger(challenger));
         challenger.observe(F::from_canonical_usize(final_poly_log_degree));
         challenger.observe(F::from_canonical_usize(final_queries));

--- a/slop/crates/whir/src/config.rs
+++ b/slop/crates/whir/src/config.rs
@@ -3,17 +3,6 @@ use serde::{Deserialize, Serialize};
 use slop_algebra::{Field, TwoAdicField};
 use slop_challenger::VariableLengthChallenger;
 
-// - `num_variables >= starting_interleaved_log_height`
-// - `starting_interleaved_log_height = \\sum round_params[i].folding_factor + final_poly_log_degree`
-// - `starting_domain_log_size = starting_interleaved_log_height + starting_log_inv_rate`
-// - `domain_generator` has order `2^starting_domain_log_size`
-// - `round_params[i].evaluation_domain_log_size = starting_domain_log_size - i - 1`
-
-// Note that the last condition in particular required `starting_domain_log_size >= round_params.len()`.
-// The following condition is required and checked:
-
-// - `round_params.len() = num_expeceted_commitments`
-
 /// A fully expanded WHIR configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WhirProofShape<F> {

--- a/slop/crates/whir/src/config.rs
+++ b/slop/crates/whir/src/config.rs
@@ -1,5 +1,6 @@
+use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
-use slop_algebra::{Field, PrimeField, PrimeField32, TwoAdicField};
+use slop_algebra::{Field, TwoAdicField};
 use slop_challenger::VariableLengthChallenger;
 
 /// A fully expanded WHIR configuration.
@@ -120,7 +121,7 @@ impl<F: TwoAdicField> WhirProofShape<F> {
         }
     }
 }
-impl<F: PrimeField32> WhirProofShape<F> {
+impl<F: Field> WhirProofShape<F> {
     pub fn check_usizes_bound_by_field_order(&self) -> bool {
         let &WhirProofShape {
             starting_ood_samples,
@@ -136,12 +137,12 @@ impl<F: PrimeField32> WhirProofShape<F> {
             ..
         } = self;
         let mut result = true;
-        let order = F::ORDER_U32 as usize;
-        result &= starting_ood_samples <= order;
-        result &= starting_log_inv_rate <= order;
-        result &= starting_interleaved_log_height <= order;
-        result &= starting_domain_log_size <= order;
-        result &= starting_folding_pow_bits.iter().all(|&b| b <= order);
+        let order = F::order();
+        result &= BigUint::from(starting_ood_samples) <= order;
+        result &= BigUint::from(starting_log_inv_rate) <= order;
+        result &= BigUint::from(starting_interleaved_log_height) <= order;
+        result &= BigUint::from(starting_domain_log_size) <= order;
+        result &= starting_folding_pow_bits.iter().all(|&b| BigUint::from(b) <= order);
         round_parameters.iter().for_each(|rp| {
             let &RoundConfig {
                 folding_factor,
@@ -152,18 +153,18 @@ impl<F: PrimeField32> WhirProofShape<F> {
                 ood_samples,
                 log_inv_rate,
             } = rp;
-            result &= folding_factor <= order
-                && evaluation_domain_log_size <= order
-                && queries_pow_bits <= order
-                && pow_bits.iter().all(|&b| b <= order)
-                && num_queries <= order
-                && ood_samples <= order
-                && log_inv_rate <= order;
+            result &= BigUint::from(folding_factor) <= order
+                && BigUint::from(evaluation_domain_log_size) <= order
+                && BigUint::from(queries_pow_bits) <= order
+                && pow_bits.iter().all(|&b| BigUint::from(b) <= order)
+                && BigUint::from(num_queries) <= order
+                && BigUint::from(ood_samples) <= order
+                && BigUint::from(log_inv_rate) <= order;
         });
-        result &= final_poly_log_degree <= order;
-        result &= final_queries <= order;
-        result &= final_pow_bits <= order;
-        result &= final_folding_pow_bits.iter().all(|&b| b <= order);
+        result &= BigUint::from(final_poly_log_degree) <= order;
+        result &= BigUint::from(final_queries) <= order;
+        result &= BigUint::from(final_pow_bits) <= order;
+        result &= final_folding_pow_bits.iter().all(|&b| BigUint::from(b) <= order);
         result
     }
     pub fn write_to_challenger<D: Copy, C: VariableLengthChallenger<F, D>>(
@@ -189,26 +190,30 @@ impl<F: PrimeField32> WhirProofShape<F> {
         challenger.observe(F::from_canonical_usize(starting_log_inv_rate));
         challenger.observe(F::from_canonical_usize(starting_interleaved_log_height));
         challenger.observe(F::from_canonical_usize(starting_domain_log_size));
-        challenger.observe_variable_length_slice(
-            &starting_folding_pow_bits
-                .iter()
-                .copied()
-                .map(F::from_canonical_usize)
-                .collect::<Vec<_>>(),
-        );
-        assert!(round_parameters.len() <= F::ORDER_U32 as usize);
+        challenger
+            .observe_variable_length_slice(
+                &starting_folding_pow_bits
+                    .iter()
+                    .copied()
+                    .map(F::from_canonical_usize)
+                    .collect::<Vec<_>>(),
+            )
+            .unwrap();
+        assert!(BigUint::from(round_parameters.len()) <= F::order());
         challenger.observe(F::from_canonical_usize(round_parameters.len()));
         round_parameters.iter().for_each(|f| f.write_to_challenger(challenger));
         challenger.observe(F::from_canonical_usize(final_poly_log_degree));
         challenger.observe(F::from_canonical_usize(final_queries));
         challenger.observe(F::from_canonical_usize(final_pow_bits));
-        challenger.observe_variable_length_slice(
-            &final_folding_pow_bits
-                .iter()
-                .copied()
-                .map(F::from_canonical_usize)
-                .collect::<Vec<_>>(),
-        );
+        challenger
+            .observe_variable_length_slice(
+                &final_folding_pow_bits
+                    .iter()
+                    .copied()
+                    .map(F::from_canonical_usize)
+                    .collect::<Vec<_>>(),
+            )
+            .unwrap();
     }
 }
 /// Round specific configuration
@@ -238,9 +243,11 @@ impl RoundConfig {
         challenger.observe(F::from_canonical_usize(self.folding_factor));
         challenger.observe(F::from_canonical_usize(self.evaluation_domain_log_size));
         challenger.observe(F::from_canonical_usize(self.queries_pow_bits));
-        challenger.observe_variable_length_slice(
-            &self.pow_bits.iter().copied().map(F::from_canonical_usize).collect::<Vec<_>>(),
-        );
+        challenger
+            .observe_variable_length_slice(
+                &self.pow_bits.iter().copied().map(F::from_canonical_usize).collect::<Vec<_>>(),
+            )
+            .unwrap();
         challenger.observe(F::from_canonical_usize(self.num_queries));
         challenger.observe(F::from_canonical_usize(self.ood_samples));
         challenger.observe(F::from_canonical_usize(self.log_inv_rate));

--- a/slop/crates/whir/src/config.rs
+++ b/slop/crates/whir/src/config.rs
@@ -3,6 +3,17 @@ use serde::{Deserialize, Serialize};
 use slop_algebra::{Field, TwoAdicField};
 use slop_challenger::VariableLengthChallenger;
 
+// - `num_variables >= starting_interleaved_log_height`
+// - `starting_interleaved_log_height = \\sum round_params[i].folding_factor + final_poly_log_degree`
+// - `starting_domain_log_size = starting_interleaved_log_height + starting_log_inv_rate`
+// - `domain_generator` has order `2^starting_domain_log_size`
+// - `round_params[i].evaluation_domain_log_size = starting_domain_log_size - i - 1`
+
+// Note that the last condition in particular required `starting_domain_log_size >= round_params.len()`.
+// The following condition is required and checked:
+
+// - `round_params.len() = num_expeceted_commitments`
+
 /// A fully expanded WHIR configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WhirProofShape<F> {

--- a/slop/crates/whir/src/config.rs
+++ b/slop/crates/whir/src/config.rs
@@ -15,6 +15,37 @@ pub struct UncheckedWhirProofShape {
 }
 
 impl UncheckedWhirProofShape {
+    pub fn default_whir_config() -> Self {
+        let folding_factor = 4;
+        Self {
+            starting_ood_samples: 1,
+            starting_log_inv_rate: 1,
+            starting_interleaved_log_height: 12,
+            starting_folding_pow_bits: vec![10; folding_factor],
+            round_parameters: vec![
+                RoundConfig {
+                    folding_factor,
+                    evaluation_domain_log_size: 12,
+                    queries_pow_bits: 10,
+                    pow_bits: vec![10; folding_factor],
+                    num_queries: 90,
+                    ood_samples: 1,
+                },
+                RoundConfig {
+                    folding_factor,
+                    evaluation_domain_log_size: 11,
+                    queries_pow_bits: 10,
+                    pow_bits: vec![10; folding_factor],
+                    num_queries: 15,
+                    ood_samples: 1,
+                },
+            ],
+            final_queries: 10,
+            final_pow_bits: 10,
+            final_folding_pow_bits: vec![10; 8],
+        }
+    }
+
     pub fn big_beautiful_whir_config() -> Self {
         let folding_factor = 4;
         Self {
@@ -51,37 +82,6 @@ impl UncheckedWhirProofShape {
             final_queries: 9,
             final_folding_pow_bits: vec![0; 8],
             final_pow_bits: 16,
-        }
-    }
-
-    pub fn default_whir_config() -> Self {
-        let folding_factor = 4;
-        Self {
-            starting_ood_samples: 1,
-            starting_log_inv_rate: 1,
-            starting_interleaved_log_height: 12,
-            starting_folding_pow_bits: vec![10; folding_factor],
-            round_parameters: vec![
-                RoundConfig {
-                    folding_factor,
-                    evaluation_domain_log_size: 12,
-                    queries_pow_bits: 10,
-                    pow_bits: vec![10; folding_factor],
-                    num_queries: 90,
-                    ood_samples: 1,
-                },
-                RoundConfig {
-                    folding_factor,
-                    evaluation_domain_log_size: 11,
-                    queries_pow_bits: 10,
-                    pow_bits: vec![10; folding_factor],
-                    num_queries: 15,
-                    ood_samples: 1,
-                },
-            ],
-            final_queries: 10,
-            final_pow_bits: 10,
-            final_folding_pow_bits: vec![10; 8],
         }
     }
 }
@@ -210,7 +210,6 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> WhirProofShape<F, EF> {
         &self,
         challenger: &mut C,
     ) {
-        assert!(self.check_usizes_bound_by_field_order());
         let &WhirProofShape {
             starting_ood_samples,
             starting_log_inv_rate,
@@ -220,11 +219,12 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> WhirProofShape<F, EF> {
             final_queries,
             final_pow_bits,
             ref final_folding_pow_bits,
-            ..
+            _marker,
         } = self;
         challenger.observe(F::from_canonical_usize(starting_ood_samples));
         challenger.observe(F::from_canonical_usize(starting_log_inv_rate));
         challenger.observe(F::from_canonical_usize(starting_interleaved_log_height));
+        // It is ok to unwrap the error here because this function is only called Verifier initialization.
         challenger
             .observe_variable_length_slice(
                 &starting_folding_pow_bits
@@ -239,6 +239,7 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> WhirProofShape<F, EF> {
         round_parameters.iter().for_each(|f| f.write_to_challenger(challenger));
         challenger.observe(F::from_canonical_usize(final_queries));
         challenger.observe(F::from_canonical_usize(final_pow_bits));
+        // It is ok to unwrap the error here because this function is only called Verifier initialization.
         challenger
             .observe_variable_length_slice(
                 &final_folding_pow_bits
@@ -325,6 +326,7 @@ impl RoundConfig {
         challenger.observe(F::from_canonical_usize(self.folding_factor));
         challenger.observe(F::from_canonical_usize(self.evaluation_domain_log_size));
         challenger.observe(F::from_canonical_usize(self.queries_pow_bits));
+        // It is ok to unwrap the result here because this function is only called at Verifier initialization.
         challenger
             .observe_variable_length_slice(
                 &self.pow_bits.iter().copied().map(F::from_canonical_usize).collect::<Vec<_>>(),

--- a/slop/crates/whir/src/config.rs
+++ b/slop/crates/whir/src/config.rs
@@ -3,18 +3,18 @@ use serde::{Deserialize, Serialize};
 use slop_algebra::{ExtensionField, Field, PrimeField64, TwoAdicField};
 use slop_challenger::VariableLengthChallenger;
 
-pub struct UncheckedWhirProofShape {
+pub struct UncheckedWhirProofShape<F> {
     pub starting_ood_samples: usize,
     pub starting_log_inv_rate: usize,
     pub starting_interleaved_log_height: usize,
     pub starting_folding_pow_bits: Vec<usize>,
-    pub round_parameters: Vec<RoundConfig>,
+    pub round_parameters: Vec<RoundConfig<F>>,
     pub final_queries: usize,
     pub final_folding_pow_bits: Vec<usize>,
     pub final_pow_bits: usize,
 }
 
-impl UncheckedWhirProofShape {
+impl<F: Field> UncheckedWhirProofShape<F> {
     pub fn default_whir_config() -> Self {
         let folding_factor = 4;
         Self {
@@ -23,22 +23,8 @@ impl UncheckedWhirProofShape {
             starting_interleaved_log_height: 12,
             starting_folding_pow_bits: vec![10; folding_factor],
             round_parameters: vec![
-                RoundConfig {
-                    folding_factor,
-                    evaluation_domain_log_size: 12,
-                    queries_pow_bits: 10,
-                    pow_bits: vec![10; folding_factor],
-                    num_queries: 90,
-                    ood_samples: 1,
-                },
-                RoundConfig {
-                    folding_factor,
-                    evaluation_domain_log_size: 11,
-                    queries_pow_bits: 10,
-                    pow_bits: vec![10; folding_factor],
-                    num_queries: 15,
-                    ood_samples: 1,
-                },
+                RoundConfig::new(folding_factor, 10, vec![10; folding_factor], 90, 1),
+                RoundConfig::new(folding_factor, 10, vec![10; folding_factor], 15, 1),
             ],
             final_queries: 10,
             final_pow_bits: 10,
@@ -54,33 +40,11 @@ impl UncheckedWhirProofShape {
             starting_interleaved_log_height: 20,
             starting_folding_pow_bits: vec![0; 10],
             round_parameters: vec![
-                RoundConfig {
-                    folding_factor,
-                    evaluation_domain_log_size: 20,
-                    queries_pow_bits: 16,
-                    pow_bits: vec![0; folding_factor],
-                    num_queries: 84,
-                    ood_samples: 2,
-                },
-                RoundConfig {
-                    folding_factor,
-                    evaluation_domain_log_size: 19,
-                    queries_pow_bits: 16,
-                    pow_bits: vec![0; folding_factor],
-                    num_queries: 21,
-                    ood_samples: 2,
-                },
-                RoundConfig {
-                    folding_factor,
-                    evaluation_domain_log_size: 18,
-                    queries_pow_bits: 16,
-                    pow_bits: vec![0; folding_factor],
-                    num_queries: 12,
-                    ood_samples: 2,
-                },
+                RoundConfig::new(folding_factor, 16, vec![0; folding_factor], 84, 2),
+                RoundConfig::new(folding_factor, 16, vec![0; folding_factor], 21, 2),
             ],
             final_queries: 9,
-            final_folding_pow_bits: vec![0; 8],
+            final_folding_pow_bits: vec![0; 12],
             final_pow_bits: 16,
         }
     }
@@ -101,7 +65,7 @@ pub struct WhirProofShape<F, EF> {
     starting_folding_pow_bits: Vec<usize>,
 
     /// The round-specific parameters.
-    round_parameters: Vec<RoundConfig>,
+    round_parameters: Vec<RoundConfig<F>>,
 
     /// Number of queries in the last round
     final_queries: usize,
@@ -116,12 +80,13 @@ pub struct WhirProofShape<F, EF> {
 }
 
 impl<F: TwoAdicField + PrimeField64, EF: ExtensionField<F>> WhirProofShape<F, EF> {
-    pub fn new(config: UncheckedWhirProofShape) -> Self {
-        let starting_domain_log_size =
-            config.starting_interleaved_log_height + config.starting_log_inv_rate;
+    pub fn new(config: UncheckedWhirProofShape<F>) -> Self {
+        let starting_domain_log_size = config
+            .starting_interleaved_log_height
+            .checked_add(config.starting_log_inv_rate)
+            .unwrap();
 
         assert!(starting_domain_log_size >= config.round_parameters.len(), "each STIR round reduces the domain size by 1, so starting_domain_log_size must be at least round_params.len()");
-        assert!(config.round_parameters.iter().enumerate().all(|(i, param)| param.evaluation_domain_log_size == starting_domain_log_size - i - 1), "each STIR round reduces the domain size by 1, so each round's evaluation_domain_log_size must be equal to starting_domain_log_size - i - 1");
         assert!(
             config.starting_interleaved_log_height < (usize::BITS as usize),
             "starting_interleaved_log_height must be less than usize::BITS"
@@ -132,20 +97,38 @@ impl<F: TwoAdicField + PrimeField64, EF: ExtensionField<F>> WhirProofShape<F, EF
         );
         assert!(1 << starting_domain_log_size < F::ORDER_U64);
 
-        assert!(config.starting_folding_pow_bits.iter().all(|&bits| 1 << bits < F::ORDER_U64));
-        assert!(config.final_folding_pow_bits.iter().all(|&bits| 1 << bits < F::ORDER_U64));
-        assert!(1 << config.final_pow_bits < F::ORDER_U64);
+        assert!(config
+            .starting_folding_pow_bits
+            .iter()
+            .all(|&bits| bits < (usize::BITS as usize) && 1 << bits < F::ORDER_U64));
+        assert!(config
+            .final_folding_pow_bits
+            .iter()
+            .all(|&bits| bits < (usize::BITS as usize) && 1 << bits < F::ORDER_U64));
+        assert!(
+            config.final_pow_bits < (usize::BITS as usize)
+                && 1 << config.final_pow_bits < F::ORDER_U64
+        );
 
         for round_param in &config.round_parameters {
             assert!(round_param.folding_factor < usize::BITS as usize);
+            assert!(round_param.queries_pow_bits < (usize::BITS as usize));
 
             // Check that the folding factor does not overflow when multiplied by EF::D
             assert!(!(1usize << round_param.folding_factor).overflowing_mul(EF::D).1);
 
             assert!(1 << round_param.queries_pow_bits < F::ORDER_U64);
 
-            assert!(round_param.pow_bits.iter().all(|&bits| 1 << bits < F::ORDER_U64));
+            assert!(round_param
+                .pow_bits
+                .iter()
+                .all(|&bits| bits < (usize::BITS as usize) && 1 << bits < F::ORDER_U64));
         }
+
+        let num_folded_variables =
+            config.round_parameters.iter().map(|p| p.folding_factor).sum::<usize>();
+
+        assert!(config.starting_interleaved_log_height.checked_sub(num_folded_variables).is_some());
 
         let result = Self {
             starting_ood_samples: config.starting_ood_samples,
@@ -159,13 +142,16 @@ impl<F: TwoAdicField + PrimeField64, EF: ExtensionField<F>> WhirProofShape<F, EF
             _marker: std::marker::PhantomData,
         };
 
-        assert!(result.check_usizes_bound_by_field_order());
+        // The check before calling the constructor guarantees no overflow here.
         assert!(result.final_poly_log_degree() < usize::BITS as usize);
+
+        assert!(result.check_usizes_bound_by_field_order());
+
         result
     }
 }
 impl<F: TwoAdicField, EF: ExtensionField<F>> WhirProofShape<F, EF> {
-    pub fn check_usizes_bound_by_field_order(&self) -> bool {
+    fn check_usizes_bound_by_field_order(&self) -> bool {
         let &WhirProofShape {
             starting_ood_samples,
             starting_log_inv_rate,
@@ -179,31 +165,35 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> WhirProofShape<F, EF> {
         } = self;
         let mut result = true;
         let order = F::order();
-        result &= BigUint::from(starting_ood_samples) <= order;
-        result &= BigUint::from(starting_log_inv_rate) <= order;
-        result &= BigUint::from(starting_interleaved_log_height) <= order;
-        result &= BigUint::from(self.starting_domain_log_size()) <= order;
-        result &= starting_folding_pow_bits.iter().all(|&b| BigUint::from(b) <= order);
+        result &= BigUint::from(starting_ood_samples) < order;
+        result &= BigUint::from(starting_log_inv_rate) < order;
+        result &= BigUint::from(starting_interleaved_log_height) < order;
+        result &= BigUint::from(self.starting_domain_log_size()) < order;
+        result &= starting_folding_pow_bits.iter().all(|&b| BigUint::from(b) < order);
         round_parameters.iter().for_each(|rp| {
             let &RoundConfig {
                 folding_factor,
-                evaluation_domain_log_size,
                 queries_pow_bits,
                 ref pow_bits,
                 num_queries,
                 ood_samples,
+                _marker,
             } = rp;
-            result &= BigUint::from(folding_factor) <= order
-                && BigUint::from(evaluation_domain_log_size) <= order
-                && BigUint::from(queries_pow_bits) <= order
-                && pow_bits.iter().all(|&b| BigUint::from(b) <= order)
-                && BigUint::from(num_queries) <= order
-                && BigUint::from(ood_samples) <= order;
+            result &= BigUint::from(folding_factor) < order
+                && BigUint::from(queries_pow_bits) < order
+                && pow_bits.iter().all(|&b| BigUint::from(b) < order)
+                && BigUint::from(num_queries) < order
+                && BigUint::from(ood_samples) < order;
         });
-        result &= BigUint::from(self.final_poly_log_degree()) <= order;
-        result &= BigUint::from(final_queries) <= order;
-        result &= BigUint::from(final_pow_bits) <= order;
-        result &= final_folding_pow_bits.iter().all(|&b| BigUint::from(b) <= order);
+        result &= BigUint::from(self.final_poly_log_degree()) < order;
+        result &= BigUint::from(final_queries) < order;
+        result &= BigUint::from(final_pow_bits) < order;
+        result &= final_folding_pow_bits.iter().all(|&b| BigUint::from(b) < order);
+        // Checks on vector lengths not overflowing field order.
+        result &= BigUint::from(round_parameters.len()) < F::order();
+        result &= BigUint::from(final_folding_pow_bits.len()) < F::order();
+        result &= BigUint::from(starting_folding_pow_bits.len()) < F::order();
+        result &= round_parameters.iter().all(|p| BigUint::from(p.pow_bits.len()) < F::order());
         result
     }
     pub fn write_to_challenger<D: Copy, C: VariableLengthChallenger<F, D>>(
@@ -224,7 +214,8 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> WhirProofShape<F, EF> {
         challenger.observe(F::from_canonical_usize(starting_ood_samples));
         challenger.observe(F::from_canonical_usize(starting_log_inv_rate));
         challenger.observe(F::from_canonical_usize(starting_interleaved_log_height));
-        // It is ok to unwrap the error here because this function is only called Verifier initialization.
+        // It is ok to unwrap the error here because the error path is excluded at `WhirProofShape`
+        // initialization.
         challenger
             .observe_variable_length_slice(
                 &starting_folding_pow_bits
@@ -234,12 +225,13 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> WhirProofShape<F, EF> {
                     .collect::<Vec<_>>(),
             )
             .unwrap();
-        assert!(BigUint::from(round_parameters.len()) <= F::order());
+
         challenger.observe(F::from_canonical_usize(round_parameters.len()));
         round_parameters.iter().for_each(|f| f.write_to_challenger(challenger));
         challenger.observe(F::from_canonical_usize(final_queries));
         challenger.observe(F::from_canonical_usize(final_pow_bits));
-        // It is ok to unwrap the error here because this function is only called Verifier initialization.
+        // It is ok to unwrap the error here because the error path is excluded at `WhirProofShape`
+        // initialization.
         challenger
             .observe_variable_length_slice(
                 &final_folding_pow_bits
@@ -278,7 +270,7 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> WhirProofShape<F, EF> {
         &self.starting_folding_pow_bits
     }
 
-    pub fn round_parameters(&self) -> &[RoundConfig] {
+    pub fn round_parameters(&self) -> &[RoundConfig<F>] {
         &self.round_parameters
     }
 
@@ -303,11 +295,9 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> WhirProofShape<F, EF> {
 }
 /// Round specific configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RoundConfig {
+pub struct RoundConfig<F> {
     /// Folding factor for this round.
     pub folding_factor: usize,
-    /// Size of evaluation domain (of oracle sent in this round)
-    pub evaluation_domain_log_size: usize,
     /// Number of bits of proof of work (for the queries).
     pub queries_pow_bits: usize,
     /// Number of bits of proof of work (for the folding).
@@ -316,17 +306,33 @@ pub struct RoundConfig {
     pub num_queries: usize,
     /// Number of OOD samples in this round
     pub ood_samples: usize,
+    // A marker to prevent accidental construction of `RoundConfig` without `new`.
+    _marker: std::marker::PhantomData<F>,
 }
 
-impl RoundConfig {
-    pub fn write_to_challenger<F: Field, D: Copy, C: VariableLengthChallenger<F, D>>(
-        &self,
-        challenger: &mut C,
-    ) {
+impl<F: Field> RoundConfig<F> {
+    pub fn new(
+        folding_factor: usize,
+        queries_pow_bits: usize,
+        pow_bits: Vec<usize>,
+        num_queries: usize,
+        ood_samples: usize,
+    ) -> Self {
+        assert!(BigUint::from(pow_bits.len()) < F::order());
+        Self {
+            folding_factor,
+            queries_pow_bits,
+            pow_bits,
+            num_queries,
+            ood_samples,
+            _marker: std::marker::PhantomData,
+        }
+    }
+    fn write_to_challenger<D: Copy, C: VariableLengthChallenger<F, D>>(&self, challenger: &mut C) {
         challenger.observe(F::from_canonical_usize(self.folding_factor));
-        challenger.observe(F::from_canonical_usize(self.evaluation_domain_log_size));
         challenger.observe(F::from_canonical_usize(self.queries_pow_bits));
-        // It is ok to unwrap the result here because this function is only called at Verifier initialization.
+        // It is ok to unwrap the result here because the error path is excluded when constructing
+        // the `RoundConfig` via the `new` function.
         challenger
             .observe_variable_length_slice(
                 &self.pow_bits.iter().copied().map(F::from_canonical_usize).collect::<Vec<_>>(),

--- a/slop/crates/whir/src/config.rs
+++ b/slop/crates/whir/src/config.rs
@@ -134,6 +134,7 @@ impl<F: TwoAdicField + PrimeField64, EF: ExtensionField<F>> WhirProofShape<F, EF
 
         assert!(config.starting_folding_pow_bits.iter().all(|&bits| 1 << bits < F::ORDER_U64));
         assert!(config.final_folding_pow_bits.iter().all(|&bits| 1 << bits < F::ORDER_U64));
+        assert!(1 << config.final_pow_bits < F::ORDER_U64);
 
         for round_param in &config.round_parameters {
             assert!(round_param.folding_factor < usize::BITS as usize);

--- a/slop/crates/whir/src/config.rs
+++ b/slop/crates/whir/src/config.rs
@@ -142,7 +142,7 @@ impl<F: TwoAdicField + PrimeField64, EF: ExtensionField<F>> WhirProofShape<F, EF
             _marker: std::marker::PhantomData,
         };
 
-        // The check before calling the constructor guarantees no overflow here.
+        // The check before calling the constructor guarantees no underflow in the subtraction in the function call.
         assert!(result.final_poly_log_degree() < usize::BITS as usize);
 
         assert!(result.check_usizes_bound_by_field_order());

--- a/slop/crates/whir/src/prover.rs
+++ b/slop/crates/whir/src/prover.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use derive_where::derive_where;
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
-use slop_algebra::{AbstractField, ExtensionField, Field};
+use slop_algebra::{AbstractField, ExtensionField, Field, TwoAdicField};
 use slop_alloc::CpuBackend;
 use slop_challenger::{
     CanObserve, CanSampleBits, FieldChallenger, GrindingChallenger, IopCtx,
@@ -89,7 +89,7 @@ where
 {
     dft: D,
     merkle_prover: MerkleProver,
-    config: WhirProofShape<GC::F>,
+    config: WhirProofShape<GC::F, GC::EF>,
     _marker: std::marker::PhantomData<GC>,
 }
 
@@ -148,17 +148,18 @@ impl<GC, MerkleProver, D> Prover<GC, MerkleProver, D>
 where
     GC: IopCtx,
     D: Dft<GC::F>,
+    GC::F: TwoAdicField,
     GC::Challenger: VariableLengthChallenger<GC::F, GC::Digest>,
     MerkleProver: TensorCsProver<GC, CpuBackend> + ComputeTcsOpenings<GC, CpuBackend>,
 {
-    pub fn new(dft: D, merkle_prover: MerkleProver, config: WhirProofShape<GC::F>) -> Self {
+    pub fn new(dft: D, merkle_prover: MerkleProver, config: WhirProofShape<GC::F, GC::EF>) -> Self {
         Self { dft, merkle_prover, config, _marker: std::marker::PhantomData }
     }
 
     pub fn parse_commitment_data(
         &self,
         challenger: &mut GC::Challenger,
-        config: &WhirProofShape<GC::F>,
+        config: &WhirProofShape<GC::F, GC::EF>,
         rounds: Rounds<WhirProverData<GC, MerkleProver>>,
     ) -> WitnessData<GC, MerkleProver> {
         let num_variables = rounds
@@ -170,7 +171,7 @@ where
 
         let num_non_zero_entries: usize =
             rounds.iter().map(|r| r.polynomial.guts().as_slice().len()).sum();
-        let ood_points: Vec<Point<GC::EF>> = (0..config.starting_ood_samples)
+        let ood_points: Vec<Point<GC::EF>> = (0..config.starting_ood_samples())
             .map(|_| {
                 (0..num_variables)
                     .map(|_| challenger.sample_ext_element())
@@ -187,30 +188,29 @@ where
                     .iter()
                     .map(|r| {
                         let num_entries = r.polynomial.guts().total_len();
-                        assert!(
-                            num_entries.is_multiple_of(1 << config.starting_interleaved_log_height)
-                        );
+                        assert!(num_entries
+                            .is_multiple_of(1 << config.starting_interleaved_log_height()));
                         r.polynomial.guts().clone().reshape([
-                            1 << config.starting_interleaved_log_height,
-                            num_entries / (1 << config.starting_interleaved_log_height),
+                            1 << config.starting_interleaved_log_height(),
+                            num_entries / (1 << config.starting_interleaved_log_height()),
                         ])
                     })
                     .chain(once(Tensor::from(vec![GC::F::zero(); num_to_add]).reshape([
-                        1 << config.starting_interleaved_log_height,
-                        num_to_add / (1 << config.starting_interleaved_log_height),
+                        1 << config.starting_interleaved_log_height(),
+                        num_to_add / (1 << config.starting_interleaved_log_height()),
                     ]))),
             )
             .into_buffer()
             .to_vec();
 
             assert_eq!(result.len(), 1 << num_variables);
-            for i in 0..(num_to_add >> config.starting_interleaved_log_height) {
-                for j in 0..(1 << config.starting_interleaved_log_height) {
+            for i in 0..(num_to_add >> config.starting_interleaved_log_height()) {
+                for j in 0..(1 << config.starting_interleaved_log_height()) {
                     assert_eq!(
-                        result[(num_non_zero_entries >> config.starting_interleaved_log_height)
+                        result[(num_non_zero_entries >> config.starting_interleaved_log_height())
                             + i
                             + (j << (num_variables
-                                - config.starting_interleaved_log_height as u32))],
+                                - config.starting_interleaved_log_height() as u32))],
                         GC::F::zero()
                     );
                 }
@@ -221,8 +221,8 @@ where
             interleave_chain(rounds.iter().map(|r| {
                 let num_entries = r.polynomial.guts().total_len();
                 r.polynomial.guts().clone().reshape([
-                    1 << config.starting_interleaved_log_height,
-                    num_entries / (1 << config.starting_interleaved_log_height),
+                    1 << config.starting_interleaved_log_height(),
+                    num_entries / (1 << config.starting_interleaved_log_height()),
                 ])
             }))
             .into_buffer()
@@ -266,9 +266,9 @@ where
         witness_data: Rounds<WhirProverData<GC, MerkleProver>>,
         claim: GC::EF,
         challenger: &mut GC::Challenger,
-        config: &WhirProofShape<GC::F>,
+        config: &WhirProofShape<GC::F, GC::EF>,
     ) -> WhirProof<GC> {
-        let n_rounds = config.round_parameters.len();
+        let n_rounds = config.round_parameters().len();
 
         let witness_data = self.parse_commitment_data(challenger, config, witness_data);
 
@@ -294,25 +294,27 @@ where
         let (initial_sumcheck_polynomials, mut folding_randomness, mut claimed_sum) =
             sumcheck_prover.compute_sumcheck_polynomials(
                 claimed_sum,
-                num_variables - config.starting_interleaved_log_height,
-                &config.starting_folding_pow_bits,
+                num_variables - config.starting_interleaved_log_height(),
+                config.starting_folding_pow_bits(),
                 challenger,
             );
 
-        let mut generator = config.domain_generator;
+        let mut generator = config.domain_generator();
         let mut merkle_proofs = Vec::with_capacity(n_rounds);
         let mut query_proof_of_works = Vec::with_capacity(n_rounds);
         let mut sumcheck_polynomials = Vec::with_capacity(n_rounds);
 
-        let mut prev_domain_log_size = config.starting_domain_log_size;
-        let mut prev_folding_factor = num_variables - config.starting_interleaved_log_height;
+        let mut prev_domain_log_size = config.starting_domain_log_size();
+        let mut prev_folding_factor = num_variables - config.starting_interleaved_log_height();
         let (mut prev_prover_data, mut prev_committed_data) = (
             witness_data.commitment_data,
             witness_data.committed_data.into_iter().map(Arc::new).collect::<Rounds<_>>(),
         );
 
+        let mut num_remaining_variables = config.starting_interleaved_log_height();
+
         for round_index in 0..n_rounds {
-            let round_params = &config.round_parameters[round_index];
+            let round_params = &config.round_parameters()[round_index];
 
             let num_nonzero_entries = match &sumcheck_prover.f_vec {
                 KOrEfMle::K(mle) => mle.inner().as_ref().unwrap().num_non_zero_entries(),
@@ -326,8 +328,16 @@ where
                 ]),
             };
 
-            let encoding =
-                batch_dft::<_, GC::F, GC::EF>(&self.dft, inner_evals, round_params.log_inv_rate);
+            // We encode via a log inverse rate such that there are `1 << round_params.folding_factor`
+            // messages each of height `1<<(num_remaining_variables - round_params.folding_factor)`
+            // and the codewords have height `1 << round_params.evaluation_domain_log_size`.
+            // Hence the log inverse rate is `round_params.evaluation_domain_log_size - (num_remaining_variables - round_params.folding_factor)`.
+            let log_inv_rate = round_params.evaluation_domain_log_size
+                - (num_remaining_variables - round_params.folding_factor);
+            // Update the number of remaining variables.
+            num_remaining_variables -= round_params.folding_factor;
+
+            let encoding = batch_dft::<_, GC::F, GC::EF>(&self.dft, inner_evals, log_inv_rate);
 
             let encoding_base = encoding.flatten_to_base();
 
@@ -484,13 +494,13 @@ where
         let mut final_polynomial =
             f_vec.inner().as_ref().unwrap().guts().clone().into_buffer().to_vec();
 
-        final_polynomial.resize(1 << config.final_poly_log_degree, GC::EF::zero());
+        final_polynomial.resize(1 << config.final_poly_log_degree(), GC::EF::zero());
 
         challenger.observe_constant_length_extension_slice(&final_polynomial);
 
-        let final_pow = challenger.grind(config.final_pow_bits);
+        let final_pow = challenger.grind(config.final_pow_bits());
 
-        let final_id_indices = (0..config.final_queries)
+        let final_id_indices = (0..config.final_queries())
             .map(|_| challenger.sample_bits(prev_domain_log_size))
             .collect::<Vec<_>>();
 
@@ -509,8 +519,8 @@ where
 
         let (final_sumcheck_polynomials, _, _) = sumcheck_prover.compute_sumcheck_polynomials(
             claimed_sum,
-            config.final_poly_log_degree,
-            &config.final_folding_pow_bits,
+            config.final_poly_log_degree(),
+            config.final_folding_pow_bits(),
             challenger,
         );
 
@@ -538,6 +548,7 @@ impl<GC, MerkleProver, D> MultilinearPcsProver<GC, WhirProof<GC>> for Prover<GC,
 where
     GC: IopCtx,
     D: Dft<GC::F>,
+    GC::F: TwoAdicField,
     MerkleProver: TensorCsProver<GC, CpuBackend> + ComputeTcsOpenings<GC, CpuBackend>,
 {
     type ProverData = WhirProverData<GC, MerkleProver>;
@@ -550,7 +561,7 @@ where
     ) -> Result<(<GC as IopCtx>::Digest, Self::ProverData, usize), Self::ProverError> {
         let len: usize = mles.iter().map(|mle| mle.guts().as_slice().len()).sum();
         let added_zeroes =
-            len.next_multiple_of(1 << self.config.starting_interleaved_log_height) - len;
+            len.next_multiple_of(1 << self.config.starting_interleaved_log_height()) - len;
         let tensor: Tensor<GC::F, CpuBackend> = mles
             .iter()
             .flat_map(|mle| mle.guts().transpose().as_slice().to_vec())
@@ -559,7 +570,7 @@ where
             .reshape([len + added_zeroes, 1]);
         let concatenated_mles = Mle::new(tensor);
 
-        let starting_interleaved_height = self.config.starting_interleaved_log_height;
+        let starting_interleaved_height = self.config.starting_interleaved_log_height();
         let num_non_zero_entries = concatenated_mles.num_non_zero_entries();
 
         let inner_evals = concatenated_mles
@@ -571,7 +582,8 @@ where
             ])
             .transpose();
 
-        let encoding = batch_dft(&self.dft, inner_evals.clone(), self.config.starting_log_inv_rate);
+        let encoding =
+            batch_dft(&self.dft, inner_evals.clone(), self.config.starting_log_inv_rate());
 
         let (commitment, prover_data) =
             self.merkle_prover.commit_tensors(encoding.clone().into()).unwrap();
@@ -594,7 +606,7 @@ where
         challenger: &mut <GC as IopCtx>::Challenger,
     ) -> Result<WhirProof<GC>, Self::ProverError> {
         let (folding_point, stacked_point) = eval_point
-            .split_at(eval_point.dimension() - self.config.starting_interleaved_log_height);
+            .split_at(eval_point.dimension() - self.config.starting_interleaved_log_height());
         let eval_point = stacked_point
             .iter()
             .copied()
@@ -610,7 +622,7 @@ where
     }
 
     fn log_max_padding_amount(&self) -> u32 {
-        self.config.starting_interleaved_log_height as u32
+        self.config.starting_interleaved_log_height() as u32
     }
 }
 
@@ -831,7 +843,7 @@ mod tests {
     use slop_utils::setup_logger;
 
     use super::*;
-    use crate::{config::WhirProofShape, verifier::Verifier};
+    use crate::{config::WhirProofShape, verifier::Verifier, UncheckedWhirProofShape};
 
     type F = KoalaBear;
     type EF = BinomialExtensionField<F, 4>;
@@ -1137,7 +1149,7 @@ mod tests {
         GC: IopCtx<F: TwoAdicField, EF: TwoAdicField + ExtensionField<GC::F>>,
         MerkleProver: TensorCsProver<GC, CpuBackend> + ComputeTcsOpenings<GC, CpuBackend>,
     >(
-        config: WhirProofShape<GC::F>,
+        config: WhirProofShape<GC::F, GC::EF>,
         merkle_prover: MerkleProver,
         rounds: Rounds<Message<Mle<GC::F>>>,
     ) where
@@ -1152,7 +1164,7 @@ mod tests {
                     .iter()
                     .map(|m| m.guts().as_slice().len())
                     .sum::<usize>()
-                    .next_multiple_of(1 << config.starting_interleaved_log_height)
+                    .next_multiple_of(1 << config.starting_interleaved_log_height())
             })
             .collect::<Vec<_>>();
         let num_variables = round_areas.iter().sum::<usize>().next_power_of_two().ilog2() as usize;
@@ -1233,7 +1245,7 @@ mod tests {
         GC: IopCtx<F: TwoAdicField, EF: TwoAdicField + ExtensionField<GC::F>>,
         MerkleProver: TensorCsProver<GC, CpuBackend> + ComputeTcsOpenings<GC, CpuBackend>,
     >(
-        config: WhirProofShape<GC::F>,
+        config: WhirProofShape<GC::F, GC::EF>,
         num_variables: usize,
         merkle_prover: MerkleProver,
     ) where
@@ -1259,7 +1271,7 @@ mod tests {
         GC: IopCtx<F: TwoAdicField, EF: TwoAdicField + ExtensionField<GC::F>>,
         MerkleProver: TensorCsProver<GC, CpuBackend> + ComputeTcsOpenings<GC, CpuBackend>,
     >(
-        config: WhirProofShape<GC::F>,
+        config: WhirProofShape<GC::F, GC::EF>,
         num_variables: usize,
         merkle_prover: MerkleProver,
     ) where
@@ -1284,7 +1296,8 @@ mod tests {
 
     #[test]
     fn whir_test_multi_round_koala_bear() {
-        let config = WhirProofShape::default_whir_config();
+        let config = UncheckedWhirProofShape::default_whir_config();
+        let config = WhirProofShape::<KoalaBear, BinomialExtensionField<KoalaBear, 4>>::new(config);
         let merkle_prover: Poseidon2KoalaBear16Prover = FieldMerkleTreeProver::default();
 
         whir_test_multi_round::<_, _>(config, 16, merkle_prover);
@@ -1292,7 +1305,8 @@ mod tests {
 
     #[test]
     fn whir_test_e2e_koala_bear() {
-        let config = WhirProofShape::default_whir_config();
+        let config = UncheckedWhirProofShape::default_whir_config();
+        let config = WhirProofShape::<KoalaBear, BinomialExtensionField<KoalaBear, 4>>::new(config);
         let merkle_prover: Poseidon2KoalaBear16Prover = FieldMerkleTreeProver::default();
         whir_test_single_round::<_, _>(config, 16, merkle_prover);
     }
@@ -1300,14 +1314,16 @@ mod tests {
     #[test]
     #[ignore = "test used for benchmarking"]
     fn whir_test_realistic_koala_bear() {
-        let config = WhirProofShape::<KoalaBear>::big_beautiful_whir_config();
+        let config = UncheckedWhirProofShape::default_whir_config();
+        let config = WhirProofShape::<KoalaBear, BinomialExtensionField<KoalaBear, 4>>::new(config);
         let merkle_prover: Poseidon2KoalaBear16Prover = FieldMerkleTreeProver::default();
         whir_test_single_round::<_, _>(config, 28, merkle_prover);
     }
 
     #[test]
     fn whir_test_e2e_baby_bear() {
-        let config = WhirProofShape::default_whir_config();
+        let config = UncheckedWhirProofShape::default_whir_config();
+        let config = WhirProofShape::<BabyBear, BinomialExtensionField<BabyBear, 4>>::new(config);
         let merkle_prover: Poseidon2BabyBear16Prover = FieldMerkleTreeProver::default();
         whir_test_single_round::<_, _>(config, 16, merkle_prover);
     }
@@ -1315,14 +1331,16 @@ mod tests {
     #[test]
     #[ignore = "test used for benchmarking"]
     fn whir_test_realistic_baby_bear() {
-        let config = WhirProofShape::big_beautiful_whir_config();
+        let config = UncheckedWhirProofShape::default_whir_config();
+        let config = WhirProofShape::<BabyBear, BinomialExtensionField<BabyBear, 4>>::new(config);
         let merkle_prover: Poseidon2BabyBear16Prover = FieldMerkleTreeProver::default();
         whir_test_single_round::<_, _>(config, 28, merkle_prover);
     }
 
     #[test]
     fn jagged_whir_test_baby_bear() {
-        let config = WhirProofShape::default_whir_config();
+        let config = UncheckedWhirProofShape::default_whir_config();
+        let config = WhirProofShape::<BabyBear, BinomialExtensionField<BabyBear, 4>>::new(config);
         let merkle_prover: Poseidon2BabyBear16Prover = FieldMerkleTreeProver::default();
 
         test_jagged_whir_generic::<_, _>(config, merkle_prover);
@@ -1332,7 +1350,7 @@ mod tests {
         GC: IopCtx<F: TwoAdicField, EF: TwoAdicField + ExtensionField<GC::F>>,
         MerkleProver: TensorCsProver<GC, CpuBackend> + ComputeTcsOpenings<GC, CpuBackend>,
     >(
-        config: WhirProofShape<GC::F>,
+        config: WhirProofShape<GC::F, GC::EF>,
         merkle_prover: MerkleProver,
     ) where
         rand::distributions::Standard: rand::distributions::Distribution<GC::F>,

--- a/slop/crates/whir/src/prover.rs
+++ b/slop/crates/whir/src/prover.rs
@@ -1160,6 +1160,7 @@ mod tests {
         let mut rng = rand::rngs::StdRng::seed_from_u64(42);
 
         let mut challenger_prover = GC::default_challenger();
+        challenger_prover.observe(GC::F::from_canonical_usize(rounds.len()));
         config.write_to_challenger(&mut challenger_prover);
         let mut challenger_verifier = GC::default_challenger();
 
@@ -1385,6 +1386,7 @@ mod tests {
 
         let mut challenger_prover = jagged_verifier.challenger();
         // Write the config to the challenger before proving.
+        challenger_prover.observe(GC::F::from_canonical_usize(num_rounds));
         config.write_to_challenger(&mut challenger_prover);
 
         let jagged_prover =

--- a/slop/crates/whir/src/prover.rs
+++ b/slop/crates/whir/src/prover.rs
@@ -269,6 +269,9 @@ where
         config: &WhirProofShape<GC::F, GC::EF>,
     ) -> WhirProof<GC> {
         let n_rounds = config.round_parameters().len();
+        let num_variables = query_vector.num_variables() as usize;
+
+        challenger.observe(GC::F::from_canonical_usize(num_variables));
 
         let witness_data = self.parse_commitment_data(challenger, config, witness_data);
 
@@ -281,8 +284,6 @@ where
         let mut parsed_commitments = Vec::with_capacity(n_rounds);
 
         parsed_commitments.push(witness_data.parsed_commitment.clone());
-
-        let num_variables = query_vector.num_variables() as usize;
 
         let mut sumcheck_prover = SumcheckProver::<GC, GC::F>::new(
             witness_data.polynomial.clone(),
@@ -330,10 +331,10 @@ where
 
             // We encode via a log inverse rate such that there are `1 << round_params.folding_factor`
             // messages each of height `1<<(num_remaining_variables - round_params.folding_factor)`
-            // and the codewords have height `1 << round_params.evaluation_domain_log_size`.
-            // Hence the log inverse rate is `round_params.evaluation_domain_log_size - (num_remaining_variables - round_params.folding_factor)`.
-            let log_inv_rate = round_params.evaluation_domain_log_size
-                - (num_remaining_variables - round_params.folding_factor);
+            // and the codewords have height `prev_domain_log_size -1`.
+            // Hence the log inverse rate is `prev_domain_log_size - 1 - (num_remaining_variables - round_params.folding_factor)`.
+            let log_inv_rate =
+                prev_domain_log_size - 1 - (num_remaining_variables - round_params.folding_factor);
             // Update the number of remaining variables.
             num_remaining_variables -= round_params.folding_factor;
 
@@ -403,8 +404,6 @@ where
                 .collect();
 
             let num_openings: usize = merkle_openings.iter().map(|o| o.sizes()[1]).sum();
-
-            // assert!(num_openings <= 1 << prev_folding_factor);
 
             let merkle_proof: Vec<_> = prev_prover_data
                 .into_iter()
@@ -479,7 +478,7 @@ where
             // Update
             generator = generator.square();
             prev_folding_factor = round_params.folding_factor;
-            prev_domain_log_size = round_params.evaluation_domain_log_size;
+            prev_domain_log_size -= 1;
             (prev_prover_data, prev_committed_data) = (
                 vec![prover_data].into_iter().collect(),
                 vec![Arc::new(encoding_base)].into_iter().collect(),
@@ -830,7 +829,7 @@ mod tests {
 
     use rand::{distributions::Standard, prelude::Distribution, thread_rng, Rng, SeedableRng};
     use slop_algebra::{extension::BinomialExtensionField, TwoAdicField, UnivariatePolynomial};
-    use slop_baby_bear::BabyBear;
+    use slop_baby_bear::{baby_bear_poseidon2::BabyBearDegree4Duplex, BabyBear};
     use slop_commit::Rounds;
     use slop_dft::p3::Radix2DitParallel;
     use slop_jagged::{JaggedEvalSumcheckProver, JaggedPcsVerifier, JaggedProver};
@@ -1226,9 +1225,9 @@ mod tests {
             rounds.iter().count(),
             &mut challenger_verifier,
         );
-        verifier
-            .observe_commitment(&commitments, &mut challenger_verifier, rounds.iter().count())
-            .unwrap();
+
+        challenger_verifier.observe_constant_length_digest_slice(&commitments);
+
         verifier
             .verify_trusted_evaluation(
                 &commitments,
@@ -1296,7 +1295,7 @@ mod tests {
 
     #[test]
     fn whir_test_multi_round_koala_bear() {
-        let config = UncheckedWhirProofShape::default_whir_config();
+        let config = UncheckedWhirProofShape::<KoalaBear>::default_whir_config();
         let config = WhirProofShape::<KoalaBear, BinomialExtensionField<KoalaBear, 4>>::new(config);
         let merkle_prover: Poseidon2KoalaBear16Prover = FieldMerkleTreeProver::default();
 
@@ -1305,7 +1304,7 @@ mod tests {
 
     #[test]
     fn whir_test_e2e_koala_bear() {
-        let config = UncheckedWhirProofShape::default_whir_config();
+        let config = UncheckedWhirProofShape::<KoalaBear>::default_whir_config();
         let config = WhirProofShape::<KoalaBear, BinomialExtensionField<KoalaBear, 4>>::new(config);
         let merkle_prover: Poseidon2KoalaBear16Prover = FieldMerkleTreeProver::default();
         whir_test_single_round::<_, _>(config, 16, merkle_prover);
@@ -1314,7 +1313,7 @@ mod tests {
     #[test]
     #[ignore = "test used for benchmarking"]
     fn whir_test_realistic_koala_bear() {
-        let config = UncheckedWhirProofShape::default_whir_config();
+        let config = UncheckedWhirProofShape::<KoalaBear>::big_beautiful_whir_config();
         let config = WhirProofShape::<KoalaBear, BinomialExtensionField<KoalaBear, 4>>::new(config);
         let merkle_prover: Poseidon2KoalaBear16Prover = FieldMerkleTreeProver::default();
         whir_test_single_round::<_, _>(config, 28, merkle_prover);
@@ -1322,16 +1321,16 @@ mod tests {
 
     #[test]
     fn whir_test_e2e_baby_bear() {
-        let config = UncheckedWhirProofShape::default_whir_config();
+        let config = UncheckedWhirProofShape::<BabyBear>::default_whir_config();
         let config = WhirProofShape::<BabyBear, BinomialExtensionField<BabyBear, 4>>::new(config);
         let merkle_prover: Poseidon2BabyBear16Prover = FieldMerkleTreeProver::default();
-        whir_test_single_round::<_, _>(config, 16, merkle_prover);
+        whir_test_single_round::<BabyBearDegree4Duplex, _>(config, 16, merkle_prover);
     }
 
     #[test]
     #[ignore = "test used for benchmarking"]
     fn whir_test_realistic_baby_bear() {
-        let config = UncheckedWhirProofShape::default_whir_config();
+        let config = UncheckedWhirProofShape::<BabyBear>::big_beautiful_whir_config();
         let config = WhirProofShape::<BabyBear, BinomialExtensionField<BabyBear, 4>>::new(config);
         let merkle_prover: Poseidon2BabyBear16Prover = FieldMerkleTreeProver::default();
         whir_test_single_round::<_, _>(config, 28, merkle_prover);
@@ -1339,7 +1338,7 @@ mod tests {
 
     #[test]
     fn jagged_whir_test_baby_bear() {
-        let config = UncheckedWhirProofShape::default_whir_config();
+        let config = UncheckedWhirProofShape::<BabyBear>::default_whir_config();
         let config = WhirProofShape::<BabyBear, BinomialExtensionField<BabyBear, 4>>::new(config);
         let merkle_prover: Poseidon2BabyBear16Prover = FieldMerkleTreeProver::default();
 

--- a/slop/crates/whir/src/prover.rs
+++ b/slop/crates/whir/src/prover.rs
@@ -413,7 +413,7 @@ where
                 .collect();
             let merkle_proof = merkle_proof
                 .into_iter()
-                .zip(merkle_openings.into_iter())
+                .zip(merkle_openings)
                 .map(|(proof, opening)| MerkleTreeOpeningAndProof { values: opening, proof })
                 .collect::<Vec<_>>();
             let merkle_read_values: Vec<Mle<GC::EF>> = if round_index != 0 {

--- a/slop/crates/whir/src/verifier.rs
+++ b/slop/crates/whir/src/verifier.rs
@@ -383,11 +383,8 @@ where
                         proof
                             .values
                             .clone()
+                            .into_extension::<GC::EF>()
                             .into_buffer()
-                            .to_vec()
-                            .chunks_exact(GC::EF::D)
-                            .map(|v| GC::EF::from_base_slice(v))
-                            .collect::<Vec<_>>()
                             .chunks_exact(1 << prev_folding_factor)
                             .map(|v| Mle::new(v.to_vec().into()))
                             .collect::<Vec<_>>()
@@ -498,10 +495,7 @@ where
             .values
             .clone()
             .into_buffer()
-            .to_vec()
-            .chunks_exact(GC::EF::D)
-            .map(|v| GC::EF::from_base_slice(v))
-            .collect::<Vec<_>>()
+            .into_extension::<GC::EF>()
             .chunks_exact(1 << prev_folding_factor)
             .map(|v| Mle::new(v.to_vec().into()))
             .collect();

--- a/slop/crates/whir/src/verifier.rs
+++ b/slop/crates/whir/src/verifier.rs
@@ -1,4 +1,3 @@
-use itertools::Itertools;
 use std::iter::once;
 
 use serde::{Deserialize, Serialize};
@@ -198,23 +197,17 @@ where
             ));
         }
 
+        if !round_areas
+            .iter()
+            .all(|area| area.is_multiple_of(1 << self.config.starting_interleaved_log_height))
+        {
+            return Err(WhirProofError::IncorrectShape);
+        }
+
         let expected_widths = round_areas
             .iter()
             .map(|area| (*area) >> self.config.starting_interleaved_log_height)
             .collect::<Vec<_>>();
-
-        for (merkle_proof, area) in proof.initial_merkle_proof.iter().zip_eq(round_areas.iter()) {
-            if merkle_proof.proof.width << self.config.starting_interleaved_log_height != *area {
-                println!(
-                    "proof width: {}, proof log height: {}, expected area {}, area: {}",
-                    merkle_proof.proof.width,
-                    merkle_proof.proof.log_tensor_height,
-                    area,
-                    merkle_proof.proof.width << merkle_proof.proof.log_tensor_height
-                );
-                return Err(WhirProofError::IncorrectShape);
-            }
-        }
 
         let ood_points: Vec<Point<GC::EF>> = (0..config.starting_ood_samples)
             .map(|_| {

--- a/slop/crates/whir/src/verifier.rs
+++ b/slop/crates/whir/src/verifier.rs
@@ -1,7 +1,7 @@
 use std::iter::once;
 
 use serde::{Deserialize, Serialize};
-use slop_algebra::{AbstractExtensionField, AbstractField, UnivariatePolynomial};
+use slop_algebra::{AbstractExtensionField, AbstractField, TwoAdicField, UnivariatePolynomial};
 use slop_challenger::{
     CanObserve, CanSampleBits, FieldChallenger, GrindingChallenger, IopCtx,
     VariableLengthChallenger,
@@ -19,7 +19,7 @@ pub struct Verifier<GC>
 where
     GC: IopCtx,
 {
-    pub config: WhirProofShape<GC::F>,
+    pub config: WhirProofShape<GC::F, GC::EF>,
     merkle_verifier: MerkleTreeTcs<GC>,
     pub num_expected_commitments: usize,
 }
@@ -102,6 +102,8 @@ pub enum WhirProofError {
     InvalidNumberOfCommitments(usize, usize),
     #[error("proof has incorrect shape")]
     IncorrectShape,
+    #[error("number of variables does not exceed starting_interleaved_log_height")]
+    StartingInterleavedLogHeightExceedsNumVariables,
 }
 
 impl From<(SumcheckError, usize)> for WhirProofError {
@@ -136,11 +138,12 @@ pub fn map_to_pow<F: AbstractField>(mut elem: F, len: usize) -> Point<F> {
 impl<GC> Verifier<GC>
 where
     GC: IopCtx,
+    GC::F: TwoAdicField,
     GC::Challenger: VariableLengthChallenger<GC::F, GC::Digest>,
 {
     pub fn new(
         merkle_verifier: MerkleTreeTcs<GC>,
-        config: WhirProofShape<GC::F>,
+        config: WhirProofShape<GC::F, GC::EF>,
         num_expected_commitments: usize,
         challenger: &mut GC::Challenger,
     ) -> Self {
@@ -177,7 +180,11 @@ where
         challenger: &mut GC::Challenger,
     ) -> Result<(Point<GC::EF>, GC::EF), WhirProofError> {
         let config = &self.config;
-        let n_rounds = config.round_parameters.len();
+        let n_rounds = config.round_parameters().len();
+
+        if num_variables < config.starting_interleaved_log_height() {
+            return Err(WhirProofError::StartingInterleavedLogHeightExceedsNumVariables);
+        }
 
         if n_rounds == 0
             || proof.merkle_proofs.len() != n_rounds - 1
@@ -199,17 +206,17 @@ where
 
         if !round_areas
             .iter()
-            .all(|area| area.is_multiple_of(1 << self.config.starting_interleaved_log_height))
+            .all(|area| area.is_multiple_of(1 << self.config.starting_interleaved_log_height()))
         {
             return Err(WhirProofError::IncorrectShape);
         }
 
         let expected_widths = round_areas
             .iter()
-            .map(|area| (*area) >> self.config.starting_interleaved_log_height)
+            .map(|area| (*area) >> self.config.starting_interleaved_log_height())
             .collect::<Vec<_>>();
 
-        let ood_points: Vec<Point<GC::EF>> = (0..config.starting_ood_samples)
+        let ood_points: Vec<Point<GC::EF>> = (0..config.starting_ood_samples())
             .map(|_| {
                 (0..num_variables)
                     .map(|_| challenger.sample_ext_element())
@@ -231,9 +238,9 @@ where
         }
 
         // Check that the number of OOD answers in the proof matches the expected value.
-        if commitment.ood_answers.len() != config.starting_ood_samples {
+        if commitment.ood_answers.len() != config.starting_ood_samples() {
             return Err(WhirProofError::InvalidNumberOfOODSamples(
-                config.starting_ood_samples,
+                config.starting_ood_samples(),
                 commitment.ood_answers.len(),
             ));
         }
@@ -257,8 +264,8 @@ where
             .verify_sumcheck(
                 &proof.initial_sumcheck_polynomials,
                 claimed_sum,
-                num_variables - config.starting_interleaved_log_height,
-                &config.starting_folding_pow_bits,
+                num_variables - config.starting_interleaved_log_height(),
+                config.starting_folding_pow_bits(),
                 challenger,
             )
             .map_err(|err| (err, 0))?;
@@ -272,15 +279,16 @@ where
 
         // This is relative to the previous commitment (i.e. prev_commitment has a domain size of
         // this size)
-        let mut domain_size = config.starting_interleaved_log_height + config.starting_log_inv_rate;
-        let mut generator = config.domain_generator;
+        let mut domain_size =
+            config.starting_interleaved_log_height() + config.starting_log_inv_rate();
+        let mut generator = config.domain_generator();
         let mut prev_commitment = commitment;
 
-        let mut prev_folding_factor = num_variables - config.starting_interleaved_log_height;
-        let mut num_variables = config.starting_interleaved_log_height;
+        let mut prev_folding_factor = num_variables - config.starting_interleaved_log_height();
+        let mut num_variables = config.starting_interleaved_log_height();
 
         for round_index in 0..n_rounds {
-            let round_params = &config.round_parameters[round_index];
+            let round_params = &config.round_parameters()[round_index];
             // Because of the length checks at the start of the verification, the checked access isn't
             // expected to produce an error.
             let new_commitment =
@@ -351,13 +359,13 @@ where
                 let expected_width = if round_index == 0 {
                     expected_widths[i]
                 } else {
-                    (1 << config.round_parameters[round_index - 1].folding_factor) * GC::EF::D
+                    (1 << config.round_parameters()[round_index - 1].folding_factor) * GC::EF::D
                 };
 
                 let expected_log_height = if round_index == 0 {
-                    config.starting_interleaved_log_height + config.starting_log_inv_rate
+                    config.starting_interleaved_log_height() + config.starting_log_inv_rate()
                 } else {
-                    config.round_parameters[round_index - 1].evaluation_domain_log_size
+                    config.round_parameters()[round_index - 1].evaluation_domain_log_size
                 };
                 self.merkle_verifier
                     .verify_tensor_openings(
@@ -454,9 +462,9 @@ where
         }
 
         // Now, we want to verify the final evaluations
-        if proof.final_polynomial.len() != 1 << config.final_poly_log_degree {
+        if proof.final_polynomial.len() != 1 << config.final_poly_log_degree() {
             return Err(WhirProofError::InvalidDegreeFinalPolynomial(
-                1 << config.final_poly_log_degree,
+                1 << config.final_poly_log_degree(),
                 proof.final_polynomial.len(),
             ));
         }
@@ -466,11 +474,11 @@ where
         let final_poly = proof.final_polynomial.clone();
         let final_poly_uv = UnivariatePolynomial::new(final_poly.clone());
 
-        if !challenger.check_witness(config.final_pow_bits, proof.final_pow) {
+        if !challenger.check_witness(config.final_pow_bits(), proof.final_pow) {
             return Err(WhirProofError::PowError);
         }
 
-        let final_id_indices = (0..config.final_queries)
+        let final_id_indices = (0..config.final_queries())
             .map(|_| challenger.sample_bits(domain_size))
             .collect::<Vec<_>>();
         let final_id_values: Vec<GC::F> = final_id_indices
@@ -484,8 +492,8 @@ where
                 &prev_commitment.commitment[0],
                 &final_id_indices,
                 &proof.final_merkle_opening_and_proof.values,
-                (1 << config.round_parameters[n_rounds - 1].folding_factor) * GC::EF::D,
-                config.round_parameters[n_rounds - 1].evaluation_domain_log_size,
+                (1 << config.round_parameters()[n_rounds - 1].folding_factor) * GC::EF::D,
+                config.round_parameters()[n_rounds - 1].evaluation_domain_log_size,
                 &proof.final_merkle_opening_and_proof.proof,
             )
             .map_err(|_| WhirProofError::InvalidMerkleAuthentication)?;
@@ -519,8 +527,8 @@ where
             .verify_sumcheck(
                 &proof.final_sumcheck_polynomials,
                 claimed_sum,
-                config.final_poly_log_degree,
-                &config.final_folding_pow_bits,
+                config.final_poly_log_degree(),
+                config.final_folding_pow_bits(),
                 challenger,
             )
             .map_err(|err| (err, n_rounds + 1))?;
@@ -601,6 +609,7 @@ where
 impl<GC> MultilinearPcsVerifier<GC> for Verifier<GC>
 where
     GC: IopCtx,
+    GC::F: TwoAdicField,
 {
     type Proof = WhirProof<GC>;
 
@@ -628,7 +637,7 @@ where
             challenger,
         )?;
         let (folding_point, stacking_point) =
-            point.split_at(point.dimension() - self.config.starting_interleaved_log_height);
+            point.split_at(point.dimension() - self.config.starting_interleaved_log_height());
         let point = stacking_point
             .iter()
             .copied()
@@ -643,7 +652,7 @@ where
     /// The jagged verifier will assume that the underlying PCS will pad commitments to a multiple
     /// of `1<<log.stacking_height(verifier)`.
     fn log_stacking_height(verifier: &Self) -> u32 {
-        verifier.config.starting_interleaved_log_height as u32
+        verifier.config.starting_interleaved_log_height() as u32
     }
 }
 

--- a/slop/crates/whir/src/verifier.rs
+++ b/slop/crates/whir/src/verifier.rs
@@ -146,6 +146,8 @@ where
         challenger: &mut GC::Challenger,
     ) -> Self {
         assert_ne!(num_expected_commitments, 0, "commitment must exist");
+        assert!(num_expected_commitments <= 1 << 12, "too many commitments");
+        challenger.observe(GC::F::from_canonical_usize(num_expected_commitments));
         config.write_to_challenger::<GC::Digest, GC::Challenger>(challenger);
         Self { merkle_verifier, config, num_expected_commitments }
     }

--- a/slop/crates/whir/src/verifier.rs
+++ b/slop/crates/whir/src/verifier.rs
@@ -292,6 +292,10 @@ where
                 ));
             }
 
+            if new_commitment.commitment.len() != 1 {
+                return Err(WhirProofError::IncorrectShape);
+            }
+
             // Observe the commitments
             new_commitment.commitment.iter().for_each(|c| {
                 challenger.observe(*c);
@@ -448,9 +452,6 @@ where
             prev_folding_factor = round_params.folding_factor;
             generator = generator.square();
             num_variables -= round_params.folding_factor;
-            if prev_commitment.commitment.len() != 1 {
-                return Err(WhirProofError::IncorrectShape);
-            }
         }
 
         // Now, we want to verify the final evaluations

--- a/slop/crates/whir/src/verifier.rs
+++ b/slop/crates/whir/src/verifier.rs
@@ -384,8 +384,10 @@ where
                             .values
                             .clone()
                             .into_buffer()
-                            .into_extension::<GC::EF>()
                             .to_vec()
+                            .chunks_exact(GC::EF::D)
+                            .map(|v| GC::EF::from_base_slice(v))
+                            .collect::<Vec<_>>()
                             .chunks_exact(1 << prev_folding_factor)
                             .map(|v| Mle::new(v.to_vec().into()))
                             .collect::<Vec<_>>()
@@ -496,8 +498,10 @@ where
             .values
             .clone()
             .into_buffer()
-            .into_extension::<GC::EF>()
             .to_vec()
+            .chunks_exact(GC::EF::D)
+            .map(|v| GC::EF::from_base_slice(v))
+            .collect::<Vec<_>>()
             .chunks_exact(1 << prev_folding_factor)
             .map(|v| Mle::new(v.to_vec().into()))
             .collect();

--- a/slop/crates/whir/src/verifier.rs
+++ b/slop/crates/whir/src/verifier.rs
@@ -146,6 +146,20 @@ where
     GC::F: TwoAdicField,
     GC::Challenger: VariableLengthChallenger<GC::F, GC::Digest>,
 {
+    /// Construct a new WHIR verifier for a given proof shape and number of commitments.
+    ///
+    /// It is important to call this function *before* absorbing the WHIR commitments into the challenger.
+    /// This ensures that the challenger is correctly seeded with protocol shape before the main protocol starts.
+    /// The Fiat-Shamir challenger passed here by reference should then be used as the challenger for the main protocol.
+    ///
+    /// An example of unsound usage: observe a slice of `commitments` into a `challenger` -> pass that
+    /// challenger to the `Verifier::new` function -> call `Self::verify` with that challenger and
+    /// that slice of `commitments`. The first two steps must be swapped for correct Fiat-Shamir seeding.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if `num_expected_commitments` is zero or larger than or equal to 4096 (this is a somewhat large bound that provides some DOS protection).
+    /// - Panics if the field order is smaller than 2^12 because `num_expected_commitments` should not exceed the field size for the challenger observation.
     pub fn new(
         merkle_verifier: MerkleTreeTcs<GC>,
         config: WhirProofShape<GC::F, GC::EF>,

--- a/slop/crates/whir/src/verifier.rs
+++ b/slop/crates/whir/src/verifier.rs
@@ -9,7 +9,7 @@ use slop_challenger::{
 use slop_commit::Rounds;
 use slop_merkle_tree::{MerkleTreeOpeningAndProof, MerkleTreeTcs};
 use slop_multilinear::{Mle, MultilinearPcsVerifier, Point};
-use slop_utils::reverse_bits_len;
+use slop_utils::{log2_ceil_usize, reverse_bits_len};
 use thiserror::Error;
 
 use crate::{config::WhirProofShape, interleave_chain};
@@ -174,13 +174,14 @@ where
         &self,
         commitments: &[GC::Digest],
         round_areas: &[usize],
-        num_variables: usize,
         claim: GC::EF,
         proof: &WhirProof<GC>,
         challenger: &mut GC::Challenger,
     ) -> Result<(Point<GC::EF>, GC::EF), WhirProofError> {
         let config = &self.config;
         let n_rounds = config.round_parameters().len();
+
+        let num_variables = log2_ceil_usize(round_areas.iter().sum::<usize>());
 
         if num_variables < config.starting_interleaved_log_height() {
             return Err(WhirProofError::StartingInterleavedLogHeightExceedsNumVariables);
@@ -628,14 +629,8 @@ where
         proof: &Self::Proof,
         challenger: &mut <GC as IopCtx>::Challenger,
     ) -> Result<(), Self::VerifierError> {
-        let (randomness, claimed_value) = self.verify(
-            commitments,
-            round_polynomial_sizes,
-            point.dimension(),
-            evaluation_claims,
-            proof,
-            challenger,
-        )?;
+        let (randomness, claimed_value) =
+            self.verify(commitments, round_polynomial_sizes, evaluation_claims, proof, challenger)?;
         let (folding_point, stacking_point) =
             point.split_at(point.dimension() - self.config.starting_interleaved_log_height());
         let point = stacking_point

--- a/slop/crates/whir/src/verifier.rs
+++ b/slop/crates/whir/src/verifier.rs
@@ -1,7 +1,10 @@
 use std::iter::once;
 
+use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
-use slop_algebra::{AbstractExtensionField, AbstractField, TwoAdicField, UnivariatePolynomial};
+use slop_algebra::{
+    AbstractExtensionField, AbstractField, Field, TwoAdicField, UnivariatePolynomial,
+};
 use slop_challenger::{
     CanObserve, CanSampleBits, FieldChallenger, GrindingChallenger, IopCtx,
     VariableLengthChallenger,
@@ -104,6 +107,8 @@ pub enum WhirProofError {
     IncorrectShape,
     #[error("number of variables does not exceed starting_interleaved_log_height")]
     StartingInterleavedLogHeightExceedsNumVariables,
+    #[error("the total area overflows usize")]
+    AreaOverflow,
 }
 
 impl From<(SumcheckError, usize)> for WhirProofError {
@@ -148,24 +153,11 @@ where
         challenger: &mut GC::Challenger,
     ) -> Self {
         assert_ne!(num_expected_commitments, 0, "commitment must exist");
-        assert!(num_expected_commitments <= 1 << 12, "too many commitments");
+        assert!(GC::F::order() >= BigUint::from((1 << 12) as u64), "field order too small");
+        assert!(num_expected_commitments < 1 << 12, "too many commitments");
         challenger.observe(GC::F::from_canonical_usize(num_expected_commitments));
         config.write_to_challenger::<GC::Digest, GC::Challenger>(challenger);
         Self { merkle_verifier, config, num_expected_commitments }
-    }
-
-    pub fn observe_commitment(
-        &self,
-        commitment: &[GC::Digest],
-        challenger: &mut GC::Challenger,
-        expected_length: usize,
-    ) -> Result<(), WhirProofError> {
-        if commitment.len() != expected_length {
-            Err(WhirProofError::InvalidNumberOfCommitments(expected_length, commitment.len()))
-        } else {
-            challenger.observe_constant_length_digest_slice(commitment);
-            Ok(())
-        }
     }
 
     /// The claim is that < f, v > = claim.
@@ -181,7 +173,13 @@ where
         let config = &self.config;
         let n_rounds = config.round_parameters().len();
 
+        let mut total_area: usize = 0;
+        for area in round_areas {
+            total_area = total_area.checked_add(*area).ok_or(WhirProofError::AreaOverflow)?;
+        }
+
         let num_variables = log2_ceil_usize(round_areas.iter().sum::<usize>());
+        challenger.observe(GC::F::from_canonical_usize(num_variables));
 
         if num_variables < config.starting_interleaved_log_height() {
             return Err(WhirProofError::StartingInterleavedLogHeightExceedsNumVariables);
@@ -363,11 +361,7 @@ where
                     (1 << config.round_parameters()[round_index - 1].folding_factor) * GC::EF::D
                 };
 
-                let expected_log_height = if round_index == 0 {
-                    config.starting_domain_log_size()
-                } else {
-                    config.round_parameters()[round_index - 1].evaluation_domain_log_size
-                };
+                let expected_log_height = domain_size;
                 self.merkle_verifier
                     .verify_tensor_openings(
                         merkle_commitment,
@@ -455,11 +449,11 @@ where
                 .concat(),
             );
 
-            domain_size = round_params.evaluation_domain_log_size;
             prev_commitment = new_commitment;
             prev_folding_factor = round_params.folding_factor;
             generator = generator.square();
             num_variables -= round_params.folding_factor;
+            domain_size -= 1;
         }
 
         // Now, we want to verify the final evaluations
@@ -494,7 +488,7 @@ where
                 &final_id_indices,
                 &proof.final_merkle_opening_and_proof.values,
                 (1 << config.round_parameters()[n_rounds - 1].folding_factor) * GC::EF::D,
-                config.round_parameters()[n_rounds - 1].evaluation_domain_log_size,
+                domain_size,
                 &proof.final_merkle_opening_and_proof.proof,
             )
             .map_err(|_| WhirProofError::InvalidMerkleAuthentication)?;

--- a/slop/crates/whir/src/verifier.rs
+++ b/slop/crates/whir/src/verifier.rs
@@ -279,8 +279,8 @@ where
 
         // This is relative to the previous commitment (i.e. prev_commitment has a domain size of
         // this size)
-        let mut domain_size =
-            config.starting_interleaved_log_height() + config.starting_log_inv_rate();
+        let mut domain_size = config.starting_domain_log_size();
+
         let mut generator = config.domain_generator();
         let mut prev_commitment = commitment;
 
@@ -363,7 +363,7 @@ where
                 };
 
                 let expected_log_height = if round_index == 0 {
-                    config.starting_interleaved_log_height() + config.starting_log_inv_rate()
+                    config.starting_domain_log_size()
                 } else {
                     config.round_parameters()[round_index - 1].evaluation_domain_log_size
                 };

--- a/slop/crates/whir/src/verifier.rs
+++ b/slop/crates/whir/src/verifier.rs
@@ -192,7 +192,7 @@ where
             total_area = total_area.checked_add(*area).ok_or(WhirProofError::AreaOverflow)?;
         }
 
-        let num_variables = log2_ceil_usize(round_areas.iter().sum::<usize>());
+        let num_variables = log2_ceil_usize(total_area);
         challenger.observe(GC::F::from_canonical_usize(num_variables));
 
         if num_variables < config.starting_interleaved_log_height() {

--- a/sp1-gpu/crates/logup_gkr/src/lib.rs
+++ b/sp1-gpu/crates/logup_gkr/src/lib.rs
@@ -225,9 +225,11 @@ where
     let host_numerator = numerator.to_host().unwrap();
     let host_denominator = denominator.to_host().unwrap();
     challenger
-        .observe_variable_length_extension_slice(host_numerator.guts().as_buffer().as_slice());
+        .observe_variable_length_extension_slice(host_numerator.guts().as_buffer().as_slice())
+        .unwrap();
     challenger
-        .observe_variable_length_extension_slice(host_denominator.guts().as_buffer().as_slice());
+        .observe_variable_length_extension_slice(host_denominator.guts().as_buffer().as_slice())
+        .unwrap();
 
     let output_host = LogUpGkrOutput { numerator: host_numerator, denominator: host_denominator };
 
@@ -277,9 +279,11 @@ where
 
         // Observe the openings.
         if let Some(prep_eval) = openings.preprocessed_trace_evaluations.as_ref() {
-            challenger.observe_variable_length_extension_slice(prep_eval);
+            challenger.observe_variable_length_extension_slice(prep_eval).unwrap();
         }
-        challenger.observe_variable_length_extension_slice(&openings.main_trace_evaluations);
+        challenger
+            .observe_variable_length_extension_slice(&openings.main_trace_evaluations)
+            .unwrap();
 
         chip_evaluations.insert(chip.name().to_string(), openings);
     }

--- a/sp1-gpu/crates/zerocheck/src/lib.rs
+++ b/sp1-gpu/crates/zerocheck/src/lib.rs
@@ -675,14 +675,14 @@ where
             local: individual_column_evals[preprocessed_ptr..preprocessed_ptr + preprocessed_width]
                 .to_vec(),
         };
-        challenger.observe_variable_length_extension_slice(&preprocessed.local);
+        challenger.observe_variable_length_extension_slice(&preprocessed.local).unwrap();
         preprocessed_ptr += preprocessed_width;
 
         let width = chip.width();
 
         let main =
             AirOpenedValues { local: individual_column_evals[main_ptr..main_ptr + width].to_vec() };
-        challenger.observe_variable_length_extension_slice(&main.local);
+        challenger.observe_variable_length_extension_slice(&main.local).unwrap();
         main_ptr += width;
 
         opened_values.insert(
@@ -1451,8 +1451,10 @@ pub mod tests {
 
         // Observe the openings
         for (_, opening) in opened_values.chips.iter() {
-            challenger.observe_variable_length_extension_slice(&opening.preprocessed.local);
-            challenger.observe_variable_length_extension_slice(&opening.main.local);
+            challenger
+                .observe_variable_length_extension_slice(&opening.preprocessed.local)
+                .unwrap();
+            challenger.observe_variable_length_extension_slice(&opening.main.local).unwrap();
         }
     }
 


### PR DESCRIPTION
The main fixes in this PR are:

1. Check whether the length of a variable-length slice passed to the challenger overflows the field order, and return an error if so.
2. Move the `into_extension()` methods on Buffer and Tensor to CPU-specific implementations that use safe Rust. The generic-backend versions are not needed.
3. Removed redundant fields of the `WhirProofShape` struct (ones that could be deduced from equalities like `starting_domain_log_size = starting_interleaved_log_height + starting_inv_log_rate`), and created a new struct `UncheckedWhirProofShape` that has all the same fields but `pub`. Made a constructor for `WhirProofShape` that takes in an `UncheckedWhirProofShape` and performs consistency checks on the shape, panicking if the unchecked shape is invalid. The `WhirProofShape` struct fields are only accessed via getters.