### PR TITLE
fix: allow expected zkVM entrypoint warnings

### DIFF
--- a/crates/zkvm/entrypoint/src/lib.rs
+++ b/crates/zkvm/entrypoint/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![allow(dead_code, static_mut_refs, unused_imports)]
 
 #[cfg(target_os = "zkvm")]
 use {


### PR DESCRIPTION
This PR suppresses expected warnings in the zkVM entrypoint crate so the current Succinct zkVM toolchain can compile test artifacts without hitting a warning-rendering ICE.

1. Context

While preparing low-VRAM GPU benchmark evidence for the CUDA prover path, the test-artifacts build repeatedly failed before any benchmark could run.

The failure happened inside rustc +succinct 1.93.0-dev while emitting warnings from crates/zkvm/entrypoint/src/lib.rs. The observed panic was:

slice index starts at 16 but ends at 14

The query stack ended in check_mod_deathness / analysis for crate sp1_zkvm. The generated local ICE report path was:

crates/zkvm/entrypoint/rustc-ice-2026-05-20T14_55_26-8010.txt

2. Change

This PR adds a crate-level allow for the warning categories emitted by this entrypoint crate:

dead_code
static_mut_refs
unused_imports

This is intentionally narrow. It does not change runtime code, proving logic, public APIs, or CUDA kernels.

3. Validation

Validated on a local RTX 5090 machine using the current branch from main commit 98a376e87ec9dd5c3ae3495b98846bf921d6035b.

Command 1:

CARGO_BUILD_JOBS=1 SP1_SKIP_PROGRAM_BUILD=false cargo bench -p sp1-gpu-logup-gkr --bench gkr -- random:20

Result:

populate_circuit/random/core_2^20: 1.989 ms to 2.271 ms, mean 2.120 ms
prove/random/core_2^20: 112.32 ms to 117.77 ms, mean 113.80 ms

Command 2:

CARGO_BUILD_JOBS=1 SP1_SKIP_PROGRAM_BUILD=false cargo bench -p sp1-gpu-shard-prover --bench prove_trusted_evaluations -- random:20

Result:

prove_trusted_evaluations/random/core_2^20: 50.530 ms to 54.764 ms, mean 52.622 ms

4. Caveat

This PR is not a performance optimization. It is a small build/benchmark enablement change. The value is that GPU prover microbenchmarks can complete and produce repeatable evidence instead of being blocked by warning emission in the current zkVM toolchain.
