### PR TITLE
feat: invalid hint exit code for prover-hint failures

### DIFF
--- a/crates/core/executor/src/context.rs
+++ b/crates/core/executor/src/context.rs
@@ -8,7 +8,9 @@ use sp1_primitives::consts::fd::LOWEST_ALLOWED_FD;
 
 /// The status code of the execution.
 ///
-/// Currently the only supported status codes are `0` for success and `1` for failure.
+/// Supported codes: `0` (success), `1` (panic), and `3` (invalid prover hint).
+/// Exit code 3 is emitted by patched crates when a prover-supplied hint fails
+/// verification — this disambiguates it from a regular Rust panic.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct StatusCode(u32);
 
@@ -17,7 +19,11 @@ impl StatusCode {
     pub const SUCCESS: Self = Self(0);
     /// The panic status code.
     pub const PANIC: Self = Self(1);
-    /// Accept either success or panic.
+    /// The invalid-prover-hint status code. Emitted by `sp1_lib::invalid_hint!`
+    /// (and the patched crypto crates) when a hint fails its consistency
+    /// check, so a malicious prover cannot forge a regular panic.
+    pub const INVALID_HINT: Self = Self(3);
+    /// Accept any of the supported status codes.
     pub const ANY: Self = Self(u32::MAX);
 
     /// Create a new status code from a u32.
@@ -26,13 +32,14 @@ impl StatusCode {
     /// * `code` - The status code to create.
     ///
     /// # Returns
-    /// * `Some(StatusCode)` - The status code if it is valid: {0, 1}.
+    /// * `Some(StatusCode)` - The status code if it is valid: {0, 1, 3}.
     /// * `None` - The status code is not valid.
     #[must_use]
     pub const fn new(code: u32) -> Option<Self> {
         match code {
             0 => Some(Self::SUCCESS),
             1 => Some(Self::PANIC),
+            3 => Some(Self::INVALID_HINT),
             _ => None,
         }
     }
@@ -46,7 +53,7 @@ impl StatusCode {
     /// Check if the status code is equal to the given value.
     #[must_use]
     pub const fn is_accepted_code(&self, code: u32) -> bool {
-        (code == 0 || code == 1) && (self.0 == Self::ANY.0 || self.0 == code)
+        matches!(code, 0 | 1 | 3) && (self.0 == Self::ANY.0 || self.0 == code)
     }
 }
 

--- a/crates/test-artifacts/programs/Cargo.lock
+++ b/crates/test-artifacts/programs/Cargo.lock
@@ -38,7 +38,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "sha3",
- "tiny-keccak 2.0.2 (git+https://github.com/sp1-patches/tiny-keccak?tag=patch-2.0.2-sp1-6.0.0)",
+ "tiny-keccak 2.0.2 (git+https://github.com/sp1-patches/tiny-keccak?tag=patch-2.0.2-sp1-6.2.0)",
 ]
 
 [[package]]
@@ -744,7 +744,7 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
-source = "git+https://github.com/sp1-patches/curve25519-dalek?tag=patch-4.1.3-sp1-6.0.0#ade3f90a82efc7c58c4ae1ecb4d48bbe673c2a8f"
+source = "git+https://github.com/sp1-patches/curve25519-dalek?tag=patch-4.1.3-sp1-6.2.0#b251b2a155f859d00375f73bc2c937f025f7b4b4"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -760,7 +760,7 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek-derive"
 version = "0.1.1"
-source = "git+https://github.com/sp1-patches/curve25519-dalek?tag=patch-4.1.3-sp1-6.0.0#ade3f90a82efc7c58c4ae1ecb4d48bbe673c2a8f"
+source = "git+https://github.com/sp1-patches/curve25519-dalek?tag=patch-4.1.3-sp1-6.2.0#b251b2a155f859d00375f73bc2c937f025f7b4b4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1071,7 +1071,7 @@ dependencies = [
 [[package]]
 name = "ed25519-dalek"
 version = "2.1.1"
-source = "git+https://github.com/sp1-patches/curve25519-dalek?tag=patch-4.1.3-sp1-6.0.0#ade3f90a82efc7c58c4ae1ecb4d48bbe673c2a8f"
+source = "git+https://github.com/sp1-patches/curve25519-dalek?tag=patch-4.1.3-sp1-6.2.0#b251b2a155f859d00375f73bc2c937f025f7b4b4"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
@@ -1736,7 +1736,7 @@ name = "keccak256-test"
 version = "1.1.0"
 dependencies = [
  "sp1-zkvm",
- "tiny-keccak 2.0.2 (git+https://github.com/sp1-patches/tiny-keccak?tag=patch-2.0.2-sp1-6.0.0)",
+ "tiny-keccak 2.0.2 (git+https://github.com/sp1-patches/tiny-keccak?tag=patch-2.0.2-sp1-6.2.0)",
 ]
 
 [[package]]
@@ -3352,7 +3352,7 @@ dependencies = [
 [[package]]
 name = "tiny-keccak"
 version = "2.0.2"
-source = "git+https://github.com/sp1-patches/tiny-keccak?tag=patch-2.0.2-sp1-6.0.0#957430a459f7a2332ab5bab4a12f9b473bb95c87"
+source = "git+https://github.com/sp1-patches/tiny-keccak?tag=patch-2.0.2-sp1-6.2.0#c3f95bcc35b391101d0cf0abe91ea4c8423868b0"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -3518,7 +3518,7 @@ dependencies = [
  "hex",
  "sha2 0.10.9",
  "sp1-zkvm",
- "tiny-keccak 2.0.2 (git+https://github.com/sp1-patches/tiny-keccak?tag=patch-2.0.2-sp1-6.0.0)",
+ "tiny-keccak 2.0.2 (git+https://github.com/sp1-patches/tiny-keccak?tag=patch-2.0.2-sp1-6.2.0)",
 ]
 
 [[package]]

--- a/crates/test-artifacts/programs/Cargo.toml
+++ b/crates/test-artifacts/programs/Cargo.toml
@@ -56,6 +56,6 @@ tiny-keccak = { version = "2.0.2", features = ["keccak"] }
 sha2-v0-9-8 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", branch = "patch-v0.9.8" }
 ed25519-consensus = { git = "https://github.com/sp1-patches/ed25519-consensus", branch = "patch-v2.1.0" }
 sp1-lib = { path = "../../../crates/zkvm/lib" }
-tiny-keccak-patched = { git = "https://github.com/sp1-patches/tiny-keccak", tag = "patch-2.0.2-sp1-6.0.0", package = "tiny-keccak", features = [
+tiny-keccak-patched = { git = "https://github.com/sp1-patches/tiny-keccak", tag = "patch-2.0.2-sp1-6.2.0", package = "tiny-keccak", features = [
   "keccak",
 ] }

--- a/crates/test-artifacts/programs/ed25519/Cargo.toml
+++ b/crates/test-artifacts/programs/ed25519/Cargo.toml
@@ -6,5 +6,5 @@ publish = false
 
 [dependencies]
 sp1-zkvm = {  path = "../../../../crates/zkvm/entrypoint" }
-ed25519-dalek = { git = "https://github.com/sp1-patches/curve25519-dalek", tag = "patch-4.1.3-sp1-6.0.0" }
+ed25519-dalek = { git = "https://github.com/sp1-patches/curve25519-dalek", tag = "patch-4.1.3-sp1-6.2.0" }
 hex-literal = "0.4.1"

--- a/crates/verifier/guest-verify-programs/Cargo.lock
+++ b/crates/verifier/guest-verify-programs/Cargo.lock
@@ -2253,7 +2253,7 @@ dependencies = [
 [[package]]
 name = "substrate-bn-succinct-rs"
 version = "0.6.0"
-source = "git+https://github.com/sp1-patches/bn?tag=patch-0.6.0-sp1-6.0.0#717dbe5e2270940faa46b646c6b2d639c82fb949"
+source = "git+https://github.com/sp1-patches/bn?tag=patch-0.6.0-sp1-6.2.0#af2ee646c36ad80a44a15b91db0a2b648b517b44"
 dependencies = [
  "bytemuck",
  "byteorder",

--- a/crates/verifier/guest-verify-programs/Cargo.toml
+++ b/crates/verifier/guest-verify-programs/Cargo.toml
@@ -31,4 +31,4 @@ blake3 = ["sp1-zkvm/blake3"]
 
 [patch.crates-io]
 sp1-lib = { path = "../../zkvm/lib" }
-bn = { git = "https://github.com/sp1-patches/bn", tag = "patch-0.6.0-sp1-6.0.0", package = "substrate-bn-succinct-rs" }
+bn = { git = "https://github.com/sp1-patches/bn", tag = "patch-0.6.0-sp1-6.2.0", package = "substrate-bn-succinct-rs" }

--- a/crates/zkvm/entrypoint/src/syscalls/halt.rs
+++ b/crates/zkvm/entrypoint/src/syscalls/halt.rs
@@ -17,6 +17,7 @@ cfg_if::cfg_if! {
 ///
 /// Before halting, the syscall will commit to the public values.
 #[allow(unused_variables)]
+#[no_mangle]
 pub extern "C" fn syscall_halt(exit_code: u8) -> ! {
     #[cfg(target_os = "zkvm")]
     unsafe {

--- a/crates/zkvm/lib/src/io.rs
+++ b/crates/zkvm/lib/src/io.rs
@@ -1,5 +1,5 @@
 #![allow(unused_unsafe)]
-use crate::{read_vec_raw, syscall_write, ReadVecResult};
+use crate::{halt_invalid_hint, read_vec_raw, syscall_write, ReadVecResult};
 use serde::{de::DeserializeOwned, Serialize};
 use std::io::{Result, Write};
 
@@ -43,14 +43,31 @@ pub fn read_vec() -> Vec<u8> {
     let ReadVecResult { ptr, len, capacity } = unsafe { read_vec_raw() };
 
     if ptr.is_null() {
-        panic!(
-            "Tried to read from the input stream, but it was empty @ {} \n
-            Was the correct data written into SP1Stdin?",
-            std::panic::Location::caller()
-        )
+        empty_input_stream_halt();
     }
 
     unsafe { Vec::from_raw_parts(ptr, len, capacity) }
+}
+
+/// The input stream is prover-controlled, so an empty read is an invalid-hint
+/// condition rather than a regular panic. We print the same diagnostic message
+/// to stderr (FD 2) that `panic!` would have, then halt with exit code 3 so a
+/// malicious prover cannot forge a regular panic (exit code 1) by withholding
+/// hint data.
+#[track_caller]
+#[cold]
+#[inline(never)]
+fn empty_input_stream_halt() -> ! {
+    let msg = std::format!(
+        "Tried to read from the input stream, but it was empty @ {}\n\
+         Was the correct data written into SP1Stdin?\n\
+         Halting with exit code 3 (invalid prover hint).\n",
+        std::panic::Location::caller()
+    );
+    unsafe {
+        syscall_write(2, msg.as_ptr(), msg.len());
+    }
+    halt_invalid_hint()
 }
 
 /// Read a deserializable object from the input stream.
@@ -72,11 +89,7 @@ pub fn read<T: DeserializeOwned>() -> T {
     let ReadVecResult { ptr, len, capacity } = unsafe { read_vec_raw() };
 
     if ptr.is_null() {
-        panic!(
-            "Tried to read from the input stream, but it was empty @ {} \n
-            Was the correct data written into SP1Stdin?",
-            std::panic::Location::caller()
-        )
+        empty_input_stream_halt();
     }
 
     // 1. `ptr` was allocated using alloc
@@ -84,7 +97,12 @@ pub fn read<T: DeserializeOwned>() -> T {
     // 3. Size and length are correct from above. Length is <= capacity.
     let vec = unsafe { Vec::from_raw_parts(ptr, len, capacity) };
 
-    bincode::deserialize(&vec).expect("deserialization failed")
+    // bincode bytes are also prover-controlled — a corrupt encoding is an
+    // invalid hint, not a regular panic.
+    match bincode::deserialize(&vec) {
+        Ok(v) => v,
+        Err(_) => halt_invalid_hint(),
+    }
 }
 
 /// Commit a serializable object to the public values stream.

--- a/crates/zkvm/lib/src/lib.rs
+++ b/crates/zkvm/lib/src/lib.rs
@@ -21,6 +21,59 @@ pub mod utils;
 #[cfg(feature = "verify")]
 pub mod verify;
 
+/// Halts the zkVM with exit code 3, signalling that a prover-supplied hint
+/// failed verification.
+///
+/// This exists to disambiguate hint-validation failures from regular Rust
+/// panics (which use exit code 1). Patches should call this on any hint check
+/// that would otherwise panic, so a malicious prover cannot forge a "panicked"
+/// proof by feeding wrong hints.
+///
+/// Prefer the [`invalid_hint!`] macro when you have a diagnostic message
+/// to attach.
+#[inline(never)]
+pub fn halt_invalid_hint() -> ! {
+    unsafe { syscall_halt(3) }
+}
+
+/// Internal helper used by [`invalid_hint!`] — write a formatted diagnostic
+/// to stderr (FD 2), then halt with exit code 3.
+///
+/// Kept out-of-line so the macro expansion stays small at every call site.
+#[doc(hidden)]
+#[cold]
+#[inline(never)]
+pub fn __invalid_hint_fmt(args: std::fmt::Arguments<'_>) -> ! {
+    let msg = std::format!("invalid prover hint: {}\n", args);
+    unsafe {
+        syscall_write(2, msg.as_ptr(), msg.len());
+    }
+    halt_invalid_hint()
+}
+
+/// Halts the zkVM with exit code 3 (invalid prover hint), optionally writing
+/// a formatted diagnostic to stderr first.
+///
+/// Format-arg syntax matches [`panic!`], but exit code 3 disambiguates
+/// hint-validation failures from regular panics (exit code 1) — a malicious
+/// prover cannot forge a panicked-program proof by feeding wrong hints.
+/// Patches should reach for this on any hint check that would otherwise panic.
+///
+/// ```ignore
+/// sp1_lib::invalid_hint!();                                    // no message
+/// sp1_lib::invalid_hint!("Fp inverse hint mismatch");
+/// sp1_lib::invalid_hint!("expected {} bytes, got {}", expected, got);
+/// ```
+#[macro_export]
+macro_rules! invalid_hint {
+    () => {{
+        $crate::halt_invalid_hint()
+    }};
+    ($($arg:tt)*) => {{
+        $crate::__invalid_hint_fmt(::core::format_args!($($arg)*))
+    }};
+}
+
 extern "C" {
     /// Halts the program with the given exit code.
     pub fn syscall_halt(exit_code: u8) -> !;

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -979,7 +979,7 @@ dependencies = [
 [[package]]
 name = "bls12_381"
 version = "0.8.0"
-source = "git+https://github.com/sp1-patches/bls12_381?tag=patch-0.8.0-sp1-6.0.0#49db1a4c27a44ef7c18e2ef448a12128972e449d"
+source = "git+https://github.com/sp1-patches/bls12_381?tag=patch-0.8.0-sp1-6.2.0#9e4e2ae4780d3d69cecbec000f5e814df2392468"
 dependencies = [
  "cfg-if",
  "ff 0.13.1",
@@ -1496,7 +1496,7 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek-ng"
 version = "4.1.1"
-source = "git+https://github.com/sp1-patches/curve25519-dalek-ng?tag=patch-4.1.1-sp1-6.0.0#5854f8bab8842ff6232469b0d93ae4160e4a503d"
+source = "git+https://github.com/sp1-patches/curve25519-dalek-ng?tag=patch-4.1.1-sp1-6.2.0#3c58f6af72122ec3cb6c15731c958c541a910050"
 dependencies = [
  "byteorder",
  "cfg-if",
@@ -2990,6 +2990,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "invalid-hint-program"
+version = "1.1.0"
+dependencies = [
+ "sp1-lib 6.2.0",
+ "sp1-zkvm",
+]
+
+[[package]]
+name = "invalid-hint-script"
+version = "1.1.0"
+dependencies = [
+ "sp1-build",
+ "sp1-core-executor",
+ "sp1-sdk",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "io-program"
 version = "1.1.0"
 dependencies = [
@@ -3148,7 +3167,7 @@ dependencies = [
 [[package]]
 name = "k256"
 version = "0.13.4"
-source = "git+https://github.com/sp1-patches/elliptic-curves?tag=patch-k256-13.4-sp1-6.0.0#0efe186cee5930a0d23501651c226bd81fcc2c15"
+source = "git+https://github.com/sp1-patches/elliptic-curves?tag=patch-k256-13.4-sp1-6.2.0#41374de1febd88e67faa695a5641ae46460a8cb6"
 dependencies = [
  "cfg-if",
  "ecdsa 0.16.9 (git+https://github.com/sp1-patches/signatures?tag=sp1-skip-verify-on-recovery)",
@@ -5513,7 +5532,7 @@ dependencies = [
 [[package]]
 name = "rsa"
 version = "0.9.6"
-source = "git+https://github.com/sp1-patches/RustCrypto-RSA?tag=patch-0.9.6-sp1-6.0.0#c38b89263da6133df656fd6916e7dd3b73a644c0"
+source = "git+https://github.com/sp1-patches/RustCrypto-RSA?tag=patch-0.9.6-sp1-6.2.0#28de3ed21f92399f78657f24915ba3ba36a95b3c"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -5913,7 +5932,7 @@ dependencies = [
 [[package]]
 name = "secp256k1"
 version = "0.29.1"
-source = "git+https://github.com/sp1-patches/rust-secp256k1?tag=patch-0.29.1-sp1-6.0.0#5daf12595f56cb549d1516d8139cb7935d79de7a"
+source = "git+https://github.com/sp1-patches/rust-secp256k1?tag=patch-0.29.1-sp1-6.2.0#db290c832939297c98910f7007eadbfea03b13aa"
 dependencies = [
  "cfg-if",
  "k256",
@@ -5949,7 +5968,7 @@ dependencies = [
 [[package]]
 name = "secp256k1-sys"
 version = "0.10.0"
-source = "git+https://github.com/sp1-patches/rust-secp256k1?tag=patch-0.29.1-sp1-6.0.0#5daf12595f56cb549d1516d8139cb7935d79de7a"
+source = "git+https://github.com/sp1-patches/rust-secp256k1?tag=patch-0.29.1-sp1-6.2.0#db290c832939297c98910f7007eadbfea03b13aa"
 dependencies = [
  "cc",
 ]
@@ -6192,7 +6211,7 @@ checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 [[package]]
 name = "sha2"
 version = "0.9.9"
-source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha2-0.9.9-sp1-6.0.0#1b29839dc1a48c4c9f744775969256830d1a9a45"
+source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha2-0.9.9-sp1-6.2.0#1b29839dc1a48c4c9f744775969256830d1a9a45"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
@@ -6204,7 +6223,7 @@ dependencies = [
 [[package]]
 name = "sha2"
 version = "0.10.8"
-source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha2-0.10.8-sp1-6.0.0#75b15faa7ce44d25435d0a3209285455540f0b7f"
+source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha2-0.10.8-sp1-6.2.0#75b15faa7ce44d25435d0a3209285455540f0b7f"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -7501,7 +7520,7 @@ dependencies = [
 [[package]]
 name = "substrate-bn-succinct-rs"
 version = "0.6.0"
-source = "git+https://github.com/sp1-patches/bn?tag=patch-0.6.0-sp1-6.0.0#f0a0eeb8784cf5611efe4f1ad2b20ce5eec14395"
+source = "git+https://github.com/sp1-patches/bn?tag=patch-0.6.0-sp1-6.2.0#af2ee646c36ad80a44a15b91db0a2b648b517b44"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -7848,7 +7867,7 @@ dependencies = [
 [[package]]
 name = "tiny-keccak"
 version = "2.0.2"
-source = "git+https://github.com/sp1-patches/tiny-keccak?tag=patch-2.0.2-sp1-6.0.0#957430a459f7a2332ab5bab4a12f9b473bb95c87"
+source = "git+https://github.com/sp1-patches/tiny-keccak?tag=patch-2.0.2-sp1-6.2.0#c3f95bcc35b391101d0cf0abe91ea4c8423868b0"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -9088,9 +9107,9 @@ checksum = "2fc5a66a20078bf1251bde995aa2fdcc4b800c70b5d92dd2c62abc5c60f679f8"
 [[patch.unused]]
 name = "curve25519-dalek"
 version = "4.1.3"
-source = "git+https://github.com/sp1-patches/curve25519-dalek?tag=patch-4.1.3-sp1-6.0.0#ade3f90a82efc7c58c4ae1ecb4d48bbe673c2a8f"
+source = "git+https://github.com/sp1-patches/curve25519-dalek?tag=patch-4.1.3-sp1-6.2.0#b251b2a155f859d00375f73bc2c937f025f7b4b4"
 
 [[patch.unused]]
 name = "sha2"
 version = "0.10.6"
-source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha2-0.10.6-sp1-6.0.0#9ed1af71d5ada0de44ee07a20fd1a8a3742a620e"
+source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha2-0.10.6-sp1-6.2.0#9ed1af71d5ada0de44ee07a20fd1a8a3742a620e"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -66,6 +66,8 @@ members = [
   "many-traps/script",
   "sigreturn/program",
   "sigreturn/script",
+  "invalid-hint/program",
+  "invalid-hint/script",
 ]
 resolver = "2"
 
@@ -89,18 +91,18 @@ serde_json = "1.0.132"
 tracing = "0.1.40"
 
 [patch.crates-io]
-curve25519-dalek = { git = "https://github.com/sp1-patches/curve25519-dalek", tag = "patch-4.1.3-sp1-6.0.0" }
-curve25519-dalek-ng = { git = "https://github.com/sp1-patches/curve25519-dalek-ng", tag = "patch-4.1.1-sp1-6.0.0" }
-# ecdsa-core = { git = "https://github.com/sp1-patches/signatures", package = "ecdsa", tag = "patch-0.16.9-sp1-6.0.0" }
-secp256k1 = { git = "https://github.com/sp1-patches/rust-secp256k1", tag = "patch-0.29.1-sp1-6.0.0" }
-sha2-v0-10-8 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.10.8-sp1-6.0.0" }
-sha2-v0-10-6 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.10.6-sp1-6.0.0" }
-sha2-v0-9-9 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.9.9-sp1-6.0.0" }
-tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", tag = "patch-2.0.2-sp1-6.0.0" }
-substrate-bn = { git = "https://github.com/sp1-patches/bn", tag = "patch-0.6.0-sp1-6.0.0", package = "substrate-bn-succinct-rs" }
-bls12_381 = { git = "https://github.com/sp1-patches/bls12_381", tag = "patch-0.8.0-sp1-6.0.0" }
-rsa = { git = "https://github.com/sp1-patches/RustCrypto-RSA", tag = "patch-0.9.6-sp1-6.0.0" }
-k256 = { git = "https://github.com/sp1-patches/elliptic-curves", tag = "patch-k256-13.4-sp1-6.0.0" }
+curve25519-dalek = { git = "https://github.com/sp1-patches/curve25519-dalek", tag = "patch-4.1.3-sp1-6.2.0" }
+curve25519-dalek-ng = { git = "https://github.com/sp1-patches/curve25519-dalek-ng", tag = "patch-4.1.1-sp1-6.2.0" }
+# ecdsa-core = { git = "https://github.com/sp1-patches/signatures", package = "ecdsa", tag = "patch-0.16.9-sp1-6.2.0" }
+secp256k1 = { git = "https://github.com/sp1-patches/rust-secp256k1", tag = "patch-0.29.1-sp1-6.2.0" }
+sha2-v0-10-8 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.10.8-sp1-6.2.0" }
+sha2-v0-10-6 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.10.6-sp1-6.2.0" }
+sha2-v0-9-9 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.9.9-sp1-6.2.0" }
+tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", tag = "patch-2.0.2-sp1-6.2.0" }
+substrate-bn = { git = "https://github.com/sp1-patches/bn", tag = "patch-0.6.0-sp1-6.2.0", package = "substrate-bn-succinct-rs" }
+bls12_381 = { git = "https://github.com/sp1-patches/bls12_381", tag = "patch-0.8.0-sp1-6.2.0" }
+rsa = { git = "https://github.com/sp1-patches/RustCrypto-RSA", tag = "patch-0.9.6-sp1-6.2.0" }
+k256 = { git = "https://github.com/sp1-patches/elliptic-curves", tag = "patch-k256-13.4-sp1-6.2.0" }
 
 # todo!(n) remove
 sp1-lib = { path = "../crates/zkvm/lib" }

--- a/examples/invalid-hint/program/Cargo.toml
+++ b/examples/invalid-hint/program/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "invalid-hint-program"
+version = "1.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+sp1-zkvm = { workspace = true }
+sp1-lib = { path = "../../../crates/zkvm/lib" }

--- a/examples/invalid-hint/program/src/main.rs
+++ b/examples/invalid-hint/program/src/main.rs
@@ -1,0 +1,29 @@
+//! Demonstrates `sp1_lib::invalid_hint!` and exit code 3.
+//!
+//! Reads one byte from stdin: when it's non-zero, the program calls
+//! `invalid_hint!`, writes a diagnostic to stderr, and halts with exit
+//! code 3 (`StatusCode::INVALID_HINT`). When it's zero, the program
+//! terminates normally.
+//!
+//! Patched crypto crates use the same primitive on hint-validation
+//! failures so a malicious prover cannot forge a regular `panic!`
+//! (exit code 1) by feeding wrong hint data.
+
+#![no_main]
+sp1_zkvm::entrypoint!(main);
+
+fn main() {
+    let trigger = sp1_lib::io::read::<u8>();
+
+    if trigger != 0 {
+        // Format args work just like `panic!` — the message gets written
+        // to FD 2 (stderr) before the program halts.
+        sp1_lib::invalid_hint!(
+            "hint check failed: trigger byte was {} (non-zero)",
+            trigger
+        );
+    }
+
+    // Happy path: commit the trigger value back to the host.
+    sp1_lib::io::commit::<u8>(&trigger);
+}

--- a/examples/invalid-hint/script/Cargo.toml
+++ b/examples/invalid-hint/script/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "invalid-hint-script"
+version = { workspace = true }
+edition = { workspace = true }
+default-run = "invalid-hint-script"
+publish = false
+
+[dependencies]
+sp1-sdk = { workspace = true }
+sp1-core-executor = { workspace = true }
+tokio = { workspace = true }
+tracing = "0.1"
+
+[build-dependencies]
+sp1-build = { workspace = true }

--- a/examples/invalid-hint/script/build.rs
+++ b/examples/invalid-hint/script/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    sp1_build::build_program("../program");
+}

--- a/examples/invalid-hint/script/src/main.rs
+++ b/examples/invalid-hint/script/src/main.rs
@@ -1,0 +1,49 @@
+//! Demonstrates SP1's exit code 3 (`StatusCode::INVALID_HINT`) for
+//! prover-hint failures.
+//!
+//! Runs the same guest program twice through the executor:
+//!   1. trigger=0 → program runs normally and exits 0.
+//!   2. trigger=1 → program calls `sp1_lib::invalid_hint!`, writes a
+//!      diagnostic to stderr, and halts with exit code 3.
+//!
+//! This is the primitive the patched crypto crates use when a hint
+//! fails verification — exit 3 distinguishes a malicious prover's
+//! "wrong hint" from a regular Rust panic (exit 1).
+
+use sp1_core_executor::StatusCode;
+use sp1_sdk::prelude::*;
+use sp1_sdk::ProverClient;
+
+const ELF: Elf = include_elf!("invalid-hint-program");
+
+#[tokio::main]
+async fn main() {
+    sp1_sdk::utils::setup_logger();
+
+    let client = ProverClient::from_env().await;
+
+    // Case 1: happy path. trigger=0 → program commits & exits 0.
+    let mut stdin = SP1Stdin::new();
+    stdin.write(&0u8);
+    let (pv, report) = client.execute(ELF, stdin).await.expect("execute failed");
+    println!("[trigger=0] exit_code = {}", report.exit_code);
+    assert_eq!(report.exit_code, 0);
+    assert_eq!(StatusCode::new(report.exit_code as u32), Some(StatusCode::SUCCESS));
+    let _ = pv;
+
+    // Case 2: invalid-hint path. trigger=1 → invalid_hint! → exit 3.
+    let mut stdin = SP1Stdin::new();
+    stdin.write(&1u8);
+    let (_pv, report) = client.execute(ELF, stdin).await.expect("execute failed");
+    println!("[trigger=1] exit_code = {}", report.exit_code);
+    assert_eq!(report.exit_code, 3);
+    assert_eq!(
+        StatusCode::new(report.exit_code as u32),
+        Some(StatusCode::INVALID_HINT)
+    );
+
+    println!(
+        "OK: invalid_hint! halts with exit code 3 (StatusCode::INVALID_HINT), \
+         distinct from a regular panic (exit code 1)."
+    );
+}

--- a/patch-testing/Cargo.lock
+++ b/patch-testing/Cargo.lock
@@ -458,7 +458,7 @@ dependencies = [
 [[package]]
 name = "bls12_381"
 version = "0.8.0"
-source = "git+https://github.com/sp1-patches/bls12_381?tag=patch-0.8.0-sp1-6.0.0#c6a3a331f8bee02913cc2c4eae2805360f888aaa"
+source = "git+https://github.com/sp1-patches/bls12_381?tag=patch-0.8.0-sp1-6.2.0#9e4e2ae4780d3d69cecbec000f5e814df2392468"
 dependencies = [
  "cfg-if",
  "ff 0.13.1",
@@ -479,6 +479,7 @@ dependencies = [
  "rand 0.8.5",
  "sp1-build",
  "sp1-core-executor",
+ "sp1-lib",
  "sp1-sdk",
  "sp1-test",
  "sp1-zkvm",
@@ -497,7 +498,7 @@ dependencies = [
  "sp1-test",
  "sp1-zkvm",
  "substrate-bn",
- "substrate-bn-succinct-rs 0.6.0 (git+https://github.com/sp1-patches/bn?tag=patch-0.6.0-sp1-6.0.0)",
+ "substrate-bn-succinct-rs 0.6.0 (git+https://github.com/sp1-patches/bn?tag=patch-0.6.0-sp1-6.2.0)",
  "tokio",
 ]
 
@@ -506,20 +507,20 @@ name = "build-host"
 version = "1.1.0"
 dependencies = [
  "bls12_381 0.8.0",
- "crypto-bigint 0.5.5 (git+https://github.com/sp1-patches/RustCrypto-bigint?tag=patch-0.5.5-sp1-6.0.0)",
- "curve25519-dalek 4.1.3 (git+https://github.com/sp1-patches/curve25519-dalek?tag=patch-4.1.3-sp1-6.0.0)",
- "curve25519-dalek-ng 4.1.1 (git+https://github.com/sp1-patches/curve25519-dalek-ng?tag=patch-4.1.1-sp1-6.0.0)",
+ "crypto-bigint 0.5.5 (git+https://github.com/sp1-patches/RustCrypto-bigint?tag=patch-0.5.5-sp1-6.2.0)",
+ "curve25519-dalek 4.1.3 (git+https://github.com/sp1-patches/curve25519-dalek?tag=patch-4.1.3-sp1-6.2.0)",
+ "curve25519-dalek-ng 4.1.1 (git+https://github.com/sp1-patches/curve25519-dalek-ng?tag=patch-4.1.1-sp1-6.2.0)",
  "rsa 0.9.6",
  "secp256k1",
  "sha2 0.10.6",
  "sha2 0.10.8",
- "sha2 0.10.9 (git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha2-0.10.9-sp1-6.0.0)",
- "sha2 0.9.9 (git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha2-0.9.9-sp1-6.0.0)",
+ "sha2 0.10.9 (git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha2-0.10.9-sp1-6.2.0)",
+ "sha2 0.9.9 (git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha2-0.9.9-sp1-6.2.0)",
  "sha3 0.10.8",
  "sp1-lib",
  "sp1-zkvm",
- "substrate-bn-succinct-rs 0.6.0 (git+https://github.com/sp1-patches/bn?tag=patch-0.6.0-sp1-6.0.0)",
- "tiny-keccak 2.0.2 (git+https://github.com/sp1-patches/tiny-keccak?tag=patch-2.0.2-sp1-6.0.0)",
+ "substrate-bn-succinct-rs 0.6.0 (git+https://github.com/sp1-patches/bn?tag=patch-0.6.0-sp1-6.2.0)",
+ "tiny-keccak 2.0.2 (git+https://github.com/sp1-patches/tiny-keccak?tag=patch-2.0.2-sp1-6.2.0)",
 ]
 
 [[package]]
@@ -954,7 +955,7 @@ dependencies = [
 [[package]]
 name = "crypto-bigint"
 version = "0.5.5"
-source = "git+https://github.com/sp1-patches/RustCrypto-bigint?tag=patch-0.5.5-sp1-6.0.0#ef85da866879b5929b1da071ebe92c082b0554b9"
+source = "git+https://github.com/sp1-patches/RustCrypto-bigint?tag=patch-0.5.5-sp1-6.2.0#ef85da866879b5929b1da071ebe92c082b0554b9"
 dependencies = [
  "rand_core 0.6.4",
  "subtle",
@@ -1006,11 +1007,11 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
-source = "git+https://github.com/sp1-patches/curve25519-dalek?tag=patch-4.1.3-sp1-6.0.0#ade3f90a82efc7c58c4ae1ecb4d48bbe673c2a8f"
+source = "git+https://github.com/sp1-patches/curve25519-dalek?tag=patch-4.1.3-sp1-6.2.0#b251b2a155f859d00375f73bc2c937f025f7b4b4"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "curve25519-dalek-derive 0.1.1 (git+https://github.com/sp1-patches/curve25519-dalek?tag=patch-4.1.3-sp1-6.0.0)",
+ "curve25519-dalek-derive 0.1.1 (git+https://github.com/sp1-patches/curve25519-dalek?tag=patch-4.1.3-sp1-6.2.0)",
  "fiat-crypto",
  "rustc_version",
  "sp1-lib",
@@ -1032,7 +1033,7 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek-derive"
 version = "0.1.1"
-source = "git+https://github.com/sp1-patches/curve25519-dalek?tag=patch-4.1.3-sp1-6.0.0#ade3f90a82efc7c58c4ae1ecb4d48bbe673c2a8f"
+source = "git+https://github.com/sp1-patches/curve25519-dalek?tag=patch-4.1.3-sp1-6.2.0#b251b2a155f859d00375f73bc2c937f025f7b4b4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1070,7 +1071,7 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek-ng"
 version = "4.1.1"
-source = "git+https://github.com/sp1-patches/curve25519-dalek-ng?tag=patch-4.1.1-sp1-6.0.0#5854f8bab8842ff6232469b0d93ae4160e4a503d"
+source = "git+https://github.com/sp1-patches/curve25519-dalek-ng?tag=patch-4.1.1-sp1-6.2.0#3c58f6af72122ec3cb6c15731c958c541a910050"
 dependencies = [
  "byteorder",
  "cfg-if",
@@ -2270,6 +2271,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "invalid-hint-test"
+version = "1.1.0"
+dependencies = [
+ "color-eyre",
+ "sp1-build",
+ "sp1-core-executor",
+ "sp1-lib",
+ "sp1-sdk",
+ "sp1-test",
+ "sp1-zkvm",
+ "tokio",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2368,7 +2383,7 @@ dependencies = [
 [[package]]
 name = "k256"
 version = "0.13.4"
-source = "git+https://github.com/sp1-patches/elliptic-curves?tag=patch-k256-13.4-sp1-6.0.0#476243d31d3ffd9d882d0e5da1f6adaa2a204b62"
+source = "git+https://github.com/sp1-patches/elliptic-curves?tag=patch-k256-13.4-sp1-6.2.0#41374de1febd88e67faa695a5641ae46460a8cb6"
 dependencies = [
  "cfg-if",
  "ecdsa 0.16.9 (git+https://github.com/sp1-patches/signatures?tag=sp1-skip-verify-on-recovery)",
@@ -3894,7 +3909,7 @@ dependencies = [
 [[package]]
 name = "rsa"
 version = "0.9.6"
-source = "git+https://github.com/sp1-patches/RustCrypto-RSA/?tag=patch-0.9.6-sp1-6.0.0#c38b89263da6133df656fd6916e7dd3b73a644c0"
+source = "git+https://github.com/sp1-patches/RustCrypto-RSA/?tag=patch-0.9.6-sp1-6.2.0#28de3ed21f92399f78657f24915ba3ba36a95b3c"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -4144,10 +4159,10 @@ dependencies = [
 [[package]]
 name = "secp256k1"
 version = "0.29.1"
-source = "git+https://github.com/sp1-patches/rust-secp256k1?tag=patch-0.29.1-sp1-6.0.0#5daf12595f56cb549d1516d8139cb7935d79de7a"
+source = "git+https://github.com/sp1-patches/rust-secp256k1?tag=patch-0.29.1-sp1-6.2.0#db290c832939297c98910f7007eadbfea03b13aa"
 dependencies = [
  "cfg-if",
- "k256 0.13.4 (git+https://github.com/sp1-patches/elliptic-curves?tag=patch-k256-13.4-sp1-6.0.0)",
+ "k256 0.13.4 (git+https://github.com/sp1-patches/elliptic-curves?tag=patch-k256-13.4-sp1-6.2.0)",
  "rand 0.8.5",
  "secp256k1-sys",
  "serde",
@@ -4170,7 +4185,7 @@ dependencies = [
 [[package]]
 name = "secp256k1-sys"
 version = "0.10.0"
-source = "git+https://github.com/sp1-patches/rust-secp256k1?tag=patch-0.29.1-sp1-6.0.0#5daf12595f56cb549d1516d8139cb7935d79de7a"
+source = "git+https://github.com/sp1-patches/rust-secp256k1?tag=patch-0.29.1-sp1-6.2.0#db290c832939297c98910f7007eadbfea03b13aa"
 dependencies = [
  "cc",
 ]
@@ -4346,7 +4361,7 @@ dependencies = [
 [[package]]
 name = "sha2"
 version = "0.9.9"
-source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha2-0.9.9-sp1-6.0.0#1b29839dc1a48c4c9f744775969256830d1a9a45"
+source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha2-0.9.9-sp1-6.2.0#1b29839dc1a48c4c9f744775969256830d1a9a45"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
@@ -4358,7 +4373,7 @@ dependencies = [
 [[package]]
 name = "sha2"
 version = "0.10.6"
-source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha2-0.10.6-sp1-6.0.0#9ed1af71d5ada0de44ee07a20fd1a8a3742a620e"
+source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha2-0.10.6-sp1-6.2.0#9ed1af71d5ada0de44ee07a20fd1a8a3742a620e"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -4368,7 +4383,7 @@ dependencies = [
 [[package]]
 name = "sha2"
 version = "0.10.8"
-source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha2-0.10.8-sp1-6.0.0#75b15faa7ce44d25435d0a3209285455540f0b7f"
+source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha2-0.10.8-sp1-6.2.0#75b15faa7ce44d25435d0a3209285455540f0b7f"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -4389,7 +4404,7 @@ dependencies = [
 [[package]]
 name = "sha2"
 version = "0.10.9"
-source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha2-0.10.9-sp1-6.0.0#e48b656ebc806117554bb33c2f8687e4637e37ff"
+source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha2-0.10.9-sp1-6.2.0#e48b656ebc806117554bb33c2f8687e4637e37ff"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -4409,7 +4424,7 @@ dependencies = [
 [[package]]
 name = "sha3"
 version = "0.10.8"
-source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha3-0.10.8-sp1-6.0.0#0a16ae7acd5cd5fbb432d884bd4aae2764a18cf7"
+source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha3-0.10.8-sp1-6.2.0#0a16ae7acd5cd5fbb432d884bd4aae2764a18cf7"
 dependencies = [
  "digest 0.10.7",
  "keccak",
@@ -5591,7 +5606,7 @@ dependencies = [
 [[package]]
 name = "substrate-bn-succinct-rs"
 version = "0.6.0"
-source = "git+https://github.com/sp1-patches/bn?tag=patch-0.6.0-sp1-6.0.0#717dbe5e2270940faa46b646c6b2d639c82fb949"
+source = "git+https://github.com/sp1-patches/bn?tag=patch-0.6.0-sp1-6.2.0#af2ee646c36ad80a44a15b91db0a2b648b517b44"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -5824,7 +5839,7 @@ dependencies = [
 [[package]]
 name = "tiny-keccak"
 version = "2.0.2"
-source = "git+https://github.com/sp1-patches/tiny-keccak?tag=patch-2.0.2-sp1-6.0.0#957430a459f7a2332ab5bab4a12f9b473bb95c87"
+source = "git+https://github.com/sp1-patches/tiny-keccak?tag=patch-2.0.2-sp1-6.2.0#c3f95bcc35b391101d0cf0abe91ea4c8423868b0"
 dependencies = [
  "cfg-if",
  "crunchy",

--- a/patch-testing/Cargo.toml
+++ b/patch-testing/Cargo.toml
@@ -14,6 +14,7 @@ members = [
   "bls12-381",
   "bn",
   "build-host",
+  "invalid-hint",
 ]
 
 exclude = [
@@ -29,6 +30,7 @@ exclude = [
   "RustCrypto-bigint/program",
   "bls12-381/program",
   "bn/program",
+  "invalid-hint/program",
 ]
 
 resolver = "2"
@@ -79,7 +81,7 @@ p256 = { version = "0.13.2", default-features = false, features = [
   "serde",
 ] }
 alloy-primitives = { version = "1.0", features = ["k256"] }
-secp256k1 = { git = "https://github.com/sp1-patches/rust-secp256k1", tag = "patch-0.29.1-sp1-6.0.0", features = [
+secp256k1 = { git = "https://github.com/sp1-patches/rust-secp256k1", tag = "patch-0.29.1-sp1-6.2.0", features = [
   "recovery",
   "global-context",
   "rand",
@@ -96,23 +98,23 @@ sp1-test = { path = "./sp1-test/" }
 
 # Import all the patches so we can test compiling them to the host
 # Note: secp256k1 is listed above because we cant have two copies linking the same library.
-sha2-v0-9-9-patched = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.9.9-sp1-6.0.0" }
-sha2-v0-10-6-patched = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.10.6-sp1-6.0.0" }
-sha2-v0-10-8-patched = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.10.8-sp1-6.0.0" }
-sha2-v0-10-9-patched = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.10.9-sp1-6.0.0" }
-sha3-v0-10-8-patched = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha3", tag = "patch-sha3-0.10.8-sp1-6.0.0" }
-crypto-bigint-patched = { git = "https://github.com/sp1-patches/RustCrypto-bigint", tag = "patch-0.5.5-sp1-6.0.0", package = "crypto-bigint" }
-tiny-keccak-patched = { git = "https://github.com/sp1-patches/tiny-keccak", tag = "patch-2.0.2-sp1-6.0.0", package = "tiny-keccak", features = [
+sha2-v0-9-9-patched = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.9.9-sp1-6.2.0" }
+sha2-v0-10-6-patched = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.10.6-sp1-6.2.0" }
+sha2-v0-10-8-patched = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.10.8-sp1-6.2.0" }
+sha2-v0-10-9-patched = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.10.9-sp1-6.2.0" }
+sha3-v0-10-8-patched = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha3", tag = "patch-sha3-0.10.8-sp1-6.2.0" }
+crypto-bigint-patched = { git = "https://github.com/sp1-patches/RustCrypto-bigint", tag = "patch-0.5.5-sp1-6.2.0", package = "crypto-bigint" }
+tiny-keccak-patched = { git = "https://github.com/sp1-patches/tiny-keccak", tag = "patch-2.0.2-sp1-6.2.0", package = "tiny-keccak", features = [
   "keccak",
 ] }
-curve25519-dalek-patched = { git = "https://github.com/sp1-patches/curve25519-dalek", tag = "patch-4.1.3-sp1-6.0.0", package = "curve25519-dalek" }
-curve25519-dalek-ng-patched = { git = "https://github.com/sp1-patches/curve25519-dalek-ng", tag = "patch-4.1.1-sp1-6.0.0", package = "curve25519-dalek-ng" }
-secp256k1-patched = { git = "https://github.com/sp1-patches/rust-secp256k1", tag = "patch-0.29.1-sp1-6.0.0", package = "secp256k1" }
-substrate-bn-patched = { git = "https://github.com/sp1-patches/bn", tag = "patch-0.6.0-sp1-6.0.0", package = "substrate-bn-succinct-rs" }
-bls12_381-patched = { git = "https://github.com/sp1-patches/bls12_381", tag = "patch-0.8.0-sp1-6.0.0", features = [
+curve25519-dalek-patched = { git = "https://github.com/sp1-patches/curve25519-dalek", tag = "patch-4.1.3-sp1-6.2.0", package = "curve25519-dalek" }
+curve25519-dalek-ng-patched = { git = "https://github.com/sp1-patches/curve25519-dalek-ng", tag = "patch-4.1.1-sp1-6.2.0", package = "curve25519-dalek-ng" }
+secp256k1-patched = { git = "https://github.com/sp1-patches/rust-secp256k1", tag = "patch-0.29.1-sp1-6.2.0", package = "secp256k1" }
+substrate-bn-patched = { git = "https://github.com/sp1-patches/bn", tag = "patch-0.6.0-sp1-6.2.0", package = "substrate-bn-succinct-rs" }
+bls12_381-patched = { git = "https://github.com/sp1-patches/bls12_381", tag = "patch-0.8.0-sp1-6.2.0", features = [
   "groups",
 ], package = "bls12_381" }
-rsa-patched = { git = "https://github.com/sp1-patches/RustCrypto-RSA/", tag = "patch-0.9.6-sp1-6.0.0", package = "rsa" }
+rsa-patched = { git = "https://github.com/sp1-patches/RustCrypto-RSA/", tag = "patch-0.9.6-sp1-6.2.0", package = "rsa" }
 crypto-bigint = "0.5.5"
 group = "0.13.0"
 lazy_static = "1.5.0"

--- a/patch-testing/RustCrypto-rsa/program/Cargo.toml
+++ b/patch-testing/RustCrypto-rsa/program/Cargo.toml
@@ -14,5 +14,5 @@ num-bigint = "0.4.0"
 rsa = { version = "=0.9.6", features = ["serde", "sha2"] }
 
 [patch.crates-io]
-rsa = { git = "https://github.com/sp1-patches/RustCrypto-RSA/", tag = "patch-0.9.6-sp1-6.0.0" }
+rsa = { git = "https://github.com/sp1-patches/RustCrypto-RSA/", tag = "patch-0.9.6-sp1-6.2.0" }
 sp1-lib = { path = "../../../crates/zkvm/lib" }

--- a/patch-testing/bls12-381/program/Cargo.toml
+++ b/patch-testing/bls12-381/program/Cargo.toml
@@ -33,7 +33,7 @@ path = "bin/test_bls_double.rs"
 [dependencies]
 sp1-lib = { path = "../../../crates/zkvm/lib" }
 sp1-zkvm = { path = "../../../crates/zkvm/entrypoint" }
-bls12_381 = { git = "https://github.com/sp1-patches/bls12_381", tag = "patch-0.8.0-sp1-6.0.0", features = [
+bls12_381 = { git = "https://github.com/sp1-patches/bls12_381", tag = "patch-0.8.0-sp1-6.2.0", features = [
     "groups",
 ] }
 

--- a/patch-testing/bls12-381/src/lib.rs
+++ b/patch-testing/bls12-381/src/lib.rs
@@ -182,3 +182,4 @@ pub fn test_bls_double_100(stdin: &mut sp1_sdk::SP1Stdin) -> impl FnOnce(sp1_sdk
         }
     }
 }
+

--- a/patch-testing/bn/program/Cargo.toml
+++ b/patch-testing/bn/program/Cargo.toml
@@ -43,7 +43,7 @@ path = "bin/test_fq_partial_ord.rs"
 [dependencies]
 sp1-zkvm = { path = "../../../crates/zkvm/entrypoint" }
 sp1-lib = { path = "../../../crates/zkvm/lib" }
-substrate-bn = { git = "https://github.com/sp1-patches/bn", tag = "patch-0.6.0-sp1-6.0.0", package = "substrate-bn-succinct-rs" }
+substrate-bn = { git = "https://github.com/sp1-patches/bn", tag = "patch-0.6.0-sp1-6.2.0", package = "substrate-bn-succinct-rs" }
 
 [patch.crates-io]
 sp1-lib = { path = "../../../crates/zkvm/lib" }

--- a/patch-testing/curve25519-dalek-ng/program/Cargo.toml
+++ b/patch-testing/curve25519-dalek-ng/program/Cargo.toml
@@ -29,6 +29,6 @@ curve25519-dalek-ng = { version = "4.1.1", default-features = false, features = 
 
 [patch.crates-io]
 # patches are not transitvely applied to patches lmao
-curve25519-dalek-ng = { package = "curve25519-dalek-ng", git = "https://github.com/sp1-patches/curve25519-dalek-ng.git", tag = "patch-4.1.1-sp1-6.0.0" }
+curve25519-dalek-ng = { package = "curve25519-dalek-ng", git = "https://github.com/sp1-patches/curve25519-dalek-ng.git", tag = "patch-4.1.1-sp1-6.2.0" }
 # Temporarily pinning to a specific version of ed25519-dalek to avoid a build failure
 sp1-lib = { path = "../../../crates/zkvm/lib" }

--- a/patch-testing/curve25519-dalek/program/Cargo.toml
+++ b/patch-testing/curve25519-dalek/program/Cargo.toml
@@ -33,6 +33,6 @@ curve25519-dalek = { version = "4.1.3", default-features = false, features = [
 ] }
 
 [patch.crates-io]
-curve25519-dalek = { git = "https://github.com/sp1-patches/curve25519-dalek", tag = "patch-4.1.3-sp1-6.0.0" }
+curve25519-dalek = { git = "https://github.com/sp1-patches/curve25519-dalek", tag = "patch-4.1.3-sp1-6.2.0" }
 # Temporarily pinning to a specific version of ed25519-dalek to avoid a build failure
 sp1-lib = { path = "../../../crates/zkvm/lib" }

--- a/patch-testing/invalid-hint/Cargo.toml
+++ b/patch-testing/invalid-hint/Cargo.toml
@@ -1,28 +1,24 @@
 [package]
-name = "bls12_381_tests"
+name = "invalid-hint-test"
 version.workspace = true
 edition.workspace = true
 publish.workspace = true
+
+[lib]
+path = "src/lib.rs"
 
 [dependencies]
 sp1-zkvm = { workspace = true }
 sp1-sdk = { workspace = true, default-features = true }
 sp1-core-executor = { workspace = true }
 sp1-lib = { workspace = true }
-rand = { workspace = true }
 sp1-test = { workspace = true }
 tokio = { workspace = true }
 color-eyre = { workspace = true }
 
-# note: we use the patched version (which should be mostly equivalent to the original, outside the vm)
-# because we want to test the field ops which are not exposed in the original
-bls12_381-patched = { workspace = true }
-group = { workspace = true }
-
 [features]
 prove = []
 gpu = ["sp1-sdk/cuda"]
-
 
 [build-dependencies]
 sp1-build = { workspace = true }

--- a/patch-testing/invalid-hint/build.rs
+++ b/patch-testing/invalid-hint/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    sp1_build::build_program("./program");
+}

--- a/patch-testing/invalid-hint/program/Cargo.toml
+++ b/patch-testing/invalid-hint/program/Cargo.toml
@@ -1,0 +1,24 @@
+[workspace]
+[package]
+name = "invalid-hint-test-program"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "invalid_hint_macro"
+path = "bin/invalid_hint_macro.rs"
+
+[[bin]]
+name = "invalid_hint_no_message"
+path = "bin/invalid_hint_no_message.rs"
+
+[[bin]]
+name = "invalid_hint_empty_input"
+path = "bin/invalid_hint_empty_input.rs"
+
+[dependencies]
+sp1-zkvm = { path = "../../../crates/zkvm/entrypoint" }
+sp1-lib = { path = "../../../crates/zkvm/lib" }
+
+[patch.crates-io]
+sp1-lib = { path = "../../../crates/zkvm/lib" }

--- a/patch-testing/invalid-hint/program/bin/invalid_hint_empty_input.rs
+++ b/patch-testing/invalid-hint/program/bin/invalid_hint_empty_input.rs
@@ -1,0 +1,12 @@
+//! Calls `read_vec` once. If the prover (test harness) didn't supply any
+//! input, the read finds an empty stream and the patched `read_vec` halts
+//! with exit code 3 (after writing the diagnostic message to stderr).
+
+#![no_main]
+sp1_zkvm::entrypoint!(main);
+
+fn main() {
+    let _ = sp1_lib::io::read_vec();
+    // If we get here, input was supplied.
+    sp1_lib::io::commit::<u8>(&0u8);
+}

--- a/patch-testing/invalid-hint/program/bin/invalid_hint_macro.rs
+++ b/patch-testing/invalid-hint/program/bin/invalid_hint_macro.rs
@@ -1,0 +1,17 @@
+//! Reads a `u8` flag from stdin. If non-zero, calls
+//! `sp1_lib::invalid_hint!("...")` and the program halts with exit code 3
+//! (after printing the message to stderr). Otherwise commits and exits 0.
+
+#![no_main]
+sp1_zkvm::entrypoint!(main);
+
+fn main() {
+    let trigger = sp1_lib::io::read::<u8>();
+    if trigger != 0 {
+        sp1_lib::invalid_hint!(
+            "test halt: trigger byte was {} (non-zero), simulating a wrong-hint exit",
+            trigger
+        );
+    }
+    sp1_lib::io::commit::<u8>(&trigger);
+}

--- a/patch-testing/invalid-hint/program/bin/invalid_hint_no_message.rs
+++ b/patch-testing/invalid-hint/program/bin/invalid_hint_no_message.rs
@@ -1,0 +1,13 @@
+//! Same as `invalid_hint_macro`, but uses the no-message form of the macro
+//! (which delegates to `halt_invalid_hint`).
+
+#![no_main]
+sp1_zkvm::entrypoint!(main);
+
+fn main() {
+    let trigger = sp1_lib::io::read::<u8>();
+    if trigger != 0 {
+        sp1_lib::invalid_hint!();
+    }
+    sp1_lib::io::commit::<u8>(&trigger);
+}

--- a/patch-testing/invalid-hint/src/lib.rs
+++ b/patch-testing/invalid-hint/src/lib.rs
@@ -1,0 +1,93 @@
+//! End-to-end smoke tests for `sp1_lib::invalid_hint!` and exit code 3.
+//!
+//! These verify the wiring works: a guest that fires `invalid_hint!` halts
+//! with `report.exit_code == 3` (`StatusCode::INVALID_HINT`), distinct from
+//! a regular panic (exit code 1).
+//!
+//! Per-patch failure tests that override hint hooks live elsewhere; those
+//! depend on routing executor hook dispatch through the
+//! user-supplied `HookRegistry`, which the current minimal executor does
+//! not yet do. Once that lands, each patched crate can add its own
+//! `invalid_<patch>_hint_halts_with_3` test using `with_hook`.
+
+#[tokio::test]
+async fn invalid_hint_macro_with_message_halts_with_3() {
+    use sp1_sdk::{include_elf, Elf, Prover, SP1Stdin};
+
+    sp1_test::setup().await;
+    const ELF: Elf = include_elf!("invalid_hint_macro");
+
+    let client = sp1_test::sp1_cpu_prover().await;
+    let mut stdin = SP1Stdin::new();
+    stdin.write(&1u8); // trigger the macro
+
+    let (_pv, report) =
+        client.execute(ELF, stdin).await.expect("execution should complete");
+
+    assert_eq!(
+        report.exit_code, 3,
+        "expected exit code 3 from invalid_hint!, got {}",
+        report.exit_code
+    );
+}
+
+#[tokio::test]
+async fn invalid_hint_macro_no_message_halts_with_3() {
+    use sp1_sdk::{include_elf, Elf, Prover, SP1Stdin};
+
+    sp1_test::setup().await;
+    const ELF: Elf = include_elf!("invalid_hint_no_message");
+
+    let client = sp1_test::sp1_cpu_prover().await;
+    let mut stdin = SP1Stdin::new();
+    stdin.write(&1u8);
+
+    let (_pv, report) =
+        client.execute(ELF, stdin).await.expect("execution should complete");
+
+    assert_eq!(
+        report.exit_code, 3,
+        "expected exit code 3 from invalid_hint!() no-arg form, got {}",
+        report.exit_code
+    );
+}
+
+#[tokio::test]
+async fn invalid_hint_macro_passthrough_exits_0() {
+    use sp1_sdk::{include_elf, Elf, Prover, SP1Stdin};
+
+    sp1_test::setup().await;
+    const ELF: Elf = include_elf!("invalid_hint_macro");
+
+    let client = sp1_test::sp1_cpu_prover().await;
+    let mut stdin = SP1Stdin::new();
+    stdin.write(&0u8); // trigger == 0 → fall through, exit 0
+
+    let (_pv, report) =
+        client.execute(ELF, stdin).await.expect("execution should complete");
+
+    assert_eq!(report.exit_code, 0, "expected normal exit 0, got {}", report.exit_code);
+}
+
+/// `read_vec()` on an empty input stream is a hint failure (the prover/hook
+/// did not supply expected data), so it must halt with exit code 3 instead
+/// of panicking with exit code 1.
+#[tokio::test]
+async fn read_vec_empty_input_halts_with_3() {
+    use sp1_sdk::{include_elf, Elf, Prover, SP1Stdin};
+
+    sp1_test::setup().await;
+    const ELF: Elf = include_elf!("invalid_hint_empty_input");
+
+    let client = sp1_test::sp1_cpu_prover().await;
+    let stdin = SP1Stdin::new(); // empty — read_vec will halt(3)
+
+    let (_pv, report) =
+        client.execute(ELF, stdin).await.expect("execution should complete");
+
+    assert_eq!(
+        report.exit_code, 3,
+        "expected halt(3) for empty input stream, got {}",
+        report.exit_code
+    );
+}

--- a/patch-testing/k256/program/Cargo.toml
+++ b/patch-testing/k256/program/Cargo.toml
@@ -32,5 +32,5 @@ k256 = { version = "0.13.4", default-features = false, features = [
 ecdsa-core = { version = "0.16.9", package = "ecdsa", features = ["verifying"] }
 
 [patch.crates-io]
-k256 = { git = "https://github.com/sp1-patches/elliptic-curves", tag = "patch-k256-13.4-sp1-6.0.0" }
+k256 = { git = "https://github.com/sp1-patches/elliptic-curves", tag = "patch-k256-13.4-sp1-6.2.0" }
 sp1-lib = { path = "../../../crates/zkvm/lib" }

--- a/patch-testing/keccak/program/Cargo.toml
+++ b/patch-testing/keccak/program/Cargo.toml
@@ -9,5 +9,5 @@ sp1-zkvm = {  path = "../../../crates/zkvm/entrypoint" }
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }
 
 [patch.crates-io]
-tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", tag = "patch-2.0.2-sp1-6.0.0" }
+tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", tag = "patch-2.0.2-sp1-6.2.0" }
 sp1-lib = { path = "../../../crates/zkvm/lib" }

--- a/patch-testing/p256/program/Cargo.toml
+++ b/patch-testing/p256/program/Cargo.toml
@@ -22,5 +22,5 @@ p256 = { version = "0.13.2", default-features = false, features = [
 ecdsa-core = { version = "0.16.9", package = "ecdsa", features = ["verifying"] }
 
 [patch.crates-io]
-p256 = { git = "https://github.com/sp1-patches/elliptic-curves", tag = "patch-p256-13.2-sp1-6.0.0" }
+p256 = { git = "https://github.com/sp1-patches/elliptic-curves", tag = "patch-p256-13.2-sp1-6.2.0" }
 sp1-lib = { path = "../../../crates/zkvm/lib" }

--- a/patch-testing/rustcrypto-bigint/program/Cargo.toml
+++ b/patch-testing/rustcrypto-bigint/program/Cargo.toml
@@ -19,4 +19,4 @@ num-bigint = "0.4.0"
 crypto-bigint = "0.5.5"
 
 [patch.crates-io]
-crypto-bigint = { git = "https://github.com/sp1-patches/RustCrypto-bigint", tag = "patch-0.5.5-sp1-6.0.0" }
+crypto-bigint = { git = "https://github.com/sp1-patches/RustCrypto-bigint", tag = "patch-0.5.5-sp1-6.2.0" }

--- a/patch-testing/secp256k1/program-v0.29.1/Cargo.toml
+++ b/patch-testing/secp256k1/program-v0.29.1/Cargo.toml
@@ -15,7 +15,7 @@ path = "bin/recover.rs"
 [dependencies]
 sp1-zkvm = {  path = "../../../crates/zkvm/entrypoint" }
 serde = { version = "1.0.215", features = ["derive"] }
-secp256k1 = { git = "https://github.com/sp1-patches/rust-secp256k1", package = "secp256k1", tag = "patch-0.29.1-sp1-6.0.0", features = [
+secp256k1 = { git = "https://github.com/sp1-patches/rust-secp256k1", package = "secp256k1", tag = "patch-0.29.1-sp1-6.2.0", features = [
     "recovery",
     "global-context",
     "serde",

--- a/patch-testing/secp256k1/program-v0.30.0/Cargo.toml
+++ b/patch-testing/secp256k1/program-v0.30.0/Cargo.toml
@@ -16,7 +16,7 @@ path = "bin/recover.rs"
 [dependencies]
 sp1-zkvm = {  path = "../../../crates/zkvm/entrypoint" }
 # serde = { version = "1.0.215", features = ["derive"] }
-secp256k1 = { git = "https://github.com/sp1-patches/rust-secp256k1", package = "secp256k1", tag = "patch-0.30.0-sp1-6.0.0", features = [
+secp256k1 = { git = "https://github.com/sp1-patches/rust-secp256k1", package = "secp256k1", tag = "patch-0.30.0-sp1-6.2.0", features = [
     "recovery",
     "global-context",
     "serde",

--- a/patch-testing/sha/program/Cargo.toml
+++ b/patch-testing/sha/program/Cargo.toml
@@ -46,9 +46,9 @@ v0-10-8 = ["dep:sha2-v0-10-8"]
 v0-10-9 = ["dep:sha2-v0-10-9"]
 
 [patch.crates-io]
-sha3 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha3", tag = "patch-sha3-0.10.8-sp1-6.0.0" }
+sha3 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha3", tag = "patch-sha3-0.10.8-sp1-6.2.0" }
 
-sha2-v0-9-9 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.9.9-sp1-6.0.0" }
-sha2-v0-10-6 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.10.6-sp1-6.0.0" }
-sha2-v0-10-8 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.10.8-sp1-6.0.0" }
-sha2-v0-10-9 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.10.9-sp1-6.0.0" }
+sha2-v0-9-9 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.9.9-sp1-6.2.0" }
+sha2-v0-10-6 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.10.6-sp1-6.2.0" }
+sha2-v0-10-8 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.10.8-sp1-6.2.0" }
+sha2-v0-10-9 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.10.9-sp1-6.2.0" }


### PR DESCRIPTION
Adds `sp1_lib::invalid_hint!` (and the underlying
`sp1_lib::halt_invalid_hint`) so patched crypto crates can halt the zkVM with exit code 3 — distinct from a regular Rust panic (exit 1) — when a prover-supplied hint fails verification. Without this, a malicious prover could forge a "panicked program" proof by feeding wrong hint data; halting on a separate exit code lets the verifier distinguish the two.

* `sp1-lib`:
  - Add `halt_invalid_hint() -> !` (calls `syscall_halt(3)`).
  - Add `invalid_hint!()` macro: panic-shaped format args, writes the diagnostic to stderr (FD 2) via `syscall_write`, then halts with exit 3.
  - `read_vec()` and `read::<T>()` now treat empty-stream / corrupt bincode as invalid-hint conditions and route through the same halt(3) path with the original "Was the correct data written into SP1Stdin?" diagnostic preserved.

* `sp1-zkvm`: `#[no_mangle]` on `syscall_halt` so the patches' extern declaration in `sp1-lib` resolves at link time. (All other syscalls in the entrypoint already had it; this was the lone omission.)

* `sp1-core-executor`: `StatusCode` gains `INVALID_HINT = 3` and accepts it in `is_accepted_code`, so verifiers can prove a halt-3 outcome.

* All seven patches that use hints now call `sp1_lib::invalid_hint!` on hint-validation failures with contextual messages: curve25519-dalek (+ ng), bls12_381, substrate-bn, k256, p256, RustCrypto-RSA. New tags pushed: `patch-X-sp1-6.2.0` across `sp1-patches/{curve25519-dalek,curve25519-dalek-ng,bls12_381,bn, elliptic-curves(k256+p256),RustCrypto-RSA,tiny-keccak, rust-secp256k1(0.29.1+0.30.0),RustCrypto-hashes(4 sha2 + sha3), RustCrypto-bigint}`.

* patch-testing: bump all tag references to `-sp1-6.2.0`. Add `patch-testing/invalid-hint` smoke-test crate (4 tests, all passing) covering the macro's halt(3) path with and without a message, the no-op trigger=0 case, and the empty-input read_vec halt path.

* examples: `examples/invalid-hint/` — guest reads a trigger byte, fires `invalid_hint!` when non-zero, then the host script asserts `report.exit_code == 3` and verifies StatusCode round- trips through `StatusCode::new(3) == Some(INVALID_HINT)`.

Followup (not in this PR): the minimal executor's `write` path hardcodes hint hook dispatch in `crates/core/executor/src/minimal/ write.rs` and ignores the user-provided `HookRegistry`. Routing through the registry would let `with_hook(FD_X, malicious_hook)` exercise per-patch failure paths (e.g. "supply a wrong Fp inverse, expect halt(3)"); leaving as a follow-up.
