### PR TITLE
feat(sdk): Add private-stdin support for the network prover

### DIFF
--- a/crates/prover-types/src/artifacts.rs
+++ b/crates/prover-types/src/artifacts.rs
@@ -42,6 +42,7 @@ pub enum ArtifactType {
     Proof,
     Groth16Circuit,
     PlonkCircuit,
+    PrivateStdin,
 }
 
 impl fmt::Display for ArtifactType {
@@ -53,6 +54,7 @@ impl fmt::Display for ArtifactType {
             Self::Proof => write!(f, "Proof"),
             Self::Groth16Circuit => write!(f, "Groth16Circuit"),
             Self::PlonkCircuit => write!(f, "PlonkCircuit"),
+            Self::PrivateStdin => write!(f, "PrivateStdin"),
         }
     }
 }

--- a/crates/sdk/src/blocking/network/mod.rs
+++ b/crates/sdk/src/blocking/network/mod.rs
@@ -69,6 +69,7 @@ impl Prover for NetworkProver {
             treasury: None,
             max_price_per_pgu: None,
             auction_timeout: None,
+            private_stdin: false,
         }
     }
 

--- a/crates/sdk/src/blocking/network/prove.rs
+++ b/crates/sdk/src/blocking/network/prove.rs
@@ -98,7 +98,10 @@ impl NetworkProveBuilder<'_> {
     /// the public URI is redacted from `ProofRequest` broadcasts. Only the
     /// requester, the network's execution oracle, and (post-settlement) the
     /// assigned fulfiller can download it via the authenticated `GetStdinUri`
-    /// RPC. Independent of [`NetworkProveBuilder::whitelist`].
+    /// RPC.
+    ///
+    /// This can be used together with [`NetworkProveBuilder::whitelist`] to limit
+    /// which fulfillers that will be able to win the auction and download stdin.
     #[must_use]
     pub fn private_stdin(mut self, enabled: bool) -> Self {
         self.private_stdin = enabled;

--- a/crates/sdk/src/blocking/network/prove.rs
+++ b/crates/sdk/src/blocking/network/prove.rs
@@ -31,6 +31,7 @@ pub struct NetworkProveBuilder<'a> {
     pub(crate) treasury: Option<Address>,
     pub(crate) max_price_per_pgu: Option<u64>,
     pub(crate) auction_timeout: Option<Duration>,
+    pub(crate) private_stdin: bool,
 }
 
 impl NetworkProveBuilder<'_> {
@@ -88,6 +89,19 @@ impl NetworkProveBuilder<'_> {
     #[must_use]
     pub fn whitelist(mut self, whitelist: Option<Vec<Address>>) -> Self {
         self.whitelist = whitelist;
+        self
+    }
+
+    /// Enable private stdin for this proof request.
+    ///
+    /// When enabled, the stdin artifact is uploaded to a private S3 prefix and
+    /// the public URI is redacted from `ProofRequest` broadcasts. Only the
+    /// requester, the network's execution oracle, and (post-settlement) the
+    /// assigned fulfiller can download it via the authenticated `GetStdinUri`
+    /// RPC. Independent of [`NetworkProveBuilder::whitelist`].
+    #[must_use]
+    pub fn private_stdin(mut self, enabled: bool) -> Self {
+        self.private_stdin = enabled;
         self
     }
 
@@ -163,6 +177,7 @@ impl NetworkProveBuilder<'_> {
             self.verifier,
             self.treasury,
             self.max_price_per_pgu,
+            self.private_stdin,
         ))
     }
 }
@@ -207,6 +222,7 @@ impl<'a> ProveRequest<'a, NetworkProver> for NetworkProveBuilder<'a> {
             self.treasury,
             self.max_price_per_pgu,
             self.auction_timeout,
+            self.private_stdin,
         ))
     }
 }

--- a/crates/sdk/src/network/client.rs
+++ b/crates/sdk/src/network/client.rs
@@ -594,16 +594,21 @@ impl NetworkClient {
         base_fee: u64,
         max_price_per_pgu: u64,
         domain: Vec<u8>,
+        private_stdin: bool,
     ) -> Result<RequestProofResponse> {
         // Calculate the deadline.
         let start = SystemTime::now();
         let since_the_epoch = start.duration_since(UNIX_EPOCH).expect("Invalid start time");
         let deadline = since_the_epoch.as_secs() + timeout_secs;
-
-        // Create the stdin artifact.
         let mut store = self.artifact_store_client().await?;
-        let stdin_uri =
-            self.create_artifact_with_content(&mut store, ArtifactType::Stdin, &stdin).await?;
+
+        let stdin_uri = self
+            .create_artifact_with_content(
+                &mut store,
+                if private_stdin { ArtifactType::PrivateStdin } else { ArtifactType::Stdin },
+                &stdin,
+            )
+            .await?;
 
         // Send the request.
         match self.network_mode {
@@ -645,6 +650,7 @@ impl NetworkClient {
                             base_fee: base_fee.to_string(),
                             max_price_per_pgu: max_price_per_pgu.to_string(),
                             variant: AuctionTransactionVariant::RequestVariant.into(),
+                            stdin_private: private_stdin,
                         };
 
                         let request_response = rpc
@@ -683,6 +689,7 @@ impl NetworkClient {
                                 .clone()
                                 .map(|list| list.into_iter().map(|addr| addr.to_vec()).collect())
                                 .unwrap_or_default(),
+                            stdin_private: private_stdin,
                         };
 
                         let request_response = rpc

--- a/crates/sdk/src/network/proto/artifact.rs
+++ b/crates/sdk/src/network/proto/artifact.rs
@@ -45,6 +45,9 @@ pub enum ArtifactType {
     State = 5,
     /// An export artifact.
     Export = 6,
+    /// A private stdin artifact stored under the private-stdins/ prefix.
+    /// Only fetched via the authenticated GetStdinUri RPC.
+    PrivateStdin = 7,
 }
 impl ArtifactType {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -60,6 +63,7 @@ impl ArtifactType {
             Self::Transaction => "TRANSACTION",
             Self::State => "STATE",
             Self::Export => "EXPORT",
+            Self::PrivateStdin => "PRIVATE_STDIN",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -72,6 +76,7 @@ impl ArtifactType {
             "TRANSACTION" => Some(Self::Transaction),
             "STATE" => Some(Self::State),
             "EXPORT" => Some(Self::Export),
+            "PRIVATE_STDIN" => Some(Self::PrivateStdin),
             _ => None,
         }
     }

--- a/crates/sdk/src/network/proto/auction/network.rs
+++ b/crates/sdk/src/network/proto/auction/network.rs
@@ -216,6 +216,24 @@ pub mod prover_network_client {
                 .insert(GrpcMethod::new("network.ProverNetwork", "GetProofRequestDetails"));
             self.inner.unary(req, path, codec).await
         }
+        /// Get a short-lived presigned URL to download a private request's stdin.
+        /// Only callable by the requester, executor, or (post-settlement) fulfiller.
+        pub async fn get_stdin_uri(
+            &mut self,
+            request: impl tonic::IntoRequest<super::super::types::GetStdinUriRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::super::types::GetStdinUriResponse>,
+            tonic::Status,
+        > {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/network.ProverNetwork/GetStdinUri");
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new("network.ProverNetwork", "GetStdinUri"));
+            self.inner.unary(req, path, codec).await
+        }
         /// Get the proof requests that meet the filter criteria.
         pub async fn get_filtered_proof_requests(
             &mut self,
@@ -2174,6 +2192,15 @@ pub mod prover_network_server {
             tonic::Response<super::super::types::GetProofRequestDetailsResponse>,
             tonic::Status,
         >;
+        /// Get a short-lived presigned URL to download a private request's stdin.
+        /// Only callable by the requester, executor, or (post-settlement) fulfiller.
+        async fn get_stdin_uri(
+            &self,
+            request: tonic::Request<super::super::types::GetStdinUriRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::super::types::GetStdinUriResponse>,
+            tonic::Status,
+        >;
         /// Get the proof requests that meet the filter criteria.
         async fn get_filtered_proof_requests(
             &self,
@@ -3319,6 +3346,48 @@ pub mod prover_network_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = GetProofRequestDetailsSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/network.ProverNetwork/GetStdinUri" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetStdinUriSvc<T: ProverNetwork>(pub Arc<T>);
+                    impl<T: ProverNetwork>
+                        tonic::server::UnaryService<super::super::types::GetStdinUriRequest>
+                        for GetStdinUriSvc<T>
+                    {
+                        type Response = super::super::types::GetStdinUriResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::super::types::GetStdinUriRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as ProverNetwork>::get_stdin_uri(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = GetStdinUriSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/crates/sdk/src/network/proto/auction/types.rs
+++ b/crates/sdk/src/network/proto/auction/types.rs
@@ -199,6 +199,10 @@ pub struct RequestProofRequestBody {
     /// The treasury address.
     #[prost(bytes = "vec", tag = "20")]
     pub treasury: ::prost::alloc::vec::Vec<u8>,
+    /// Whether the stdin is private. When true, stdin_uri must be under
+    /// the private-stdins/ prefix and is only fetchable via GetStdinUri.
+    #[prost(bool, tag = "21")]
+    pub stdin_private: bool,
 }
 #[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct RequestProofResponse {
@@ -511,6 +515,10 @@ pub struct ProofRequest {
     /// Whether the request has been canceled.
     #[prost(bool, tag = "37")]
     pub is_canceled: bool,
+    /// Whether this request's stdin is private. When true, stdin_public_uri is
+    /// empty and stdin is only fetchable via GetStdinUri by an authorized caller.
+    #[prost(bool, tag = "38")]
+    pub stdin_private: bool,
 }
 #[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct GetProofRequestStatusRequest {
@@ -561,6 +569,39 @@ pub struct GetProofRequestDetailsResponse {
     /// The detailed request.
     #[prost(message, optional, tag = "1")]
     pub request: ::core::option::Option<ProofRequest>,
+}
+#[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, ::prost::Message)]
+pub struct GetStdinUriRequest {
+    /// The message format of the body.
+    #[prost(enumeration = "MessageFormat", tag = "1")]
+    pub format: i32,
+    /// The signature of the sender.
+    #[prost(bytes = "vec", tag = "2")]
+    pub signature: ::prost::alloc::vec::Vec<u8>,
+    /// The body of the request.
+    #[prost(message, optional, tag = "3")]
+    pub body: ::core::option::Option<GetStdinUriRequestBody>,
+}
+#[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, ::prost::Message)]
+pub struct GetStdinUriRequestBody {
+    /// The account nonce of the sender.
+    #[prost(uint64, tag = "1")]
+    pub nonce: u64,
+    /// The identifier for the request.
+    #[prost(bytes = "vec", tag = "2")]
+    pub request_id: ::prost::alloc::vec::Vec<u8>,
+    /// The domain separator bytes for the request.
+    #[prost(bytes = "vec", tag = "3")]
+    pub domain: ::prost::alloc::vec::Vec<u8>,
+}
+#[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, ::prost::Message)]
+pub struct GetStdinUriResponse {
+    /// Presigned HTTPS URL for downloading the stdin artifact.
+    #[prost(string, tag = "1")]
+    pub stdin_uri: ::prost::alloc::string::String,
+    /// Unix seconds at which the URL expires.
+    #[prost(uint64, tag = "2")]
+    pub expires_at: u64,
 }
 #[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct GetFilteredProofRequestsRequest {

--- a/crates/sdk/src/network/proto/base/network.rs
+++ b/crates/sdk/src/network/proto/base/network.rs
@@ -273,6 +273,32 @@ pub mod prover_network_client {
                 );
             self.inner.unary(req, path, codec).await
         }
+        /// Get a short-lived presigned URL to download a private request's stdin.
+        /// Only callable by the requester, executor, or (post-settlement) fulfiller.
+        pub async fn get_stdin_uri(
+            &mut self,
+            request: impl tonic::IntoRequest<super::super::types::GetStdinUriRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::super::types::GetStdinUriResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/network.ProverNetwork/GetStdinUri",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("network.ProverNetwork", "GetStdinUri"));
+            self.inner.unary(req, path, codec).await
+        }
         /// Get the proof requests that meet the filter criteria.
         pub async fn get_filtered_proof_requests(
             &mut self,
@@ -3310,6 +3336,15 @@ pub mod prover_network_server {
             tonic::Response<super::super::types::GetProofRequestDetailsResponse>,
             tonic::Status,
         >;
+        /// Get a short-lived presigned URL to download a private request's stdin.
+        /// Only callable by the requester, executor, or (post-settlement) fulfiller.
+        async fn get_stdin_uri(
+            &self,
+            request: tonic::Request<super::super::types::GetStdinUriRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::super::types::GetStdinUriResponse>,
+            tonic::Status,
+        >;
         /// Get the proof requests that meet the filter criteria.
         async fn get_filtered_proof_requests(
             &self,
@@ -4625,6 +4660,54 @@ pub mod prover_network_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = GetProofRequestDetailsSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/network.ProverNetwork/GetStdinUri" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetStdinUriSvc<T: ProverNetwork>(pub Arc<T>);
+                    impl<
+                        T: ProverNetwork,
+                    > tonic::server::UnaryService<
+                        super::super::types::GetStdinUriRequest,
+                    > for GetStdinUriSvc<T> {
+                        type Response = super::super::types::GetStdinUriResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<
+                                super::super::types::GetStdinUriRequest,
+                            >,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as ProverNetwork>::get_stdin_uri(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = GetStdinUriSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/crates/sdk/src/network/proto/base/types.rs
+++ b/crates/sdk/src/network/proto/base/types.rs
@@ -48,6 +48,10 @@ pub struct RequestProofRequestBody {
     /// any prover can participate. Only applicable if the strategy is auction.
     #[prost(bytes = "vec", repeated, tag = "11")]
     pub whitelist: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+    /// Whether the stdin is private. When true, stdin_uri must be under
+    /// the private-stdins/ prefix and is only fetchable via GetStdinUri.
+    #[prost(bool, tag = "12")]
+    pub stdin_private: bool,
 }
 #[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct RequestProofResponse {
@@ -336,6 +340,10 @@ pub struct ProofRequest {
     /// The proof request error, if any.
     #[prost(enumeration = "ProofRequestError", tag = "34")]
     pub error: i32,
+    /// Whether this request's stdin is private. When true, stdin_public_uri is
+    /// empty and stdin is only fetchable via GetStdinUri by an authorized caller.
+    #[prost(bool, tag = "35")]
+    pub stdin_private: bool,
 }
 #[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct GetProofRequestStatusRequest {
@@ -386,6 +394,36 @@ pub struct GetProofRequestDetailsResponse {
     /// The detailed request.
     #[prost(message, optional, tag = "1")]
     pub request: ::core::option::Option<ProofRequest>,
+}
+#[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, ::prost::Message)]
+pub struct GetStdinUriRequest {
+    /// The message format of the body.
+    #[prost(enumeration = "MessageFormat", tag = "1")]
+    pub format: i32,
+    /// The signature of the sender.
+    #[prost(bytes = "vec", tag = "2")]
+    pub signature: ::prost::alloc::vec::Vec<u8>,
+    /// The body of the request.
+    #[prost(message, optional, tag = "3")]
+    pub body: ::core::option::Option<GetStdinUriRequestBody>,
+}
+#[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, ::prost::Message)]
+pub struct GetStdinUriRequestBody {
+    /// The account nonce of the sender.
+    #[prost(uint64, tag = "1")]
+    pub nonce: u64,
+    /// The identifier for the request.
+    #[prost(bytes = "vec", tag = "2")]
+    pub request_id: ::prost::alloc::vec::Vec<u8>,
+}
+#[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, ::prost::Message)]
+pub struct GetStdinUriResponse {
+    /// Presigned HTTPS URL for downloading the stdin artifact.
+    #[prost(string, tag = "1")]
+    pub stdin_uri: ::prost::alloc::string::String,
+    /// Unix seconds at which the URL expires.
+    #[prost(uint64, tag = "2")]
+    pub expires_at: u64,
 }
 #[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct GetFilteredProofRequestsRequest {

--- a/crates/sdk/src/network/prove.rs
+++ b/crates/sdk/src/network/prove.rs
@@ -283,8 +283,8 @@ impl NetworkProveBuilder<'_> {
     /// assigned fulfiller can download it via the authenticated `GetStdinUri`
     /// RPC.
     ///
-    /// This is independent of [`NetworkProveBuilder::whitelist`] — either can
-    /// be used without the other.
+    /// This can be used together with [`NetworkProveBuilder::whitelist`] to limit
+    /// which fulfillers that will be able to win the auction and download stdin.
     ///
     /// # Example
     /// ```rust,no_run

--- a/crates/sdk/src/network/prove.rs
+++ b/crates/sdk/src/network/prove.rs
@@ -36,6 +36,7 @@ pub struct NetworkProveBuilder<'a> {
     pub(crate) treasury: Option<Address>,
     pub(crate) max_price_per_pgu: Option<u64>,
     pub(crate) auction_timeout: Option<Duration>,
+    pub(crate) private_stdin: bool,
 }
 
 impl NetworkProveBuilder<'_> {
@@ -273,6 +274,37 @@ impl NetworkProveBuilder<'_> {
         self
     }
 
+    /// Enable private stdin for this proof request.
+    ///
+    /// # Details
+    /// When enabled, the stdin artifact is uploaded to a private S3 prefix and
+    /// the public URI is redacted from `ProofRequest` broadcasts. Only the
+    /// requester, the network's execution oracle, and (post-settlement) the
+    /// assigned fulfiller can download it via the authenticated `GetStdinUri`
+    /// RPC.
+    ///
+    /// This is independent of [`NetworkProveBuilder::whitelist`] — either can
+    /// be used without the other.
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// use sp1_sdk::{Elf, Prover, ProverClient, SP1Stdin};
+    ///
+    /// tokio_test::block_on(async {
+    ///     let elf = Elf::Static(&[1, 2, 3]);
+    ///     let stdin = SP1Stdin::new();
+    ///
+    ///     let client = ProverClient::builder().network().build().await;
+    ///     let pk = client.setup(elf).await.unwrap();
+    ///     let proof = client.prove(&pk, stdin).private_stdin(true).await.unwrap();
+    /// });
+    /// ```
+    #[must_use]
+    pub fn private_stdin(mut self, enabled: bool) -> Self {
+        self.private_stdin = enabled;
+        self
+    }
+
     /// Set the auctioneer for the proof request.
     ///
     /// # Details
@@ -493,6 +525,7 @@ impl NetworkProveBuilder<'_> {
                 self.verifier,
                 self.treasury,
                 self.max_price_per_pgu,
+                self.private_stdin,
             )
             .await
     }
@@ -549,6 +582,7 @@ impl<'a> IntoFuture for NetworkProveBuilder<'a> {
                     self.treasury,
                     self.max_price_per_pgu,
                     self.auction_timeout,
+                    self.private_stdin,
                 )
                 .await
         })

--- a/crates/sdk/src/network/prover.rs
+++ b/crates/sdk/src/network/prover.rs
@@ -87,6 +87,7 @@ impl Prover for NetworkProver {
             treasury: None,
             max_price_per_pgu: None,
             auction_timeout: None,
+            private_stdin: false,
         }
     }
 
@@ -392,6 +393,7 @@ impl NetworkProver {
         base_fee: u64,
         max_price_per_pgu: u64,
         domain: Vec<u8>,
+        private_stdin: bool,
     ) -> Result<B256> {
         if self.client.rpc_url == TEE_NETWORK_RPC_URL && strategy != FulfillmentStrategy::Reserved {
             return Err(anyhow::anyhow!(
@@ -459,6 +461,7 @@ impl NetworkProver {
                 base_fee,
                 max_price_per_pgu,
                 domain,
+                private_stdin,
             )
             .await?;
 
@@ -576,6 +579,7 @@ impl NetworkProver {
         verifier: Option<Address>,
         treasury: Option<Address>,
         max_price_per_pgu: Option<u64>,
+        private_stdin: bool,
     ) -> Result<B256> {
         let vk_hash = self.register_program(&pk.vk, &pk.elf).await?;
         let (cycle_limit, gas_limit, public_values_hash) = self
@@ -610,6 +614,7 @@ impl NetworkProver {
             base_fee,
             max_price_per_pgu,
             domain,
+            private_stdin,
         )
         .await
     }
@@ -634,6 +639,7 @@ impl NetworkProver {
         treasury: Option<Address>,
         max_price_per_pgu: Option<u64>,
         auction_timeout: Option<Duration>,
+        private_stdin: bool,
     ) -> Result<SP1ProofWithPublicValues> {
         #[allow(unused_mut)]
         let mut whitelist = whitelist.clone();
@@ -658,6 +664,7 @@ impl NetworkProver {
                     verifier,
                     treasury,
                     max_price_per_pgu,
+                    private_stdin,
                 )
                 .await?;
 


### PR DESCRIPTION
## Motivation

By default, stdin artifacts published to the network are public, and can be downloaded by anyone. In some cases, this is not desirable. You might be fine trusting specific provers, but don't want the proof inputs to be public for the world to see.

## Solution

Adds a `.private_stdin(true)` builder method to the network prover, which uploads the stdin artifact to a private s3 prefix, where only the prover that wins the bid will be able to download the stdin artifact. This can be combined with whitelisting to restrict who might be able to win the bid, and thus who might be able to access the stdin artifact.

Succinct will also have access to the artifact, and will use it for the execution oracle to calculate gas prices.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes