### PR TITLE
perf(prover): default rayon to `available_parallelism`

### DIFF
--- a/crates/prover/src/worker/builder.rs
+++ b/crates/prover/src/worker/builder.rs
@@ -297,6 +297,10 @@ impl<C: SP1ProverComponents, A, W> SP1WorkerBuilder<C, A, W> {
 
 /// Create a [SP1WorkerBuilder] for a CPU worker.
 pub fn cpu_worker_builder() -> SP1WorkerBuilder<CpuSP1ProverComponents> {
+    // Initialize the rayon thread pool before any parallel work.
+    // Defaults to physical cores (not logical/SMT) to avoid work-stealing contention.
+    slop_futures::rayon::init_global_pool();
+
     // Create the prover permits, setting it to having 4 provers.
     let prover_permits = ProverSemaphore::new(4);
 

--- a/slop/crates/futures/Cargo.toml
+++ b/slop/crates/futures/Cargo.toml
@@ -14,6 +14,7 @@ rayon = { workspace = true }
 tokio = { workspace = true, features = ["sync", "rt"] }
 futures = { workspace = true }
 thiserror = { workspace = true }
+num_cpus = { workspace = true }
 
 crossbeam = { workspace = true }
 pin-project = { workspace = true }

--- a/slop/crates/futures/src/rayon.rs
+++ b/slop/crates/futures/src/rayon.rs
@@ -11,9 +11,12 @@ static GLOBAL_POOL: OnceLock<()> = OnceLock::new();
 
 /// Initialize the rayon global thread pool.
 ///
-/// Defaults to physical core count when `RAYON_NUM_THREADS` is not set,
-/// because SMT siblings cause excessive crossbeam work-stealing contention
-/// that outweighs the parallelism benefit.
+/// Thread count selection (when `RAYON_NUM_THREADS` is not set):
+/// - Uses `min(available_parallelism, physical_cores)` to avoid both
+///   SMT oversubscription (crossbeam contention) and container overcommit.
+/// - `available_parallelism` respects cgroup CPU quotas (K8s `resources.limits.cpu`,
+///   `docker --cpus=N`) and affinity masks, so this works in containers.
+/// - `get_physical()` caps it to avoid SMT siblings on bare metal.
 ///
 /// Must be called before any rayon work (par_iter, spawn, etc.) to take effect.
 /// Safe to call multiple times — only the first call configures the pool.
@@ -22,9 +25,14 @@ pub fn init_global_pool() {
         let mut builder = rayon::ThreadPoolBuilder::new().panic_handler(panic_handler);
 
         if std::env::var("RAYON_NUM_THREADS").is_err() {
+            let cgroup_aware =
+                std::thread::available_parallelism().map(|n| n.get()).unwrap_or(1);
             let physical = num_cpus::get_physical();
-            tracing::info!("rayon pool: using {physical} threads (physical cores)");
-            builder = builder.num_threads(physical);
+            let threads = cgroup_aware.min(physical);
+            tracing::info!(
+                "rayon pool: using {threads} threads (available_parallelism={cgroup_aware}, physical={physical})"
+            );
+            builder = builder.num_threads(threads);
         }
 
         builder.build_global().ok();

--- a/slop/crates/futures/src/rayon.rs
+++ b/slop/crates/futures/src/rayon.rs
@@ -9,8 +9,26 @@ use crate::handle::TaskHandle;
 
 static GLOBAL_POOL: OnceLock<()> = OnceLock::new();
 
-fn init_global_pool() {
-    rayon::ThreadPoolBuilder::new().panic_handler(panic_handler).build_global().ok();
+/// Initialize the rayon global thread pool.
+///
+/// Defaults to physical core count when `RAYON_NUM_THREADS` is not set,
+/// because SMT siblings cause excessive crossbeam work-stealing contention
+/// that outweighs the parallelism benefit.
+///
+/// Must be called before any rayon work (par_iter, spawn, etc.) to take effect.
+/// Safe to call multiple times — only the first call configures the pool.
+pub fn init_global_pool() {
+    GLOBAL_POOL.get_or_init(|| {
+        let mut builder = rayon::ThreadPoolBuilder::new().panic_handler(panic_handler);
+
+        if std::env::var("RAYON_NUM_THREADS").is_err() {
+            let physical = num_cpus::get_physical();
+            tracing::info!("rayon pool: using {physical} threads (physical cores)");
+            builder = builder.num_threads(physical);
+        }
+
+        builder.build_global().ok();
+    });
 }
 
 fn panic_handler(panic_payload: Box<dyn Any + Send>) {
@@ -40,7 +58,7 @@ where
     F: FnOnce() -> R + Send + 'static,
     R: Send + 'static,
 {
-    GLOBAL_POOL.get_or_init(init_global_pool);
+    init_global_pool();
     let (tx, rx) = oneshot::channel();
     let (abort_handle, _) = AbortHandle::new_pair();
     rayon::spawn(move || {
@@ -56,7 +74,7 @@ where
     F: FnOnce(AbortHandle) -> R + Send + 'static,
     R: Send + 'static,
 {
-    GLOBAL_POOL.get_or_init(init_global_pool);
+    init_global_pool();
     let (tx, rx) = oneshot::channel();
     let (abort_handle, abort_registration) = AbortHandle::new_pair();
     rayon::spawn(move || {


### PR DESCRIPTION
## Summary
- Default rayon global thread pool to `min(available_parallelism, physical_cores)` instead of logical cores
- SMT siblings cause excessive crossbeam work-stealing contention (~30% of prove time at 64 threads, ~12% at 32 threads)
- Users can still override via `RAYON_NUM_THREADS` environment variable

## Benchmark results (AMD Threadripper 7970X, 32 physical / 64 logical)

| Workload | Before (64t) | After (32t) | Delta |
|----------|-------------|-------------|-------|
| fib      | 35,380ms    | 28,026ms    | **-20.8%** |
| keccak   | 42,847ms    | 35,936ms    | **-16.1%** |
| big      | 47,697ms    | 38,664ms    | **-18.9%** |

## Profile diff (fib)
- `crossbeam_epoch::with_handle`: 17.4% → 7.9% (down 55%)
- `crossbeam_epoch::try_advance`: 7.6% → 1.5% (down 80%)
- `crossbeam_deque::steal`: 5.3% → 2.9% (down 45%)

## Changes
- `slop/crates/futures/src/rayon.rs` — `init_global_pool()` now public, defaults to physical cores
- `crates/prover/src/worker/builder.rs` — calls `init_global_pool()` at start of `cpu_worker_builder()`

## Stack
1. #2726 — bench infra + baselines
2. **This PR** — E1: rayon defaults to physical cores
3. `tamir/perf-mimalloc` — E2: optional mimalloc allocator

## Test plan
- [ ] `RAYON_NUM_THREADS` unset → prover uses physical core count
- [ ] `RAYON_NUM_THREADS=64` → prover uses 64 threads (override works)
- [ ] Bench results reproducible on another machine with SMT

🤖 Generated with [Claude Code](https://claude.com/claude-code)