### PR TITLE
chore: update soundcalc script to include shrink

### DIFF
--- a/crates/primitives/src/fri_params.rs
+++ b/crates/primitives/src/fri_params.rs
@@ -4,6 +4,7 @@ use crate::SP1Field;
 
 pub const CORE_LOG_BLOWUP: usize = 2;
 pub const RECURSION_LOG_BLOWUP: usize = 2;
+pub const SP1_SHRINK_WRAP_POW_BITS: usize = 22;
 
 pub fn core_fri_config() -> FriConfig<SP1Field> {
     FriConfig::new(
@@ -27,16 +28,16 @@ pub fn recursion_fri_config() -> FriConfig<SP1Field> {
 pub fn shrink_fri_config() -> FriConfig<SP1Field> {
     FriConfig::new(
         SHRINK_LOG_BLOWUP,
-        unique_decoding_queries_with_custom_grinding(SHRINK_LOG_BLOWUP, 22),
-        22,
+        unique_decoding_queries_with_custom_grinding(SHRINK_LOG_BLOWUP, SP1_SHRINK_WRAP_POW_BITS),
+        SP1_SHRINK_WRAP_POW_BITS,
     )
 }
 
 pub fn wrap_fri_config() -> FriConfig<SP1Field> {
     FriConfig::new(
         WRAP_LOG_BLOWUP,
-        unique_decoding_queries_with_custom_grinding(WRAP_LOG_BLOWUP, 22),
-        22,
+        unique_decoding_queries_with_custom_grinding(WRAP_LOG_BLOWUP, SP1_SHRINK_WRAP_POW_BITS),
+        SP1_SHRINK_WRAP_POW_BITS,
     )
 }
 

--- a/crates/prover/scripts/gen_soundcalc_toml.rs
+++ b/crates/prover/scripts/gen_soundcalc_toml.rs
@@ -14,13 +14,12 @@ use sp1_core_machine::riscv::RiscvAir;
 use sp1_hypercube::{air::MachineAir, Machine, GKR_GRINDING_BITS, MAX_CONSTRAINT_DEGREE};
 use sp1_primitives::{
     fri_params::{
-        unique_decoding_queries, CORE_LOG_BLOWUP, RECURSION_LOG_BLOWUP, SHRINK_LOG_BLOWUP,
-        SP1_PROOF_OF_WORK_BITS, SP1_SHRINK_WRAP_POW_BITS,
+        shrink_fri_config, unique_decoding_queries, CORE_LOG_BLOWUP, RECURSION_LOG_BLOWUP,
+        SHRINK_LOG_BLOWUP, SP1_PROOF_OF_WORK_BITS, SP1_SHRINK_WRAP_POW_BITS,
     },
     SP1Field,
 };
 use sp1_prover::{
-    worker::{cpu_worker_builder, SP1LocalNode},
     CompressAir, ShrinkAir, CORE_LOG_STACKING_HEIGHT, CORE_MAX_LOG_ROW_COUNT,
     RECURSION_LOG_TRACE_AREA, SHRINK_LOG_STACKING_HEIGHT, SHRINK_LOG_TRACE_AREA,
     SHRINK_MAX_LOG_ROW_COUNT,
@@ -125,7 +124,7 @@ fn main() {
 
     let core_queries = unique_decoding_queries(CORE_LOG_BLOWUP);
     let recursion_queries = unique_decoding_queries(RECURSION_LOG_BLOWUP);
-    let shrink_queries = unique_decoding_queries(SHRINK_LOG_BLOWUP);
+    let shrink_queries = shrink_fri_config().num_queries();
 
     let core_rho = format_rho(core_blowup);
     let recursion_rho = format_rho(recursion_blowup);
@@ -225,9 +224,9 @@ name = \"shrink\"
 udr_only = true
 blowup_factor = {shrink_blowup}
 rho = {shrink_rho}
-trace_length = {shrink_trace_len} # 2^{RECURSION_MAX_LOG_ROW_COUNT}
+trace_length = {shrink_trace_len} # 2^{SHRINK_MAX_LOG_ROW_COUNT}
 trace_columns = {shrink_trace_columns}
-dense_length = {shrink_dense_len} # 2^{RECURSION_LOG_STACKING_HEIGHT}
+dense_length = {shrink_dense_len} # 2^{SHRINK_LOG_STACKING_HEIGHT}
 dense_batch = {shrink_dense_batch}
 num_constraints = {shrink_num_constraints}
 air_max_degree = {MAX_CONSTRAINT_DEGREE}
@@ -246,7 +245,7 @@ grinding_query_phase = {SP1_SHRINK_WRAP_POW_BITS}
 [[circuits.lookups]]
 name = \"lookup\"
 logup_type = \"multivariate\"
-rows_L = {recursion_trace_len}
+rows_L = {shrink_trace_len}
 rows_T = 0
 num_columns_S = {shrink_num_columns_s}
 num_lookups_M = {shrink_num_lookups_m}

--- a/crates/prover/scripts/gen_soundcalc_toml.rs
+++ b/crates/prover/scripts/gen_soundcalc_toml.rs
@@ -14,12 +14,16 @@ use sp1_core_machine::riscv::RiscvAir;
 use sp1_hypercube::{air::MachineAir, Machine, GKR_GRINDING_BITS, MAX_CONSTRAINT_DEGREE};
 use sp1_primitives::{
     fri_params::{
-        unique_decoding_queries, CORE_LOG_BLOWUP, RECURSION_LOG_BLOWUP, SP1_PROOF_OF_WORK_BITS,
+        unique_decoding_queries, CORE_LOG_BLOWUP, RECURSION_LOG_BLOWUP, SHRINK_LOG_BLOWUP,
+        SP1_PROOF_OF_WORK_BITS, SP1_SHRINK_WRAP_POW_BITS,
     },
     SP1Field,
 };
 use sp1_prover::{
-    CompressAir, CORE_LOG_STACKING_HEIGHT, CORE_MAX_LOG_ROW_COUNT, RECURSION_LOG_TRACE_AREA,
+    worker::{cpu_worker_builder, SP1LocalNode},
+    CompressAir, ShrinkAir, CORE_LOG_STACKING_HEIGHT, CORE_MAX_LOG_ROW_COUNT,
+    RECURSION_LOG_TRACE_AREA, SHRINK_LOG_STACKING_HEIGHT, SHRINK_LOG_TRACE_AREA,
+    SHRINK_MAX_LOG_ROW_COUNT,
 };
 use sp1_verifier::compressed::{RECURSION_LOG_STACKING_HEIGHT, RECURSION_MAX_LOG_ROW_COUNT};
 use tracing_subscriber::EnvFilter;
@@ -105,22 +109,37 @@ fn main() {
 
     let core = get_circuit_data(RiscvAir::<SP1Field>::machine());
     let compress = get_circuit_data(CompressAir::<SP1Field>::compress_machine());
+    let shrink = get_circuit_data(ShrinkAir::<SP1Field>::shrink_machine());
 
     let core_blowup = 1u32 << CORE_LOG_BLOWUP;
     let recursion_blowup = 1u32 << RECURSION_LOG_BLOWUP;
+    let shrink_blowup = 1u32 << SHRINK_LOG_BLOWUP;
+
     let core_trace_len: u64 = 1u64 << CORE_MAX_LOG_ROW_COUNT;
     let recursion_trace_len: u64 = 1u64 << RECURSION_MAX_LOG_ROW_COUNT;
+    let shrink_trace_len: u64 = 1u64 << SHRINK_MAX_LOG_ROW_COUNT;
+
     let core_dense_len: u64 = 1u64 << CORE_LOG_STACKING_HEIGHT;
     let recursion_dense_len: u64 = 1u64 << RECURSION_LOG_STACKING_HEIGHT;
+    let shrink_dense_len: u64 = 1u64 << SHRINK_LOG_STACKING_HEIGHT;
+
     let core_queries = unique_decoding_queries(CORE_LOG_BLOWUP);
     let recursion_queries = unique_decoding_queries(RECURSION_LOG_BLOWUP);
+    let shrink_queries = unique_decoding_queries(SHRINK_LOG_BLOWUP);
+
     let core_rho = format_rho(core_blowup);
     let recursion_rho = format_rho(recursion_blowup);
+    let shrink_rho = format_rho(shrink_blowup);
+
     let core_folding = folding_factors(CORE_LOG_STACKING_HEIGHT);
     let recursion_folding = folding_factors(RECURSION_LOG_STACKING_HEIGHT);
+    let shrink_folding = folding_factors(SHRINK_LOG_STACKING_HEIGHT);
+
     let core_dense_batch: u64 = ELEMENT_THRESHOLD / (1u64 << CORE_LOG_STACKING_HEIGHT) + 1;
     let recursion_dense_batch: u64 =
         (1u64 << RECURSION_LOG_TRACE_AREA) / (1u64 << RECURSION_LOG_STACKING_HEIGHT);
+    let shrink_dense_batch: u64 =
+        (1u64 << SHRINK_LOG_TRACE_AREA) / (1u64 << SHRINK_LOG_STACKING_HEIGHT);
 
     let toml = format!(
         "\
@@ -200,6 +219,39 @@ num_columns_S = {recursion_num_columns_s}
 num_lookups_M = {recursion_num_lookups_m}
 grinding_bits_lookup = {GKR_GRINDING_BITS}
 multilinear_fingerprint = true
+
+[[circuits]]
+name = \"shrink\"
+udr_only = true
+blowup_factor = {shrink_blowup}
+rho = {shrink_rho}
+trace_length = {shrink_trace_len} # 2^{RECURSION_MAX_LOG_ROW_COUNT}
+trace_columns = {shrink_trace_columns}
+dense_length = {shrink_dense_len} # 2^{RECURSION_LOG_STACKING_HEIGHT}
+dense_batch = {shrink_dense_batch}
+num_constraints = {shrink_num_constraints}
+air_max_degree = {MAX_CONSTRAINT_DEGREE}
+# SP1 has no \"next row\" constraints.
+opening_points = 1
+# We batch using the random `eq` polynomials.
+power_batching = false
+multilinear_batching = true
+multilinear_zerocheck = true
+num_queries = {shrink_queries}
+fri_folding_factors = {shrink_folding}
+fri_early_stop_degree = {shrink_blowup}
+grinding_batching_phase = {BATCH_GRINDING_BITS}
+grinding_query_phase = {SP1_SHRINK_WRAP_POW_BITS}
+
+[[circuits.lookups]]
+name = \"lookup\"
+logup_type = \"multivariate\"
+rows_L = {recursion_trace_len}
+rows_T = 0
+num_columns_S = {shrink_num_columns_s}
+num_lookups_M = {shrink_num_lookups_m}
+grinding_bits_lookup = {GKR_GRINDING_BITS}
+multilinear_fingerprint = true
 ",
         core_trace_columns = core.trace_columns,
         core_num_constraints = core.num_constraints,
@@ -209,6 +261,10 @@ multilinear_fingerprint = true
         recursion_num_constraints = compress.num_constraints,
         recursion_num_lookups_m = compress.num_lookups_m,
         recursion_num_columns_s = compress.num_columns_s,
+        shrink_trace_columns = shrink.trace_columns,
+        shrink_num_constraints = shrink.num_constraints,
+        shrink_num_lookups_m = shrink.num_lookups_m,
+        shrink_num_columns_s = shrink.num_columns_s,
     );
 
     if let Some(parent) = args.output.parent() {

--- a/crates/prover/src/components.rs
+++ b/crates/prover/src/components.rs
@@ -28,9 +28,14 @@ pub type CompressAir<F> = RecursionAir<F, COMPRESS_DEGREE, 2>;
 pub type ShrinkAir<F> = RecursionAir<F, SHRINK_DEGREE, 2>;
 pub type WrapAir<F> = RecursionAir<F, WRAP_DEGREE, 1>;
 
+// NOTE: This constant is not bound deterministically to the trace area of the compress shape used in
+// the prover. If dramatic changes to the compress shape are made, this constant may need to be updated.
 pub const RECURSION_LOG_TRACE_AREA: usize = 27;
-const SHRINK_LOG_STACKING_HEIGHT: u32 = 18;
-pub(crate) const SHRINK_MAX_LOG_ROW_COUNT: usize = 19;
+// NOTE: This constant is not bound deterministically to the trace area of the shrink shape used in
+// the prover. If dramatic changes to the shrink shape are made, this constant may need to be updated.
+pub const SHRINK_LOG_TRACE_AREA: usize = 25;
+pub const SHRINK_LOG_STACKING_HEIGHT: u32 = 18;
+pub const SHRINK_MAX_LOG_ROW_COUNT: usize = 19;
 
 pub(crate) const WRAP_LOG_STACKING_HEIGHT: u32 = 21;
 

--- a/crates/prover/src/worker/prover/recursion.rs
+++ b/crates/prover/src/worker/prover/recursion.rs
@@ -12,6 +12,7 @@ use crate::{
     },
     RecursionSC, SP1CircuitWitness, SP1ProverComponents,
 };
+use std::io::Write;
 use slop_algebra::PrimeField32;
 use slop_algebra::{AbstractField, PrimeField};
 use slop_bn254::Bn254Fr;
@@ -681,6 +682,12 @@ impl<A: ArtifactClient, C: SP1ProverComponents> SP1RecursionProver<A, C> {
             .prove(compress_proof)
             .instrument(tracing::info_span!("prove shrink"))
             .await?;
+
+
+        let shrink_proof_bytes = bincode::serialize(&shrink_proof).unwrap();
+        tracing::warn!("shrink proof size: {}", shrink_proof_bytes.len());
+        let mut file = std::fs::File::create("shrink_proof.bin").unwrap();
+        file.write_all(&shrink_proof_bytes).unwrap();
 
         tracing::debug_span!("verify shrink proof")
             .in_scope(|| self.shrink_prover.verify(&shrink_proof))?;

--- a/crates/prover/src/worker/prover/recursion.rs
+++ b/crates/prover/src/worker/prover/recursion.rs
@@ -683,12 +683,6 @@ impl<A: ArtifactClient, C: SP1ProverComponents> SP1RecursionProver<A, C> {
             .instrument(tracing::info_span!("prove shrink"))
             .await?;
 
-
-        let shrink_proof_bytes = bincode::serialize(&shrink_proof).unwrap();
-        tracing::warn!("shrink proof size: {}", shrink_proof_bytes.len());
-        let mut file = std::fs::File::create("shrink_proof.bin").unwrap();
-        file.write_all(&shrink_proof_bytes).unwrap();
-
         tracing::debug_span!("verify shrink proof")
             .in_scope(|| self.shrink_prover.verify(&shrink_proof))?;
 

--- a/crates/prover/src/worker/prover/recursion.rs
+++ b/crates/prover/src/worker/prover/recursion.rs
@@ -12,7 +12,6 @@ use crate::{
     },
     RecursionSC, SP1CircuitWitness, SP1ProverComponents,
 };
-use std::io::Write;
 use slop_algebra::PrimeField32;
 use slop_algebra::{AbstractField, PrimeField};
 use slop_bn254::Bn254Fr;


### PR DESCRIPTION
The shrink stage of proving results in proof sizes, when compressed via zip or Merkle pruning, below the EF goal of 600 kB for the Glamsterdam milestone. This PR modifies the soundcalc generation script to include the shrink proof system parameters.