### PR TITLE
fix(executor): report unimp traps instead of "Unknown"

### DIFF
--- a/crates/core/jit/src/backends/debug.rs
+++ b/crates/core/jit/src/backends/debug.rs
@@ -384,6 +384,9 @@ impl<B: RiscvTranspiler> SystemInstructions for DebugBackend<B> {
         extern "C" fn unimp(ctx: *mut JitContext) {
             let ctx = unsafe { &mut *ctx };
             eprintln!("Unimplemented instruction at pc: {}", ctx.pc);
+            // Trap via SIGILL so the parent maps this to a typed `Unimplemented`
+            // cause instead of a generic abort.
+            unsafe { libc::raise(libc::SIGILL) };
         }
 
         self.backend.call_extern_fn(unimp);

--- a/crates/core/jit/src/backends/x86/instruction_impl.rs
+++ b/crates/core/jit/src/backends/x86/instruction_impl.rs
@@ -1695,6 +1695,9 @@ impl SystemInstructions for TranspilerBackend {
         extern "C" fn unimp(ctx: *mut JitContext) {
             let ctx = unsafe { &mut *ctx };
             eprintln!("Unimplemented instruction at pc: {}", ctx.pc);
+            // Trap via SIGILL so the parent maps this to a typed `Unimplemented`
+            // cause instead of a generic abort.
+            unsafe { libc::raise(libc::SIGILL) };
         }
 
         self.update_pc(TEMP_A, self.pc_current);

--- a/crates/core/runner/src/native.rs
+++ b/crates/core/runner/src/native.rs
@@ -167,7 +167,7 @@ impl MinimalExecutorRunner {
                         return Ok(Some(chunk));
                     }
                     TraceResult::Finished => {
-                        self.wait_for_success();
+                        self.wait_for_success()?;
                         return Ok(None);
                     }
                     TraceResult::Crashed(details) => {
@@ -178,7 +178,7 @@ impl MinimalExecutorRunner {
                             .1
                             .join()
                             .expect("wait for log thread to finish");
-                        let opcode = match details.signal {
+                        let opcode = match details.operation {
                             1 => Opcode::LD,
                             2 => Opcode::SD,
                             _ => Opcode::UNIMP,
@@ -187,6 +187,8 @@ impl MinimalExecutorRunner {
                             libc::SIGSEGV => {
                                 ExecutionError::InvalidMemoryAccess(opcode, details.addr)
                             }
+                            // SIGILL: child hit a JIT `unimp` (see sp1-jit's unimp handler).
+                            libc::SIGILL => ExecutionError::Unimplemented(),
                             _ => ExecutionError::Other(format!(
                                 "Child native executor crashed, details: {details:?}"
                             )),
@@ -202,7 +204,7 @@ impl MinimalExecutorRunner {
                         {
                             if status.success() {
                                 // The child terminates as normals, we need to process its output.
-                                self.wait_for_success();
+                                self.wait_for_success()?;
                                 return Ok(None);
                             }
                             // The child terminates with some errors. We still want to process logs.
@@ -218,6 +220,8 @@ impl MinimalExecutorRunner {
                             }
                             let error = match (status.code(), status.signal()) {
                                 (_, Some(libc::SIGKILL)) => ExecutionError::TooMuchMemory(),
+                                // SIGILL via exit status, if the crash channel missed it.
+                                (_, Some(libc::SIGILL)) => ExecutionError::Unimplemented(),
                                 (code, signal) => ExecutionError::Other(format!("Child native executor terminates early, code: {code:?}, signal: {signal:?}")),
                             };
                             self.output = Some(Err(error.clone()));
@@ -230,26 +234,44 @@ impl MinimalExecutorRunner {
             }
         } else {
             // Tracing mode is disabled, wait for process termination
-            self.wait_for_success();
+            self.wait_for_success()?;
             Ok(None)
         }
     }
 
-    fn wait_for_success(&mut self) {
+    fn wait_for_success(&mut self) -> Result<(), ExecutionError> {
         // SP1 program terminates, wait for output and terminate child process.
         let (mut child, log_thread) = self.process.take().unwrap();
         let stdout = child.stdout.take().expect("open stdout");
         let mut stdout_reader = BufReader::new(stdout);
 
-        let output: Output = bincode::deserialize_from(&mut stdout_reader).expect("read output");
+        // Read stdout before waiting to avoid a pipe-fill deadlock; a crashed child
+        // closes the pipe (EOF) rather than blocking.
+        let output: Result<Output, _> = bincode::deserialize_from(&mut stdout_reader);
         let status = child.wait().expect("wait for child to exit");
         log_thread.join().expect("wait for log thread to finish");
-        // Normal termination, this should just return success.
-        assert!(status.success());
 
-        self.global_clk = output.global_clk;
-        self.clk = output.clk;
-        self.output = Some(Ok(output));
+        match output {
+            Ok(output) if status.success() => {
+                self.global_clk = output.global_clk;
+                self.clk = output.clk;
+                self.output = Some(Ok(output));
+                Ok(())
+            }
+            // Non-tracing runner has no crash handler, so map the exit signal to a
+            // typed cause here instead of panicking (mirrors the Timeout branch).
+            _ => {
+                let error = match (status.code(), status.signal()) {
+                    (_, Some(libc::SIGKILL)) => ExecutionError::TooMuchMemory(),
+                    (_, Some(libc::SIGILL)) => ExecutionError::Unimplemented(),
+                    (code, signal) => ExecutionError::Other(format!(
+                        "Child native executor terminated abnormally, code: {code:?}, signal: {signal:?}"
+                    )),
+                };
+                self.output = Some(Err(error.clone()));
+                Err(error)
+            }
+        }
     }
 
     fn output(&self) -> &Output {


### PR DESCRIPTION
## Why

A [mainnet proof request](https://explorer.succinct.xyz/request/0x601563cdedba343d03a5febc16e4c9963189f447cea56a30f8e5aa96b6144f8e) showed "Execution Failure Reason: Unknown" in the explorer. The guest had executed a JIT `unimp`, but the native
executor didn't capture a structured cause. It fell through to a generic abort, which the network recorded as UNSPECIFIED → "Unknown" and can read like an SP1/infra fault rather than a guest-side issue.

What the logs showed:
```
# child native executor (oracle):
CHILD …: Unimplemented instruction at pc: 2018891292
CHILD …: thread caused non-unwinding panic. aborting.

# coordinator → network:
fail_proof … extra_data={"status":3,"failure_cause":0,"cycles":0,…}
rpc: updated request 0x601563… as unexecutable (cause=UNSPECIFIED_EXECUTION_FAILURE_CAUSE)

# and on a prover, the run-past-the-trap downstream symptom:
ERROR worker/src/lib.rs:209: Fatal error … TaskType: CoreExecute,
Error: failed to execute chunk: invalid memory access for opcode unimp and address 0
```

## What
Make the `unimp` trap a clean, typed `Unimplemented` execution-failure cause, so the explorer shows an accurate, actionable reason.