### PR TITLE
fix(prover): regenerate verifier contracts atomically in release.sh

### DIFF
--- a/crates/prover/Cargo.toml
+++ b/crates/prover/Cargo.toml
@@ -91,6 +91,10 @@ name = "post_trusted_setup"
 path = "scripts/post_trusted_setup.rs"
 
 [[bin]]
+name = "post_trusted_setup_plonk"
+path = "scripts/post_trusted_setup_plonk.rs"
+
+[[bin]]
 name = "build_groth16_bn254"
 path = "scripts/build_groth16_bn254.rs"
 

--- a/crates/prover/release.sh
+++ b/crates/prover/release.sh
@@ -25,6 +25,15 @@ fi
 # Put the version in the build directory
 echo "$COMMIT_HASH $VERSION" > ./build/SP1_COMMIT
 
+# Regenerate the Solidity verifiers from the current {groth16,plonk}_vk.bin and
+# verifier_vks.bin so the .sol bundled into the tarball is always internally
+# consistent with the vk artifacts shipped alongside it. Without this step,
+# a stale `VERIFIER_HASH` or `VK_ROOT` placeholder (from a prior run, or from
+# a vk/verifier_vks update that landed after .sol generation) can ship to S3
+# and propagate into deployed verifier contracts downstream.
+cargo run --release --bin post_trusted_setup       -- --build-dir ./build/groth16
+cargo run --release --bin post_trusted_setup_plonk -- --build-dir ./build/plonk
+
 # Create archives for Groth16, Plonk, and Trusted Setup
 GROTH16_ARCHIVE="${VERSION}-groth16.tar.gz"
 PLONK_ARCHIVE="${VERSION}-plonk.tar.gz"

--- a/crates/prover/scripts/post_trusted_setup_plonk.rs
+++ b/crates/prover/scripts/post_trusted_setup_plonk.rs
@@ -1,0 +1,18 @@
+use std::path::PathBuf;
+
+use clap::Parser;
+use sp1_core_machine::utils::setup_logger;
+use sp1_prover::build::build_plonk_bn254_contracts;
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    #[arg(short, long)]
+    build_dir: PathBuf,
+}
+
+pub fn main() {
+    setup_logger();
+    let args = Args::parse();
+    build_plonk_bn254_contracts(&args.build_dir).expect("failed to build plonk contracts");
+}


### PR DESCRIPTION
## Summary

Force `.sol` regeneration from the current `{groth16,plonk}_vk.bin` and `verifier_vks.bin` as the final step of `release.sh`, before `tar`. Add a Plonk sibling to the existing `post_trusted_setup` binary so the two circuits have a symmetric regeneration entry point.

## Why

`release.sh` currently archives `./build/{groth16,plonk}/` verbatim. The `.sol` verifier files inside are generated **ahead of time** by `build_{groth16,plonk}_bn254_contracts()`, which splices `VERIFIER_HASH` (= `sha256(*_vk.bin)`) and `VK_ROOT` (derived from `verifier_vks.bin`) into a template. Nothing enforces that those inputs have not changed between `.sol` generation and archive creation.

This bit the v6.1.0 release on sepolia:

- `verifier_vks.bin` was updated after `.sol` had already been written.
- `release.sh` packaged the pre-update `.sol` into the tarball.
- Downstream, `sp1-contracts/artifacts.rs` copies `.sol` out of the tarball verbatim — so the stale `VK_ROOT` propagated into deployed verifier contracts on sepolia, causing `InvalidVkRoot()` reverts for Plonk and a `VERIFIER_HASH` / selector mismatch for Groth16.

## What changes

1. **New binary `post_trusted_setup_plonk`** — thin wrapper around the existing `build_plonk_bn254_contracts()`, mirroring `post_trusted_setup` (which only covered Groth16). Plonk uses a universal SRS so there was no per-circuit ceremony step, but `.sol` regeneration is still required whenever `verifier_vks.bin` changes — which there was no dedicated entry point for.
2. **`release.sh` calls both binaries** right before `tar`. Tarball is now internally consistent by construction — `.sol` is always derived from the `*_vk.bin` and `verifier_vks.bin` that ship alongside it.

## Alternative considered

A consistency check (assert `sha256(*_vk.bin)` matches the `VERIFIER_HASH` literal in `.sol` and recompute `VK_ROOT` to match) instead of regeneration. Rejected: still requires the operator to know how to regenerate when the check fails, which for Plonk meant no entry point existed at all. Regenerating is strictly stronger and removes the class of human-sequencing errors.

## Test plan

- [ ] `cargo build --release -p sp1-prover --bin post_trusted_setup_plonk` — compiles
- [ ] Dry-run `release.sh` against a local `./build/` and confirm `.sol` hashes match the vk artifacts post-tar