### PR TITLE
ci(release): categorize GitHub release notes by Conventional Commit prefix

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,18 @@
+# Configuration for GitHub's auto-generated release notes.
+# See: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+#
+# The release workflow post-processes the body produced by `gh release create
+# --generate-notes` to bucket PRs by Conventional Commit prefix (feat / fix /
+# perf / etc.). This file controls what GitHub feeds into that post-processor.
+
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - dependabot[bot]
+    labels:
+      - ignore-for-release
+  categories:
+    - title: All Changes
+      labels:
+        - "*"

--- a/.github/scripts/format-release-notes.py
+++ b/.github/scripts/format-release-notes.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Re-bucket GitHub's auto-generated release notes by Conventional Commit prefix.
+
+Reads the body of a release (produced by `gh release create --generate-notes`)
+from stdin and writes a categorized version to stdout. Each "* <title> by @user
+in <url>" line is sorted into a section based on the leading conventional commit
+prefix in the PR title (e.g. `feat:`, `fix(sdk):`, `perf!:`). The "New
+Contributors" and "Full Changelog" footers, if present, are preserved verbatim.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from collections import OrderedDict
+
+# Ordered map of section title -> list of conventional commit types that land in it.
+SECTIONS: "OrderedDict[str, list[str]]" = OrderedDict(
+    [
+        ("Breaking Changes", []),  # populated dynamically from `!` marker
+        ("New Features", ["feat"]),
+        ("Bug Fixes", ["fix"]),
+        ("Performance", ["perf"]),
+        ("Refactoring", ["refactor", "refac"]),
+        ("Documentation", ["docs"]),
+        ("CI & Build", ["ci", "build"]),
+        ("Chores", ["chore", "test", "style"]),
+    ]
+)
+OTHER_SECTION = "Other Changes"
+
+# Matches "* <title> by @<author> in <url>" — GitHub's standard line format.
+ENTRY_RE = re.compile(r"^\*\s+(?P<title>.*?)\s+by\s+@[\w\-\[\]]+\s+in\s+https?://\S+\s*$")
+
+# Conventional commit prefix at the start of a PR title:
+#   type(optional-scope)!?: rest
+PREFIX_RE = re.compile(r"^(?P<type>[a-zA-Z]+)(?:\([^)]*\))?(?P<bang>!?):\s*(?P<rest>.*)$")
+
+
+def bucket_for(title: str) -> tuple[str, str]:
+    """Return (section, rendered_line_body) for a PR title."""
+    m = PREFIX_RE.match(title)
+    if not m:
+        return OTHER_SECTION, title
+
+    ctype = m.group("type").lower()
+    breaking = m.group("bang") == "!"
+    # Strip the leading "type:" / "type(scope):" so the section header isn't redundant,
+    # but promote a parenthesised scope into a bold "**scope**: " prefix.
+    rest_with_scope = re.sub(
+        rf"^{re.escape(m.group('type'))}(\(([^)]*)\))?!?:\s*",
+        lambda mm: f"**{mm.group(2)}**: " if mm.group(2) else "",
+        title,
+        count=1,
+    )
+
+    if breaking:
+        return "Breaking Changes", rest_with_scope
+
+    for section, types in SECTIONS.items():
+        if ctype in types:
+            return section, rest_with_scope
+
+    return OTHER_SECTION, title
+
+
+def main() -> int:
+    body = sys.stdin.read()
+    lines = body.splitlines()
+
+    buckets: "OrderedDict[str, list[str]]" = OrderedDict()
+    for section in SECTIONS:
+        buckets[section] = []
+    buckets[OTHER_SECTION] = []
+
+    footer_lines: list[str] = []
+    in_footer = False
+
+    for line in lines:
+        stripped = line.strip()
+        # Recognise the start of footer sections produced by GitHub.
+        if stripped.startswith("## New Contributors") or stripped.startswith("**Full Changelog**"):
+            in_footer = True
+        if in_footer:
+            footer_lines.append(line)
+            continue
+
+        # Skip the auto-generated "## What's Changed" header — we render our own.
+        if stripped.startswith("## What's Changed"):
+            continue
+
+        m = ENTRY_RE.match(line)
+        if not m:
+            continue
+
+        title = m.group("title").strip()
+        section, rendered_title = bucket_for(title)
+        # Reconstruct the line, keeping the "by @user in <url>" suffix intact.
+        suffix = line[line.find(title) + len(title):]
+        buckets[section].append(f"* {rendered_title}{suffix}")
+
+    out: list[str] = ["## What's Changed", ""]
+    any_section = False
+    for section, entries in buckets.items():
+        if not entries:
+            continue
+        any_section = True
+        out.append(f"### {section}")
+        out.extend(entries)
+        out.append("")
+
+    if not any_section:
+        # Nothing parsed — fall back to the original body so we never ship an empty release.
+        sys.stdout.write(body)
+        return 0
+
+    if footer_lines:
+        # Strip leading blank lines between body and footer, but keep one separator.
+        while footer_lines and not footer_lines[0].strip():
+            footer_lines.pop(0)
+        out.extend(footer_lines)
+
+    sys.stdout.write("\n".join(out).rstrip() + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,16 @@ jobs:
           DRAFT_FLAG=${{ inputs.dry_run && '"--draft"' || '""' }}
           GH_DEBUG=api gh release create ${{ steps.release_info.outputs.tag_name }} --target "$TARGET_BRANCH" --generate-notes --latest=false $PRERELEASE_FLAG $DRAFT_FLAG
 
+      - name: Categorize release notes by Conventional Commit prefix
+        env:
+          GH_TOKEN: ${{ secrets.SP1_RELEASE_TOKEN }}
+          TAG_NAME: ${{ steps.release_info.outputs.tag_name }}
+        run: |
+          set -euo pipefail
+          gh release view "$TAG_NAME" --json body --jq .body > /tmp/release-body.md
+          python3 .github/scripts/format-release-notes.py < /tmp/release-body.md > /tmp/release-body.formatted.md
+          gh release edit "$TAG_NAME" --notes-file /tmp/release-body.formatted.md
+
       - name: Print GH version
         run: |
           gh version


### PR DESCRIPTION
## Motivation

GitHub release notes (e.g. [v6.1.0](https://github.com/succinctlabs/sp1/releases/tag/v6.1.0)) are produced by `gh release create --generate-notes` and arrive as a flat list of 100+ PR titles — actual features sit next to `chore: bump version`, dependabot bumps, and follow-up CI fixes, so they're hard to skim.

## Solution

SP1 PRs already use Conventional Commit prefixes (`feat:` / `fix:` / `perf:` / `refactor:` / `docs:` / `chore:` / `ci:`) very consistently, so we can categorize without relying on labels.

- **`.github/release.yml`** — filters dependabot and an opt-out `ignore-for-release` label out of the raw notes before they hit the post-processor.
- **`.github/scripts/format-release-notes.py`** — reads the auto-generated body and buckets each PR into sections by prefix: Breaking Changes (`type!:`), New Features, Bug Fixes, Performance, Refactoring, Documentation, CI & Build, Chores, Other. Scope (e.g. `(sdk)`) is promoted to a bold prefix on the line. "New Contributors" and "Full Changelog" footers are preserved verbatim. Falls back to the unmodified body if nothing parses, so we never ship an empty release.
- **`.github/workflows/release.yml`** — after `gh release create`, fetch the body, pipe it through the script, and `gh release edit --notes-file` it back.

Sample output (using v6.1.0-ish PRs):

```
### Breaking Changes
* bump SP1 version to v6.2.0 by @tamirhemo in https://github.com/...

### New Features
* GPU microbenchmarks by @leruaa in https://github.com/...
* **sdk**: Add private-stdin support for the network prover by @leruaa in https://github.com/...

### Bug Fixes
* **prover**: close three leak paths in distributed-controller path by @tamirhemo in https://github.com/...
```

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes

## Test plan

- [x] Ran the script against a representative v6.1.0 sample locally; categorization + scope rendering + footer preservation all behaved as expected.
- [ ] Best end-to-end verification is to manually run `release` with `dry_run: true` after merge — that path creates a draft release, generates notes, runs the post-processor, then cleans up.

https://claude.ai/code/session_01GkYUegSmh6urJPrVNba9H3

---
_Generated by [Claude Code](https://claude.ai/code/session_01GkYUegSmh6urJPrVNba9H3)_