### PR TITLE
fix(sdk): populate public value digest when calculate_gas is false

### DIFF
--- a/crates/core/executor/src/minimal.rs
+++ b/crates/core/executor/src/minimal.rs
@@ -157,6 +157,15 @@ impl MinimalExecutorEnum {
         }
     }
 
+    /// Calls `public_value_digest` to respective `MinimalExecutor`.
+    #[must_use]
+    pub fn public_value_digest(&self) -> [u32; sp1_jit::PUBLIC_VALUE_DIGEST_WORDS] {
+        match self {
+            Self::Supervisor(e) => e.public_value_digest(),
+            Self::User(e) => e.public_value_digest(),
+        }
+    }
+
     /// Calls `hints` to respective `MinimalExecutor`.
     #[must_use]
     pub fn hints(&self) -> &[(u64, Vec<u8>)] {

--- a/crates/core/executor/src/minimal/arch/portable/mod.rs
+++ b/crates/core/executor/src/minimal/arch/portable/mod.rs
@@ -5,7 +5,7 @@
 use sp1_jit::{
     debug::{self, DebugState},
     trace_capacity, Interrupt, MemValue, PageProtValue, RiscRegister, SyscallContext,
-    TraceChunkRaw,
+    TraceChunkRaw, PUBLIC_VALUE_DIGEST_WORDS,
 };
 use sp1_primitives::consts::{
     LOG_PAGE_SIZE, PROT_EXEC, PROT_FAILURE_EXEC, PROT_FAILURE_READ, PROT_FAILURE_WRITE, PROT_READ,
@@ -63,6 +63,7 @@ pub struct MinimalExecutor<M: ExecutionMode> {
     exit_code: u32,
     max_trace_size: Option<u64>,
     public_values_stream: Vec<u8>,
+    public_value_digest: [u32; PUBLIC_VALUE_DIGEST_WORDS],
     hints: Vec<(u64, Vec<u8>)>,
     maybe_unconstrained: Option<UnconstrainedCtx>,
     debug_sender: Option<mpsc::SyncSender<Option<debug::State>>>,
@@ -308,6 +309,15 @@ impl<M: ExecutionMode> SyscallContext for MinimalExecutor<M> {
         self.exit_code = exit_code;
     }
 
+    fn set_public_value_digest_word(&mut self, word_idx: u64, digest_word: u32) {
+        let idx = word_idx as usize;
+        debug_assert!(
+            idx < PUBLIC_VALUE_DIGEST_WORDS,
+            "public value digest word index out of bounds: {idx}"
+        );
+        self.public_value_digest[idx] = digest_word;
+    }
+
     fn is_unconstrained(&self) -> bool {
         self.maybe_unconstrained.is_some()
     }
@@ -439,6 +449,7 @@ impl<M: ExecutionMode> MinimalExecutor<M> {
             traces: None,
             max_trace_size,
             public_values_stream: Vec::new(),
+            public_value_digest: [0; PUBLIC_VALUE_DIGEST_WORDS],
             hints: Vec::new(),
             maybe_unconstrained: None,
             debug_sender: None,
@@ -584,6 +595,12 @@ impl<M: ExecutionMode> MinimalExecutor<M> {
     #[must_use]
     pub fn into_public_values_stream(self) -> Vec<u8> {
         self.public_values_stream
+    }
+
+    /// Get the public value digest words committed by the guest via `COMMIT` syscalls.
+    #[must_use]
+    pub fn public_value_digest(&self) -> [u32; PUBLIC_VALUE_DIGEST_WORDS] {
+        self.public_value_digest
     }
 
     /// Get the hints of the executor

--- a/crates/core/executor/src/minimal/arch/x86_64/mod.rs
+++ b/crates/core/executor/src/minimal/arch/x86_64/mod.rs
@@ -5,6 +5,7 @@ use memmap2::MmapMut;
 use sp1_jit::{
     debug, memory::AnonymousMemory, trace_capacity, DebugBackend, JitFunction, JitMemory, MemValue,
     RiscOperand, RiscRegister, RiscvTranspiler, TraceChunkHeader, TraceChunkRaw, TranspilerBackend,
+    PUBLIC_VALUE_DIGEST_WORDS,
 };
 use std::marker::PhantomData;
 use std::{
@@ -230,6 +231,12 @@ impl<M: ExecutionMode> MinimalExecutor<M> {
     #[must_use]
     pub fn into_public_values_stream(self) -> Vec<u8> {
         self.compiled.public_values_stream
+    }
+
+    /// Get the public value digest words committed by the guest via `COMMIT` syscalls.
+    #[must_use]
+    pub fn public_value_digest(&self) -> [u32; PUBLIC_VALUE_DIGEST_WORDS] {
+        self.compiled.public_value_digest
     }
 
     /// Get the hints of the JIT function.

--- a/crates/core/executor/src/minimal/ecall.rs
+++ b/crates/core/executor/src/minimal/ecall.rs
@@ -178,9 +178,12 @@ pub fn ecall_handler(ctx: &mut impl SyscallContext, code: SyscallCode) -> Result
         SyscallCode::DELETE_PROFILER_SYMBOLS => {
             Ok(delete_profile_symbols_syscall(ctx, arg1, arg2))
         }
-        SyscallCode::VERIFY_SP1_PROOF
-        | SyscallCode::COMMIT
-        | SyscallCode::COMMIT_DEFERRED_PROOFS => Ok(None),
+        SyscallCode::COMMIT => {
+            let digest_word: u32 = arg2.try_into().expect("digest word should fit in u32");
+            ctx.set_public_value_digest_word(arg1, digest_word);
+            Ok(None)
+        }
+        SyscallCode::VERIFY_SP1_PROOF | SyscallCode::COMMIT_DEFERRED_PROOFS => Ok(None),
     }
     .map(|opt: Option<u64>| opt.unwrap_or(code as u64))
 }

--- a/crates/core/jit/src/context.rs
+++ b/crates/core/jit/src/context.rs
@@ -3,6 +3,12 @@ use memmap2::{MmapMut, MmapOptions};
 use sp1_primitives::consts::{PROT_READ, PROT_WRITE};
 use std::{collections::VecDeque, io, os::fd::RawFd, ptr::NonNull, sync::mpsc};
 
+/// Number of u32 words in the public value digest emitted by `COMMIT` syscalls.
+///
+/// Mirrors `sp1_hypercube::air::PV_DIGEST_NUM_WORDS`. Kept here as a local constant to avoid
+/// pulling `sp1-hypercube` into the JIT crate's dependency graph.
+pub const PUBLIC_VALUE_DIGEST_WORDS: usize = 8;
+
 pub trait SyscallContext {
     /// Read a value from a register.
     fn rr(&self, reg: RiscRegister) -> u64;
@@ -85,6 +91,10 @@ pub trait SyscallContext {
     fn set_clk(&mut self, clk: u64);
     /// Set the exit code of the program.
     fn set_exit_code(&mut self, exit_code: u32);
+    /// Record one word of the public value digest emitted by a `COMMIT` syscall.
+    ///
+    /// `word_idx` must be `< PUBLIC_VALUE_DIGEST_WORDS`.
+    fn set_public_value_digest_word(&mut self, word_idx: u64, digest_word: u32);
     /// Returns if were in unconstrained mode.
     fn is_unconstrained(&self) -> bool;
     /// Get the global clock (total cycles executed).
@@ -282,6 +292,15 @@ impl SyscallContext for JitContext {
         self.exit_code = exit_code;
     }
 
+    fn set_public_value_digest_word(&mut self, word_idx: u64, digest_word: u32) {
+        let idx = word_idx as usize;
+        debug_assert!(
+            idx < PUBLIC_VALUE_DIGEST_WORDS,
+            "public value digest word index out of bounds: {idx}"
+        );
+        self.public_value_digest[idx] = digest_word;
+    }
+
     fn is_unconstrained(&self) -> bool {
         self.is_unconstrained == 1
     }
@@ -373,6 +392,8 @@ pub struct JitContext {
     pub(crate) debug_sender: Option<mpsc::SyncSender<Option<debug::State>>>,
     /// The exit code of the program.
     pub(crate) exit_code: u32,
+    /// The public value digest words emitted by `COMMIT` syscalls.
+    pub public_value_digest: [u32; PUBLIC_VALUE_DIGEST_WORDS],
 }
 
 impl JitContext {

--- a/crates/core/jit/src/lib.rs
+++ b/crates/core/jit/src/lib.rs
@@ -223,6 +223,9 @@ pub struct JitFunction<M> {
     pub global_clk: u64,
     pub exit_code: u32,
 
+    /// The public value digest words emitted by `COMMIT` syscalls.
+    pub public_value_digest: [u32; context::PUBLIC_VALUE_DIGEST_WORDS],
+
     pub debug_sender: Option<mpsc::SyncSender<Option<debug::State>>>,
 }
 
@@ -258,6 +261,7 @@ impl<M: JitMemory> JitFunction<M> {
             public_values_stream: Vec::new(),
             debug_sender: None,
             exit_code: 0,
+            public_value_digest: [0; context::PUBLIC_VALUE_DIGEST_WORDS],
         })
     }
 
@@ -349,6 +353,7 @@ impl<M: JitMemory> JitFunction<M> {
             tracing,
             debug_sender: self.debug_sender.clone(),
             exit_code: self.exit_code,
+            public_value_digest: self.public_value_digest,
         };
 
         tracing::debug_span!("JIT function", pc = ctx.pc, clk = ctx.clk).in_scope(|| {
@@ -361,6 +366,7 @@ impl<M: JitMemory> JitFunction<M> {
         self.clk = ctx.clk;
         self.global_clk = ctx.global_clk;
         self.exit_code = ctx.exit_code;
+        self.public_value_digest = ctx.public_value_digest;
     }
 
     fn insert_memory_image(&mut self) {
@@ -400,6 +406,7 @@ impl<M: JitResetableMemory> JitFunction<M> {
         self.input_buffer = VecDeque::new();
         self.hints = Vec::new();
         self.public_values_stream = Vec::new();
+        self.public_value_digest = [0; context::PUBLIC_VALUE_DIGEST_WORDS];
         self.memory.reset();
 
         self.insert_memory_image();

--- a/crates/core/runner-binary/src/lib.rs
+++ b/crates/core/runner-binary/src/lib.rs
@@ -21,4 +21,5 @@ pub struct Output {
     pub global_clk: u64,
     pub clk: u64,
     pub exit_code: u32,
+    pub public_value_digest: [u32; sp1_jit::PUBLIC_VALUE_DIGEST_WORDS],
 }

--- a/crates/core/runner-binary/src/main.rs
+++ b/crates/core/runner-binary/src/main.rs
@@ -110,6 +110,7 @@ fn main() {
         global_clk: compiled.global_clk,
         clk: compiled.clk,
         exit_code: compiled.exit_code,
+        public_value_digest: compiled.public_value_digest,
     };
 
     let stdout = io::stdout();

--- a/crates/core/runner/src/native.rs
+++ b/crates/core/runner/src/native.rs
@@ -331,6 +331,12 @@ impl MinimalExecutorRunner {
         self.take_output().public_values_stream
     }
 
+    /// Get the public value digest words committed by the guest via `COMMIT` syscalls.
+    #[must_use]
+    pub fn public_value_digest(&self) -> [u32; sp1_jit::PUBLIC_VALUE_DIGEST_WORDS] {
+        self.output().public_value_digest
+    }
+
     /// Get the hints of the JIT function.
     #[must_use]
     pub fn hints(&self) -> &[(u64, Vec<u8>)] {

--- a/crates/core/runner/src/portable.rs
+++ b/crates/core/runner/src/portable.rs
@@ -161,6 +161,13 @@ impl MinimalExecutorRunner {
         self.inner.into_public_values_stream()
     }
 
+    /// Get the public value digest words committed by the guest via `COMMIT` syscalls.
+    #[must_use]
+    #[inline]
+    pub fn public_value_digest(&self) -> [u32; sp1_jit::PUBLIC_VALUE_DIGEST_WORDS] {
+        self.inner.public_value_digest()
+    }
+
     /// Get the hints of the JIT function.
     #[must_use]
     #[inline]

--- a/crates/prover/src/worker/prover/execute.rs
+++ b/crates/prover/src/worker/prover/execute.rs
@@ -7,7 +7,7 @@ use sp1_core_executor::{
 use sp1_core_executor_runner::MinimalExecutorRunner;
 use sp1_core_machine::io::SP1Stdin;
 use sp1_core_machine::riscv::RiscvAir;
-use sp1_hypercube::air::PROOF_NONCE_NUM_WORDS;
+use sp1_hypercube::air::{PROOF_NONCE_NUM_WORDS, PV_DIGEST_NUM_WORDS};
 use sp1_hypercube::{Machine, MachineVerifyingKey, SP1PcsProofInner, SP1VerifyingKey};
 use sp1_jit::TraceChunkRaw;
 use sp1_primitives::io::SP1PublicValues;
@@ -167,6 +167,7 @@ pub async fn execute_with_options_and_machine(
         Report(ExecutionReport),
         PublicValues {
             public_values: SP1PublicValues,
+            public_value_digest: [u32; PV_DIGEST_NUM_WORDS],
             #[cfg(feature = "profiling")]
             cycle_tracker: hashbrown::HashMap<String, u64>,
             #[cfg(feature = "profiling")]
@@ -276,12 +277,14 @@ pub async fn execute_with_options_and_machine(
         #[cfg(feature = "profiling")]
         let invocation_tracker = minimal_executor.take_invocation_tracker();
 
+        let public_value_digest = minimal_executor.public_value_digest();
         let public_value_stream = minimal_executor.into_public_values_stream();
         let public_values = SP1PublicValues::from(&public_value_stream);
 
         tracing::info!("public_value_stream: {:?}", public_value_stream);
         Ok::<_, anyhow::Error>(ExecutorOutput::PublicValues {
             public_values,
+            public_value_digest,
             #[cfg(feature = "profiling")]
             cycle_tracker,
             #[cfg(feature = "profiling")]
@@ -292,6 +295,7 @@ pub async fn execute_with_options_and_machine(
     // Wait for all gas calculations to complete.
     let mut final_report = ExecutionReport::default();
     let mut public_values = SP1PublicValues::default();
+    let mut minimal_executor_digest: Option<[u32; PV_DIGEST_NUM_WORDS]> = None;
     #[cfg(feature = "profiling")]
     let mut cycle_tracker_data: Option<(
         hashbrown::HashMap<String, u64>,
@@ -303,12 +307,14 @@ pub async fn execute_with_options_and_machine(
             Ok(Ok(output)) => match output {
                 ExecutorOutput::PublicValues {
                     public_values: pv,
+                    public_value_digest: pvd,
                     #[cfg(feature = "profiling")]
                     cycle_tracker,
                     #[cfg(feature = "profiling")]
                     invocation_tracker,
                 } => {
                     public_values = pv;
+                    minimal_executor_digest = Some(pvd);
                     #[cfg(feature = "profiling")]
                     {
                         cycle_tracker_data = Some((cycle_tracker, invocation_tracker));
@@ -336,18 +342,19 @@ pub async fn execute_with_options_and_machine(
         final_report.invocation_tracker = invocation_tracker;
     }
 
-    // Extract the public value digest from the final VM state.
-    let public_value_digest: [u8; 32] = final_vm_state
+    // Extract the public value digest. Prefer the value tracked by the gas-estimating VM (set when
+    // `calculate_gas` is enabled), and fall back to the digest captured by the minimal executor
+    // when gas estimation is disabled and `final_vm_state` is therefore never populated.
+    let digest_words: [u32; PV_DIGEST_NUM_WORDS] = final_vm_state
         .get()
-        .map(|state| {
-            let mut committed_value_digest = [0u8; 32];
-            state.public_value_digest.iter().enumerate().for_each(|(i, word)| {
-                let bytes = word.to_le_bytes();
-                committed_value_digest[i * 4..(i + 1) * 4].copy_from_slice(&bytes);
-            });
-            committed_value_digest
-        })
+        .map(|state| state.public_value_digest)
+        .or(minimal_executor_digest)
         .ok_or(anyhow::anyhow!("Failed to extract public value digest"))?;
+    let mut public_value_digest = [0u8; 32];
+    digest_words.iter().enumerate().for_each(|(i, word)| {
+        let bytes = word.to_le_bytes();
+        public_value_digest[i * 4..(i + 1) * 4].copy_from_slice(&bytes);
+    });
 
     Ok((public_values, public_value_digest, final_report))
 }
@@ -356,25 +363,62 @@ pub async fn execute_with_options_and_machine(
 mod tests {
     use std::sync::Arc;
 
-    use sp1_core_executor::{Program, SP1Context, SP1CoreOpts};
+    use sp1_core_executor::{Program, SP1ContextBuilder, SP1CoreOpts};
     use sp1_core_machine::io::SP1Stdin;
+    use sp1_primitives::{io::SP1PublicValues, Elf};
 
     use super::{execute_with_options, SP1ExecutorConfig};
 
-    #[tokio::test]
-    async fn test_execute_with_optional_gas() {
-        let elf = test_artifacts::FIBONACCI_ELF;
-        let program = Arc::new(Program::from(&elf).unwrap());
+    async fn run(elf: &Elf, calculate_gas: bool) -> (SP1PublicValues, [u8; 32]) {
+        let program = Arc::new(Program::from(elf).unwrap());
         let mut stdin = SP1Stdin::new();
         stdin.write(&10usize);
         let opts = SP1CoreOpts::default();
         let executor_config = SP1ExecutorConfig::default();
 
-        let context = SP1Context::default();
+        let mut context_builder = SP1ContextBuilder::new();
+        context_builder.calculate_gas(calculate_gas);
+        let context = context_builder.build();
+
         let (pv, digest, report) =
             execute_with_options(program, stdin, context, opts, executor_config).await.unwrap();
-
-        assert!(pv.hash() == digest.to_vec() || pv.blake3_hash() == digest.to_vec());
         assert_eq!(report.exit_code, 0);
+        (pv, digest)
+    }
+
+    #[tokio::test]
+    async fn test_execute_with_optional_gas() {
+        // SHA-256 guest, gas estimation enabled (final_vm_state path).
+        let (pv, digest) = run(&test_artifacts::FIBONACCI_ELF, true).await;
+        assert_eq!(pv.hash(), digest.to_vec(), "sha guest digest must match pv.hash() (gas=on)");
+
+        // SHA-256 guest, gas estimation disabled — regression for "Failed to extract public value
+        // digest". The digest must come from the minimal executor's COMMIT tracking, since
+        // `final_vm_state` is never populated when `calculate_gas` is false.
+        let (pv, digest) = run(&test_artifacts::FIBONACCI_ELF, false).await;
+        assert_eq!(pv.hash(), digest.to_vec(), "sha guest digest must match pv.hash() (gas=off)");
+
+        // BLAKE3 guest, gas estimation disabled — guards against the tempting-but-wrong
+        // "always fall back to SP1PublicValues::hash()" shortcut, which would silently use sha256
+        // for a blake3-built guest.
+        let (pv, digest) = run(&test_artifacts::FIBONACCI_BLAKE3_ELF, false).await;
+        assert_eq!(
+            pv.blake3_hash(),
+            digest.to_vec(),
+            "blake3 guest digest must match pv.blake3_hash() (gas=off)",
+        );
+        assert_ne!(
+            pv.hash(),
+            digest.to_vec(),
+            "blake3 guest digest must NOT match pv.hash() (sha256)",
+        );
+
+        // BLAKE3 guest, gas estimation enabled — both paths must agree on the same digest.
+        let (pv, digest) = run(&test_artifacts::FIBONACCI_BLAKE3_ELF, true).await;
+        assert_eq!(
+            pv.blake3_hash(),
+            digest.to_vec(),
+            "blake3 guest digest must match pv.blake3_hash() (gas=on)",
+        );
     }
 }


### PR DESCRIPTION
Fixes `execute(...).calculate_gas(false)` failing during digest extraction.

The no-gas path now records the digest emitted by guest `COMMIT` syscalls in the minimal executor and uses it when `final_vm_state` is unavailable.

Tests cover gas on/off for SHA256 and blake3 guests.

Closes #2780