### PR TITLE
fix(clippy): remove useless into_iter() in whir prover zip

### DIFF
--- a/slop/crates/whir/src/prover.rs
+++ b/slop/crates/whir/src/prover.rs
@@ -404,7 +404,7 @@ where
                 .collect();
             let merkle_proof = merkle_proof
                 .into_iter()
-                .zip(merkle_openings.into_iter())
+                .zip(merkle_openings)
                 .map(|(proof, opening)| MerkleTreeOpeningAndProof { values: opening, proof })
                 .collect::<Vec<_>>();
             let merkle_read_values: Vec<Mle<GC::EF>> = if round_index != 0 {


### PR DESCRIPTION
## Summary
- `clippy::useless-conversion` lint was firing on `slop/crates/whir/src/prover.rs:407` because `.zip()` already accepts `IntoIterator`, making the explicit `.into_iter()` redundant.
- This was failing the **Formatting & Clippy** CI job on every open PR.

## Test plan
- [x] `cargo clippy -p slop-whir --all-features --all-targets -- -D warnings -A incomplete-features` passes
- [ ] CI Formatting & Clippy job is green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)