### PR TITLE
perf(gpu): arity-2 + weighted-admission concurrency

### DIFF
--- a/crates/prover/compress_shape.json
+++ b/crates/prover/compress_shape.json
@@ -1,14 +1,14 @@
 {
   "shape": {
     "heights": {
-      "BaseAlu": 592384,
-      "ExtAlu": 795264,
-      "MemoryConst": 492320,
-      "MemoryVar": 661984,
-      "Poseidon2WideDeg3": 158368,
+      "BaseAlu": 296512,
+      "ExtAlu": 764832,
+      "MemoryConst": 245888,
+      "MemoryVar": 326368,
+      "Poseidon2WideDeg3": 77920,
       "PrefixSumChecks": 224608,
       "PublicValues": 16,
-      "Select": 1087808
+      "Select": 543904
     },
     "_marker": null
   }

--- a/crates/prover/src/shapes.rs
+++ b/crates/prover/src/shapes.rs
@@ -68,7 +68,12 @@ use crate::{
     CompressAir, CORE_MAX_LOG_ROW_COUNT,
 };
 
-pub const DEFAULT_ARITY: usize = 4;
+/// The recursion compose arity — how many proofs each compose program
+/// verifies. Single source of truth: the worker config's
+/// `DEFAULT_MAX_COMPOSE_ARITY` and `DEFAULT_MAX_REDUCE_ARITY` both derive from
+/// this, so the three cannot drift (a mismatch panics with "Compress program
+/// not found for arity N").
+pub const DEFAULT_ARITY: usize = 2;
 
 /// The shape of the "normalize" program, which proves the correct execution for the verifier of a
 /// single core shard proof.

--- a/crates/prover/src/worker/config.rs
+++ b/crates/prover/src/worker/config.rs
@@ -180,7 +180,9 @@ impl SP1WorkerConfig {
 // Default values for the controller config.
 pub(crate) const DEFAULT_NUM_SPLICING_WORKERS: usize = 2;
 pub(crate) const DEFAULT_SPLICING_BUFFER_SIZE: usize = 2;
-pub(crate) const DEFAULT_MAX_REDUCE_ARITY: usize = 4;
+// Derived from the single arity source of truth (`shapes::DEFAULT_ARITY`) so
+// the compose / reduce arities cannot drift apart.
+pub(crate) const DEFAULT_MAX_REDUCE_ARITY: usize = crate::shapes::DEFAULT_ARITY;
 pub(crate) const DEFAULT_NUMBER_OF_SEND_SPLICE_WORKERS_PER_SPLICE: usize = 2;
 pub(crate) const DEFAULT_SEND_SPLICE_INPUT_BUFFER_SIZE_PER_SPLICE: usize = 2;
 
@@ -190,7 +192,7 @@ pub(crate) const DEFAULT_CORE_BUFFER_SIZE: usize = 4;
 pub(crate) const DEFAULT_NUM_SETUP_WORKERS: usize = 2;
 pub(crate) const DEFAULT_SETUP_BUFFER_SIZE: usize = 2;
 pub(crate) const DEFAULT_NORMALIZE_PROGRAM_CACHE_SIZE: usize = 5;
-pub(crate) const DEFAULT_MAX_COMPOSE_ARITY: usize = 4;
+pub(crate) const DEFAULT_MAX_COMPOSE_ARITY: usize = crate::shapes::DEFAULT_ARITY;
 
 // Default values for the recursion prover config.
 pub(crate) const DEFAULT_NUM_PREPARE_REDUCE_WORKERS: usize = DEFAULT_NUM_RECURSION_EXECUTOR_WORKERS;

--- a/sp1-gpu/crates/jagged_tracegen/src/lib.rs
+++ b/sp1-gpu/crates/jagged_tracegen/src/lib.rs
@@ -620,6 +620,28 @@ async fn copy_main_jagged_traces(
     }
 }
 
+/// Quantization unit for the prover memory-budget semaphore. Weights and the
+/// budget are both expressed in these units so `ProverSemaphore::acquire_many`
+/// (a `u32` counting semaphore) admits "whatever fits the GPU".
+pub const PROVE_WEIGHT_UNIT_BYTES: u64 = 256 * 1024 * 1024;
+
+/// Estimated GPU-DRAM footprint of one shard prove, in [`PROVE_WEIGHT_UNIT_BYTES`]
+/// units — the weight a prove acquires from the prover's memory-budget
+/// semaphore so concurrent proves cannot oversubscribe device memory.
+///
+/// Calibrated from nsys / `recursion-bench` measurements (RTX 4090):
+/// a core prove (`max_trace_size ≈ 304M` felts) ≈ 10.0 GB; a recursion prove
+/// (`≈ 134M`) ≈ 5.9 GB → linear fit `≈ 2.6 GB + 25 B/felt`.
+///
+/// TODO(gpu-calibration): re-measure per prove type; the fit is approximate
+/// and the budget carries a safety margin to absorb the error.
+pub fn prove_weight(max_trace_size: usize) -> u32 {
+    const FIXED_BYTES: u64 = 2_600_000_000;
+    const BYTES_PER_FELT: u64 = 25;
+    let footprint = FIXED_BYTES + BYTES_PER_FELT * max_trace_size as u64;
+    footprint.div_ceil(PROVE_WEIGHT_UNIT_BYTES).max(1) as u32
+}
+
 /// Corresponds to `generate_preprocessed_traces`.
 #[instrument(skip_all, level = "debug")]
 #[allow(clippy::too_many_arguments)]
@@ -637,7 +659,7 @@ pub async fn setup_tracegen<A: CudaTracegenAir<Felt>>(
     let (host_phase_tracegen, _) =
         host_preprocessed_tracegen(machine, buffer_ptr, Arc::clone(&program)).await;
 
-    let permit = prover_permit.acquire().await.unwrap();
+    let permit = prover_permit.acquire_many(prove_weight(max_trace_size)).await.unwrap();
     // - Copying host traces to the device.
     // - Generating traces on the device.
     let preprocessed_traces =
@@ -851,6 +873,7 @@ pub async fn main_tracegen<GC: IopCtx<F = Felt>, A: CudaTracegenAir<Felt>>(
     buffer: &Worker<PinnedBuffer<Felt>>,
     log_stacking_height: u32,
     max_log_row_count: u32,
+    max_trace_size: usize,
     backend: &TaskScope,
     prover_permit: ProverSemaphore,
     global_dependencies_opt: bool,
@@ -860,8 +883,11 @@ pub async fn main_tracegen<GC: IopCtx<F = Felt>, A: CudaTracegenAir<Felt>>(
         host_main_tracegen(machine, buffer.as_ptr() as usize, 0, record.clone()).await;
 
     let HostPhaseShapeInfo { traces_by_name: initial_traces, chip_set } = host_phase_shape_info;
-    let permit =
-        prover_permit.acquire().instrument(tracing::debug_span!("acquire permit")).await.unwrap();
+    let permit = prover_permit
+        .acquire_many(prove_weight(max_trace_size))
+        .instrument(tracing::debug_span!("acquire permit"))
+        .await
+        .unwrap();
     let mut jagged_traces = jagged_traces.lock().await;
 
     // Now that the permit is acquired, we can begin the following two tasks:
@@ -892,6 +918,7 @@ pub async fn main_tracegen_permit<GC: IopCtx<F = Felt>, A: CudaTracegenAir<Felt>
     buffer: &Worker<PinnedBuffer<Felt>>,
     log_stacking_height: u32,
     max_log_row_count: u32,
+    max_trace_size: usize,
     backend: &TaskScope,
     prover_permit: ProverSemaphore,
     global_dependencies_opt: bool,
@@ -903,6 +930,7 @@ pub async fn main_tracegen_permit<GC: IopCtx<F = Felt>, A: CudaTracegenAir<Felt>
         buffer,
         log_stacking_height,
         max_log_row_count,
+        max_trace_size,
         backend,
         prover_permit,
         global_dependencies_opt,
@@ -936,8 +964,11 @@ pub async fn full_tracegen<A: CudaTracegenAir<Felt>>(
         host_main_tracegen(machine, buffer.as_ptr() as usize, start_idx, record.clone()).await;
 
     // Wait for a prover to be available.
-    let permit =
-        prover_permits.acquire().instrument(tracing::debug_span!("acquire")).await.unwrap();
+    let permit = prover_permits
+        .acquire_many(prove_weight(max_trace_size))
+        .instrument(tracing::debug_span!("acquire"))
+        .await
+        .unwrap();
 
     // Now that the permit is acquired, we can begin the following two tasks:
     // - Copying host traces to the device.

--- a/sp1-gpu/crates/prover_components/src/builder.rs
+++ b/sp1-gpu/crates/prover_components/src/builder.rs
@@ -4,6 +4,7 @@ use sp1_core_machine::riscv::RiscvAir;
 use sp1_gpu_cudart::{cuda_memory_info, TaskScope};
 
 use sp1_core_executor::{SP1CoreOpts, ELEMENT_THRESHOLD};
+use sp1_gpu_jagged_tracegen::{prove_weight, CORE_MAX_TRACE_SIZE, PROVE_WEIGHT_UNIT_BYTES};
 use sp1_gpu_shard_prover::CudaShardProver;
 use sp1_hypercube::{prover::ProverSemaphore, InnerSC, Machine, MachineVerifier};
 use sp1_primitives::{SP1Field, SP1GlobalContext};
@@ -22,6 +23,28 @@ use crate::{
     new_cuda_prover, CudaProverCoreComponents, CudaProverRecursionComponents,
     SP1CudaProverComponents,
 };
+
+/// Capacity (in [`PROVE_WEIGHT_UNIT_BYTES`] units) of the prover memory-budget
+/// semaphore. Each prove acquires `prove_weight()` units before it allocates,
+/// so concurrency is bounded by "what fits GPU DRAM" rather than a fixed count.
+///
+/// Default = one core prove's weight → effectively serial (today's behaviour),
+/// and always ≥ the largest single weight so a prove can never deadlock itself.
+/// Set `SP1_GPU_PROVER_BUDGET_GB` to raise it and enable concurrent proving
+/// (requires per-prove stream routing to actually overlap on the GPU).
+fn prover_memory_budget_units() -> usize {
+    let serial_default = prove_weight(CORE_MAX_TRACE_SIZE as usize);
+    let units =
+        match std::env::var("SP1_GPU_PROVER_BUDGET_GB").ok().and_then(|s| s.parse::<f64>().ok()) {
+            Some(gb) => {
+                let bytes = gb * (1u64 << 30) as f64;
+                (bytes / PROVE_WEIGHT_UNIT_BYTES as f64) as u32
+            }
+            None => serial_default,
+        };
+    // Never below the largest single prove's weight (deadlock floor).
+    units.max(serial_default) as usize
+}
 
 pub fn local_gpu_opts() -> (SP1CoreOpts, bool) {
     let mut opts = SP1CoreOpts::default();
@@ -92,8 +115,10 @@ pub async fn cuda_worker_builder_with_machine(
     scope: TaskScope,
     machine: Machine<SP1Field, RiscvAir<SP1Field>>,
 ) -> SP1WorkerBuilder<SP1CudaProverComponents> {
-    // Create a prover permits, assuming a single proof happens at a time.
-    let prover_permits = ProverSemaphore::new(1);
+    // Prover memory-budget semaphore — each prove acquires `prove_weight()`
+    // units before allocating, so the GPU cannot be oversubscribed. Defaults
+    // to one core prove (serial); `SP1_GPU_PROVER_BUDGET_GB` raises it.
+    let prover_permits = ProverSemaphore::new(prover_memory_budget_units());
 
     // Get the core options.
     let (opts, _) = local_gpu_opts();

--- a/sp1-gpu/crates/shard_prover/src/prover.rs
+++ b/sp1-gpu/crates/shard_prover/src/prover.rs
@@ -330,6 +330,7 @@ where
             &buffer,
             self.inner.basefold_prover.log_height,
             self.inner.max_log_row_count,
+            self.inner.max_trace_size,
             &self.inner.backend,
             prover_permits,
             true,


### PR DESCRIPTION
**Draft — stacked on #2795.** arity-2 + the weighted-admission concurrency system.

## Part A — recursion compose arity 4 → 2 ✅

Halves the recursion-prover footprint — the prerequisite for core∥recursion overlap fitting a 24 GB card. `DEFAULT_ARITY` is now the single source of truth (worker config derives from it); `compress_shape.json` regenerated. vk artifacts not regenerated — runs behind `--features experimental` + `WITHOUT_VK_VERIFICATION=1` (arity-2 vk regen is circuit-adjacent, separate task).

## Part B.1 — weighted prover memory-budget semaphore ✅

Replaces the shared `ProverSemaphore(1)` with a weighted admission semaphore: capacity is a GPU-DRAM budget, each prove `acquire_many(prove_weight(max_trace_size))` before allocating. Concurrency = "whatever fits the GPU", self-tuning and GPU-size-portable.

- `prove_weight()` / `PROVE_WEIGHT_UNIT_BYTES` (256-MiB units) in jagged-tracegen; the 3 tracegen acquire sites are now weighted.
- `cuda_worker_builder` sizes the budget; default = one core prove (serial, = today), `SP1_GPU_PROVER_BUDGET_GB` raises it. Always ≥ max single weight (deadlock floor).

Corruption-safe (device-state audit + FFI pass: shared bytecode/interactions/Poseidon2 constants are read-only) and memory-safe (weight gates DRAM). **Inert for *speed* until B.2** — proves still share one `TaskScope` stream.

## Part B.2 — per-prove stream routing ⏳ (remaining)

Each admitted prove must run on its own CUDA stream to actually overlap. `TaskScope::run_in_place` already provides a fresh-stream child task; the backend propagates through `.backend()` on the trace data, so the change is: route each prove (tracegen + `prove_shard_with_data`) through `run_in_place`, threading the child scope at the ~handful of explicit `self.inner.backend` sites. Plus: the weight must be released **after** a stream sync past the prove's `cudaFreeAsync`s (stream-ordered free — else logical free races ahead of physical).

## Remaining before merge-ready

- B.2 stream routing.
- `prove_weight` calibration + budget via a GPU memory pass.
- GPU validation: no-OOM, proofs verify, measured speedup (~12% ceiling).
- arity-2 vk-artifact regeneration (separate, circuit-adjacent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)