### PR TITLE
feat(gpu-server): add experimental and mprotect feature flags

### DIFF
--- a/sp1-gpu/crates/server/Cargo.toml
+++ b/sp1-gpu/crates/server/Cargo.toml
@@ -33,4 +33,12 @@ tikv-jemallocator = { version = "0.6", features = ["profiling", "stats"] }
 workspace = true
 
 [features]
+experimental = ["sp1-prover/experimental"]
+mprotect = [
+  "experimental",
+  "sp1-core-executor/mprotect",
+  "sp1-core-machine/mprotect",
+  "sp1-gpu-prover/mprotect",
+  "sp1-prover/mprotect",
+]
 groth16-cuda = ["sp1-recursion-gnark-ffi/groth16-cuda"]


### PR DESCRIPTION
`sp1-gpu-server` did not expose the `experimental` and `mprotect` feature
flags that the rest of the workspace already provides (e.g. `sp1-sdk`), so
there was no way to build the GPU server with those code paths enabled.

This adds both features to `sp1-gpu-server`, forwarding to the matching
features of its dependencies:

- `experimental = ["sp1-prover/experimental"]`
- `mprotect` → `experimental` + `sp1-core-executor/mprotect`,
  `sp1-core-machine/mprotect`, `sp1-gpu-prover/mprotect`,
  `sp1-prover/mprotect`

Feature resolution verified with `cargo tree`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)