### PR TITLE
fix: Switch to GitHub API for toolchain downloads to allow Authentication header

### DIFF
--- a/crates/cli/src/commands/install_toolchain.rs
+++ b/crates/cli/src/commands/install_toolchain.rs
@@ -15,7 +15,8 @@ use reqwest::Client;
 use std::os::unix::fs::PermissionsExt;
 
 use crate::{
-    get_target, get_toolchain_asset_url, is_supported_target, send_with_retry, RUSTUP_TOOLCHAIN_NAME,
+    get_target, get_toolchain_asset_url, is_supported_target, send_with_retry,
+    RUSTUP_TOOLCHAIN_NAME,
 };
 
 #[derive(Parser)]

--- a/crates/cli/src/commands/install_toolchain.rs
+++ b/crates/cli/src/commands/install_toolchain.rs
@@ -15,8 +15,7 @@ use reqwest::Client;
 use std::os::unix::fs::PermissionsExt;
 
 use crate::{
-    get_target, get_toolchain_download_url, is_supported_target, send_with_retry,
-    RUSTUP_TOOLCHAIN_NAME,
+    get_target, get_toolchain_asset_url, is_supported_target, send_with_retry, RUSTUP_TOOLCHAIN_NAME,
 };
 
 #[derive(Parser)]
@@ -102,12 +101,14 @@ impl InstallToolchainCmd {
         let toolchain_archive_path = root_dir.join(toolchain_asset_name.clone());
         let toolchain_dir = root_dir.join(&target);
 
-        let toolchain_download_url =
-            get_toolchain_download_url(&client, target.to_string()).await?;
+        let toolchain_asset_url = get_toolchain_asset_url(&client, target.to_string()).await?;
 
-        // Download the toolchain.
+        // Download the toolchain via the GitHub API. Using the API asset URL with
+        // Accept: application/octet-stream works correctly with authentication,
+        // unlike browser download URLs which redirect to a CDN that rejects the
+        // Authorization header.
         let mut file = tokio::fs::File::create(toolchain_archive_path).await.unwrap();
-        download_file(&client, toolchain_download_url.as_str(), &mut file)
+        download_file(&client, toolchain_asset_url.as_str(), &mut file)
             .await
             .map_err(|e| anyhow::anyhow!(e))?;
 
@@ -181,7 +182,9 @@ pub async fn download_file(
     use futures::StreamExt;
     use tokio::io::AsyncWriteExt;
 
-    let res = send_with_retry(client, reqwest::Method::GET, url, "Download")
+    let mut headers = reqwest::header::HeaderMap::new();
+    headers.insert(reqwest::header::ACCEPT, "application/octet-stream".parse().unwrap());
+    let res = send_with_retry(client, reqwest::Method::GET, url, Some(headers), "Download")
         .await
         .map_err(|e| e.to_string())?;
 

--- a/crates/cli/src/commands/install_toolchain.rs
+++ b/crates/cli/src/commands/install_toolchain.rs
@@ -15,7 +15,7 @@ use reqwest::Client;
 use std::os::unix::fs::PermissionsExt;
 
 use crate::{
-    get_target, get_toolchain_download_url, is_supported_target, send_with_retry, url_exists,
+    get_target, get_toolchain_download_url, is_supported_target, send_with_retry,
     RUSTUP_TOOLCHAIN_NAME,
 };
 
@@ -104,13 +104,6 @@ impl InstallToolchainCmd {
 
         let toolchain_download_url =
             get_toolchain_download_url(&client, target.to_string()).await?;
-
-        let artifact_exists = url_exists(&client, toolchain_download_url.as_str()).await;
-        if !artifact_exists {
-            return Err(anyhow::anyhow!(
-                "Unsupported architecture. Please build the toolchain from source."
-            ));
-        }
 
         // Download the toolchain.
         let mut file = tokio::fs::File::create(toolchain_archive_path).await.unwrap();

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -58,13 +58,6 @@ pub(crate) async fn send_with_retry(
     )
 }
 
-pub async fn url_exists(client: &Client, url: &str) -> bool {
-    match client.head(url).send().await {
-        Ok(res) => res.status().is_success(),
-        Err(_) => false,
-    }
-}
-
 #[allow(unreachable_code)]
 pub fn is_supported_target() -> bool {
     #[cfg(all(target_arch = "x86_64", target_os = "linux"))]

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -25,6 +25,7 @@ pub(crate) async fn send_with_retry(
     client: &Client,
     method: reqwest::Method,
     url: &str,
+    headers: Option<reqwest::header::HeaderMap>,
     operation: &str,
 ) -> Result<reqwest::Response> {
     let mut last_err = None;
@@ -39,7 +40,11 @@ pub(crate) async fn send_with_retry(
             );
             sleep(backoff).await;
         }
-        match client.request(method.clone(), url).send().await {
+        let mut request = client.request(method.clone(), url);
+        if let Some(ref headers) = headers {
+            request = request.headers(headers.clone());
+        }
+        match request.send().await {
             Ok(res) if res.status().is_success() => return Ok(res),
             Ok(res) => {
                 let status = res.status();
@@ -86,11 +91,16 @@ pub fn get_target() -> String {
     target.to_string()
 }
 
-pub async fn get_toolchain_download_url(client: &Client, target: String) -> Result<String> {
+/// Find the toolchain asset for the given target in the GitHub releases API and return
+/// its API download URL. Using the API URL (with `Accept: application/octet-stream`)
+/// instead of the browser download URL ensures authentication works correctly, including
+/// for draft releases.
+pub async fn get_toolchain_asset_url(client: &Client, target: String) -> Result<String> {
     let response = send_with_retry(
         client,
         reqwest::Method::GET,
         "https://api.github.com/repos/succinctlabs/rust/releases",
+        None,
         "Fetching GitHub releases",
     )
     .await?;
@@ -100,7 +110,7 @@ pub async fn get_toolchain_download_url(client: &Client, target: String) -> Resu
 
     let releases = all_releases.as_array().context("GitHub API response was not a JSON array")?;
 
-    releases
+    let release = releases
         .iter()
         .find(|release| {
             release["tag_name"].as_str() == Some(LATEST_SUPPORTED_TOOLCHAIN_VERSION_TAG)
@@ -109,7 +119,14 @@ pub async fn get_toolchain_download_url(client: &Client, target: String) -> Resu
             format!("No release found for tag: {LATEST_SUPPORTED_TOOLCHAIN_VERSION_TAG}")
         })?;
 
-    Ok(format!(
-        "https://github.com/succinctlabs/rust/releases/download/{LATEST_SUPPORTED_TOOLCHAIN_VERSION_TAG}/rust-toolchain-{target}.tar.gz"
-    ))
+    let expected_name = format!("rust-toolchain-{target}.tar.gz");
+    let assets = release["assets"].as_array().context("Release has no assets array")?;
+    let asset = assets
+        .iter()
+        .find(|a| a["name"].as_str() == Some(&expected_name))
+        .with_context(|| {
+            format!("No asset '{expected_name}' found in release {LATEST_SUPPORTED_TOOLCHAIN_VERSION_TAG}")
+        })?;
+
+    asset["url"].as_str().map(String::from).context("Asset has no API URL")
 }


### PR DESCRIPTION
## Motivation

Toolchain installation fails (all four platform test jobs). The install-toolchain command uses an authenticated reqwest client for all HTTP requests, including downloads from GitHub release URLs. These URLs redirect to a CDN that rejects the Authorization header, causing a 401.

## Solution

Switch from browser download URLs (github.com/.../releases/download/...) to the GitHub Releases API for asset downloads. `get_toolchain_download_url` is replaced with `get_toolchain_asset_url`, which looks up the actual asset in the API response and returns its API URL. Downloads use `Accept: application/octet-stream`, which works correctly with authentication and also supports draft releases. The `url_exists` check is removed since asset existence is now verified directly via the API response.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes