### PR TITLE
fix(sp1-gpu): bind socket before CUDA init to avoid cold-start race

### DIFF
--- a/crates/cuda/src/client.rs
+++ b/crates/cuda/src/client.rs
@@ -144,8 +144,10 @@ impl CudaClientInner {
     async fn connect_inner(cuda_id: u32) -> Result<UnixStream, CudaClientError> {
         let socket_path = socket_path(cuda_id);
 
-        // Retry a few times, just in case the server hasnt started yet.
-        for _ in 0..10 {
+        // One-shot wait at first connect; zero cost after the socket appears.
+        // Cold `sp1-gpu-server` exec loads CUDA/icicle .so via /dev/nvidia*
+        // ioctls (~3s), done twice per spawn (--version + real child).
+        for _ in 0..600 {
             let Ok(this) = Self::connect_once(&socket_path).await else {
                 tokio::time::sleep(Duration::from_millis(100)).await;
                 continue;

--- a/sp1-gpu/crates/server/src/main.rs
+++ b/sp1-gpu/crates/server/src/main.rs
@@ -7,7 +7,9 @@ static GLOBAL: Jemalloc = Jemalloc;
 
 use clap::Parser;
 use server::Server;
+use sp1_cuda::client::socket_path;
 use sp1_gpu_cudart::run_in_place;
+use tokio::net::UnixListener;
 
 mod server;
 
@@ -34,9 +36,26 @@ async fn main() {
         .parse()
         .expect("Expected only one CUDA device as a u32");
 
+    eprintln!(
+        "Running sp1-gpu-server {} with device {}",
+        sp1_primitives::SP1_CRATE_VERSION,
+        cuda_device_id
+    );
+
+    // Bind the socket *before* CUDA init. CUDA context creation can take
+    // several seconds on cold GPUs; if the listener isn't ready by then the
+    // sp1-cuda client's 1s reconnect window fires and panics the parent.
+    let socket_path = socket_path(cuda_device_id);
+    if let Err(e) = std::fs::remove_file(&socket_path) {
+        tracing::warn!("Failed to remove orphaned socket: {}", e);
+    }
+    let listener =
+        UnixListener::bind(&socket_path).expect("Failed to bind to socket addr");
+    tracing::info!("Server listening @ {}", socket_path.display());
+
     let server = Server { cuda_device_id };
 
-    if let Err(e) = run_in_place(|scope| server.run(scope)).await.await {
+    if let Err(e) = run_in_place(|scope| server.run(scope, listener, socket_path)).await.await {
         eprintln!("Error running server: {e}");
     }
 }

--- a/sp1-gpu/crates/server/src/server.rs
+++ b/sp1-gpu/crates/server/src/server.rs
@@ -1,14 +1,12 @@
 use sp1_core_executor::SP1Context;
-use sp1_cuda::{
-    api::{Request, Response},
-    client::socket_path,
-};
+use sp1_cuda::api::{Request, Response};
 use sp1_gpu_cudart::TaskScope;
 use sp1_gpu_prover::cuda_worker_builder;
 use sp1_primitives::Elf;
 use sp1_prover::worker::{SP1LocalNode, SP1LocalNodeBuilder};
 use sp1_prover::SP1VerifyingKey;
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 use std::io;
 use std::sync::Arc;
@@ -37,21 +35,11 @@ struct ConnectionCtx {
 
 impl Server {
     /// Run the server, indefinitely.
-    pub async fn run(self, task_scope: TaskScope) {
-        eprintln!(
-            "Running sp1-gpu-server {} with device {}",
-            sp1_primitives::SP1_CRATE_VERSION,
-            self.cuda_device_id
-        );
-        let socket_path = socket_path(self.cuda_device_id);
-
-        // Try to remove the socket file socket incase the file was never cleaned up.
-        if let Err(e) = std::fs::remove_file(&socket_path) {
-            tracing::warn!("Failed to remove orphaned socket: {}", e);
-        }
-
-        let listener = UnixListener::bind(&socket_path).expect("Failed to bind to socket addr");
-
+    ///
+    /// The listener is bound in `main` before CUDA init so that the sp1-cuda
+    /// client can connect to the socket immediately. Accept requests enqueue in
+    /// the kernel's backlog and are drained once the prover is ready below.
+    pub async fn run(self, task_scope: TaskScope, listener: UnixListener, socket_path: PathBuf) {
         let prover = Arc::new(
             SP1LocalNodeBuilder::from_worker_client_builder(
                 cuda_worker_builder(task_scope.clone()).await,
@@ -61,7 +49,7 @@ impl Server {
             .unwrap(),
         );
 
-        tracing::info!("Server listening @ {}", socket_path.display());
+        tracing::info!("CUDA prover ready, accepting connections @ {}", socket_path.display());
         loop {
             tokio::select! {
                 res = listener.accept() => {


### PR DESCRIPTION
## Summary

Fixes the `Could not connect to "sp1-gpu-server" socket` panic on GPU 1+ during multi-GPU cold starts. Reliably reproduced on a 4-GPU host before this change.

## Root cause

Cold `sp1-gpu-server` startup spends ~2–3 s initializing CUDA before binding its Unix socket at `/tmp/sp1-cuda-<id>.sock`. The `sp1-cuda` client only retried for 1 s (10 × 100 ms), so every GPU beyond the first timed out while the child was still warming up; the parent then panicked and `kill_on_drop` SIGKILLed the child before its own error logs flushed — which is why the surface error is the misleading "could not connect" message rather than any actual CUDA progress.

## Fix

Two small changes on the startup path:

- **`sp1-gpu-server`**: hoist `remove_file` + `UnixListener::bind` out of `Server::run` into `main` so the socket exists immediately after `exec`. New clients enqueue in the kernel `listen(2)` backlog (Linux default ≥ 128) while CUDA is warming up; the existing accept loop drains them once the prover is ready. No ordering or concurrency change visible to callers.
- **`sp1-cuda` client**: widen the reconnect window from 10 × 100 ms (1 s) to 600 × 100 ms (60 s). Belt-and-braces against slow first-time CUDA init; once the socket exists the loop exits on its first iteration so steady-state cost is unchanged.

With both fixes applied, all four GPUs come up cleanly on every run on the same host that previously failed every time.

## Commits

- `dd09c1dd0` fix(sp1-gpu-server): bind socket before CUDA init
- `4569c9e34` fix(sp1-cuda): widen client reconnect window to 60s