### PR TITLE
fix(sdk): treat gRPC Cancelled as transient when polling proof status

### DIFF
--- a/crates/sdk/src/network/retry.rs
+++ b/crates/sdk/src/network/retry.rs
@@ -56,7 +56,8 @@ where
                         Code::Unavailable
                         | Code::DeadlineExceeded
                         | Code::Internal
-                        | Code::Aborted => {
+                        | Code::Aborted
+                        | Code::Cancelled => {
                             tracing::warn!(
                                 "Network temporarily unavailable when {} due to {}, retrying...",
                                 operation_name,


### PR DESCRIPTION
## What

Add `Code::Cancelled` to the transient set in retry.rs so it's retried with backoff instead of marked permanent.

## Why

The retry classifier treats Code::Cancelled as permanent. But the only Cancelled that reaches retry.rs is transport-level. A hyper connection-close (`is_canceled() → Status::cancelled`) or tonic's own 60s per-RPC timeout. So one transient blip during the status-poll loop aborts the entire proof wait, even though the proof fulfills normally.

Surfaced by Agglayer/Polygon repeatedly hitting:
```
Permanent error encountered when getting proof request status: operation was canceled
```

Proof was fulfilled on-chain; the client just gave up polling.

