### PR TITLE
fix(sdk): delegate EnvProver::verify to the inner prover

### DIFF
--- a/crates/sdk/src/blocking/env/mod.rs
+++ b/crates/sdk/src/blocking/env/mod.rs
@@ -7,7 +7,10 @@
 use crate::blocking::NetworkProver;
 #[cfg(feature = "cuda")]
 use crate::blocking::{cuda::builder::CudaProverBuilder, CudaProver};
-use crate::blocking::{prover::BaseProveRequest, CpuProver, LightProver, MockProver, Prover};
+use crate::{
+    blocking::{prover::BaseProveRequest, CpuProver, LightProver, MockProver, Prover},
+    SP1ProofWithPublicValues, SP1VerificationError, StatusCode,
+};
 use sp1_core_executor::SP1CoreOpts;
 
 pub mod pk;
@@ -17,7 +20,7 @@ pub use pk::EnvProvingKey;
 use prove::EnvProveRequest;
 use sp1_core_machine::io::SP1Stdin;
 use sp1_primitives::Elf;
-use sp1_prover::worker::SP1NodeCore;
+use sp1_prover::{worker::SP1NodeCore, SP1VerifyingKey};
 
 /// A prover that can execute programs and generate proofs with a different implementation based on
 /// the value of the `SP1_PROVER` environment variable.
@@ -151,5 +154,63 @@ impl Prover for EnvProver {
 
     fn prove<'a>(&'a self, pk: &'a Self::ProvingKey, stdin: SP1Stdin) -> Self::ProveRequest<'a> {
         EnvProveRequest { base: BaseProveRequest::new(self, pk, stdin) }
+    }
+
+    fn verify(
+        &self,
+        proof: &SP1ProofWithPublicValues,
+        vkey: &SP1VerifyingKey,
+        status_code: Option<StatusCode>,
+    ) -> Result<(), SP1VerificationError> {
+        match self {
+            Self::Cpu(prover) => prover.verify(proof, vkey, status_code),
+            #[cfg(feature = "cuda")]
+            Self::Cuda(prover) => prover.verify(proof, vkey, status_code),
+            Self::Mock(prover) => prover.verify(proof, vkey, status_code),
+            Self::Light(prover) => prover.verify(proof, vkey, status_code),
+            #[cfg(feature = "network")]
+            Self::Network(prover) => prover.verify(proof, vkey, status_code),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        blocking::{
+            prover::{ProveRequest, Prover},
+            MockProver,
+        },
+        utils::setup_logger,
+        SP1Stdin,
+    };
+
+    use super::EnvProver;
+
+    /// Regression: `EnvProver::Mock(...)` must delegate `verify` to the inner `MockProver`
+    /// for Plonk and Groth16 proofs. Before the dispatch fix, the trait default routed mock
+    /// proofs through the real verifier and failed parsing the formatted BN254 vkey hash
+    /// string with `invalid digit found in string`.
+    #[test]
+    fn test_envprover_mock_verifies_plonk_and_groth16() {
+        setup_logger();
+        let mock = MockProver::new();
+        let pk = mock.setup(test_artifacts::FIBONACCI_ELF).expect("failed to setup proving key");
+
+        let mut stdin = SP1Stdin::new();
+        stdin.write(&10usize);
+        let plonk_proof =
+            mock.prove(&pk, stdin).plonk().run().expect("failed to create mock Plonk proof");
+
+        let mut stdin = SP1Stdin::new();
+        stdin.write(&10usize);
+        let groth16_proof =
+            mock.prove(&pk, stdin).groth16().run().expect("failed to create mock Groth16 proof");
+
+        let env = EnvProver::Mock(mock);
+        env.verify(&plonk_proof, &pk.vk, None)
+            .expect("EnvProver::Mock must verify a mock Plonk proof");
+        env.verify(&groth16_proof, &pk.vk, None)
+            .expect("EnvProver::Mock must verify a mock Groth16 proof");
     }
 }

--- a/crates/sdk/src/env/mod.rs
+++ b/crates/sdk/src/env/mod.rs
@@ -5,7 +5,8 @@
 
 use crate::{
     prover::{BaseProveRequest, SendFutureResult},
-    CpuProver, LightProver, MockProver, Prover,
+    CpuProver, LightProver, MockProver, Prover, SP1ProofWithPublicValues, SP1VerificationError,
+    StatusCode,
 };
 
 #[cfg(feature = "cuda")]
@@ -22,7 +23,7 @@ pub use pk::EnvProvingKey;
 use prove::EnvProveRequest;
 use sp1_core_machine::io::SP1Stdin;
 use sp1_primitives::Elf;
-use sp1_prover::worker::SP1NodeCore;
+use sp1_prover::{worker::SP1NodeCore, SP1VerifyingKey};
 
 /// A prover that can execute programs and generate proofs with a different implementation based on
 /// the value of the `SP1_PROVER` environment variable.
@@ -159,5 +160,57 @@ impl Prover for EnvProver {
 
     fn prove<'a>(&'a self, pk: &'a Self::ProvingKey, stdin: SP1Stdin) -> Self::ProveRequest<'a> {
         EnvProveRequest { base: BaseProveRequest::new(self, pk, stdin) }
+    }
+
+    fn verify(
+        &self,
+        proof: &SP1ProofWithPublicValues,
+        vkey: &SP1VerifyingKey,
+        status_code: Option<StatusCode>,
+    ) -> Result<(), SP1VerificationError> {
+        match self {
+            Self::Cpu(prover) => prover.verify(proof, vkey, status_code),
+            #[cfg(feature = "cuda")]
+            Self::Cuda(prover) => prover.verify(proof, vkey, status_code),
+            Self::Mock(prover) => prover.verify(proof, vkey, status_code),
+            Self::Light(prover) => prover.verify(proof, vkey, status_code),
+            #[cfg(feature = "network")]
+            Self::Network(prover) => prover.verify(proof, vkey, status_code),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{prover::ProveRequest, utils::setup_logger, MockProver, Prover, SP1Stdin};
+
+    use super::EnvProver;
+
+    /// Regression: `EnvProver::Mock(...)` must delegate `verify` to the inner `MockProver`
+    /// for Plonk and Groth16 proofs. Before the dispatch fix, the trait default routed mock
+    /// proofs through the real verifier and failed parsing the formatted BN254 vkey hash
+    /// string with `invalid digit found in string`.
+    #[tokio::test]
+    async fn test_envprover_mock_verifies_plonk_and_groth16() {
+        setup_logger();
+        let mock = MockProver::new().await;
+        let pk =
+            mock.setup(test_artifacts::FIBONACCI_ELF).await.expect("failed to setup proving key");
+
+        let mut stdin = SP1Stdin::new();
+        stdin.write(&10usize);
+        let plonk_proof =
+            mock.prove(&pk, stdin).plonk().await.expect("failed to create mock Plonk proof");
+
+        let mut stdin = SP1Stdin::new();
+        stdin.write(&10usize);
+        let groth16_proof =
+            mock.prove(&pk, stdin).groth16().await.expect("failed to create mock Groth16 proof");
+
+        let env = EnvProver::Mock(mock);
+        env.verify(&plonk_proof, &pk.vk, None)
+            .expect("EnvProver::Mock must verify a mock Plonk proof");
+        env.verify(&groth16_proof, &pk.vk, None)
+            .expect("EnvProver::Mock must verify a mock Groth16 proof");
     }
 }


### PR DESCRIPTION
## Summary

`EnvProver` already delegates `setup` and `prove` to the selected inner prover via enum-match dispatch, but `verify` was falling back to the trait default instead of delegating to the inner prover. This is a wrapper dispatch bug.

This changes behavior for variants with specialized `verify` implementations, specifically `MockProver` and `NetworkProver`:

- **`EnvProver::Mock`** — The trait default routed mock Plonk/Groth16 proofs through the real verifier. `MockProver::verify` instead checks public inputs via `verify_mock_public_inputs`, which is the only path that can verify a mock proof correctly. Through `EnvProver`, that override was being skipped, and verification failed while parsing the formatted BN254 vkey hash string in the mock proof's `public_inputs[0]`.
- **`EnvProver::Network`** — The trait default also bypassed `NetworkProver::verify`, including its TEE proof verification hook. `NetworkProver::verify` runs `verify_tee_proof` against the configured TEE signers when a `tee_proof` is present, then falls through to the standard verifier; the trait default does not.

## Fix

Add a synchronous `verify` override to both `impl Prover for EnvProver` blocks (`crates/sdk/src/env/mod.rs` and `crates/sdk/src/blocking/env/mod.rs`) that mirrors the existing `inner`/`setup`/`prove` enum-match dispatch:

```rust
fn verify(
    &self,
    proof: &SP1ProofWithPublicValues,
    vkey: &SP1VerifyingKey,
    status_code: Option<StatusCode>,
) -> Result<(), SP1VerificationError> {
    match self {
        Self::Cpu(prover) => prover.verify(proof, vkey, status_code),
        #[cfg(feature = "cuda")]
        Self::Cuda(prover) => prover.verify(proof, vkey, status_code),
        Self::Mock(prover) => prover.verify(proof, vkey, status_code),
        Self::Light(prover) => prover.verify(proof, vkey, status_code),
        #[cfg(feature = "network")]
        Self::Network(prover) => prover.verify(proof, vkey, status_code),
    }
}
```

CPU/Light/CUDA behavior is preserved because their inner `verify` resolves to the same default verifier; the dispatch is explicit but functionally a no-op for those variants.

## Tests

Added focused regression tests in both `crates/sdk/src/env/mod.rs` and `crates/sdk/src/blocking/env/mod.rs`:

- `test_envprover_mock_verifies_plonk_and_groth16` — generates mock Plonk and Groth16 proofs via `MockProver` and asserts both verify successfully when wrapped in `EnvProver::Mock(...)`. Async test uses `#[tokio::test]`; blocking test uses `#[test]`.

These guard the dispatch path itself, which was the only thing this change touches.

## Verification

- `cargo check -p sp1-sdk` — clean
- `cargo check -p sp1-sdk --features network` — clean (`Box<NetworkProver>` resolves via auto-deref in the blocking variant)
- `cargo check -p sp1-sdk --features blocking,network` — clean
- `cargo test -p sp1-sdk --lib -- env::tests::test_envprover_mock_verifies_plonk_and_groth16` — passed
- `cargo test -p sp1-sdk --lib --features blocking -- blocking::env::tests::test_envprover_mock_verifies_plonk_and_groth16` — passed
- `cargo fmt -- --check` on the changed files — clean
- `cargo clippy -p sp1-sdk --tests --features blocking` — clean for `sp1-sdk`

## Out of scope

- Canonicalizing mock proof `public_inputs[0]` formatting in `crates/sdk/src/proof.rs` (`create_mock_proof` / `verify_mock_public_inputs`). The current format relies on `Bn254Fr`'s `Display` impl rather than the canonical `BigUint` decimal used by real proofs; aligning these is a separate hardening change and is intentionally not bundled here.
- `Prover::verify` trait default impl is unchanged.
- No changes to other prover variant implementations.
