### PR TITLE
docs(cli): document installed version check

### DIFF
--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -31,3 +31,12 @@ After installing the CLI, you can run it by simply running the following command
 ```bash
 cargo prove
 ```
+
+To check which version of the CLI is currently installed, run:
+
+```bash
+cargo prove --version
+```
+
+If you installed the CLI with `sp1up`, the installer also prints the installed version after
+the binary is downloaded.


### PR DESCRIPTION
Fixes #2493

Failure mechanism:
users installing the CLI via sp1up were not told in the CLI README how to check which cargo-prove version is currently installed, even though the binary already exposes that information and sp1up already prints it after install.

Semantic change:
document cargo prove --version in the CLI README and note that sp1up prints the installed version after download.

Preserved invariant:
this does not change CLI or installer behavior; it only documents the already-supported version check path suggested in the issue discussion.

Testing:
validated with git diff --check. No code-path validation was needed because the patch is documentation-only and points to existing behavior in crates/cli/src/bin/cargo-prove.rs and sp1up/sp1up.