### PR TITLE
perf(gpu): seed-and-grow zerocheck chunker

### DIFF
--- a/sp1-gpu/crates/air/src/ir/chunker.rs
+++ b/sp1-gpu/crates/air/src/ir/chunker.rs
@@ -1,11 +1,22 @@
-//! Greedy first-fit-decreasing chunker.
+//! Seed-and-grow chunker.
 //!
 //! Given the per-constraint analysis, packs constraints into chunks bounded
-//! by a register-pressure
-//! budget (max leafset per chunk → downstream `max_reg` → MAX_REGS template
-//! tier). Heuristic: sort constraints by descending leafset size, then for
-//! each, pick the chunk that minimizes the number of NEW unique leaves
-//! introduced.
+//! by a register-pressure budget (max leafset per chunk → downstream
+//! `max_reg` → MAX_REGS template tier). The objective is to minimise the
+//! total column-load traffic: `Σ over chunks of |chunk.leafset|`. A column
+//! shared by K chunks is fetched from memory K times, so a poor packing
+//! amplifies column loads (the dominant memory traffic of the zerocheck
+//! kernel).
+//!
+//! Heuristic: open a chunk on the largest unplaced constraint, then
+//! repeatedly pull in the unplaced constraint that adds the *fewest new
+//! leaves* until the budget is exhausted, then move on to the next chunk.
+//! Growing one chunk to fullness before opening the next concentrates
+//! column overlap far better than placing each constraint into the
+//! best-so-far chunk (the earlier first-fit-decreasing heuristic): measured
+//! on `RiscvAir`, seed-and-grow cuts the machine-wide column-load factor
+//! from 4.4x to 1.6x at `max_leafset = 256`, and is never worse at any
+//! budget.
 //!
 //! If a single constraint already exceeds the budget, it becomes its own
 //! chunk — flagged for the scheduler to route to the escape-valve lowering.
@@ -101,14 +112,22 @@ pub fn chunk_dag(constraints: &[ConstraintInfo], budget: &ChunkBudget) -> Vec<Ch
     chunks
 }
 
-/// Inner workhorse: greedy first-fit-decreasing over a constraint subset.
+/// Inner workhorse: seed-and-grow over a constraint subset.
+///
+/// Constraints are visited in descending-leafset order. The first unplaced
+/// constraint seeds a new chunk; the chunk is then grown by repeatedly
+/// pulling in the unplaced constraint that adds the fewest new leaves, until
+/// no remaining constraint fits the budget. Then the next unplaced
+/// constraint seeds the following chunk.
 fn chunk_subset(
     constraints: &[ConstraintInfo],
     indices: &[usize],
     budget: &ChunkBudget,
 ) -> Vec<Chunk> {
-    // First-fit decreasing: sort indices by descending leafset size, then by
-    // descending work.
+    // Descending leafset size, then descending work — the hardest-to-place
+    // constraints become seeds. `sort_by` is stable, so ties keep input
+    // order, which keeps the output deterministic (the bytecode must be
+    // machine-stable).
     let mut order: Vec<usize> = indices.to_vec();
     order.sort_by(|&a, &b| {
         constraints[b]
@@ -118,58 +137,66 @@ fn chunk_subset(
             .then_with(|| constraints[b].work.cmp(&constraints[a].work))
     });
 
+    // Every position strictly before the current seed is already placed —
+    // either it was consumed as a member, or it seeded an earlier chunk —
+    // so the candidate scan only needs to look forward.
+    let mut placed = vec![false; order.len()];
     let mut chunks: Vec<Chunk> = Vec::new();
-    for ci in order {
-        let c = &constraints[ci];
 
-        // Find an existing chunk that can absorb this constraint with the
-        // fewest new unique leaves.
-        let mut best: Option<(usize, usize)> = None; // (chunk_idx, new_leaf_count)
-        for (i, chunk) in chunks.iter().enumerate() {
-            // Quick rejection: would exceed constraint cap.
-            if chunk.constraint_indices.len() as u32 + 1 > budget.max_constraints_per_chunk {
-                continue;
+    for seed_pos in 0..order.len() {
+        if placed[seed_pos] {
+            continue;
+        }
+        placed[seed_pos] = true;
+        let seed = &constraints[order[seed_pos]];
+
+        let mut leafset: HashSet<ColumnLeaf> = seed.column_leaves.iter().copied().collect();
+        let mut constraint_indices = vec![order[seed_pos]];
+        let mut depth_max = seed.depth;
+        let mut shape = seed.shape;
+
+        // Grow: pull in the fewest-new-leaves constraint until nothing fits.
+        loop {
+            if constraint_indices.len() as u32 >= budget.max_constraints_per_chunk {
+                break;
             }
-            // Compute the prospective union size.
-            let new_leaves = c.column_leaves.difference(&chunk.leafset).count();
-            let new_union = chunk.leafset.len() + new_leaves;
-            if new_union as u32 > budget.max_leafset {
-                continue;
+            let mut best: Option<(usize, usize)> = None; // (pos, new_leaf_count)
+            for cand_pos in (seed_pos + 1)..order.len() {
+                if placed[cand_pos] {
+                    continue;
+                }
+                let c = &constraints[order[cand_pos]];
+                let new_leaves = c.column_leaves.difference(&leafset).count();
+                if leafset.len() + new_leaves > budget.max_leafset as usize {
+                    continue;
+                }
+                if best.is_none_or(|(_, bn)| new_leaves < bn) {
+                    best = Some((cand_pos, new_leaves));
+                    if new_leaves == 0 {
+                        break; // can't beat a free add
+                    }
+                }
             }
-            if best.is_none_or(|(_, bn)| new_leaves < bn) {
-                best = Some((i, new_leaves));
+            match best {
+                Some((cand_pos, _)) => {
+                    placed[cand_pos] = true;
+                    let c = &constraints[order[cand_pos]];
+                    leafset.extend(c.column_leaves.iter().copied());
+                    constraint_indices.push(order[cand_pos]);
+                    depth_max = depth_max.max(c.depth);
+                    if !matches!(c.shape, ConstraintShape::LinearWeightedSum) {
+                        shape = ConstraintShape::General;
+                    }
+                }
+                None => break,
             }
         }
 
-        match best {
-            Some((idx, _)) => {
-                let chunk = &mut chunks[idx];
-                for &leaf in &c.column_leaves {
-                    chunk.leafset.insert(leaf);
-                }
-                chunk.constraint_indices.push(ci);
-                chunk.depth_max = chunk.depth_max.max(c.depth);
-                if !matches!(c.shape, ConstraintShape::LinearWeightedSum) {
-                    chunk.shape = ConstraintShape::General;
-                }
-            }
-            None => {
-                // Could not fit into any existing chunk → emit a fresh one.
-                // If the constraint alone exceeds the budget, flag it.
-                let oversize_singleton = c.column_leaves.len() as u32 > budget.max_leafset;
-                let mut leafset = HashSet::with_capacity(c.column_leaves.len());
-                for &leaf in &c.column_leaves {
-                    leafset.insert(leaf);
-                }
-                chunks.push(Chunk {
-                    constraint_indices: vec![ci],
-                    leafset,
-                    depth_max: c.depth,
-                    shape: c.shape,
-                    oversize_singleton,
-                });
-            }
-        }
+        // A lone constraint that overflows the budget on its own is the
+        // scheduler's escape-valve case.
+        let oversize_singleton =
+            constraint_indices.len() == 1 && leafset.len() as u32 > budget.max_leafset;
+        chunks.push(Chunk { constraint_indices, leafset, depth_max, shape, oversize_singleton });
     }
     chunks
 }


### PR DESCRIPTION
Stacked on #2797 (which is stacked on #2795 `feat/gpu-zerocheck-v2`). The diff is one file — `sp1-gpu/crates/air/src/ir/chunker.rs`.

## Motivation

#2797's `chunk_efficiency` example measured that the chunker emits **9.4× more column loads** than the distinct-column floor at the default `CHUNKER_MAX_LEAFSET=64`. The chunker's objective is to minimise total column-load traffic — `Σ over chunks of |chunk.leafset|` — because a column shared by K chunks is fetched from memory K times, and column reads are the dominant memory traffic of the zerocheck kernel (see the zerocheck ablation work).

## Change

Replace first-fit-decreasing with **seed-and-grow**: open a chunk on the largest unplaced constraint, then repeatedly pull in the unplaced constraint that adds the fewest new column leaves until the budget is full, then move on. Growing each chunk to fullness before opening the next concentrates column overlap far better than placing each constraint into the best-so-far chunk.

Machine-wide reload factor on `RiscvAir` (`cargo run --release --example chunk_efficiency -p sp1-gpu-air`):

| `max_leafset` | FFD (old) | seed-and-grow (new) |
|---|---|---|
| 64 (default) | 9.40× | 8.95× |
| 128 | 4.94× | 3.63× |
| 256 | 4.42× | **1.56×** |

A/B'd against the old packer and a locality-sorted variant — seed-and-grow wins at every budget and never loses.

## Safety

- **Correctness-preserving**: chunking is only a *grouping* of constraints; the machine-stable bytecode is identical for any budget-respecting grouping. The distinct-column union is unchanged (53,338 before and after).
- **Deterministic**: stable sort + strict tie-break — required for machine-stable bytecode.
- Same leafset budget → same `MAX_REGS` template tier, no kernel-side change.
- All `sp1-gpu-zerocheck` tests pass, including `test_zerocheck_real_traces` and `test_machine_bytecode_scaling`.

## Honest scoping

At the default `max_leafset=64` the win is small (9.40 → 8.95×) — there, the **budget**, not the packer, is the wall: the wide field-arithmetic precompiles (Bls12381/Bn254/Ed) have individual constraints near or above 64 leaves, so no packer can pair them. The larger value of this PR is that it makes the leafset budget *effective* — at 128/256 a good packer recovers 2–3× more than FFD does. That sets up a budget retune (which cross-tiers `MAX_REGS` and needs a GPU wall-time sweep — out of scope here). A GPU A/B is recommended before claiming a kernel speedup from this PR alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)