### PR TITLE
fix(zkvm): rename memcpy.s jump-table label to avoid LTO symbol collision

### DIFF
--- a/crates/zkvm/entrypoint/src/memcpy.s
+++ b/crates/zkvm/entrypoint/src/memcpy.s
@@ -246,7 +246,7 @@ memcpy:                                 # @memcpy
 	addi	a4, a4, -1
 	slli	a4, a4, 2
 1:
-	auipc	a5, %pcrel_hi(.LJTI0_0)                # Use PC-relative addressing in 64-bit mode
+	auipc	a5, %pcrel_hi(.LJTImemcpy0_0)          # Use PC-relative addressing in 64-bit mode
 	addi	a5, a5, %pcrel_lo(1b)
 	add	a4, a4, a5
 	lwu	a5, 0(a4)
@@ -767,7 +767,7 @@ memcpy:                                 # @memcpy
 	.size	memcpy, .Lfunc_end0-memcpy
 	.section	.rodata,"a",@progbits
 	.p2align	2, 0x0
-.LJTI0_0:
+.LJTImemcpy0_0:
 	.word	.LBBmemcpy0_13
 	.word	.LBBmemcpy0_35
 	.word	.LBBmemcpy0_29


### PR DESCRIPTION
## Summary

Guest builds using fat LTO can fail to assemble with `error: symbol '.LJTI0_0' is already defined`. The bundled `memcpy.s` (injected via `global_asm!`) left its jump-table label at the compiler-default name `.LJTI0_0`. Under fat LTO all crates merge into a single module and the `global_asm!` text is concatenated into it; if the function the compiler numbers `0` owns a jump table, it generates its own `.LJTI0_0`, colliding with the hand-written label.

The basic-block labels in this file were already de-collided (`.LBBmemcpy0_*`); the jump-table label was missed. This applies the same treatment.

## What changed

- `crates/zkvm/entrypoint/src/memcpy.s`: rename `.LJTI0_0` → `.LJTImemcpy0_0` at its definition and its `%pcrel_hi` reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)