### PR TITLE
fix(gpu-server): forward experimental to sp1-gpu-prover

### DIFF
--- a/sp1-gpu/crates/server/Cargo.toml
+++ b/sp1-gpu/crates/server/Cargo.toml
@@ -33,7 +33,7 @@ tikv-jemallocator = { version = "0.6", features = ["profiling", "stats"] }
 workspace = true
 
 [features]
-experimental = ["sp1-prover/experimental"]
+experimental = ["sp1-prover/experimental", "sp1-gpu-prover/experimental"]
 mprotect = [
   "experimental",
   "sp1-core-executor/mprotect",


### PR DESCRIPTION
Follow-up to #2832.

`sp1-gpu-server`'s `experimental` feature forwarded only to
`sp1-prover/experimental`, but the CUDA worker components live in
`sp1-gpu-prover`, which has its own `experimental` feature. Code gated
on `#[cfg(feature = "experimental")]` in `sp1-gpu-prover`
(`prover_components/src/builder.rs`) was compiled out when the server was
built with `--features experimental`, so e.g. the `WITHOUT_VK_VERIFICATION`
runtime switch in the CUDA worker builder had no effect.

Forward `experimental` to `sp1-gpu-prover/experimental` as well so the
feature applies to the CUDA prover path. (`mprotect` already reaches it via
`sp1-gpu-prover/mprotect`.)

Verified with `cargo tree -p sp1-gpu-server --features experimental -i sp1-gpu-prover`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)