### PR TITLE
fix(sp1-cuda): avoid destructor panic when cleanup runs outside a Tokio runtime

### DIFF
--- a/crates/cuda/src/client.rs
+++ b/crates/cuda/src/client.rs
@@ -7,6 +7,7 @@ use sp1_prover::worker::ProofFromNetwork;
 use sp1_prover_types::network_base_types::ProofMode;
 use std::{
     collections::HashMap,
+    future::Future,
     path::{Path, PathBuf},
     sync::{Arc, LazyLock, Weak},
     time::Duration,
@@ -218,12 +219,71 @@ impl Drop for CudaClientInner {
     fn drop(&mut self) {
         let stream = self.stream.take().expect("stream already taken");
 
-        tokio::spawn(async move {
+        spawn_cleanup_task(async move {
             let mut stream = stream.lock().await;
 
             if let Err(e) = stream.shutdown().await {
                 tracing::error!("Failed to shutdown the stream: {}", e);
             }
         });
+    }
+}
+
+pub(crate) fn spawn_cleanup_task<F>(future: F)
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    if let Ok(handle) = tokio::runtime::Handle::try_current() {
+        handle.spawn(future);
+        return;
+    }
+
+    let thread =
+        std::thread::Builder::new().name("sp1-cuda-cleanup".to_string()).spawn(move || {
+            let runtime = match tokio::runtime::Builder::new_current_thread().enable_all().build() {
+                Ok(runtime) => runtime,
+                Err(err) => {
+                    tracing::error!("Failed to create Tokio runtime for CUDA cleanup: {}", err);
+                    return;
+                }
+            };
+
+            runtime.block_on(future);
+        });
+
+    if let Err(err) = thread {
+        tracing::error!("Failed to spawn CUDA cleanup thread: {}", err);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::spawn_cleanup_task;
+    use std::time::Duration;
+
+    #[test]
+    fn spawn_cleanup_task_works_without_runtime() {
+        let (tx, rx) = std::sync::mpsc::channel();
+
+        spawn_cleanup_task(async move {
+            tx.send(()).expect("cleanup signal should send");
+        });
+
+        rx.recv_timeout(Duration::from_secs(5))
+            .expect("cleanup task should finish without a Tokio runtime");
+    }
+
+    #[tokio::test]
+    async fn spawn_cleanup_task_works_with_runtime() {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+
+        spawn_cleanup_task(async move {
+            tx.send(()).expect("cleanup signal should send");
+        });
+
+        tokio::time::timeout(Duration::from_secs(5), rx)
+            .await
+            .expect("cleanup task should finish on the current Tokio runtime")
+            .expect("cleanup signal should be received");
     }
 }

--- a/crates/cuda/src/pk.rs
+++ b/crates/cuda/src/pk.rs
@@ -60,7 +60,7 @@ impl Drop for SessionKey {
         let client = self.client.clone();
         let id = std::mem::take(&mut self.id);
 
-        tokio::spawn(async move {
+        crate::client::spawn_cleanup_task(async move {
             if let Err(e) = client.destroy(id).await {
                 tracing::error!("Failed to destroy session key: {}", e);
             }


### PR DESCRIPTION
Fixes #2673

### Summary

`sp1-cuda` currently schedules cleanup work from `Drop` using `tokio::spawn`.

That is fine while a Tokio runtime is still active, but it panics if the CUDA proving key or client is dropped after the runtime has already been torn down. Because the panic happens in a destructor, the process then aborts during cleanup.

This patch keeps the existing behavior when a runtime is active, but falls back to a small dedicated cleanup thread with its own current-thread Tokio runtime when cleanup happens outside Tokio runtime context.

### What changed

- added `spawn_cleanup_task` in `crates/cuda/src/client.rs`
- `CudaClientInner::drop()` now uses that helper instead of calling `tokio::spawn` directly
- `SessionKey::drop()` now uses the same helper for async `Destroy`
- added unit coverage for cleanup scheduling with and without an active Tokio runtime

### Why this is the right scope

This PR is intentionally narrow.

It only addresses the destructor-time panic / abort path reported in `#2673`. It does not change proving logic, proof generation, server protocol, or lower level CUDA task execution behavior.

### Repro / verification

I verified this locally on a Linux WSL CUDA setup with an RTX 5090.

Before the patch, a minimal raw CUDA repro that:

1. creates a raw `sp1_cuda::CudaProver`
2. runs setup successfully
3. drops the Tokio runtime
4. then drops the proving key / client

would panic with:

- `there is no reactor running`
- followed by `panic in a destructor during cleanup`

After this patch, the same local repro completes cleanup without panic.

I also ran:

```bash
cargo test -p sp1-cuda spawn_cleanup_task -- --nocapture
```

### Notes

While reproducing on current `main`, I also hit some environment/bootstrap noise that is separate from the reported cleanup bug:

- slow first-run download of the prebuilt `sp1-gpu-server` asset
- missing `libcudart.so.12` in the local WSL runtime until `libcudart12` was installed

I am not including any changes for that here because they are orthogonal to the cleanup panic itself, and I wanted to keep this PR small and reviewable.
