### PR TITLE
feat(sdk): add hosted mode to NetworkProver

### DIFF
--- a/crates/sdk/src/blocking/client.rs
+++ b/crates/sdk/src/blocking/client.rs
@@ -171,7 +171,33 @@ impl ProverClientBuilder {
             rpc_url: None,
             tee_signers: None,
             network_mode: Some(mode),
+            hosted: false,
             machine: self.machine.clone(),
         }
+    }
+
+    /// Builds a hosted [`NetworkProver`] for self-hosted clusters talking to the network-gateway.
+    ///
+    /// # Details
+    /// A hosted prover runs in [`NetworkMode::Reserved`] and makes `prove(&pk, stdin)` skip local
+    /// simulation and use the maximum cycle and gas limits by default, so no network-specific
+    /// toggles are needed. The defaults remain overridable per request.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use sp1_sdk::blocking::{Elf, ProveRequest, Prover, ProverClient, SP1Stdin};
+    ///
+    /// let elf = Elf::Static(&[1, 2, 3]);
+    /// let stdin = SP1Stdin::new();
+    ///
+    /// let prover = ProverClient::builder().hosted().build();
+    /// let pk = prover.setup(elf).unwrap();
+    /// let proof = prover.prove(&pk, stdin).compressed().run().unwrap();
+    /// ```
+    #[cfg(feature = "network")]
+    #[must_use]
+    #[allow(clippy::unused_self)]
+    pub fn hosted(&self) -> NetworkProverBuilder {
+        self.network_for(NetworkMode::Reserved).hosted()
     }
 }

--- a/crates/sdk/src/blocking/network/builder.rs
+++ b/crates/sdk/src/blocking/network/builder.rs
@@ -19,6 +19,7 @@ pub struct NetworkProverBuilder {
     pub(crate) tee_signers: Option<Vec<Address>>,
     pub(crate) signer: Option<NetworkSigner>,
     pub(crate) network_mode: Option<NetworkMode>,
+    pub(crate) hosted: bool,
     pub(crate) machine: Machine<SP1Field, RiscvAir<SP1Field>>,
 }
 
@@ -44,6 +45,7 @@ impl NetworkProverBuilder {
             tee_signers: None,
             signer: None,
             network_mode: None,
+            hosted: false,
             machine,
         }
     }
@@ -102,6 +104,27 @@ impl NetworkProverBuilder {
         self
     }
 
+    /// Configures the prover for hosted proving.
+    ///
+    /// # Details
+    /// Hosted proving runs in [`NetworkMode::Reserved`] and makes `prove(&pk, stdin)` skip local
+    /// simulation and use the maximum cycle and gas limits by default, with no network-specific
+    /// toggles required. This matches the behavior expected by self-hosted clusters talking to the
+    /// network-gateway. The defaults remain overridable per request.
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// use sp1_sdk::blocking::ProverClient;
+    ///
+    /// let prover = ProverClient::builder().network().hosted().build();
+    /// ```
+    #[must_use]
+    pub fn hosted(mut self) -> Self {
+        self.hosted = true;
+        self.network_mode = Some(NetworkMode::Reserved);
+        self
+    }
+
     /// Sets the list of TEE signers, used for verifying TEE proofs.
     #[must_use]
     pub fn tee_signers(mut self, tee_signers: &[Address]) -> Self {
@@ -143,6 +166,7 @@ impl NetworkProverBuilder {
             tee_signers: self.tee_signers,
             signer: self.signer,
             network_mode: self.network_mode,
+            hosted: self.hosted,
             machine: self.machine,
         };
         let prover = crate::blocking::block_on(async_builder.build());

--- a/crates/sdk/src/client.rs
+++ b/crates/sdk/src/client.rs
@@ -209,7 +209,34 @@ impl ProverClientBuilder {
             rpc_url: None,
             tee_signers: None,
             network_mode: Some(mode),
+            hosted: false,
             machine: self.machine.clone(),
         }
+    }
+
+    /// Builds a hosted [`NetworkProver`] for self-hosted clusters talking to the network-gateway.
+    ///
+    /// # Details
+    /// A hosted prover runs in [`NetworkMode::Reserved`] and makes `prove(&pk, stdin).await` skip
+    /// local simulation and use the maximum cycle and gas limits by default, so no
+    /// network-specific toggles are needed. The defaults remain overridable per request.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use sp1_sdk::{Elf, ProveRequest, Prover, ProverClient, SP1Stdin};
+    ///
+    /// tokio_test::block_on(async {
+    ///     let elf = Elf::Static(&[1, 2, 3]);
+    ///     let stdin = SP1Stdin::new();
+    ///
+    ///     let prover = ProverClient::builder().hosted().build().await;
+    ///     let pk = prover.setup(elf).await.unwrap();
+    ///     let proof = prover.prove(&pk, stdin).compressed().await.unwrap();
+    /// });
+    /// ```
+    #[cfg(feature = "network")]
+    #[must_use]
+    pub fn hosted(&self) -> NetworkProverBuilder {
+        self.network_for(NetworkMode::Reserved).hosted()
     }
 }

--- a/crates/sdk/src/env/mod.rs
+++ b/crates/sdk/src/env/mod.rs
@@ -111,16 +111,22 @@ impl EnvProver {
             "mock" => Self::Mock(MockProver::new_with_machine(machine).await),
             "light" => Self::Light(LightProver::new_with_machine(machine).await),
             #[cfg(feature = "network")]
-            "network" => {
+            "network" | "hosted" => {
                 let private_key =
                     std::env::var("NETWORK_PRIVATE_KEY").ok().filter(|k| !k.is_empty()).expect(
                         "NETWORK_PRIVATE_KEY environment variable is not set. \
                 Please set it to your private key or use the .private_key() method.",
                     );
 
-                let network_builder =
+                let mut network_builder =
                     crate::network::builder::NetworkProverBuilder::new_with_machine(machine)
                         .private_key(&private_key);
+
+                // `hosted` is a network prover in reserved mode that skips simulation and proves up
+                // to the maximum limits by default, so it stays an `EnvProver::Network` variant.
+                if prover == "hosted" {
+                    network_builder = network_builder.hosted();
+                }
 
                 Self::Network(network_builder.build().await)
             }

--- a/crates/sdk/src/network/builder.rs
+++ b/crates/sdk/src/network/builder.rs
@@ -21,6 +21,7 @@ pub struct NetworkProverBuilder {
     pub(crate) tee_signers: Option<Vec<Address>>,
     pub(crate) signer: Option<NetworkSigner>,
     pub(crate) network_mode: Option<NetworkMode>,
+    pub(crate) hosted: bool,
     pub(crate) machine: Machine<SP1Field, RiscvAir<SP1Field>>,
 }
 
@@ -46,6 +47,7 @@ impl NetworkProverBuilder {
             tee_signers: None,
             signer: None,
             network_mode: None,
+            hosted: false,
             machine,
         }
     }
@@ -101,6 +103,27 @@ impl NetworkProverBuilder {
     #[must_use]
     pub fn private(mut self) -> Self {
         self.rpc_url = Some(TEE_NETWORK_RPC_URL.to_string());
+        self
+    }
+
+    /// Configures the prover for hosted proving.
+    ///
+    /// # Details
+    /// Hosted proving runs in [`NetworkMode::Reserved`] and makes `prove(&pk, stdin).await` skip
+    /// local simulation and use the maximum cycle and gas limits by default, with no
+    /// network-specific toggles required. This matches the behavior expected by self-hosted
+    /// clusters talking to the network-gateway. The defaults remain overridable per request.
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// use sp1_sdk::ProverClient;
+    ///
+    /// let prover = ProverClient::builder().network().hosted().build();
+    /// ```
+    #[must_use]
+    pub fn hosted(mut self) -> Self {
+        self.hosted = true;
+        self.network_mode = Some(NetworkMode::Reserved);
         self
     }
 
@@ -224,5 +247,26 @@ impl NetworkProverBuilder {
         NetworkProver::new_with_machine(signer, &rpc_url, network_mode, self.machine)
             .await
             .with_tee_signers(tee_signers)
+            .with_hosted(self.hosted)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_is_not_hosted() {
+        let builder = NetworkProverBuilder::new();
+        assert!(!builder.hosted);
+        assert_eq!(builder.network_mode, None);
+    }
+
+    #[test]
+    fn test_hosted_sets_flag_and_reserved_mode() {
+        let builder = NetworkProverBuilder::new().hosted();
+        assert!(builder.hosted);
+        // Hosted proving always runs in reserved mode.
+        assert_eq!(builder.network_mode, Some(NetworkMode::Reserved));
     }
 }

--- a/crates/sdk/src/network/prover.rs
+++ b/crates/sdk/src/network/prover.rs
@@ -48,6 +48,14 @@ pub struct NetworkProver {
     pub(crate) node: SP1LightNode,
     pub(crate) tee_signers: Vec<Address>,
     pub(crate) network_mode: NetworkMode,
+    /// Whether to use hosted defaults for proof requests.
+    ///
+    /// When set, [`NetworkProver::prove`] skips local simulation and sets the cycle and gas limits
+    /// to their maximum, so that `prove(&pk, stdin).await` works without any network-specific
+    /// toggles. This is the behavior wanted by self-hosted clusters talking to the
+    /// network-gateway. It is independent of [`NetworkMode`]; a hosted prover runs in
+    /// [`NetworkMode::Reserved`].
+    pub(crate) hosted: bool,
 }
 
 impl Prover for NetworkProver {
@@ -71,13 +79,19 @@ impl Prover for NetworkProver {
     fn prove<'a>(&'a self, pk: &'a Self::ProvingKey, stdin: SP1Stdin) -> Self::ProveRequest<'a> {
         let strategy = self.default_fulfillment_strategy();
 
+        // A hosted prover skips simulation and proves up to the maximum limits by default, so that
+        // `prove(&pk, stdin).await` works with no network-specific toggles. These remain overridable
+        // per request via the builder methods.
+        let (skip_simulation, cycle_limit, gas_limit) =
+            if self.hosted { (true, Some(u64::MAX), Some(u64::MAX)) } else { (false, None, None) };
+
         NetworkProveBuilder {
             base: BaseProveRequest::new(self, pk, stdin),
             timeout: None,
             strategy,
-            skip_simulation: false,
-            cycle_limit: None,
-            gas_limit: None,
+            skip_simulation,
+            cycle_limit,
+            gas_limit,
             tee_2fa: false,
             min_auction_period: 0,
             whitelist: None,
@@ -155,13 +169,22 @@ impl NetworkProver {
         let signer = signer.into();
         let node = SP1LightNode::new_with_machine(machine).await;
         let client = NetworkClient::new(signer, rpc_url, network_mode);
-        Self { client, node, tee_signers: vec![], network_mode }
+        Self { client, node, tee_signers: vec![], network_mode, hosted: false }
     }
 
     /// Sets the list of TEE signers, used for verifying TEE proofs.
     #[must_use]
     pub fn with_tee_signers(mut self, tee_signers: Vec<Address>) -> Self {
         self.tee_signers = tee_signers;
+        self
+    }
+
+    /// Sets whether this prover uses hosted defaults (skip simulation, max cycle and gas limits).
+    ///
+    /// See [`NetworkProver::hosted`] for details.
+    #[must_use]
+    pub(crate) fn with_hosted(mut self, hosted: bool) -> Self {
+        self.hosted = hosted;
         self
     }
 


### PR DESCRIPTION
## Summary

Adds an opt-in "hosted" mode to `NetworkProver` for self-hosted clusters talking to the network-gateway. A hosted prover runs in `Reserved` mode and defaults to skipping local simulation with maximum cycle and gas limits, so `client.prove(&pk, stdin).await` works with no network-specific toggles. The defaults remain overridable per request, and existing `Reserved`/`Mainnet` behavior is unchanged.

## What changed

- `NetworkProver` gains a `hosted` flag; `prove()` derives `skip_simulation = true` and `cycle_limit = gas_limit = u64::MAX` from it (otherwise unchanged).
- Exposed via `ProverClient::builder().hosted()`, `NetworkProverBuilder::hosted()`, and `SP1_PROVER=hosted` (reusing the existing `EnvProver::Network` variant — no new enum/key variants).
- Mirrored across the `blocking` API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)