### PR TITLE
feat(artifact): add `wait_for_upload_headroom` producer-side backpressure hook

### DIFF
--- a/crates/prover-types/src/artifacts.rs
+++ b/crates/prover-types/src/artifacts.rs
@@ -152,6 +152,20 @@ pub trait ArtifactClient: Send + Sync + Clone + 'static {
         artifact_type: ArtifactType,
     ) -> impl Future<Output = Result<()>> + Send;
 
+    /// Block until the store has room for an upload of this artifact.
+    ///
+    /// Default is a no-op; memory-bounded stores (Redis) override to re-introduce
+    /// the producer/consumer backpressure lost across a distributed split. The
+    /// return type is deliberately `()` — this call is advisory and must never
+    /// fail a proof. Implementations that can't determine store state should
+    /// return silently and let the upload proceed.
+    fn wait_for_upload_headroom(
+        &self,
+        _artifact: &impl ArtifactId,
+    ) -> impl Future<Output = ()> + Send {
+        async {}
+    }
+
     fn try_delete(
         &self,
         artifact: &impl ArtifactId,

--- a/crates/prover/src/worker/controller/core.rs
+++ b/crates/prover/src/worker/controller/core.rs
@@ -566,6 +566,11 @@ pub(super) async fn create_core_proving_task<A: ArtifactClient, W: WorkerClient>
         TraceData::Memory(_) | TraceData::Precompile(_, _) => None,
     };
 
+    // Block if the artifact store is near capacity — the distributed analog of the
+    // local node's `ProverSemaphore` backpressure. Advisory (returns `()`, cannot
+    // fail the proof). No-op for S3 / in-memory stores.
+    artifact_client.wait_for_upload_headroom(&record_artifact).await;
+
     artifact_client
         .upload(&record_artifact, trace_data)
         .await


### PR DESCRIPTION
## What

Adds one defaulted trait method to `ArtifactClient` and one call to it in `create_core_proving_task`, right before the trace-chunk `upload()`.

## Why

External provers running sp1-cluster with `NODE_ARTIFACT_STORE=redis` are hitting Redis OOM on large requests (recent repro: 278 B cycles / 266 B PGUs, ~8 k shards, 512 GB Redis)

## Root cause

the local node's implicit backpressure (`ProverSemaphore`) is lost when sp1-cluster distributes producer and consumer across a gRPC boundary. `SendSpliceWorker` uploads a ~200 MB trace chunk to Redis, calls `submit_task`, the coordinator accepts the row in milliseconds and returns, the producer loops. Redis fills faster than GPUs drain it.

## Fix

Restores backpressure by giving the artifact store a way to say "I'm full, slow down." The executor asks before every upload; the store answers based on its own state.

Companion PR: https://github.com/succinctlabs/sp1-cluster/pull/84
