### PR TITLE
feat: Allow for more columns in zerocheck

### DIFF
--- a/sp1-gpu/crates/sys/include/tracegen/jagged_tracegen/jagged.cuh
+++ b/sp1-gpu/crates/sys/include/tracegen/jagged_tracegen/jagged.cuh
@@ -100,7 +100,7 @@ struct JaggedMle {
         size_t zeroIdx = i << 1;
         size_t restrictedIndex = (output.startIndices[colIdx] << 1) + rowIdx;
 
-        uint32_t info = this->denseData.fixLastVariable(output.denseData, restrictedIndex, zeroIdx);
+        uint64_t info = this->denseData.fixLastVariable(output.denseData, restrictedIndex, zeroIdx);
 
         // If this row does not have a length that is a multiple of four, the next row will have an
         // odd length. So we need to add some extra padding to the next row.

--- a/sp1-gpu/crates/sys/include/zerocheck/jagged_mle.cuh
+++ b/sp1-gpu/crates/sys/include/zerocheck/jagged_mle.cuh
@@ -39,19 +39,19 @@ struct InfoBuffer {
 
   public:
     /// data
-    uint32_t* data;
-    
-    __forceinline__ __device__ uint32_t fixLastVariable(
+    uint64_t* data;
+
+    __forceinline__ __device__ uint64_t fixLastVariable(
         InfoBuffer& other,
         size_t restrictedIdx,
         size_t zeroIdx
     ) const {
-        uint32_t info = data[zeroIdx];
+        uint64_t info = data[zeroIdx];
         other.data[restrictedIdx] = info;
         return info;
     }
 
-    __forceinline__ __device__ void pad_const(InfoBuffer& other, size_t restrictedIdx, uint32_t value) const {
+    __forceinline__ __device__ void pad_const(InfoBuffer& other, size_t restrictedIdx, uint64_t value) const {
         other.data[restrictedIdx] = value;
     }
 };

--- a/sp1-gpu/crates/sys/lib/zerocheck/jagged_mle.cu
+++ b/sp1-gpu/crates/sys/lib/zerocheck/jagged_mle.cu
@@ -17,7 +17,7 @@ __global__ void fixLastVariableJagged(
 
 __global__ void initializeJaggedInfo(
     JaggedMle<InfoBuffer> jaggedMle,
-    const uint32_t* values,
+    const uint64_t* values,
     uint32_t length,
     uint32_t num_info) {
     for (size_t i = blockIdx.x * blockDim.x + threadIdx.x; i < length;

--- a/sp1-gpu/crates/sys/lib/zerocheck/zerocheck_eval.cu
+++ b/sp1-gpu/crates/sys/lib/zerocheck/zerocheck_eval.cu
@@ -69,12 +69,12 @@ __global__ void jaggedConstraintPolyEval(
     felt_t eval_point = get_input_point(xValueIdx);
 
     for (size_t idx = blockDim.x * blockIdx.x + threadIdx.x; idx < totalLen; idx += blockDim.x * gridDim.x) {
-        uint32_t packed_info = inputJaggedInfo.denseData.data[idx << 1];
+        uint64_t packed_info = inputJaggedInfo.denseData.data[idx << 1];
         assert(packed_info == inputJaggedInfo.denseData.data[idx << 1 | 1]);
 
-        uint32_t chip_idx = (packed_info >> 1) & 0x7F;
-        uint32_t preprocessed_idx = (packed_info >> 8) & 0x3FF;
-        uint32_t main_idx = (packed_info >> 18) & 0x3FFF;
+        uint32_t chip_idx = (packed_info >> 1) & 0x7FFF;
+        uint32_t preprocessed_idx = (packed_info >> 16) & 0xFFFF;
+        uint32_t main_idx = (packed_info >> 32) & 0xFFFFFFFF;
         uint32_t num_preprocessed_columns = preprocessed_column[chip_idx];
         uint32_t num_main_columns = main_column[chip_idx];
 

--- a/sp1-gpu/crates/zerocheck/src/data.rs
+++ b/sp1-gpu/crates/zerocheck/src/data.rs
@@ -57,7 +57,7 @@ pub struct DenseBuffer<F, B: Backend = TaskScope> {
 
 #[derive(Clone)]
 pub struct InfoBuffer<B: Backend = TaskScope> {
-    pub data: Buffer<u32, B>,
+    pub data: Buffer<u64, B>,
 }
 
 /// The raw pointer equivalent of [`DenseBuffer`] for use in cuda kernels.
@@ -69,7 +69,7 @@ pub struct DenseBufferRaw<F> {
 /// The raw pointer equivalent of [`InfoBuffer`] for use in cuda kernels.
 #[repr(C)]
 pub struct InfoBufferRaw {
-    data: *const u32,
+    data: *const u64,
 }
 
 /// The mutable raw pointer equivalent of [`DenseBuffer`] for use in cuda kernels.
@@ -81,7 +81,7 @@ pub struct DenseBufferMutRaw<F> {
 /// The mutable raw pointer equivalent of [`InfoBuffer`] for use in cuda kernels.
 #[repr(C)]
 pub struct InfoBufferMutRaw {
-    data: *mut u32,
+    data: *mut u64,
 }
 
 impl<F, A: Backend> DenseBuffer<F, A> {
@@ -104,7 +104,7 @@ impl<F, A: Backend> DenseBuffer<F, A> {
 
 impl<A: Backend> InfoBuffer<A> {
     #[inline]
-    pub fn new(data: Buffer<u32, A>) -> Self {
+    pub fn new(data: Buffer<u64, A>) -> Self {
         Self { data }
     }
 
@@ -115,7 +115,7 @@ impl<A: Backend> InfoBuffer<A> {
     }
 
     #[inline]
-    pub fn into_parts(self) -> Buffer<u32, A> {
+    pub fn into_parts(self) -> Buffer<u64, A> {
         self.data
     }
 }

--- a/sp1-gpu/crates/zerocheck/src/lib.rs
+++ b/sp1-gpu/crates/zerocheck/src/lib.rs
@@ -210,19 +210,22 @@ where
 }
 
 /// The format is `is_first || chip_idx || prep_start || main_start` in little endian.
-/// `is_first` is a bit, `chip_idx` is 7 bits, `prep_start` is 10 bits, and `main_start` is 14 bits.
-pub fn pack_info(is_first: bool, chip_idx: u32, prep_start: u32, main_start: u32) -> u32 {
-    (is_first as u32) + (chip_idx << 1) + (prep_start << 8) + (main_start << 18)
+/// `is_first` is 1 bit, `chip_idx` is 15 bits, `prep_start` is 16 bits, and `main_start` is 32 bits.
+pub fn pack_info(is_first: bool, chip_idx: u32, prep_start: u32, main_start: u32) -> u64 {
+    (is_first as u64)
+        + ((chip_idx as u64) << 1)
+        + ((prep_start as u64) << 16)
+        + ((main_start as u64) << 32)
 }
 
 /// The `packed_info` is `is_first || chip_idx || prep_start || main_start` in little endian.
-/// `is_first` is a bit, `chip_idx` is 7 bits, `prep_start` is 10 bits, and `main_start` is 14 bits.
-pub fn unpack_info(packed_info: u32) -> (u32, u32, u32, u32) {
+/// `is_first` is 1 bit, `chip_idx` is 15 bits, `prep_start` is 16 bits, and `main_start` is 32 bits.
+pub fn unpack_info(packed_info: u64) -> (u32, u32, u32, u32) {
     (
-        (packed_info & 1),
-        ((packed_info >> 1) & 0x7F),
-        (packed_info >> 8) & 0x3FF,
-        (packed_info >> 18) & 0x3FFF,
+        (packed_info & 1) as u32,
+        ((packed_info >> 1) & 0x7FFF) as u32,
+        ((packed_info >> 16) & 0xFFFF) as u32,
+        ((packed_info >> 32) & 0xFFFFFFFF) as u32,
     )
 }
 
@@ -735,6 +738,7 @@ pub mod tests {
 
     use sp1_gpu_air::codegen_cuda_eval;
     use sp1_primitives::SP1Field;
+
     use std::collections::{BTreeMap, BTreeSet};
     use std::marker::PhantomData;
     use std::ops::Deref;
@@ -793,7 +797,7 @@ pub mod tests {
         type Record = ExecutionRecord;
         type Program = Program;
 
-        fn name(&self) -> &'static str {
+        fn name(&self) -> &str {
             match self {
                 Self::Chip1(chip) => <ZerocheckTestChip1 as MachineAir<F>>::name(chip),
                 Self::Chip2(chip) => <ZerocheckTestChip2 as MachineAir<F>>::name(chip),

--- a/sp1-gpu/crates/zerocheck/src/lib.rs
+++ b/sp1-gpu/crates/zerocheck/src/lib.rs
@@ -797,7 +797,7 @@ pub mod tests {
         type Record = ExecutionRecord;
         type Program = Program;
 
-        fn name(&self) -> &str {
+        fn name(&self) -> &'static str {
             match self {
                 Self::Chip1(chip) => <ZerocheckTestChip1 as MachineAir<F>>::name(chip),
                 Self::Chip2(chip) => <ZerocheckTestChip2 as MachineAir<F>>::name(chip),

--- a/sp1-gpu/crates/zerocheck/src/primitives.rs
+++ b/sp1-gpu/crates/zerocheck/src/primitives.rs
@@ -166,7 +166,7 @@ pub fn evaluate_jagged_columns(
 
 pub fn initialize_jagged_dense_info(
     heights: Vec<u32>,
-    values: Vec<u32>,
+    values: Vec<u64>,
     backend: &TaskScope,
 ) -> JaggedDenseInfo<TaskScope> {
     let buffer_start_idx = once(0)
@@ -184,7 +184,7 @@ pub fn initialize_jagged_dense_info(
 
     let total_len = buffer_start_idx.last().unwrap() * 2;
     let info_buffer =
-        Buffer::<u32, TaskScope>::with_capacity_in(total_len as usize, backend.clone());
+        Buffer::<u64, TaskScope>::with_capacity_in(total_len as usize, backend.clone());
     let info_cols_buffer =
         Buffer::<u32, TaskScope>::with_capacity_in(total_len as usize / 2, backend.clone());
 
@@ -228,7 +228,7 @@ pub fn evaluate_jagged_info_fix_last_variable(
     let output_start_idx =
         DeviceBuffer::from_host(&buffer_start_idx, backend).unwrap().into_inner();
     let new_data =
-        Buffer::<u32, TaskScope>::with_capacity_in(new_total_length as usize, backend.clone());
+        Buffer::<u64, TaskScope>::with_capacity_in(new_total_length as usize, backend.clone());
     let new_cols = Buffer::<u32, TaskScope>::with_capacity_in(
         (new_total_length / 2) as usize,
         backend.clone(),


### PR DESCRIPTION
In the context of supporting APCs, we need a lot of `air_idx`.
Currently, the maximum is `1 << 7`.
This PR uses 64 bits for the jagged info instead of 32 bits, increasing the number of possible `air_idx` to `1 << 15`.