### PR TITLE
test(gpu): zerocheck kernel cost decomposition (decode ablation)

### DIFF
--- a/sp1-gpu/crates/sys/lib/zerocheck/sequential.cu
+++ b/sp1-gpu/crates/sys/lib/zerocheck/sequential.cu
@@ -21,6 +21,15 @@
 
 namespace cg = cooperative_groups;
 
+// Decode-cost ablation. When set to 1, the bytecode loop keeps the per-instr
+// fetch + opcode switch but replaces every case body with a single cheap
+// regs[] write — no trace loads, no field arithmetic. The gap vs mode 0 is
+// the bytecode loop's loads+arithmetic; mode-1 wall time is the interpreter
+// floor (fetch + dispatch). Default 0; flip to measure, do not ship as 1.
+#ifndef ZC_DECODE_ONLY
+#define ZC_DECODE_ONLY 0
+#endif
+
 namespace {
 
 // ============================================================================
@@ -89,7 +98,34 @@ __global__ void zerocheck_fused_sequential(
         ext_t acc = ext_t::zero();
 
         for (uint32_t i = 0; i < cm.n_instrs; i++) {
+#if ZC_DECODE_ONLY == 3 || ZC_DECODE_ONLY == 4
+            // Mode 3/4 — empty bytecode loop: no fetch, no body. regs[] left
+            // uninitialized; asserts read garbage — timing only. Mode 4 also
+            // skips the GKR sweep, so mode 3 − mode 4 = the GKR column sweep
+            // and mode 4 = asserts + reduce + setup.
+            (void)i;
+#else
             DagInstr instr = cm.instrs[i];
+#if ZC_DECODE_ONLY == 1
+            // Mode 1 — decode + dispatch: keep the fetch + opcode switch,
+            // replace every body with one cheap regs[] write. No trace loads,
+            // no field arithmetic.
+            switch (instr.opcode) {
+            case BC_LOAD_LEAF:   regs[instr.out] = K(felt_t::from_canonical_u32(instr.a)); break;
+            case BC_LOAD_CONST:  regs[instr.out] = K(felt_t::from_canonical_u32(instr.b)); break;
+            case BC_LOAD_PUBLIC: regs[instr.out] = K(felt_t::from_canonical_u32(instr.a ^ instr.b)); break;
+            case BC_ADD_F:       regs[instr.out] = regs[instr.a]; break;
+            case BC_SUB_F:       regs[instr.out] = regs[instr.b]; break;
+            case BC_MUL_F:       regs[instr.out] = regs[instr.a]; break;
+            case BC_NEG_F:       regs[instr.out] = regs[instr.b]; break;
+            default: break;
+            }
+#elif ZC_DECODE_ONLY == 2
+            // Mode 2 — no dispatch: keep the fetch, drop the switch entirely,
+            // one cheap regs[] write. (mode 1 − mode 2 = the switch dispatch;
+            // mode 2 itself = fetch + asserts + gkr + reduce.)
+            regs[instr.out] = K::zero();
+#else
             switch (instr.opcode) {
             case BC_LOAD_LEAF: {
                 LeafRef leaf = cm.leaves[instr.a];
@@ -134,6 +170,8 @@ __global__ void zerocheck_fused_sequential(
             default:
                 break;
             }
+#endif
+#endif
         }
 
         for (uint32_t i = 0; i < cm.n_asserts; i++) {
@@ -145,6 +183,7 @@ __global__ void zerocheck_fused_sequential(
             acc += alpha * regs[reg];
         }
 
+#if ZC_DECODE_ONLY != 4
         if (cm.gkr_main_width != 0 || cm.gkr_prep_width != 0) {
             for (uint32_t i = 0; i < cm.gkr_main_width; i++) {
                 K z = K::load(trace_data, cm.main_ptr + i * cm.height + (row_idx << 1));
@@ -198,6 +237,7 @@ __global__ void zerocheck_fused_sequential(
             ext_t geq_v = (e == 0) ? geq_z : (geq_z + ep_v * (geq_o - geq_z));
             acc -= geq_v * cm.padded_row_adjustment;
         }
+#endif
 
         if (row_idx < row_limit) {
             ext_t eq = ext_t::load(partial_lagrange, row_idx);

--- a/sp1-gpu/crates/sys/lib/zerocheck/sequential.cu
+++ b/sp1-gpu/crates/sys/lib/zerocheck/sequential.cu
@@ -21,11 +21,21 @@
 
 namespace cg = cooperative_groups;
 
-// Decode-cost ablation. When set to 1, the bytecode loop keeps the per-instr
-// fetch + opcode switch but replaces every case body with a single cheap
-// regs[] write — no trace loads, no field arithmetic. The gap vs mode 0 is
-// the bytecode loop's loads+arithmetic; mode-1 wall time is the interpreter
-// floor (fetch + dispatch). Default 0; flip to measure, do not ship as 1.
+// Cost-decomposition ablation for zerocheck_fused_sequential. Each mode strips
+// one more component; a component's cost is the wall-time gap between two
+// adjacent modes. Default 0 (kernel byte-identical to production).
+//
+//   0  full kernel
+//   1  bytecode loop = fetch + opcode switch only (bodies → cheap regs[] write)
+//   2  + drop the opcode switch (fetch only)
+//   3  + drop the bytecode loop entirely
+//   4  + drop the GKR column sweep
+//   5  + drop the asserts loop
+//   6  + drop the block reduction (every thread stores racily — timing only)
+//   7  + drop the per-row chunk binary search (chunk_idx forced to 0)
+//
+// Modes 3-7 leave regs[]/acc partly undefined: results are garbage, timing
+// only. Do not ship as anything but 0.
 #ifndef ZC_DECODE_ONLY
 #define ZC_DECODE_ONLY 0
 #endif
@@ -90,7 +100,12 @@ __global__ void zerocheck_fused_sequential(
          idx += stride)
     {
         // Find chunk index for this idx.
+#if ZC_DECODE_ONLY >= 7
+        uint32_t chunk_idx = 0;  // mode >=7: skip the per-row chunk binary search
+        (void)n_chunks;
+#else
         uint32_t chunk_idx = upper_bound_u32_local(row_starts, n_chunks + 1, idx) - 1;
+#endif
         uint32_t row_idx = idx - row_starts[chunk_idx];
         ChunkMeta cm = chunk_meta[chunk_idx];
         const felt_t* consts = reinterpret_cast<const felt_t*>(cm.consts);
@@ -98,11 +113,9 @@ __global__ void zerocheck_fused_sequential(
         ext_t acc = ext_t::zero();
 
         for (uint32_t i = 0; i < cm.n_instrs; i++) {
-#if ZC_DECODE_ONLY == 3 || ZC_DECODE_ONLY == 4
-            // Mode 3/4 — empty bytecode loop: no fetch, no body. regs[] left
-            // uninitialized; asserts read garbage — timing only. Mode 4 also
-            // skips the GKR sweep, so mode 3 − mode 4 = the GKR column sweep
-            // and mode 4 = asserts + reduce + setup.
+#if ZC_DECODE_ONLY >= 3
+            // Mode >=3 — empty bytecode loop: no fetch, no body. regs[] left
+            // uninitialized; downstream reads are garbage — timing only.
             (void)i;
 #else
             DagInstr instr = cm.instrs[i];
@@ -174,6 +187,7 @@ __global__ void zerocheck_fused_sequential(
 #endif
         }
 
+#if ZC_DECODE_ONLY < 5
         for (uint32_t i = 0; i < cm.n_asserts; i++) {
             uint16_t reg = cm.assert_regs[i];
             // Bytecode stores chip-relative alpha indices; shift into the
@@ -182,8 +196,9 @@ __global__ void zerocheck_fused_sequential(
             ext_t alpha = ext_t::load(powers_of_alpha, alpha_idx);
             acc += alpha * regs[reg];
         }
+#endif
 
-#if ZC_DECODE_ONLY != 4
+#if ZC_DECODE_ONLY < 4
         if (cm.gkr_main_width != 0 || cm.gkr_prep_width != 0) {
             for (uint32_t i = 0; i < cm.gkr_main_width; i++) {
                 K z = K::load(trace_data, cm.main_ptr + i * cm.height + (row_idx << 1));
@@ -246,6 +261,7 @@ __global__ void zerocheck_fused_sequential(
         }
     }
 
+#if ZC_DECODE_ONLY < 6
     extern __shared__ unsigned char smem[];
     ext_t* shared = reinterpret_cast<ext_t*>(smem);
 
@@ -258,6 +274,12 @@ __global__ void zerocheck_fused_sequential(
         // the existing host aggregation that sums 3 ext per block.
         ext_t::store(partials, blockIdx.x * 3 + (uint32_t)e, block_sum);
     }
+#else
+    // Mode >=6: drop the block reduction. Every thread stores its own
+    // thread_acc racily — garbage result, timing only — so all threads'
+    // per-row accumulation stays live (no DCE).
+    ext_t::store(partials, blockIdx.x * 3 + (uint32_t)e, thread_acc);
+#endif
 }
 
 } // namespace


### PR DESCRIPTION
**Draft — measurement scaffolding, not a behavior change.** Stacked on #2795. `ZC_DECODE_ONLY` defaults to 0 (kernel byte-identical; all 10 `sp1-gpu-zerocheck` tests pass).

## Why

To decide whether the zerocheck kernel's interpreter overhead (instruction fetch + opcode dispatch + the runtime-indexed `regs[]` array) is large enough to justify a JIT/codegen path or a cooperative-DAG redesign — i.e. *measure before scoping*.

## Method

`ZC_DECODE_ONLY` progressively strips `zerocheck_fused_sequential`; each component falls out of a mode difference. Bench: `cargo bench -p sp1-gpu-zerocheck --bench zerocheck`, `CHUNKER_MAX_LEAFSET=64`, 4090.

| mode | what runs | all-chips 2²⁸ | core 2²⁵ |
|---|---|---|---|
| 0 | full kernel | 126.45 ms | 22.50 ms |
| 1 | bytecode loop = fetch + dispatch only | 114.61 ms | 16.47 ms |
| 2 | + drop the opcode switch | 108.17 ms | 12.24 ms |
| 3 | empty bytecode loop (asserts + GKR + reduce) | 98.16 ms | 8.87 ms |
| 4 | also drop GKR sweep (asserts + reduce + setup) | 49.93 ms | 4.85 ms |

## Decomposition (% of full kernel)

| component | all-chips | core |
|---|---|---|
| trace loads + field arithmetic | 9% | 27% |
| opcode dispatch (the `switch`) | 5% | 19% |
| instr fetch + `regs[]` traffic | 8% | 15% |
| **GKR column sweep** | **38%** | **18%** |
| **asserts + reduce + binary-search + setup** | **40%** | **22%** |

## Findings

1. **The bytecode interpreter is not the bottleneck.** Decode + dispatch + `regs[]` traffic is ~13% (all-chips) / ~34% (core); the DAG's field arithmetic is another 9% / 27%. A JIT/codegen path removes only the first slice — **not worth the loss of runtime-defined-circuit flexibility** at this share.
2. **The GKR opening-correction sweep is ~38% of the kernel** on precompile-heavy workloads — a full ext-weighted column sum over every chip column, every round. Previously unexamined; the single fattest target.
3. **The asserts + reduce + per-row binary-search tail is ~40%** (all-chips). The chunk-dispatch binary search likely hurts when there are many chunks.
4. Workload-dependent: the bytecode loop is 22% of the kernel on `all-chips` but 61% on `core` — real RSP shards sit between.

## Next

Split mode 4 (binary-search vs asserts vs reduce) and profile the GKR sweep — that 38–78% tail is where the win is, ahead of a cooperative-DAG redesign of the (minority) interpreter loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)