### PR TITLE
chore(sp1-gpu/sys): clean up CUDA build flags and version requirements

### DIFF
--- a/sp1-gpu/crates/sys/CMakeLists.txt
+++ b/sp1-gpu/crates/sys/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.30)
+cmake_minimum_required(VERSION 3.24)
 project(sp1-gpu-cuda LANGUAGES CXX CUDA)
 
 # Require CUDA 12.0+
@@ -19,16 +19,16 @@ set(CMAKE_CUDA_STANDARD_REQUIRED ON)
 set(CMAKE_CUDA_USE_RESPONSE_FILE_FOR_INCLUDES OFF)
 
 # Architecture flags
+# sm_100 / sm_120 (Blackwell) require CUDA 12.8+; older toolchains can't compile them.
 if(DEFINED CUDA_ARCHS)
     # Convert comma-separated string to CMake list (semicolon-separated)
     string(REPLACE "," ";" CUDA_ARCHS_LIST "${CUDA_ARCHS}")
     set(CMAKE_CUDA_ARCHITECTURES ${CUDA_ARCHS_LIST})
-elseif(CUDA_VERSION_MAJOR EQUAL 12 AND CUDA_VERSION_MINOR GREATER_EQUAL 8)
-    set(CMAKE_CUDA_ARCHITECTURES 80 86 89 90 100 120)
-elseif(CUDA_VERSION_MAJOR GREATER_EQUAL 13)
+elseif((CUDA_VERSION_MAJOR EQUAL 12 AND CUDA_VERSION_MINOR GREATER_EQUAL 8)
+        OR CUDA_VERSION_MAJOR GREATER_EQUAL 13)
     set(CMAKE_CUDA_ARCHITECTURES 80 86 89 90 100 120)
 else()
-    set(CMAKE_CUDA_ARCHITECTURES 80 86 89)
+    set(CMAKE_CUDA_ARCHITECTURES 80 86 89 90)
 endif()
 
 # Build type defaults to Release
@@ -39,22 +39,25 @@ endif()
 # Common CUDA flags
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -default-stream=per-thread")
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-relaxed-constexpr")
-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --use_fast_math")
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -lineinfo")
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler -fopenmp")
-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler -fPIE")
+# -fPIC (not -fPIE): the static archive may be linked into a cdylib downstream.
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler -fPIC")
 
-# Enable relocatable device code for cross-file device function calls
-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -rdc=true")
+# Relocatable device code (-rdc=true) for cross-file device function calls.
+# Setting the variable here initializes CUDA_SEPARABLE_COMPILATION on every
+# target created afterwards (including the per-module OBJECT libraries),
+# so each .cu file is compiled with -dc and the final STATIC target performs
+# device linking.
+set(CMAKE_CUDA_SEPARABLE_COMPILATION ON)
 
-# Debug flags
+# Debug build: -G implies -O0 device-side; nvcc warns when combined with -O.
 if(PROFILE_DEBUG_DATA)
-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -G")
+    set(CMAKE_CUDA_FLAGS_DEBUG "-O0 -G")
+else()
+    set(CMAKE_CUDA_FLAGS_DEBUG "-O3")
 endif()
-
-# Release optimization
 set(CMAKE_CUDA_FLAGS_RELEASE "-O3")
-set(CMAKE_CUDA_FLAGS_DEBUG "-O3")  # Currently both use O3 per original Makefile
 
 # Get the actual source directory (where this CMakeLists.txt lives)
 set(CSL_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
## Summary

Audit and cleanup of [sp1-gpu/crates/sys/CMakeLists.txt](https://github.com/succinctlabs/sp1/blob/audit/sp1-gpu-cmake-fixes/sp1-gpu/crates/sys/CMakeLists.txt). Seven changes, one file, no behavioral regressions:

- **Lower `cmake_minimum_required` 3.30 → 3.24.** Nothing in the file actually requires 3.30, and the bump excluded users on Ubuntu 22.04/24.04, Debian 12, and RHEL 9 (default cmake < 3.30) from out-of-the-box builds.
- **`-Xcompiler -fPIE` → `-fPIC`.** The static archive may be linked into a downstream `cdylib` by Rust, which requires PIC — `-fPIE` is the wrong flag for code that may end up inside a shared object.
- **Honor `PROFILE_DEBUG_DATA` properly.** Previously combined `-G` with `-O3`, which nvcc warns against (`-G` implies `-O0` device-side). Now uses `-O0 -G` only when debug data is requested.
- **Add `sm_90` (H100) to the default arch list for CUDA 12.0–12.7.** The README claims H100 support but the fallback omitted it, forcing PTX JIT.
- **Remove global `--use_fast_math`.** Defensible default for a crypto library; can be re-enabled per-target if a specific kernel benefits. CUTLASS, risc0, and ICICLE all avoid setting it globally.
- **Collapse duplicate CUDA 12.8+ / 13+ branches** (had identical arch lists).
- **Replace global `-rdc=true` with `set(CMAKE_CUDA_SEPARABLE_COMPILATION ON)`.** The modern target-property-based form. Initializes the property on every subsequent target (including the per-module OBJECT libraries), so each `.cu` is compiled with `-dc` and the final STATIC target performs device linking. `CUDA_RESOLVE_DEVICE_SYMBOLS ON` on `sys-cuda` (already present) still forces device linking into the static archive — necessary because Rust's linker doesn't know about CUDA device linking.

## Test plan

- [x] `cmake -S . -B build -DCBINDGEN_INCLUDE_DIR=… -DCUDA_ARCHS=89` configures clean (CMake 4.0, CUDA 13.1).
- [x] Verbose build of `algebra_objs` confirms nvcc receives `-rdc=true`, `-fPIC`, `-O3`, `-lineinfo`, no `--use_fast_math`.
- [x] Full `sys-cuda` static library builds end-to-end, including device linking. Only pre-existing source warnings appear.
- [ ] CI build on the supported CUDA toolchain matrix.
- [ ] Smoke run a node benchmark (`cargo run --release -p sp1-gpu-perf --bin node -- --program v6/fibonacci-20m --mode core`) on a target GPU to confirm no perf regression from removing `--use_fast_math`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)