### PR TITLE
chore: evaluations type removed in GPU prover

### DIFF
--- a/sp1-gpu/crates/logup_gkr/src/lib.rs
+++ b/sp1-gpu/crates/logup_gkr/src/lib.rs
@@ -10,7 +10,7 @@ use itertools::Itertools;
 use slop_algebra::AbstractField;
 use slop_alloc::HasBackend;
 use slop_challenger::{CanObserve, FieldChallenger, IopCtx, VariableLengthChallenger};
-use slop_multilinear::{MultilinearPcsChallenger, Point};
+use slop_multilinear::{MleEval, MultilinearPcsChallenger, Point};
 use sp1_gpu_basefold::{DeviceGrindingChallenger, GrindingPowCudaProver};
 use sp1_gpu_cudart::{DevicePoint, TaskScope};
 use tracing::instrument;
@@ -256,7 +256,7 @@ where
     // We accomplish this by doing jagged fix last variable on the evaluation point.
     let eval_point = eval_point.last_k(num_row_variables as usize);
     let host_evaluations = round_batch_evaluations(&eval_point, jagged_trace_data);
-    let [preprocessed, main] = host_evaluations.rounds.try_into().unwrap();
+    let [preprocessed, main]: [Vec<MleEval<Ext>>; 2] = host_evaluations.rounds.try_into().unwrap();
 
     let mut chip_evaluations = BTreeMap::new();
 

--- a/sp1-gpu/crates/shard_prover/src/prover.rs
+++ b/sp1-gpu/crates/shard_prover/src/prover.rs
@@ -8,7 +8,7 @@ use slop_jagged::{
     unzip_and_prefix_sums, JaggedLittlePolynomialProverParams, JaggedPcsProof, JaggedProverData,
     JaggedProverError, PrefixSumsMaxLogRowCount,
 };
-use slop_multilinear::{Evaluations, MleEval, MultilinearPcsVerifier, Point};
+use slop_multilinear::{MleEval, MultilinearPcsVerifier, Point};
 use sp1_gpu_air::air_block::BlockAir;
 use sp1_gpu_air::SymbolicProverFolder;
 use sp1_gpu_basefold::{CudaStackedPcsProverData, DeviceGrindingChallenger, FriCudaProver};
@@ -376,7 +376,7 @@ impl<GC: IopCtx<F = Felt, EF = Ext>, PC: CudaShardProverComponents<GC>>
     pub fn prove_trusted_evaluations(
         &self,
         eval_point: Point<Ext>,
-        evaluation_claims: Rounds<Evaluations<Ext, TaskScope>>,
+        evaluation_claims: Rounds<MleEval<Ext, TaskScope>>,
         all_mles: &JaggedTraceMle<Felt, TaskScope>,
         prover_data: Rounds<&JaggedProverData<GC, CudaStackedPcsProverData<GC>>>,
         challenger: &mut GC::Challenger,
@@ -405,13 +405,11 @@ impl<GC: IopCtx<F = Felt, EF = Ext>, PC: CudaShardProverComponents<GC>>
 
         let z_row = eval_point.clone();
 
-        let backend = evaluation_claims[0][0].backend().clone();
+        let backend = evaluation_claims[0].backend().clone();
 
         // First, allocate a buffer for all of the column claims on device.
-        let total_column_claims = evaluation_claims
-            .iter()
-            .map(|evals| evals.iter().map(|evals| evals.num_polynomials()).sum::<usize>())
-            .sum::<usize>();
+        let total_column_claims =
+            evaluation_claims.iter().map(|evals| evals.num_polynomials()).sum::<usize>();
 
         // Add in the dummy padding columns added during the stacked PCS commitment.
         let total_len = total_column_claims
@@ -423,10 +421,8 @@ impl<GC: IopCtx<F = Felt, EF = Ext>, PC: CudaShardProverComponents<GC>>
         // Then, copy the column claims from the evaluation claims into the buffer, inserting extra
         // zeros for the dummy columns.
         for (column_claim_round, data) in evaluation_claims.into_iter().zip(prover_data.iter()) {
-            for column_claim in column_claim_round.into_iter() {
-                column_claims
-                    .extend_from_device_slice(column_claim.into_evaluations().as_buffer())?;
-            }
+            column_claims
+                .extend_from_device_slice(column_claim_round.into_evaluations().as_buffer())?;
             column_claims
                 .extend_from_host_slice(vec![Ext::zero(); data.padding_column_count].as_slice())?;
         }
@@ -656,8 +652,9 @@ impl<GC: IopCtx<F = Felt, EF = Ext>, PC: CudaShardProverComponents<GC>>
 
         // Get the evaluation point for the trace polynomials.
         let evaluation_point = zerocheck_partial_sumcheck_proof.point_and_eval.0.clone();
-        let mut preprocessed_evaluation_claims: Option<Evaluations<GC::EF, TaskScope>> = None;
-        let mut main_evaluation_claims = Evaluations::new(vec![]);
+        let mut preprocessed_host: Vec<GC::EF> = Vec::new();
+        let mut main_host: Vec<GC::EF> = Vec::new();
+        let mut has_preprocessed = false;
 
         let alloc = self.backend.clone();
 
@@ -665,25 +662,30 @@ impl<GC: IopCtx<F = Felt, EF = Ext>, PC: CudaShardProverComponents<GC>>
             let prep_local = &open_values.preprocessed.local;
             let main_local = &open_values.main.local;
             if !prep_local.is_empty() {
-                let host_mle_eval = MleEval::from(prep_local.clone());
-                let device_tensor =
-                    sp1_gpu_cudart::DeviceTensor::from_host(host_mle_eval.evaluations(), &alloc)
-                        .unwrap();
-                let preprocessed_evals = MleEval::new(device_tensor.into_inner());
-                if let Some(preprocessed_claims) = preprocessed_evaluation_claims.as_mut() {
-                    preprocessed_claims.push(preprocessed_evals);
-                } else {
-                    let evals = Evaluations::new(vec![preprocessed_evals]);
-                    preprocessed_evaluation_claims = Some(evals);
-                }
+                has_preprocessed = true;
+                preprocessed_host.extend_from_slice(prep_local);
             }
-            let host_mle_eval = MleEval::from(main_local.clone());
-            let device_tensor =
-                sp1_gpu_cudart::DeviceTensor::from_host(host_mle_eval.evaluations(), &alloc)
-                    .unwrap();
-            let main_evals = MleEval::new(device_tensor.into_inner());
-            main_evaluation_claims.push(main_evals);
+            main_host.extend_from_slice(main_local);
         }
+
+        let main_evaluation_claims = MleEval::new(
+            sp1_gpu_cudart::DeviceTensor::from_host(
+                &MleEval::from(main_host).into_evaluations(),
+                &alloc,
+            )
+            .unwrap()
+            .into_inner(),
+        );
+        let preprocessed_evaluation_claims = has_preprocessed.then(|| {
+            MleEval::new(
+                sp1_gpu_cudart::DeviceTensor::from_host(
+                    &MleEval::from(preprocessed_host).into_evaluations(),
+                    &alloc,
+                )
+                .unwrap()
+                .into_inner(),
+            )
+        });
 
         let round_evaluation_claims = preprocessed_evaluation_claims
             .into_iter()
@@ -837,21 +839,21 @@ mod tests {
 
             let prover_data = Rounds::from_iter([&preprocessed_prover_data, &main_prover_data]);
 
-            // The evaluation_claims are already on host (CpuBackend).
-            // We need to convert them to device evaluations for the prover.
+            // The evaluation_claims are already on host (CpuBackend) and split per chip.
+            // Pack each round's per-chip evaluations into a single host buffer, then upload
+            // once per round to the device.
             let mut new_evaluation_claims = Vec::new();
             for round_evals in evaluation_claims.iter() {
-                let mut round_claims = Vec::new();
+                let mut round_host: Vec<Ext> = Vec::new();
                 for eval in round_evals.iter() {
-                    // Copy the host MleEval to device
-                    let device_tensor =
-                        sp1_gpu_cudart::DeviceTensor::from_host(eval.evaluations(), &scope)
-                            .unwrap();
-                    let device_eval = MleEval::new(device_tensor.into_inner());
-                    round_claims.push(device_eval);
+                    round_host.extend_from_slice(eval.to_vec().as_slice());
                 }
-                let evals = Evaluations::new(round_claims);
-                new_evaluation_claims.push(evals);
+                let device_tensor = sp1_gpu_cudart::DeviceTensor::from_host(
+                    &MleEval::from(round_host).into_evaluations(),
+                    &scope,
+                )
+                .unwrap();
+                new_evaluation_claims.push(MleEval::new(device_tensor.into_inner()));
             }
 
             let mut prover_challenger = challenger.clone();

--- a/sp1-gpu/crates/zerocheck/src/primitives.rs
+++ b/sp1-gpu/crates/zerocheck/src/primitives.rs
@@ -2,7 +2,7 @@ use crate::data::{InfoBuffer, JaggedDenseInfo};
 use slop_algebra::{AbstractField, ExtensionField, Field};
 use slop_alloc::{Backend, Buffer, CpuBackend, HasBackend, Slice};
 use slop_commit::Rounds;
-use slop_multilinear::{Evaluations, MleEval, Point};
+use slop_multilinear::{MleEval, Point};
 use slop_tensor::Tensor;
 use sp1_gpu_cudart::sys::runtime::KernelPtr;
 use sp1_gpu_cudart::sys::v2_kernels::{
@@ -310,12 +310,12 @@ pub fn evaluate_jagged_mle_chunked<F: Field>(
     output_eval.into_inner()
 }
 
-/// Evaluates each chip at `stacked_point` and returns the evaluations in a `Rounds<Evaluations>` form.
+/// Evaluates each chip at `stacked_point` and returns the evaluations as `Rounds<Vec<MleEval>>`.
 /// Inserts padding for chips included in the smallest cluster, but not the actual trace.
 pub fn round_batch_evaluations(
     stacked_point: &Point<Ext>,
     jagged_trace_mle: &JaggedTraceMle<Felt, TaskScope>,
-) -> Rounds<Evaluations<Ext>> {
+) -> Rounds<Vec<MleEval<Ext>>> {
     let evaluations = evaluate_traces(jagged_trace_mle, stacked_point);
 
     fn mle_eval_from_slice<A: Backend>(slice: &Slice<Ext, A>, backend: &A) -> MleEval<Ext, A> {
@@ -351,7 +351,7 @@ pub fn round_batch_evaluations(
     }
 
     let preprocessed_host_evaluations =
-        preprocessed_host_evaluations.into_iter().collect::<Evaluations<_, _>>();
+        preprocessed_host_evaluations.into_iter().collect::<Vec<_>>();
 
     // Skip the padding column, if it exists.
     evals_so_far = jagged_trace_mle.dense().preprocessed_cols;
@@ -373,7 +373,7 @@ pub fn round_batch_evaluations(
             evals_so_far += offset.num_polys;
         }
     }
-    let main_host_evaluations = main_host_evaluations.into_iter().collect::<Evaluations<_, _>>();
+    let main_host_evaluations = main_host_evaluations.into_iter().collect::<Vec<_>>();
 
     Rounds::from_iter([preprocessed_host_evaluations, main_host_evaluations])
 }


### PR DESCRIPTION
Evaluations type was an unused wrapper in the GPU prover. Claude PR to remove it. 