### PR TITLE
ci(gnark): publish a multi-arch manifest for sp1-gnark tag

### DIFF
--- a/.github/workflows/docker-publish-gnark.yml
+++ b/.github/workflows/docker-publish-gnark.yml
@@ -55,15 +55,41 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push AMD64 image
+      # Push only a per-arch tag; merge-manifest assembles the bare tag below.
+      - name: Build and push ${{ matrix.arch }} image
         uses: docker/build-push-action@v5
         with:
           context: .
           file: ./Dockerfile.gnark-ffi
           platforms: ${{ matrix.platform }}
           push: ${{ inputs.dry-run != true }}
-          tags: |
-            ghcr.io/succinctlabs/sp1-gnark:${{ inputs.docker-tag }}
-            ghcr.io/succinctlabs/sp1-gnark:${{ github.sha }}-${{ matrix.arch }}
+          tags: ghcr.io/succinctlabs/sp1-gnark:${{ github.sha }}-${{ matrix.arch }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  # Assemble the bare tag's manifest list from the per-arch images
+  merge-manifest:
+    name: merge-manifest
+    needs: docker-publish-gnark
+    if: ${{ inputs.dry-run != true }}
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Set up Docker BuildX
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log into registry ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create multi-arch manifest
+        run: |
+          docker buildx imagetools create \
+            -t ghcr.io/succinctlabs/sp1-gnark:${{ inputs.docker-tag }} \
+            ghcr.io/succinctlabs/sp1-gnark:${{ github.sha }}-amd64 \
+            ghcr.io/succinctlabs/sp1-gnark:${{ github.sha }}-arm64


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Publish `sp1-gnark` as a multi-arch (amd64 + arm64) manifest so version tag resolves to arm64 on Apple Silicon instead of whichever arch pushed last. Default docker prover backend pulls `ghcr.io/succinctlabs/sp1-gnark:<tag>`, but tag is amd64-only, groth16/plonk wrapping on Apple Silicon falls back to QEMU/Rosetta (slow, sometimes SIGILLs):

```
$ docker buildx imagetools inspect ghcr.io/succinctlabs/sp1-gnark:v6.1.0
  Platform: linux/amd64
  Platform: unknown/unknown   # provenance attestation, not arm64
```

arm64 image is built, but `docker-publish-gnark.yml`'s `amd64`/`arm64` matrix jobs both push same bare `${docker-tag}` with no manifest step, the tag goes single-arch, arm64 survives only as `:<sha>-arm64`.

## Solution

- each matrix job pushes only `:<sha>-<arch>`
- A `merge-manifest` job assembles the bare tag from both via `docker buildx imagetools create`

Native per-arch builds preserved, version tag becomes a manifest list, so Docker picks arm64 natively on Apple Silicon. 

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes