### PR TITLE
fix(prover): preserve typed ExecutionError through `execute_with_options`

### DIFF
--- a/crates/prover/src/worker/prover/execute.rs
+++ b/crates/prover/src/worker/prover/execute.rs
@@ -207,7 +207,9 @@ pub async fn execute_with_options(
                     let total_instructions = report.total_instruction_count();
                     if total_instructions >= max_cycles {
                         tracing::debug!("Cycle limit reached, stopping execution");
-                        return Err(anyhow::anyhow!("cycle limit reached"));
+                        return Err(anyhow::Error::new(ExecutionError::ExceededCycleLimit(
+                            max_cycles,
+                        )));
                     }
                 }
 
@@ -227,10 +229,7 @@ pub async fn execute_with_options(
     // Spawn a blocking task to run the minimal executor.
     let final_vm_state_clone = final_vm_state.clone();
     join_set.spawn_blocking(move || {
-        while let Some(chunk) = minimal_executor
-            .try_execute_chunk()
-            .map_err(|e| anyhow::anyhow!("Execute chunk failed: {e}"))?
-        {
+        while let Some(chunk) = minimal_executor.try_execute_chunk()? {
             let handle = gas_engine
                 .blocking_submit(GasExecutingTask {
                     chunk,


### PR DESCRIPTION
Downstream PR: https://github.com/succinctlabs/sp1-cluster/pull/77

## Problem

v6 failed proofs show "Execution Failure Reason: Unknown" in the explorer even when the underlying cause is a cycle limit. v5 correctly shows "The request's cycle limit was exceeded".

## Root cause

`execute_with_options` stringifies typed `ExecutionError` values into fresh `anyhow!("...")` errors at two sites, erasing the variant:

  - `execute.rs:210` — `Err(anyhow!("cycle limit reached"))` instead of `ExecutionError::ExceededCycleLimit`
  - `execute.rs:234` — `try_execute_chunk().map_err(|e| anyhow!("Execute chunk failed: {e}"))?` where `try_execute_chunk` returns `Result<_, ExecutionError>`

Downstream, sp1-cluster's `execute_only` task downcasts the anyhow error and matches on the variant. Stringified errors fall through to `Unspecified`, which is what the explorer renders as "Unknown".
