### PR TITLE
fix(ci): split patch-testing workflow for fork PR support

### DIFF
--- a/.github/workflows/patch-testing-cycles-comment.yml
+++ b/.github/workflows/patch-testing-cycles-comment.yml
@@ -44,5 +44,5 @@ jobs:
         env:
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OLD_CYCLE_STATS: ${{ github.workspace }}/old_cycle_stats.json
-          NEW_CYCLE_STATS: ${{ github.workspace }}/new_cycle_stats.json
+          OLD_CYCLE_STATS: ${{ github.workspace }}/patch-testing/old_cycle_stats.json
+          NEW_CYCLE_STATS: ${{ github.workspace }}/patch-testing/new_cycle_stats.json

--- a/.github/workflows/patch-testing-cycles-comment.yml
+++ b/.github/workflows/patch-testing-cycles-comment.yml
@@ -1,0 +1,46 @@
+name: Patch Testing Cycles Comment
+
+on:
+  workflow_run:
+    workflows: ["Patch Testing Cycles"]
+    types: [completed]
+
+jobs:
+  post-comment:
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+    steps:
+      - name: "Checkout sources"
+        uses: "actions/checkout@v6"
+
+      - name: Setup CI
+        uses: ./.github/actions/setup
+        with:
+          pull_token: ${{ secrets.PRIVATE_PULL_TOKEN }}
+
+      - name: "Download cycle stats"
+        uses: actions/download-artifact@v4
+        with:
+          name: patch-testing-results
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Get PR number"
+        id: pr
+        run: |
+          # Get the PR number from the workflow run
+          PR_NUMBER=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }} --jq '.pull_requests[0].number')
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Post comment to PR"
+        run: |
+          cd ./patch-testing
+          RUST_BACKTRACE=full cargo run --bin post-to-github
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/patch-testing-cycles-comment.yml
+++ b/.github/workflows/patch-testing-cycles-comment.yml
@@ -44,3 +44,5 @@ jobs:
         env:
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OLD_CYCLE_STATS: ${{ github.workspace }}/old_cycle_stats.json
+          NEW_CYCLE_STATS: ${{ github.workspace }}/new_cycle_stats.json

--- a/.github/workflows/patch-testing-cycles.yml
+++ b/.github/workflows/patch-testing-cycles.yml
@@ -56,6 +56,9 @@ jobs:
         run: |
           cd ./patch-testing
           cargo run --bin compare-results
+        env:
+          OLD_CYCLE_STATS: ${{ github.workspace }}/old_cycle_stats.json
+          NEW_CYCLE_STATS: ${{ github.workspace }}/new_cycle_stats.json
 
       - name: "Upload cycle stats"
         uses: actions/upload-artifact@v4

--- a/.github/workflows/patch-testing-cycles.yml
+++ b/.github/workflows/patch-testing-cycles.yml
@@ -52,6 +52,13 @@ jobs:
           cd ./patch-testing
           SP1_PATCH_BENCH=../old_cycle_stats.json cargo test --release -- --test-threads=1
 
+      - name: "Debug: check cycle stats files"
+        run: |
+          echo "Workspace: ${{ github.workspace }}"
+          ls -la ${{ github.workspace }}/*cycle_stats* || echo "No cycle stats files in workspace root"
+          ls -la ${{ github.workspace }}/patch-testing/*cycle_stats* || echo "No cycle stats files in patch-testing/"
+          find ${{ github.workspace }} -name "*cycle_stats*" 2>/dev/null || echo "No cycle stats files found anywhere"
+
       - name: "Compare results"
         run: |
           cd ./patch-testing

--- a/.github/workflows/patch-testing-cycles.yml
+++ b/.github/workflows/patch-testing-cycles.yml
@@ -52,10 +52,16 @@ jobs:
           cd ./patch-testing
           SP1_PATCH_BENCH=../old_cycle_stats.json cargo test --release -- --test-threads=1
 
-      - name: "Compare results and create comment"
+      - name: "Compare results"
         run: |
           cd ./patch-testing
-          RUST_BACKTRACE=full cargo run --bin post-to-github
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          cargo run --bin compare-results
+
+      - name: "Upload cycle stats"
+        uses: actions/upload-artifact@v4
+        with:
+          name: patch-testing-results
+          path: |
+            new_cycle_stats.json
+            old_cycle_stats.json
+          retention-days: 1

--- a/.github/workflows/patch-testing-cycles.yml
+++ b/.github/workflows/patch-testing-cycles.yml
@@ -52,26 +52,19 @@ jobs:
           cd ./patch-testing
           SP1_PATCH_BENCH=../old_cycle_stats.json cargo test --release -- --test-threads=1
 
-      - name: "Debug: check cycle stats files"
-        run: |
-          echo "Workspace: ${{ github.workspace }}"
-          ls -la ${{ github.workspace }}/*cycle_stats* || echo "No cycle stats files in workspace root"
-          ls -la ${{ github.workspace }}/patch-testing/*cycle_stats* || echo "No cycle stats files in patch-testing/"
-          find ${{ github.workspace }} -name "*cycle_stats*" 2>/dev/null || echo "No cycle stats files found anywhere"
-
       - name: "Compare results"
         run: |
           cd ./patch-testing
           cargo run --bin compare-results
         env:
-          OLD_CYCLE_STATS: ${{ github.workspace }}/old_cycle_stats.json
-          NEW_CYCLE_STATS: ${{ github.workspace }}/new_cycle_stats.json
+          OLD_CYCLE_STATS: ${{ github.workspace }}/patch-testing/old_cycle_stats.json
+          NEW_CYCLE_STATS: ${{ github.workspace }}/patch-testing/new_cycle_stats.json
 
       - name: "Upload cycle stats"
         uses: actions/upload-artifact@v4
         with:
           name: patch-testing-results
           path: |
-            new_cycle_stats.json
-            old_cycle_stats.json
+            patch-testing/new_cycle_stats.json
+            patch-testing/old_cycle_stats.json
           retention-days: 1

--- a/patch-testing/Cargo.lock
+++ b/patch-testing/Cargo.lock
@@ -865,6 +865,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "crash-context"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031ed29858d90cfdf27fe49fae28028a1f20466db97962fa2f4ea34809aeebf3"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "mach2",
+]
+
+[[package]]
+name = "crash-handler"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0df5c9639f4942eb7702b964b3f9adf03a55724a57558cc177407388a8b936e2"
+dependencies = [
+ "cfg-if",
+ "crash-context",
+ "libc",
+ "mach2",
+ "parking_lot",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1302,20 +1326,6 @@ name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
-
-[[package]]
-name = "downloader"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac1e888d6830712d565b2f3a974be3200be9296bc1b03db8251a4cbf18a4a34"
-dependencies = [
- "digest 0.10.7",
- "futures",
- "rand 0.8.5",
- "reqwest",
- "thiserror 1.0.69",
- "tokio",
-]
 
 [[package]]
 name = "dynasm"
@@ -2459,9 +2469,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libloading"
@@ -2537,6 +2547,15 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "matchers"
@@ -3542,7 +3561,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -3562,7 +3581,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -4690,6 +4709,7 @@ dependencies = [
  "slop-poseidon2",
  "slop-symmetric",
  "slop-tensor",
+ "slop-utils",
  "thiserror 1.0.69",
  "zkhash",
 ]
@@ -4923,6 +4943,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp1-core-executor-runner"
+version = "6.0.2"
+dependencies = [
+ "base64 0.22.1",
+ "bincode",
+ "cargo_metadata",
+ "hashbrown 0.14.5",
+ "hex",
+ "libc",
+ "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp1-core-executor",
+ "sp1-core-executor-runner-binary",
+ "sp1-jit",
+ "sp1-primitives",
+ "sysinfo",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "sp1-core-executor-runner-binary"
+version = "6.0.2"
+dependencies = [
+ "bincode",
+ "crash-handler",
+ "libc",
+ "serde",
+ "sp1-core-executor",
+ "sp1-jit",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "sp1-core-machine"
 version = "6.0.2"
 dependencies = [
@@ -4950,6 +5003,7 @@ dependencies = [
  "slop-uni-stark",
  "snowbridge-amcl",
  "sp1-core-executor",
+ "sp1-core-executor-runner",
  "sp1-curves",
  "sp1-derive",
  "sp1-hypercube",
@@ -5066,6 +5120,7 @@ version = "6.0.2"
 dependencies = [
  "dynasmrt",
  "hashbrown 0.14.5",
+ "libc",
  "memfd",
  "memmap2",
  "serde",
@@ -5113,7 +5168,6 @@ dependencies = [
  "bincode",
  "clap",
  "dirs",
- "downloader",
  "either",
  "enum-map",
  "eyre",
@@ -5144,6 +5198,7 @@ dependencies = [
  "slop-stacked",
  "slop-symmetric",
  "sp1-core-executor",
+ "sp1-core-executor-runner",
  "sp1-core-machine",
  "sp1-derive",
  "sp1-hypercube",
@@ -5327,18 +5382,9 @@ dependencies = [
  "num-bigint 0.4.6",
  "serde",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-algebra",
- "slop-alloc",
- "slop-basefold",
- "slop-commit",
- "slop-jagged",
- "slop-merkle-tree",
- "slop-multilinear",
- "slop-stacked",
- "slop-sumcheck",
- "slop-tensor",
  "sp1-build",
  "sp1-core-executor",
+ "sp1-core-executor-runner",
  "sp1-core-machine",
  "sp1-cuda",
  "sp1-hypercube",

--- a/patch-testing/sp1-test/Cargo.toml
+++ b/patch-testing/sp1-test/Cargo.toml
@@ -23,3 +23,7 @@ console-subscriber = { workspace = true }
 [[bin]]
 name = "post-to-github"
 path = "bin/post_to_github.rs"
+
+[[bin]]
+name = "compare-results"
+path = "bin/compare_results.rs"

--- a/patch-testing/sp1-test/bin/compare_results.rs
+++ b/patch-testing/sp1-test/bin/compare_results.rs
@@ -1,8 +1,13 @@
 use sp1_test::{utils::pretty_comparison, BenchEntry};
 
 pub fn main() {
-    let old_cycle_stats = std::fs::read_to_string("../old_cycle_stats.json").unwrap();
-    let new_cycle_stats = std::fs::read_to_string("../new_cycle_stats.json").unwrap();
+    let old_path =
+        std::env::var("OLD_CYCLE_STATS").unwrap_or_else(|_| "../old_cycle_stats.json".to_string());
+    let new_path =
+        std::env::var("NEW_CYCLE_STATS").unwrap_or_else(|_| "../new_cycle_stats.json".to_string());
+
+    let old_cycle_stats = std::fs::read_to_string(&old_path).unwrap();
+    let new_cycle_stats = std::fs::read_to_string(&new_path).unwrap();
 
     let old_cycle_stats: Vec<BenchEntry> = serde_json::from_str(&old_cycle_stats).unwrap();
     let new_cycle_stats: Vec<BenchEntry> = serde_json::from_str(&new_cycle_stats).unwrap();

--- a/patch-testing/sp1-test/bin/compare_results.rs
+++ b/patch-testing/sp1-test/bin/compare_results.rs
@@ -1,7 +1,4 @@
-use sp1_test::{
-    utils::{post_to_github_pr_sync, pretty_comparison},
-    BenchEntry,
-};
+use sp1_test::{utils::pretty_comparison, BenchEntry};
 
 pub fn main() {
     let old_cycle_stats = std::fs::read_to_string("../old_cycle_stats.json").unwrap();
@@ -13,11 +10,4 @@ pub fn main() {
     let comparison = pretty_comparison(old_cycle_stats, new_cycle_stats).unwrap();
 
     println!("{comparison}");
-
-    let pr_number = std::env::var("PR_NUMBER").unwrap();
-    let token = std::env::var("GITHUB_TOKEN").unwrap();
-    let github_repo = std::env::var("GITHUB_REPOSITORY").unwrap();
-    let (owner, repo) = github_repo.split_once('/').unwrap();
-
-    post_to_github_pr_sync(owner, repo, &pr_number, &token, &comparison).unwrap();
 }

--- a/patch-testing/sp1-test/bin/post_to_github.rs
+++ b/patch-testing/sp1-test/bin/post_to_github.rs
@@ -4,8 +4,13 @@ use sp1_test::{
 };
 
 pub fn main() {
-    let old_cycle_stats = std::fs::read_to_string("../old_cycle_stats.json").unwrap();
-    let new_cycle_stats = std::fs::read_to_string("../new_cycle_stats.json").unwrap();
+    let old_path =
+        std::env::var("OLD_CYCLE_STATS").unwrap_or_else(|_| "../old_cycle_stats.json".to_string());
+    let new_path =
+        std::env::var("NEW_CYCLE_STATS").unwrap_or_else(|_| "../new_cycle_stats.json".to_string());
+
+    let old_cycle_stats = std::fs::read_to_string(&old_path).unwrap();
+    let new_cycle_stats = std::fs::read_to_string(&new_path).unwrap();
 
     let old_cycle_stats: Vec<BenchEntry> = serde_json::from_str(&old_cycle_stats).unwrap();
     let new_cycle_stats: Vec<BenchEntry> = serde_json::from_str(&new_cycle_stats).unwrap();


### PR DESCRIPTION
## Summary
- The `patch-testing-cycles` workflow fails with a 403 when posting comments on fork PRs because GitHub gives fork PRs a read-only `GITHUB_TOKEN`
- Split into two workflows: the `pull_request`-triggered workflow runs tests and uploads cycle stats as artifacts, and a new `workflow_run`-triggered workflow downloads the artifacts and posts the PR comment with full write permissions
- Also fixes JSON file paths in the binaries to correctly read from the repo root

## Test plan
- [ ] Verify the `patch-testing-cycles` workflow completes successfully and uploads artifacts
- [ ] Verify the `patch-testing-cycles-comment` workflow triggers and posts the comparison comment
- [ ] Test with a fork PR to confirm the 403 is resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)