### PR TITLE
feat(sdk): sync FulfillmentStatus and treat Reverted/Expired as terminal

### DIFF
--- a/crates/sdk/src/network/error.rs
+++ b/crates/sdk/src/network/error.rs
@@ -22,6 +22,20 @@ pub enum Error {
         request_id: Vec<u8>,
     },
 
+    /// The proof request failed during settlement.
+    #[error("Proof request 0x{} failed during settlement", hex::encode(.request_id))]
+    RequestReverted {
+        /// The ID of the request that failed during settlement.
+        request_id: Vec<u8>,
+    },
+
+    /// The proof request expired at its deadline without a proof being submitted (terminal).
+    #[error("Proof request 0x{} expired before a proof was submitted", hex::encode(.request_id))]
+    RequestExpired {
+        /// The ID of the request that expired.
+        request_id: Vec<u8>,
+    },
+
     /// The proof request timed out.
     #[error("Proof request 0x{} timed out", hex::encode(.request_id))]
     RequestTimedOut {

--- a/crates/sdk/src/network/proto/auction/types.rs
+++ b/crates/sdk/src/network/proto/auction/types.rs
@@ -3891,10 +3891,9 @@ pub enum FulfillmentStatus {
     Fulfilled = 3,
     /// The request cannot be fulfilled.
     Unfulfillable = 4,
-    /// The Clear was soft-reverted by the vApp STF. Terminal; no balance impact.
+    /// The request failed during settlement. Terminal; no proof is recorded.
     Reverted = 5,
-    /// Request sat at ASSIGNED past its deadline without the prover ever submitting
-    /// a proof. Terminal; STF never received a Clear for it. No balance impact.
+    /// The request expired at its deadline without a proof being submitted. Terminal.
     Expired = 6,
 }
 impl FulfillmentStatus {

--- a/crates/sdk/src/network/proto/base/types.rs
+++ b/crates/sdk/src/network/proto/base/types.rs
@@ -4466,10 +4466,9 @@ pub enum FulfillmentStatus {
     Fulfilled = 3,
     /// The request cannot be fulfilled.
     Unfulfillable = 4,
-    /// The Clear was soft-reverted by the vApp STF. Terminal; no balance impact.
+    /// The request failed during settlement. Terminal; no proof is recorded.
     Reverted = 5,
-    /// Request sat at ASSIGNED past its deadline without the prover ever submitting
-    /// a proof. Terminal; STF never received a Clear for it. No balance impact.
+    /// The request expired at its deadline without a proof being submitted. Terminal.
     Expired = 6,
 }
 impl FulfillmentStatus {

--- a/crates/sdk/src/network/proto/base/types.rs
+++ b/crates/sdk/src/network/proto/base/types.rs
@@ -4466,6 +4466,11 @@ pub enum FulfillmentStatus {
     Fulfilled = 3,
     /// The request cannot be fulfilled.
     Unfulfillable = 4,
+    /// The Clear was soft-reverted by the vApp STF. Terminal; no balance impact.
+    Reverted = 5,
+    /// Request sat at ASSIGNED past its deadline without the prover ever submitting
+    /// a proof. Terminal; STF never received a Clear for it. No balance impact.
+    Expired = 6,
 }
 impl FulfillmentStatus {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -4479,6 +4484,8 @@ impl FulfillmentStatus {
             Self::Assigned => "ASSIGNED",
             Self::Fulfilled => "FULFILLED",
             Self::Unfulfillable => "UNFULFILLABLE",
+            Self::Reverted => "REVERTED",
+            Self::Expired => "EXPIRED",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -4489,6 +4496,8 @@ impl FulfillmentStatus {
             "ASSIGNED" => Some(Self::Assigned),
             "FULFILLED" => Some(Self::Fulfilled),
             "UNFULFILLABLE" => Some(Self::Unfulfillable),
+            "REVERTED" => Some(Self::Reverted),
+            "EXPIRED" => Some(Self::Expired),
             _ => None,
         }
     }

--- a/crates/sdk/src/network/proto/mod.rs
+++ b/crates/sdk/src/network/proto/mod.rs
@@ -309,20 +309,4 @@ mod tests {
         );
     }
 
-    #[test]
-    fn fulfillment_status_numeric_values_match_across_trees() {
-        // Both proto trees describe the same wire format. If a future regen drifts
-        // one tree's discriminant out of sync, the runtime selection in `mod.rs`
-        // would produce mismatched semantics — pin the equality directly.
-        assert_eq!(
-            base_types::FulfillmentStatus::Reverted as i32,
-            auction_types::FulfillmentStatus::Reverted as i32,
-        );
-        assert_eq!(
-            base_types::FulfillmentStatus::Expired as i32,
-            auction_types::FulfillmentStatus::Expired as i32,
-        );
-        assert_eq!(base_types::FulfillmentStatus::Reverted as i32, 5);
-        assert_eq!(base_types::FulfillmentStatus::Expired as i32, 6);
-    }
 }

--- a/crates/sdk/src/network/proto/mod.rs
+++ b/crates/sdk/src/network/proto/mod.rs
@@ -254,3 +254,75 @@ impl From<auction_types::GetProofRequestParamsResponse> for GetProofRequestParam
         Self::Auction(response)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    // Regression guard: the RPC can now return FulfillmentStatus values 5 (REVERTED)
+    // and 6 (EXPIRED). Older SDKs without these variants hit
+    // `FulfillmentStatus::try_from(i).unwrap()` in prover.rs and panicked. These
+    // tests pin the wire numbers + string names for both the `base` and `auction`
+    // proto trees so they stay in sync with network-services/proto/types.proto.
+
+    use super::{auction_types, base_types};
+
+    #[test]
+    fn base_fulfillment_status_reverted_and_expired_wire_values() {
+        assert_eq!(
+            base_types::FulfillmentStatus::try_from(5_i32).unwrap(),
+            base_types::FulfillmentStatus::Reverted,
+        );
+        assert_eq!(
+            base_types::FulfillmentStatus::try_from(6_i32).unwrap(),
+            base_types::FulfillmentStatus::Expired,
+        );
+        assert_eq!(base_types::FulfillmentStatus::Reverted.as_str_name(), "REVERTED");
+        assert_eq!(base_types::FulfillmentStatus::Expired.as_str_name(), "EXPIRED");
+        assert_eq!(
+            base_types::FulfillmentStatus::from_str_name("REVERTED"),
+            Some(base_types::FulfillmentStatus::Reverted),
+        );
+        assert_eq!(
+            base_types::FulfillmentStatus::from_str_name("EXPIRED"),
+            Some(base_types::FulfillmentStatus::Expired),
+        );
+    }
+
+    #[test]
+    fn auction_fulfillment_status_reverted_and_expired_wire_values() {
+        assert_eq!(
+            auction_types::FulfillmentStatus::try_from(5_i32).unwrap(),
+            auction_types::FulfillmentStatus::Reverted,
+        );
+        assert_eq!(
+            auction_types::FulfillmentStatus::try_from(6_i32).unwrap(),
+            auction_types::FulfillmentStatus::Expired,
+        );
+        assert_eq!(auction_types::FulfillmentStatus::Reverted.as_str_name(), "REVERTED");
+        assert_eq!(auction_types::FulfillmentStatus::Expired.as_str_name(), "EXPIRED");
+        assert_eq!(
+            auction_types::FulfillmentStatus::from_str_name("REVERTED"),
+            Some(auction_types::FulfillmentStatus::Reverted),
+        );
+        assert_eq!(
+            auction_types::FulfillmentStatus::from_str_name("EXPIRED"),
+            Some(auction_types::FulfillmentStatus::Expired),
+        );
+    }
+
+    #[test]
+    fn fulfillment_status_numeric_values_match_across_trees() {
+        // Both proto trees describe the same wire format. If a future regen drifts
+        // one tree's discriminant out of sync, the runtime selection in `mod.rs`
+        // would produce mismatched semantics — pin the equality directly.
+        assert_eq!(
+            base_types::FulfillmentStatus::Reverted as i32,
+            auction_types::FulfillmentStatus::Reverted as i32,
+        );
+        assert_eq!(
+            base_types::FulfillmentStatus::Expired as i32,
+            auction_types::FulfillmentStatus::Expired as i32,
+        );
+        assert_eq!(base_types::FulfillmentStatus::Reverted as i32, 5);
+        assert_eq!(base_types::FulfillmentStatus::Expired as i32, 6);
+    }
+}

--- a/crates/sdk/src/network/prover.rs
+++ b/crates/sdk/src/network/prover.rs
@@ -1079,20 +1079,6 @@ mod decision_tests {
     }
 
     #[test]
-    fn fulfilled_returns_proof() {
-        let (proof, status) = decide_status_outcome(
-            rid(),
-            ExecutionStatus::Executed,
-            FulfillmentStatus::Fulfilled,
-            None,
-            false,
-        )
-        .unwrap();
-        assert!(proof.is_none());
-        assert_eq!(status, FulfillmentStatus::Fulfilled);
-    }
-
-    #[test]
     fn unexecutable_maps_to_request_unexecutable() {
         let err = decide_status_outcome(
             rid(),

--- a/crates/sdk/src/network/prover.rs
+++ b/crates/sdk/src/network/prover.rs
@@ -121,6 +121,66 @@ impl Prover for NetworkProver {
     }
 }
 
+/// Returns `true` if the error is a wait-loop terminal failure that the auction fallback path
+/// should retry against high-availability provers. The retry is single-shot — guarded by
+/// `whitelist.is_none()` at the call site, which is set on retry — so adding a variant here
+/// cannot produce an unbounded retry loop.
+///
+/// Settlement failures (`RequestReverted`) are deliberately NOT retryable by default. The SDK only
+/// sees the terminal status, not a stable retry reason, so retrying here can burn more PROVE on
+/// deterministic failures. Callers who own a different policy can inspect the error and resubmit.
+fn should_retry_with_ha_fallback(error: &Error) -> bool {
+    matches!(
+        error,
+        Error::RequestUnfulfillable { .. }
+            | Error::RequestTimedOut { .. }
+            | Error::RequestAuctionTimedOut { .. }
+            | Error::RequestExpired { .. }
+    )
+}
+
+/// Maps the post-RPC status to a public outcome. Pure logic, kept separate from the RPC path so
+/// the decision boundaries are unit-testable without mocking transport.
+///
+/// Priority (matches the inline order in `process_proof_status` prior to this extraction):
+///   1. `FulfillmentStatus::Fulfilled` -> `Ok((proof, Fulfilled))` even past deadline
+///   2. `ExecutionStatus::Unexecutable` -> `Error::RequestUnexecutable`
+///   3. `FulfillmentStatus::Unfulfillable` -> `Error::RequestUnfulfillable`
+///   4. `FulfillmentStatus::Reverted` -> `Error::RequestReverted`
+///   5. `FulfillmentStatus::Expired` -> `Error::RequestExpired`
+///   6. `deadline_exceeded` -> `Error::RequestTimedOut`
+///   7. otherwise (Unspecified, Requested, Assigned) -> `Ok((None, status))` for the caller to poll
+fn decide_status_outcome(
+    request_id: B256,
+    execution_status: ExecutionStatus,
+    fulfillment_status: FulfillmentStatus,
+    maybe_proof: Option<SP1ProofWithPublicValues>,
+    deadline_exceeded: bool,
+) -> Result<(Option<SP1ProofWithPublicValues>, FulfillmentStatus)> {
+    if fulfillment_status == FulfillmentStatus::Fulfilled {
+        return Ok((maybe_proof, fulfillment_status));
+    }
+    if execution_status == ExecutionStatus::Unexecutable {
+        return Err(Error::RequestUnexecutable { request_id: request_id.to_vec() }.into());
+    }
+    match fulfillment_status {
+        FulfillmentStatus::Unfulfillable => {
+            return Err(Error::RequestUnfulfillable { request_id: request_id.to_vec() }.into());
+        }
+        FulfillmentStatus::Reverted => {
+            return Err(Error::RequestReverted { request_id: request_id.to_vec() }.into());
+        }
+        FulfillmentStatus::Expired => {
+            return Err(Error::RequestExpired { request_id: request_id.to_vec() }.into());
+        }
+        _ => {}
+    }
+    if deadline_exceeded {
+        return Err(Error::RequestTimedOut { request_id: request_id.to_vec() }.into());
+    }
+    Ok((None, fulfillment_status))
+}
+
 impl NetworkProver {
     /// Creates a new [`NetworkProver`] with the given signer and network mode.
     ///
@@ -351,31 +411,22 @@ impl NetworkProver {
         let (status, maybe_proof): (GetProofRequestStatusResponse, Option<ProofFromNetwork>) =
             self.client.get_proof_request_status(request_id, remaining_timeout).await?;
 
-        let maybe_proof = maybe_proof.map(Into::into);
+        let maybe_proof: Option<SP1ProofWithPublicValues> = maybe_proof.map(Into::into);
 
         let execution_status = ExecutionStatus::try_from(status.execution_status()).unwrap();
         let fulfillment_status = FulfillmentStatus::try_from(status.fulfillment_status()).unwrap();
 
-        // Check fulfillment before the deadline — a fulfilled proof should be
-        // returned even if polled after the deadline has passed.
-        if fulfillment_status == FulfillmentStatus::Fulfilled {
-            return Ok((maybe_proof, fulfillment_status));
-        }
-        if execution_status == ExecutionStatus::Unexecutable {
-            return Err(Error::RequestUnexecutable { request_id: request_id.to_vec() }.into());
-        }
-        if fulfillment_status == FulfillmentStatus::Unfulfillable {
-            return Err(Error::RequestUnfulfillable { request_id: request_id.to_vec() }.into());
-        }
-
-        // Only check the deadline for requests that are still in progress.
         let current_time =
             std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();
-        if current_time > status.deadline() {
-            return Err(Error::RequestTimedOut { request_id: request_id.to_vec() }.into());
-        }
+        let deadline_exceeded = current_time > status.deadline();
 
-        Ok((None, fulfillment_status))
+        decide_status_outcome(
+            request_id,
+            execution_status,
+            fulfillment_status,
+            maybe_proof,
+            deadline_exceeded,
+        )
     }
 
     /// Requests a proof from the prover network, returning the request ID.
@@ -728,12 +779,8 @@ impl NetworkProver {
                     // Check if this is a Mainnet auction request that we can retry.
                     if self.network_mode == NetworkMode::Mainnet {
                         if let Some(network_error) = e.downcast_ref::<Error>() {
-                            if matches!(
-                                network_error,
-                                Error::RequestUnfulfillable { .. }
-                                    | Error::RequestTimedOut { .. }
-                                    | Error::RequestAuctionTimedOut { .. }
-                            ) && strategy == FulfillmentStrategy::Auction
+                            if should_retry_with_ha_fallback(network_error)
+                                && strategy == FulfillmentStrategy::Auction
                                 && whitelist.is_none()
                             {
                                 tracing::warn!(
@@ -1004,5 +1051,163 @@ mod tests {
         // Older RPCs return tick_size=0; must pass the buffered value through unchanged.
         assert_eq!(align_to_tick(1_234_567_890, 0), 1_234_567_890);
         assert_eq!(align_to_tick(1_234_567_890, 1), 1_234_567_890);
+    }
+}
+
+#[cfg(test)]
+mod decision_tests {
+    use super::*;
+
+    fn rid() -> B256 {
+        B256::from([0xab; 32])
+    }
+
+    #[test]
+    fn fulfilled_takes_precedence_over_unexecutable_and_deadline() {
+        // Per #2737 ordering: a Fulfilled proof should be returned even if both Unexecutable
+        // and the deadline are concurrent — the proof is in hand.
+        let (proof, status) = decide_status_outcome(
+            rid(),
+            ExecutionStatus::Unexecutable,
+            FulfillmentStatus::Fulfilled,
+            None,
+            true,
+        )
+        .unwrap();
+        assert!(proof.is_none());
+        assert_eq!(status, FulfillmentStatus::Fulfilled);
+    }
+
+    #[test]
+    fn fulfilled_returns_proof() {
+        let (proof, status) = decide_status_outcome(
+            rid(),
+            ExecutionStatus::Executed,
+            FulfillmentStatus::Fulfilled,
+            None,
+            false,
+        )
+        .unwrap();
+        assert!(proof.is_none());
+        assert_eq!(status, FulfillmentStatus::Fulfilled);
+    }
+
+    #[test]
+    fn unexecutable_maps_to_request_unexecutable() {
+        let err = decide_status_outcome(
+            rid(),
+            ExecutionStatus::Unexecutable,
+            FulfillmentStatus::Assigned,
+            None,
+            false,
+        )
+        .unwrap_err();
+        assert!(matches!(err.downcast_ref::<Error>(), Some(Error::RequestUnexecutable { .. })));
+    }
+
+    #[test]
+    fn unfulfillable_maps_to_request_unfulfillable() {
+        let err = decide_status_outcome(
+            rid(),
+            ExecutionStatus::Executed,
+            FulfillmentStatus::Unfulfillable,
+            None,
+            false,
+        )
+        .unwrap_err();
+        assert!(matches!(err.downcast_ref::<Error>(), Some(Error::RequestUnfulfillable { .. })));
+    }
+
+    #[test]
+    fn reverted_maps_to_request_reverted() {
+        let err = decide_status_outcome(
+            rid(),
+            ExecutionStatus::Executed,
+            FulfillmentStatus::Reverted,
+            None,
+            false,
+        )
+        .unwrap_err();
+        let net = err.downcast_ref::<Error>().expect("network error");
+        assert!(matches!(net, Error::RequestReverted { .. }));
+        assert!(net.to_string().contains("failed during settlement"));
+    }
+
+    #[test]
+    fn expired_maps_to_request_expired() {
+        let err = decide_status_outcome(
+            rid(),
+            ExecutionStatus::Executed,
+            FulfillmentStatus::Expired,
+            None,
+            false,
+        )
+        .unwrap_err();
+        let net = err.downcast_ref::<Error>().expect("network error");
+        assert!(matches!(net, Error::RequestExpired { .. }));
+        assert!(net.to_string().contains("expired"));
+    }
+
+    #[test]
+    fn deadline_exceeded_maps_to_request_timed_out_for_in_progress_states() {
+        for fs in [
+            FulfillmentStatus::UnspecifiedFulfillmentStatus,
+            FulfillmentStatus::Requested,
+            FulfillmentStatus::Assigned,
+        ] {
+            let err = decide_status_outcome(rid(), ExecutionStatus::Executed, fs, None, true)
+                .unwrap_err();
+            assert!(
+                matches!(err.downcast_ref::<Error>(), Some(Error::RequestTimedOut { .. })),
+                "fs={fs:?} should map to RequestTimedOut when deadline exceeded",
+            );
+        }
+    }
+
+    #[test]
+    fn polling_states_return_ok_with_status() {
+        for fs in [
+            FulfillmentStatus::UnspecifiedFulfillmentStatus,
+            FulfillmentStatus::Requested,
+            FulfillmentStatus::Assigned,
+        ] {
+            let (proof, status) =
+                decide_status_outcome(rid(), ExecutionStatus::Executed, fs, None, false).unwrap();
+            assert!(proof.is_none());
+            assert_eq!(status, fs);
+        }
+    }
+
+    #[test]
+    fn ha_fallback_retries_expired_but_not_reverted() {
+        let request_id = rid().to_vec();
+        // Expired joins the existing retryable set.
+        assert!(should_retry_with_ha_fallback(&Error::RequestExpired {
+            request_id: request_id.clone()
+        }));
+        assert!(should_retry_with_ha_fallback(&Error::RequestUnfulfillable {
+            request_id: request_id.clone()
+        }));
+        assert!(should_retry_with_ha_fallback(&Error::RequestTimedOut {
+            request_id: request_id.clone()
+        }));
+        assert!(should_retry_with_ha_fallback(&Error::RequestAuctionTimedOut {
+            request_id: request_id.clone()
+        }));
+        // Settlement failures stay terminal by default; retry policy needs caller context.
+        assert!(!should_retry_with_ha_fallback(&Error::RequestReverted {
+            request_id: request_id.clone()
+        }));
+        // RequestUnexecutable also stays out of the retry set (pre-existing behavior).
+        assert!(!should_retry_with_ha_fallback(&Error::RequestUnexecutable { request_id }));
+    }
+
+    #[test]
+    fn error_display_strings_for_new_variants() {
+        let request_id = vec![0xde, 0xad, 0xbe, 0xef];
+        let reverted = Error::RequestReverted { request_id: request_id.clone() }.to_string();
+        assert_eq!(reverted, "Proof request 0xdeadbeef failed during settlement");
+        let expired = Error::RequestExpired { request_id }.to_string();
+        assert_eq!(expired, "Proof request 0xdeadbeef expired before a proof was submitted");
     }
 }


### PR DESCRIPTION
## Summary

- Syncs SDK `FulfillmentStatus` with wire values the RPC can already return: `REVERTED=5`, `EXPIRED=6`.
- Stops SDK polling from panicking or spinning on those terminal states.
- Maps terminal outcomes to user-safe SDK errors:
  - `REVERTED` -> `Proof request 0x... failed during settlement`
  - `EXPIRED` -> `Proof request 0x... expired before a proof was submitted`
- Keeps HA fallback simple: retry `RequestExpired` like timeout errors; do not retry `RequestReverted` by default.

## Notes

- This intentionally does not do a full proto regen.
- This intentionally does not add Explorer/product display mapping.
- Future unknown enum drift, e.g. fs=7, still hits the existing `try_from(...).unwrap()` path.
- New public `Error` variants can break exhaustive downstream matches, but as a compile error instead of today’s runtime panic.

## Verification

- `cargo +nightly fmt --all -- --check`
- `cargo build --release -p sp1-sdk --features network`
- `cargo test --release -p sp1-sdk --features network --lib` -- 38/38 pass
- `cargo clippy --release -p sp1-sdk --features network --lib --tests -- -D warnings`
- `git diff --check origin/main...HEAD`
