### PR TITLE
fix(prover): use neutral error in verify_public_values

### DIFF
--- a/crates/prover/src/verify.rs
+++ b/crates/prover/src/verify.rs
@@ -57,6 +57,14 @@ bn254 proof"
     InvalidPublicValues,
 }
 
+#[derive(Error, Debug)]
+enum PublicValuesVerificationError {
+    #[error(
+        "the public values in the sp1 proof do not match the public values in the inner proof"
+    )]
+    InvalidPublicValues,
+}
+
 /// The verifying key for the program wrapping an SP1 proof into a SNARK friendly format.
 pub const WRAP_VK_BYTES: &[u8] = include_bytes!("../wrap_vk.bin");
 
@@ -828,7 +836,7 @@ pub fn verify_public_values(
     if sha256_public_values_hash != expected_public_values_hash {
         let blake3_public_values_hash = public_values.hash_bn254_with_fn(blake3_hash);
         if blake3_public_values_hash != expected_public_values_hash {
-            return Err(Groth16VerificationError::InvalidPublicValues.into());
+            return Err(PublicValuesVerificationError::InvalidPublicValues.into());
         }
     }
 


### PR DESCRIPTION
 ## Motivation
                                                                                                                                                                                                     
  `verify_public_values` is shared by both Plonk and Groth16 verification paths, but on failure it always returned `Groth16VerificationError::InvalidPublicValues`.                                  
                                                                                                                                                                                                     
  This caused error-type semantic leakage: a Plonk verification failure could be reported as a Groth16 error, which hurts observability and makes upstream error handling/debugging less reliable.   
                                                                                                                                                                                                     
  ## Solution                                                                                                                                                                                        
                                                                                                                                                                                                     
  Use a protocol-neutral error in `verify_public_values` instead of hardcoding a Groth16-specific error.                                                                                             
                                                                                                                                                                                                     
  ### What changed                                                                                                                                                                                   
                                                                                                                                                                                                     
  - Added an internal neutral error type: `PublicValuesVerificationError`.                                                                                                                           
  - Updated `verify_public_values` to return `PublicValuesVerificationError::InvalidPublicValues` on hash mismatch.                                                                                  
  - Kept verification logic unchanged (SHA256/Blake3 dual-hash check is untouched).                                                                                                                  
  - Kept scope minimal to `crates/prover/src/verify.rs`.                                                                                                                                             
                                                                                                                                                                                                     
  This preserves behavior while fixing error semantics so shared validation code no longer encodes Groth16-specific context.
                                                                                                                                                                                                     
  ## PR Checklist                                                                                                                                                                                    
                                                                                                                                                                                                     
  - [ ] Added Tests                                                                                                                                                                                  
  - [ ] Added Documentation                                                                                                                                                                          
  - [ ] Breaking changes 