### PR TITLE
perf(gpu): more efficient interpolation for zerocheck evaluation points

### DIFF
--- a/sp1-gpu/crates/jagged_tracegen/src/test_utils.rs
+++ b/sp1-gpu/crates/jagged_tracegen/src/test_utils.rs
@@ -239,7 +239,6 @@ pub mod random {
 /// (`random` / `json/<path>` / `real/<program>`) is parsed once and applied uniformly.
 #[cfg(any(test, feature = "test-utils"))]
 pub mod bench_utils {
-    use std::ops::Add;
     use std::sync::Arc;
 
     use std::collections::BTreeSet;

--- a/sp1-gpu/crates/jagged_tracegen/src/test_utils.rs
+++ b/sp1-gpu/crates/jagged_tracegen/src/test_utils.rs
@@ -239,6 +239,7 @@ pub mod random {
 /// (`random` / `json/<path>` / `real/<program>`) is parsed once and applied uniformly.
 #[cfg(any(test, feature = "test-utils"))]
 pub mod bench_utils {
+    use std::ops::Add;
     use std::sync::Arc;
 
     use std::collections::BTreeSet;
@@ -247,6 +248,8 @@ pub mod bench_utils {
     use rand::Rng;
     use slop_algebra::AbstractField;
     use slop_futures::queue::WorkerQueue;
+    use sp1_core_machine::riscv::AddChip;
+    use sp1_core_machine::SupervisorMode;
     use sp1_core_machine::{io::SP1Stdin, riscv::RiscvAir};
     use sp1_gpu_cudart::{run_sync_in_place, PinnedBuffer, TaskScope};
     use sp1_gpu_utils::{Felt, JaggedTraceMle};
@@ -650,16 +653,22 @@ pub mod bench_utils {
     /// type and its alphabetical iteration order — synthetic chip layout has to match for
     /// per-chip slicing to land on the right columns.
     ///
-    /// `Core` returns the smallest cluster the machine knows about. This relies on a structural
-    /// assumption about how `RiscvAir::machine()` builds clusters: extension and precompile
-    /// clusters all stack chips on top of the base core cluster, so the smallest is the base.
+    /// `Core` returns the smallest cluster the machine knows about containing the Add chip.
+    /// This relies on a structural assumption about how `RiscvAir::machine()` builds clusters:
+    /// clusters with Add all stack chips on top of the base core cluster, so the smallest is the base.
     fn cluster_chip_set(
         machine: &Machine<Felt, RiscvAir<Felt>>,
         cluster: ChipCluster,
     ) -> BTreeSet<Chip<Felt, RiscvAir<Felt>>> {
         match cluster {
             ChipCluster::Core => {
-                machine.smallest_cluster(&BTreeSet::new()).expect("machine has no clusters").clone()
+                let add_chip = AddChip::<SupervisorMode> { _phantom: Default::default() };
+                let add_chip = RiscvAir::<Felt>::Add(add_chip);
+                let add_chip = Chip::new(add_chip);
+                machine
+                    .smallest_cluster(&BTreeSet::from_iter([add_chip]))
+                    .expect("machine has no clusters")
+                    .clone()
             }
             ChipCluster::AllChips => machine.chips().iter().cloned().collect(),
         }

--- a/sp1-gpu/crates/sys/include/zerocheck/zerocheck_eval.cuh
+++ b/sp1-gpu/crates/sys/include/zerocheck/zerocheck_eval.cuh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "config.cuh"
+#include <cstdint>
 #include <stdio.h>
 
 struct Instruction {
@@ -18,12 +19,12 @@ struct JaggedConstraintFolder {
     const K* data;
     size_t preprocessed_ptr;
     size_t main_ptr;
-    size_t height;
+    uint32_t height;
     const felt_t* publicValues;
     const ext_t* powersOfAlpha;
-    size_t constraintIndex;
+    uint32_t constraintIndex;
     ext_t accumulator;
-    size_t rowIdx;
+    uint32_t rowIdx;
     unsigned char eval_point;
 
   public:
@@ -39,24 +40,22 @@ struct JaggedConstraintFolder {
             K zeroPrepVal = K::load(data, preprocessed_ptr + idx * height + (rowIdx << 1));
             K onePrepVal = K::load(data, preprocessed_ptr + idx * height + (rowIdx << 1 | 1));
             K result = zeroPrepVal;
-            K diff;
-            K two_diff;
+            K multi_diff;
             switch (eval_point) {
                 case 0:
                     break;
                 case 2:
-                    diff = onePrepVal - zeroPrepVal;
-                    two_diff = diff + diff;
-                    result+= two_diff;
+                    multi_diff = onePrepVal - zeroPrepVal;
+                    multi_diff = multi_diff + multi_diff;
+                    result += multi_diff;
                     break;
                 case 4:
-                    diff = onePrepVal - zeroPrepVal;
-                    two_diff = diff + diff;
-                    K four_diff = two_diff + two_diff;
-                    result += four_diff;
+                    multi_diff = onePrepVal - zeroPrepVal;
+                    multi_diff = multi_diff + multi_diff;
+                    multi_diff = multi_diff + multi_diff;
+                    result += multi_diff;
                     break;
                 default:
-                    printf("eval_point: %u\n", eval_point);
                     assert(0);
                     break;
             }
@@ -69,18 +68,17 @@ struct JaggedConstraintFolder {
                 case 0:
                     break;
                 case 2:
-                    diff = oneMainVal - zeroMainVal;
-                    two_diff = diff + diff;
-                    result+= two_diff;
+                    multi_diff = oneMainVal - zeroMainVal;
+                    multi_diff = multi_diff + multi_diff;
+                    result += multi_diff;
                     break;
                 case 4:
-                    diff = oneMainVal - zeroMainVal;
-                    two_diff = diff + diff;
-                    K four_diff = two_diff + two_diff;
-                    result += four_diff;
+                    multi_diff = oneMainVal - zeroMainVal;
+                    multi_diff = multi_diff + multi_diff;
+                    multi_diff = multi_diff + multi_diff;
+                    result += multi_diff;
                     break;
                 default:
-                    printf("eval_point: %u\n", eval_point);
                     assert(0);
                     break;
             }

--- a/sp1-gpu/crates/sys/include/zerocheck/zerocheck_eval.cuh
+++ b/sp1-gpu/crates/sys/include/zerocheck/zerocheck_eval.cuh
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "config.cuh"
-#include <cstdint>
 #include <stdio.h>
 
 struct Instruction {

--- a/sp1-gpu/crates/sys/include/zerocheck/zerocheck_eval.cuh
+++ b/sp1-gpu/crates/sys/include/zerocheck/zerocheck_eval.cuh
@@ -24,7 +24,7 @@ struct JaggedConstraintFolder {
     size_t constraintIndex;
     ext_t accumulator;
     size_t rowIdx;
-    felt_t eval_point;
+    unsigned char eval_point;
 
   public:
     __device__ JaggedConstraintFolder() {}
@@ -38,11 +38,53 @@ struct JaggedConstraintFolder {
         case 2:
             K zeroPrepVal = K::load(data, preprocessed_ptr + idx * height + (rowIdx << 1));
             K onePrepVal = K::load(data, preprocessed_ptr + idx * height + (rowIdx << 1 | 1));
-            return zeroPrepVal + eval_point * (onePrepVal - zeroPrepVal);
+            K result = zeroPrepVal;
+            K diff;
+            K two_diff;
+            switch (eval_point) {
+                case 0:
+                    break;
+                case 2:
+                    diff = onePrepVal - zeroPrepVal;
+                    two_diff = diff + diff;
+                    result+= two_diff;
+                    break;
+                case 4:
+                    diff = onePrepVal - zeroPrepVal;
+                    two_diff = diff + diff;
+                    K four_diff = two_diff + two_diff;
+                    result += four_diff;
+                    break;
+                default:
+                    printf("eval_point: %u\n", eval_point);
+                    assert(0);
+                    break;
+            }
+            return result;
         case 4:
             K zeroMainVal = K::load(data, main_ptr + idx * height + (rowIdx << 1));
             K oneMainVal = K::load(data, main_ptr + idx * height + (rowIdx << 1 | 1));
-            return zeroMainVal + eval_point * (oneMainVal - zeroMainVal);
+            result = zeroMainVal;
+            switch (eval_point) {
+                case 0:
+                    break;
+                case 2:
+                    diff = oneMainVal - zeroMainVal;
+                    two_diff = diff + diff;
+                    result+= two_diff;
+                    break;
+                case 4:
+                    diff = oneMainVal - zeroMainVal;
+                    two_diff = diff + diff;
+                    K four_diff = two_diff + two_diff;
+                    result += four_diff;
+                    break;
+                default:
+                    printf("eval_point: %u\n", eval_point);
+                    assert(0);
+                    break;
+            }
+            return result;
         case 9:
             return K(felt_t::load(publicValues, idx));
         default:

--- a/sp1-gpu/crates/sys/lib/zerocheck/zerocheck_eval.cu
+++ b/sp1-gpu/crates/sys/lib/zerocheck/zerocheck_eval.cu
@@ -19,8 +19,8 @@ namespace cg = cooperative_groups;
 #define DEBUG(...) // Do nothing
 #endif
 
-__device__ inline felt_t get_input_point(size_t idx) {
-    return felt_t::from_canonical_u32(2 * idx);
+__device__ inline unsigned char get_input_point(size_t idx) {
+    return (unsigned char)(2 * idx);
 }
 
 __device__ inline ext_t geq_eval(size_t idx, uint32_t threshold, ext_t eq_coefficient) {
@@ -66,7 +66,7 @@ __global__ void jaggedConstraintPolyEval(
 
     // This kernel assumes that a single block deals with a single `xValueIdx`.
     size_t xValueIdx = blockDim.z * blockIdx.z + threadIdx.z;
-    felt_t eval_point = get_input_point(xValueIdx);
+    unsigned char eval_point = get_input_point(xValueIdx);
 
     for (size_t idx = blockDim.x * blockIdx.x + threadIdx.x; idx < totalLen; idx += blockDim.x * gridDim.x) {
         uint64_t packed_info = inputJaggedInfo.denseData.data[idx << 1];
@@ -89,7 +89,7 @@ __global__ void jaggedConstraintPolyEval(
         size_t program_end_idx = evalProgramIndices[airBlockIdx + 1];
         size_t f_constant_offset = evalConstantsFIndices[airBlockIdx];
         size_t ef_constant_offset = evalConstantsEFIndices[airBlockIdx];
-        
+
         for (size_t i = 0; i < MEMORY_SIZE; i++) {
             expr_f[i] = K::zero();
         }


### PR DESCRIPTION
The interpolation to the zerocheck evaluation points 0,2,4 currently happens via a field multiplication. This can instead be replaced by 0,1, or 2 additions, which is what the current PR does.