### PR TITLE
fix(sdk): enable only network and blocking features for docs.rs build

### DIFF
--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -123,7 +123,7 @@ groth16-cuda = ["sp1-recursion-gnark-ffi/groth16-cuda", "native-gnark"]
 slow-tests = []
 
 [package.metadata.docs.rs]
-all-features = true
+features = ["network", "blocking"]
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Motivation

The docs.rs build sandbox does not have golang installed, which is required for building with the native-gnark feature. 

All features were enabled here:
https://github.com/succinctlabs/sp1/pull/2682

Which caused the build to fail here:
https://docs.rs/crate/sp1-sdk/6.1.0/builds

## Solution
Explicitly enable network/blocking features, as that was the intent of the previous PR, but without enabling the native-gnark feature, to avoid depending on golang in the docs.rs build sandbox

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes