### PR TITLE
chore(prover): ignore test_dev_artifacts_uploaded_to_s3 by default

### DIFF
--- a/crates/prover/src/build.rs
+++ b/crates/prover/src/build.rs
@@ -707,6 +707,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "requires AWS credentials for the sp1-circuit-artifacts-dev bucket; run with `--ignored` when validating dev artifact uploads"]
     async fn test_dev_artifacts_uploaded_to_s3() {
         use crate::build::DEV_CIRCUIT_ARTIFACTS_S3_BUCKET;
 


### PR DESCRIPTION
## Summary
- `test_dev_artifacts_uploaded_to_s3` shells out to `aws s3api head-object` against the private `sp1-circuit-artifacts-dev` bucket, so it fails on fork PRs where GitHub Actions does not pass AWS secrets (e.g. [#2737's Test (x86-64) run](https://github.com/succinctlabs/sp1/actions/runs/24795540156/job/72565145136) panicked at [build.rs:732](crates/prover/src/build.rs#L732) with `Groth 16 artifact not found`, even though the PR didn't touch anything circuit-related).
- Mark the test `#[ignore]` so `cargo test` / CI skip it by default. It can still be run explicitly during sprints that change `WRAP_VK_BYTES` via `cargo test -- --ignored`.

## Test plan
- [ ] `cargo test --release -p sp1-prover build::tests::test_dev_artifacts_uploaded_to_s3` — confirms the test is ignored by default
- [ ] `cargo test --release -p sp1-prover build::tests::test_dev_artifacts_uploaded_to_s3 -- --ignored` — confirms it still runs when explicitly requested (with AWS credentials)

🤖 Generated with [Claude Code](https://claude.com/claude-code)