### PR TITLE
fix: Parse empty proof_nonce as `None` instead of `Artifact("")`

### DIFF
--- a/crates/prover/src/worker/controller/mod.rs
+++ b/crates/prover/src/worker/controller/mod.rs
@@ -603,7 +603,10 @@ impl TryFrom<&[Artifact]> for ControllerInputs {
             ProofMode::try_from(parsed).map_err(|e| TaskError::Fatal(e.into()))?
         };
         let cycle_limit = inputs.get(3).and_then(|a| a.clone().to_id().parse::<u64>().ok());
-        let proof_nonce = inputs.get(4).cloned();
+        let proof_nonce = match inputs.get(4) {
+            Some(Artifact(s)) if !s.is_empty() => Some(Artifact(s.clone())),
+            _ => None,
+        };
         let metadata = match inputs.get(5) {
             Some(Artifact(s)) if !s.is_empty() => serde_json::from_str(s),
             _ => Ok(Default::default()),


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes