### PR TITLE
fix(ci): download patch-testing artifact into patch-testing/

### DIFF
--- a/.github/workflows/patch-testing-cycles-comment.yml
+++ b/.github/workflows/patch-testing-cycles-comment.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: patch-testing-results
+          path: patch-testing
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
- The \"Patch Testing Cycles Comment\" workflow has been failing with `No such file or directory` when `post-to-github` tries to read the cycle stats.
- Root cause: `upload-artifact@v4` strips the least-common-ancestor from multi-file `path:` lists, so the archive for `patch-testing/{old,new}_cycle_stats.json` contains just `old_cycle_stats.json` and `new_cycle_stats.json`. The download step had no `path:`, so the files extracted to `\$GITHUB_WORKSPACE/` while `OLD_CYCLE_STATS` / `NEW_CYCLE_STATS` env vars point to `\$GITHUB_WORKSPACE/patch-testing/*.json`.
- Fix: add `path: patch-testing` to the download step so files land where the env vars expect them.

Regression introduced in #2707 when the cross-job artifact transfer was added.

## Test plan
- [ ] CI: confirm the `Patch Testing Cycles Comment` workflow succeeds on this PR and posts a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)