### PR TITLE
fix(prover): release per-proof task bookkeeping and artifacts in SP1LocalNode

### DIFF
--- a/crates/prover-types/src/artifacts.rs
+++ b/crates/prover-types/src/artifacts.rs
@@ -331,10 +331,67 @@ pub trait ArtifactClient: Send + Sync + Clone + 'static {
     }
 }
 
+/// A proof-scoped index of live in-memory artifacts, shared between the local
+/// worker client (which records a proof's artifacts as it submits tasks) and
+/// [`InMemoryArtifactClient`] (which drops them as they are deleted). Because the
+/// deleter maintains it, it only ever holds artifacts that are still live - so it
+/// stays bounded - and `take` returns whatever a proof leaked so it can be freed.
+#[derive(Clone, Default)]
+pub struct ProofArtifacts(Arc<std::sync::Mutex<ProofArtifactsInner>>);
+
+#[derive(Default)]
+struct ProofArtifactsInner {
+    by_proof: HashMap<String, HashSet<String>>,
+    of_artifact: HashMap<String, String>,
+}
+
+impl ProofArtifacts {
+    /// Record `artifact` as belonging to `proof`.
+    pub fn track(&self, proof: &str, artifact: &str) {
+        let mut g = self.0.lock().unwrap();
+        g.by_proof.entry(proof.to_owned()).or_default().insert(artifact.to_owned());
+        g.of_artifact.insert(artifact.to_owned(), proof.to_owned());
+    }
+
+    /// Drop `artifact` from the index (called when it is deleted).
+    pub fn untrack(&self, artifact: &str) {
+        let mut g = self.0.lock().unwrap();
+        if let Some(proof) = g.of_artifact.remove(artifact) {
+            if let Some(set) = g.by_proof.get_mut(&proof) {
+                set.remove(artifact);
+                if set.is_empty() {
+                    g.by_proof.remove(&proof);
+                }
+            }
+        }
+    }
+
+    /// Remove and return the artifacts still tracked for `proof` (the ones it
+    /// leaked - everything else was already deleted and untracked).
+    pub fn take(&self, proof: &str) -> HashSet<String> {
+        let mut g = self.0.lock().unwrap();
+        let ids = g.by_proof.remove(proof).unwrap_or_default();
+        for id in &ids {
+            g.of_artifact.remove(id);
+        }
+        ids
+    }
+
+    /// Total number of tracked (live) artifacts across all proofs.
+    pub fn len(&self) -> usize {
+        self.0.lock().unwrap().of_artifact.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
 #[derive(Clone)]
 pub struct InMemoryArtifactClient {
     artifacts: Arc<RwLock<HashMap<String, Vec<u8>>>>,
     refs: Arc<Mutex<HashMap<String, HashSet<String>>>>,
+    index: ProofArtifacts,
 }
 
 impl fmt::Debug for InMemoryArtifactClient {
@@ -345,9 +402,16 @@ impl fmt::Debug for InMemoryArtifactClient {
 
 impl InMemoryArtifactClient {
     pub fn new() -> Self {
+        Self::with_index(ProofArtifacts::default())
+    }
+
+    /// Create a client whose deletions also prune `index`. Share one index with
+    /// the local worker client so a proof's artifacts drop out as they go.
+    pub fn with_index(index: ProofArtifacts) -> Self {
         Self {
             artifacts: Arc::new(RwLock::new(HashMap::new())),
             refs: Arc::new(Mutex::new(HashMap::new())),
+            index,
         }
     }
 }
@@ -390,8 +454,8 @@ impl ArtifactClient for InMemoryArtifactClient {
     }
 
     async fn delete(&self, artifact: &impl ArtifactId, _artifact_type: ArtifactType) -> Result<()> {
-        let mut artifacts = self.artifacts.write().await;
-        artifacts.remove(artifact.id());
+        self.artifacts.write().await.remove(artifact.id());
+        self.index.untrack(artifact.id());
         Ok(())
     }
 
@@ -403,6 +467,7 @@ impl ArtifactClient for InMemoryArtifactClient {
         let mut artifact_map = self.artifacts.write().await;
         for artifact in artifacts {
             artifact_map.remove(artifact.id());
+            self.index.untrack(artifact.id());
         }
         Ok(())
     }

--- a/crates/prover-types/src/artifacts.rs
+++ b/crates/prover-types/src/artifacts.rs
@@ -464,9 +464,16 @@ impl ArtifactClient for InMemoryArtifactClient {
         artifacts: &[impl ArtifactId],
         _artifact_type: ArtifactType,
     ) -> Result<()> {
-        let mut artifact_map = self.artifacts.write().await;
+        // Drop bytes first under the tokio lock, then prune the (independent)
+        // proof-artifact index. Splitting the critical sections keeps the tokio
+        // write lock from being held while we churn the index's std mutex.
+        {
+            let mut artifact_map = self.artifacts.write().await;
+            for artifact in artifacts {
+                artifact_map.remove(artifact.id());
+            }
+        }
         for artifact in artifacts {
-            artifact_map.remove(artifact.id());
             self.index.untrack(artifact.id());
         }
         Ok(())

--- a/crates/prover/src/worker/client/local.rs
+++ b/crates/prover/src/worker/client/local.rs
@@ -3,7 +3,8 @@ use std::{collections::BTreeMap, sync::Arc};
 use hashbrown::{HashMap, HashSet};
 use mti::prelude::{MagicTypeIdExt, V7};
 use sp1_prover_types::{
-    Artifact, ArtifactClient, ArtifactType, ProofRequestStatus, TaskStatus, TaskType,
+    Artifact, ArtifactClient, ArtifactType, ProofArtifacts, ProofRequestStatus, TaskStatus,
+    TaskType,
 };
 use tokio::sync::{mpsc, watch, RwLock};
 
@@ -28,13 +29,11 @@ pub struct LocalWorkerClientChannels {
 pub struct LocalWorkerClientInner {
     db: LocalDb,
     proof_index: ProofIndex,
-    /// Artifact ids submitted under each in-flight proof, recorded by
-    /// `submit_task`. On `complete_proof` they move to `pending_artifact_cleanup`.
-    proof_artifacts: RwLock<HashMap<ProofId, HashSet<String>>>,
-    /// Artifacts of completed proofs awaiting deletion. The worker client holds
-    /// no artifact-client handle, so `LocalWorkerClient::cleanup` drains this
-    /// with a client passed in by the owner (`SP1LocalNode`).
-    pending_artifact_cleanup: RwLock<HashSet<String>>,
+    /// Per-proof index of the artifacts each task references, recorded by
+    /// `submit_task`. Shared with the node's artifact client, which prunes it on
+    /// delete, so it only holds live artifacts; `cleanup` deletes whatever a
+    /// completed proof leaked.
+    artifact_index: ProofArtifacts,
     input_task_queues: HashMap<TaskType, mpsc::Sender<(TaskId, RawTaskRequest)>>,
     task_channels: RwLock<HashMap<TaskId, MessageChannelState>>,
 }
@@ -44,7 +43,7 @@ impl LocalWorkerClientInner {
         TaskId::new("local_worker".create_type_id::<V7>().to_string())
     }
 
-    fn init() -> (Self, LocalWorkerClientChannels) {
+    fn init(artifact_index: ProofArtifacts) -> (Self, LocalWorkerClientChannels) {
         let mut task_outputs = BTreeMap::new();
         let mut task_queues = HashMap::new();
         for task_type in [
@@ -70,17 +69,9 @@ impl LocalWorkerClientInner {
 
         let db = Arc::new(RwLock::new(HashMap::new()));
         let proof_index = Arc::new(RwLock::new(HashMap::new()));
-        let proof_artifacts = RwLock::new(HashMap::new());
-        let pending_artifact_cleanup = RwLock::new(HashSet::new());
         let task_channels = RwLock::new(HashMap::new());
-        let inner = Self {
-            db,
-            proof_index,
-            proof_artifacts,
-            pending_artifact_cleanup,
-            input_task_queues: task_queues,
-            task_channels,
-        };
+        let inner =
+            Self { db, proof_index, artifact_index, input_task_queues: task_queues, task_channels };
         (inner, LocalWorkerClientChannels { task_receivers: task_outputs })
     }
 }
@@ -93,7 +84,14 @@ impl LocalWorkerClient {
     /// Creates a new local worker client.
     #[must_use]
     pub fn init() -> (Self, LocalWorkerClientChannels) {
-        let (inner, channels) = LocalWorkerClientInner::init();
+        Self::init_with_index(ProofArtifacts::default())
+    }
+
+    /// Like [`init`](Self::init) but sharing `artifact_index` with the node's
+    /// artifact client, so a proof's artifacts are pruned as they are deleted.
+    #[must_use]
+    pub fn init_with_index(artifact_index: ProofArtifacts) -> (Self, LocalWorkerClientChannels) {
+        let (inner, channels) = LocalWorkerClientInner::init(artifact_index);
         (Self { inner: Arc::new(inner) }, channels)
     }
 
@@ -124,13 +122,12 @@ impl LocalWorkerClient {
         Ok(())
     }
 
-    /// Delete the artifacts of completed proofs (recorded by `submit_task`,
-    /// stashed by `complete_proof`). The worker client holds no artifact-client
-    /// handle, so the owner - `SP1LocalNode` - passes one in. Best-effort:
-    /// already-deleted artifacts are a no-op.
-    pub async fn cleanup(&self, artifact_client: &impl ArtifactClient) {
-        let ids: Vec<String> = self.inner.pending_artifact_cleanup.write().await.drain().collect();
-        for id in ids {
+    /// Delete the artifacts a completed proof leaked - whatever is still tracked
+    /// for it (most were already deleted inline during proving and pruned from
+    /// the shared index). The worker client shares the index but holds no
+    /// artifact-client handle, so the owner - `SP1LocalNode` - passes one in.
+    pub async fn cleanup(&self, proof_id: &ProofId, artifact_client: &impl ArtifactClient) {
+        for id in self.inner.artifact_index.take(&proof_id.to_string()) {
             let _ = artifact_client
                 .try_delete(&Artifact(id), ArtifactType::UnspecifiedArtifactType)
                 .await;
@@ -156,15 +153,12 @@ impl WorkerClient for LocalWorkerClient {
             .entry(task.context.proof_id.clone())
             .or_insert_with(HashSet::new)
             .insert(task_id.clone());
-        // Record the task's artifacts under this proof so they can be cleaned up
-        // once the proof completes (see `cleanup`).
-        {
-            let mut proof_artifacts = self.inner.proof_artifacts.write().await;
-            let entry =
-                proof_artifacts.entry(task.context.proof_id.clone()).or_insert_with(HashSet::new);
-            for artifact in task.inputs.iter().chain(task.outputs.iter()) {
-                entry.insert(artifact.0.clone());
-            }
+        // Record the task's artifacts under this proof. The shared index is
+        // pruned as artifacts are deleted, so it holds only live ones; `cleanup`
+        // deletes whatever the proof leaves behind.
+        let proof = task.context.proof_id.to_string();
+        for artifact in task.inputs.iter().chain(task.outputs.iter()) {
+            self.inner.artifact_index.track(&proof, &artifact.0);
         }
         // Create a db entry for the task.
         let (tx, rx) = watch::channel(TaskStatus::Pending);
@@ -193,12 +187,8 @@ impl WorkerClient for LocalWorkerClient {
         _status: ProofRequestStatus,
         _extra_data: impl Into<String> + Send,
     ) -> anyhow::Result<()> {
-        // Stash this proof's recorded artifacts for deletion by `cleanup`. Done
-        // before the index lookup below so it runs regardless of that result.
-        if let Some(ids) = self.inner.proof_artifacts.write().await.remove(&proof_id) {
-            self.inner.pending_artifact_cleanup.write().await.extend(ids);
-        }
-        // Remove the proof from the proof index.
+        // (Artifacts are released separately via `cleanup`, which the node calls
+        // with its artifact client.) Remove the proof from the proof index.
         let tasks = self
             .inner
             .proof_index
@@ -336,14 +326,14 @@ pub mod test_utils {
 
 #[cfg(test)]
 mod tests {
-    use sp1_prover_types::InMemoryArtifactClient;
+    use sp1_prover_types::{InMemoryArtifactClient, ProofArtifacts};
 
     use super::*;
     use crate::worker::{RequesterId, TaskContext};
 
-    fn controller_request(proof_id: &ProofId, artifact: &Artifact) -> RawTaskRequest {
+    fn controller_request(proof_id: &ProofId, artifacts: &[&Artifact]) -> RawTaskRequest {
         RawTaskRequest {
-            inputs: vec![artifact.clone()],
+            inputs: artifacts.iter().map(|a| (*a).clone()).collect(),
             outputs: vec![],
             context: TaskContext {
                 proof_id: proof_id.clone(),
@@ -354,50 +344,61 @@ mod tests {
         }
     }
 
-    /// Completing a proof (`complete_proof` + `cleanup`) must release all of its
-    /// task bookkeeping (`db`, `proof_index`) and delete its artifacts - and
-    /// proving many proofs on the reused client must not accumulate any of it.
-    /// This is the regression test for the per-proof leak in the local node.
+    /// Across many proofs on a reused client, the per-proof task bookkeeping
+    /// (`db`, `proof_index`) and the shared artifact index must all return to
+    /// empty: artifacts deleted inline are pruned from the index (no tombstones),
+    /// and `cleanup` deletes whatever a proof leaked. Regression test for the
+    /// per-proof leak in the local node.
     #[tokio::test]
     async fn proof_cleanup_releases_all_state() {
-        let (client, mut channels) = LocalWorkerClient::init();
-        let artifacts = InMemoryArtifactClient::default();
+        // Share one artifact index between the two clients, as SP1LocalNode does.
+        let index = ProofArtifacts::default();
+        let (client, mut channels) = LocalWorkerClient::init_with_index(index.clone());
+        let artifacts = InMemoryArtifactClient::with_index(index.clone());
         let controller_rx = channels.task_receivers.get_mut(&TaskType::Controller).unwrap();
 
         for i in 0..10 {
             let proof_id = ProofId::new(format!("proof-{i}"));
-            let artifact = artifacts.create_artifact().unwrap();
-            artifacts.upload_raw(&artifact, ArtifactType::Program, vec![0u8; 1024]).await.unwrap();
+            let inline = artifacts.create_artifact().unwrap();
+            let leaked = artifacts.create_artifact().unwrap();
+            for a in [&inline, &leaked] {
+                artifacts.upload_raw(a, ArtifactType::Program, vec![0u8; 1024]).await.unwrap();
+            }
 
             client
-                .submit_task(TaskType::Controller, controller_request(&proof_id, &artifact))
+                .submit_task(
+                    TaskType::Controller,
+                    controller_request(&proof_id, &[&inline, &leaked]),
+                )
                 .await
                 .unwrap();
             // Drain the bounded input queue so the next iteration can submit.
             controller_rx.recv().await.unwrap();
 
-            // The task and its artifact are now tracked.
+            // Both artifacts and the task bookkeeping are now tracked.
+            assert_eq!(index.len(), 2);
             assert_eq!(client.inner.proof_index.read().await.len(), 1);
             assert_eq!(client.inner.db.read().await.len(), 1);
-            assert!(artifacts.exists(&artifact, ArtifactType::Program).await.unwrap());
 
-            // Completing the proof and cleaning up must release everything.
+            // Deleting one inline (as the controller does mid-proof) prunes it
+            // from the shared index - no tombstone left behind.
+            artifacts.delete(&inline, ArtifactType::Program).await.unwrap();
+            assert_eq!(index.len(), 1, "index kept a tombstone for a deleted artifact");
+
+            // Completing the proof releases its task bookkeeping; cleanup deletes
+            // whatever it leaked.
             client
                 .complete_proof(proof_id.clone(), None, ProofRequestStatus::Completed, "")
                 .await
                 .unwrap();
-            client.cleanup(&artifacts).await;
+            client.cleanup(&proof_id, &artifacts).await;
 
+            assert!(index.is_empty(), "artifact index leaked after proof {i}");
             assert!(client.inner.db.read().await.is_empty(), "db leaked after proof {i}");
             assert!(client.inner.proof_index.read().await.is_empty(), "proof_index leaked");
-            assert!(client.inner.proof_artifacts.read().await.is_empty(), "proof_artifacts leaked");
             assert!(
-                client.inner.pending_artifact_cleanup.read().await.is_empty(),
-                "pending artifact cleanup leaked"
-            );
-            assert!(
-                !artifacts.exists(&artifact, ArtifactType::Program).await.unwrap(),
-                "artifact not deleted after proof {i}"
+                !artifacts.exists(&leaked, ArtifactType::Program).await.unwrap(),
+                "leaked artifact not deleted after proof {i}"
             );
         }
     }

--- a/crates/prover/src/worker/client/local.rs
+++ b/crates/prover/src/worker/client/local.rs
@@ -196,9 +196,23 @@ impl WorkerClient for LocalWorkerClient {
             .await
             .remove(&proof_id)
             .ok_or_else(|| anyhow::anyhow!("proof does not exist for id {proof_id}"))?;
-        // Prune the db for all tasks that are related to this proof and clean them up.
-        for task_id in tasks {
-            self.inner.db.write().await.remove(&task_id);
+        // Prune the db and any message channels for the proof's tasks. Two
+        // short critical sections rather than one holding both writer locks
+        // (avoids nesting and keeps each scope's hold time bounded by
+        // hashmap removes, not the loop body). `update_task_status` removes
+        // a task's channel when it reaches a terminal status; doing it here
+        // too covers tasks that never did (e.g. an error mid-proof).
+        {
+            let mut db = self.inner.db.write().await;
+            for task_id in &tasks {
+                db.remove(task_id);
+            }
+        }
+        {
+            let mut channels = self.inner.task_channels.write().await;
+            for task_id in &tasks {
+                channels.remove(task_id);
+            }
         }
         Ok(())
     }
@@ -365,7 +379,7 @@ mod tests {
                 artifacts.upload_raw(a, ArtifactType::Program, vec![0u8; 1024]).await.unwrap();
             }
 
-            client
+            let task_id = client
                 .submit_task(
                     TaskType::Controller,
                     controller_request(&proof_id, &[&inline, &leaked]),
@@ -374,11 +388,16 @@ mod tests {
                 .unwrap();
             // Drain the bounded input queue so the next iteration can submit.
             controller_rx.recv().await.unwrap();
+            // Send a task message - this lazily creates a `task_channels` entry
+            // that `update_task_status` would normally clean up on a terminal
+            // status, but won't if the task never reaches one.
+            client.send_task_message(&task_id, vec![1, 2, 3]).await.unwrap();
 
-            // Both artifacts and the task bookkeeping are now tracked.
+            // Bookkeeping, artifact index, and task channel are all populated.
             assert_eq!(index.len(), 2);
             assert_eq!(client.inner.proof_index.read().await.len(), 1);
             assert_eq!(client.inner.db.read().await.len(), 1);
+            assert_eq!(client.inner.task_channels.read().await.len(), 1);
 
             // Deleting one inline (as the controller does mid-proof) prunes it
             // from the shared index - no tombstone left behind.
@@ -396,6 +415,10 @@ mod tests {
             assert!(index.is_empty(), "artifact index leaked after proof {i}");
             assert!(client.inner.db.read().await.is_empty(), "db leaked after proof {i}");
             assert!(client.inner.proof_index.read().await.is_empty(), "proof_index leaked");
+            assert!(
+                client.inner.task_channels.read().await.is_empty(),
+                "task_channels leaked after proof {i}",
+            );
             assert!(
                 !artifacts.exists(&leaked, ArtifactType::Program).await.unwrap(),
                 "leaked artifact not deleted after proof {i}"

--- a/crates/prover/src/worker/client/local.rs
+++ b/crates/prover/src/worker/client/local.rs
@@ -333,3 +333,72 @@ pub mod test_utils {
         worker_client
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use sp1_prover_types::InMemoryArtifactClient;
+
+    use super::*;
+    use crate::worker::{RequesterId, TaskContext};
+
+    fn controller_request(proof_id: &ProofId, artifact: &Artifact) -> RawTaskRequest {
+        RawTaskRequest {
+            inputs: vec![artifact.clone()],
+            outputs: vec![],
+            context: TaskContext {
+                proof_id: proof_id.clone(),
+                parent_id: None,
+                parent_context: None,
+                requester_id: RequesterId::new("test"),
+            },
+        }
+    }
+
+    /// Completing a proof (`complete_proof` + `cleanup`) must release all of its
+    /// task bookkeeping (`db`, `proof_index`) and delete its artifacts - and
+    /// proving many proofs on the reused client must not accumulate any of it.
+    /// This is the regression test for the per-proof leak in the local node.
+    #[tokio::test]
+    async fn proof_cleanup_releases_all_state() {
+        let (client, mut channels) = LocalWorkerClient::init();
+        let artifacts = InMemoryArtifactClient::default();
+        let controller_rx = channels.task_receivers.get_mut(&TaskType::Controller).unwrap();
+
+        for i in 0..10 {
+            let proof_id = ProofId::new(format!("proof-{i}"));
+            let artifact = artifacts.create_artifact().unwrap();
+            artifacts.upload_raw(&artifact, ArtifactType::Program, vec![0u8; 1024]).await.unwrap();
+
+            client
+                .submit_task(TaskType::Controller, controller_request(&proof_id, &artifact))
+                .await
+                .unwrap();
+            // Drain the bounded input queue so the next iteration can submit.
+            controller_rx.recv().await.unwrap();
+
+            // The task and its artifact are now tracked.
+            assert_eq!(client.inner.proof_index.read().await.len(), 1);
+            assert_eq!(client.inner.db.read().await.len(), 1);
+            assert!(artifacts.exists(&artifact, ArtifactType::Program).await.unwrap());
+
+            // Completing the proof and cleaning up must release everything.
+            client
+                .complete_proof(proof_id.clone(), None, ProofRequestStatus::Completed, "")
+                .await
+                .unwrap();
+            client.cleanup(&artifacts).await;
+
+            assert!(client.inner.db.read().await.is_empty(), "db leaked after proof {i}");
+            assert!(client.inner.proof_index.read().await.is_empty(), "proof_index leaked");
+            assert!(client.inner.proof_artifacts.read().await.is_empty(), "proof_artifacts leaked");
+            assert!(
+                client.inner.pending_artifact_cleanup.read().await.is_empty(),
+                "pending artifact cleanup leaked"
+            );
+            assert!(
+                !artifacts.exists(&artifact, ArtifactType::Program).await.unwrap(),
+                "artifact not deleted after proof {i}"
+            );
+        }
+    }
+}

--- a/crates/prover/src/worker/client/local.rs
+++ b/crates/prover/src/worker/client/local.rs
@@ -127,9 +127,19 @@ impl LocalWorkerClient {
     /// the shared index). The worker client shares the index but holds no
     /// artifact-client handle, so the owner - `SP1LocalNode` - passes one in.
     pub async fn cleanup(&self, proof_id: &ProofId, artifact_client: &impl ArtifactClient) {
-        for id in self.inner.artifact_index.take(&proof_id.to_string()) {
+        let leftovers: Vec<Artifact> = self
+            .inner
+            .artifact_index
+            .take(&proof_id.to_string())
+            .into_iter()
+            .map(Artifact)
+            .collect();
+        if !leftovers.is_empty() {
+            // One batch delete instead of N per-id calls (one tokio lock
+            // acquisition instead of N). Best-effort: if it fails, the proof is
+            // already untracked, so any leftover bytes are just unreferenced.
             let _ = artifact_client
-                .try_delete(&Artifact(id), ArtifactType::UnspecifiedArtifactType)
+                .delete_batch(&leftovers, ArtifactType::UnspecifiedArtifactType)
                 .await;
         }
     }

--- a/crates/prover/src/worker/client/local.rs
+++ b/crates/prover/src/worker/client/local.rs
@@ -2,7 +2,9 @@ use std::{collections::BTreeMap, sync::Arc};
 
 use hashbrown::{HashMap, HashSet};
 use mti::prelude::{MagicTypeIdExt, V7};
-use sp1_prover_types::{ProofRequestStatus, TaskStatus, TaskType};
+use sp1_prover_types::{
+    Artifact, ArtifactClient, ArtifactType, ProofRequestStatus, TaskStatus, TaskType,
+};
 use tokio::sync::{mpsc, watch, RwLock};
 
 use crate::worker::{
@@ -26,6 +28,13 @@ pub struct LocalWorkerClientChannels {
 pub struct LocalWorkerClientInner {
     db: LocalDb,
     proof_index: ProofIndex,
+    /// Artifact ids submitted under each in-flight proof, recorded by
+    /// `submit_task`. On `complete_proof` they move to `pending_artifact_cleanup`.
+    proof_artifacts: RwLock<HashMap<ProofId, HashSet<String>>>,
+    /// Artifacts of completed proofs awaiting deletion. The worker client holds
+    /// no artifact-client handle, so `LocalWorkerClient::cleanup` drains this
+    /// with a client passed in by the owner (`SP1LocalNode`).
+    pending_artifact_cleanup: RwLock<HashSet<String>>,
     input_task_queues: HashMap<TaskType, mpsc::Sender<(TaskId, RawTaskRequest)>>,
     task_channels: RwLock<HashMap<TaskId, MessageChannelState>>,
 }
@@ -61,8 +70,17 @@ impl LocalWorkerClientInner {
 
         let db = Arc::new(RwLock::new(HashMap::new()));
         let proof_index = Arc::new(RwLock::new(HashMap::new()));
+        let proof_artifacts = RwLock::new(HashMap::new());
+        let pending_artifact_cleanup = RwLock::new(HashSet::new());
         let task_channels = RwLock::new(HashMap::new());
-        let inner = Self { db, proof_index, input_task_queues: task_queues, task_channels };
+        let inner = Self {
+            db,
+            proof_index,
+            proof_artifacts,
+            pending_artifact_cleanup,
+            input_task_queues: task_queues,
+            task_channels,
+        };
         (inner, LocalWorkerClientChannels { task_receivers: task_outputs })
     }
 }
@@ -105,6 +123,19 @@ impl LocalWorkerClient {
 
         Ok(())
     }
+
+    /// Delete the artifacts of completed proofs (recorded by `submit_task`,
+    /// stashed by `complete_proof`). The worker client holds no artifact-client
+    /// handle, so the owner - `SP1LocalNode` - passes one in. Best-effort:
+    /// already-deleted artifacts are a no-op.
+    pub async fn cleanup(&self, artifact_client: &impl ArtifactClient) {
+        let ids: Vec<String> = self.inner.pending_artifact_cleanup.write().await.drain().collect();
+        for id in ids {
+            let _ = artifact_client
+                .try_delete(&Artifact(id), ArtifactType::UnspecifiedArtifactType)
+                .await;
+        }
+    }
 }
 
 impl Clone for LocalWorkerClient {
@@ -125,6 +156,16 @@ impl WorkerClient for LocalWorkerClient {
             .entry(task.context.proof_id.clone())
             .or_insert_with(HashSet::new)
             .insert(task_id.clone());
+        // Record the task's artifacts under this proof so they can be cleaned up
+        // once the proof completes (see `cleanup`).
+        {
+            let mut proof_artifacts = self.inner.proof_artifacts.write().await;
+            let entry =
+                proof_artifacts.entry(task.context.proof_id.clone()).or_insert_with(HashSet::new);
+            for artifact in task.inputs.iter().chain(task.outputs.iter()) {
+                entry.insert(artifact.0.clone());
+            }
+        }
         // Create a db entry for the task.
         let (tx, rx) = watch::channel(TaskStatus::Pending);
         self.inner.db.write().await.insert(task_id.clone(), (tx, rx));
@@ -152,6 +193,11 @@ impl WorkerClient for LocalWorkerClient {
         _status: ProofRequestStatus,
         _extra_data: impl Into<String> + Send,
     ) -> anyhow::Result<()> {
+        // Stash this proof's recorded artifacts for deletion by `cleanup`. Done
+        // before the index lookup below so it runs regardless of that result.
+        if let Some(ids) = self.inner.proof_artifacts.write().await.remove(&proof_id) {
+            self.inner.pending_artifact_cleanup.write().await.extend(ids);
+        }
         // Remove the proof from the proof index.
         let tasks = self
             .inner

--- a/crates/prover/src/worker/node/full/init.rs
+++ b/crates/prover/src/worker/node/full/init.rs
@@ -5,7 +5,7 @@ use sp1_core_machine::riscv::RiscvAir;
 use sp1_hypercube::{prover::ProverSemaphore, Machine};
 use sp1_primitives::SP1Field;
 use sp1_prover_types::{
-    ArtifactClient, ArtifactType, InMemoryArtifactClient, TaskStatus, TaskType,
+    ArtifactClient, ArtifactType, InMemoryArtifactClient, ProofArtifacts, TaskStatus, TaskType,
 };
 use tokio::{sync::mpsc, task::JoinSet};
 use tracing::Instrument;
@@ -47,8 +47,11 @@ impl<C: SP1ProverComponents> SP1LocalNodeBuilder<C> {
     /// This method can be used to initialize a node from a worker client builder that has already
     /// been configured with the desired prover components.
     pub fn from_worker_client_builder(builder: SP1WorkerBuilder<C>) -> Self {
-        let artifact_client = InMemoryArtifactClient::new();
-        let (worker_client, channels) = LocalWorkerClient::init();
+        // One shared per-proof artifact index: the worker client records a
+        // proof's artifacts, the artifact client prunes them as they're deleted.
+        let artifact_index = ProofArtifacts::default();
+        let artifact_client = InMemoryArtifactClient::with_index(artifact_index.clone());
+        let (worker_client, channels) = LocalWorkerClient::init_with_index(artifact_index);
         let machine = builder.machine().clone();
         let worker_builder =
             builder.with_artifact_client(artifact_client).with_worker_client(worker_client);

--- a/crates/prover/src/worker/node/full/mod.rs
+++ b/crates/prover/src/worker/node/full/mod.rs
@@ -236,20 +236,11 @@ impl SP1LocalNode {
             tracing::warn!("failed to release task bookkeeping for proof {proof_id}: {e}");
         }
 
-        // Always delete the per-proof input/output artifacts (best-effort), so a
-        // failed proof does not leave its ELF/stdin/output in the artifact store.
-        let _ = self.inner.artifact_client.try_delete(&elf_artifact, ArtifactType::Program).await;
-        let _ = self.inner.artifact_client.try_delete(&stdin_artifact, ArtifactType::Stdin).await;
-        let _ = self
-            .inner
-            .artifact_client
-            .try_delete(&output_artifact, ArtifactType::UnspecifiedArtifactType)
-            .await;
-        let _ = self
-            .inner
-            .artifact_client
-            .try_delete(&proof_nonce_artifact, ArtifactType::UnspecifiedArtifactType)
-            .await;
+        // Delete every artifact the worker client recorded for this proof - the
+        // top-level inputs/outputs plus any intermediates the controller left
+        // behind (e.g. on an error path). Best-effort; most are already deleted
+        // inline during proving, so this is the backstop that bounds growth.
+        self.inner.worker_client.cleanup(&self.inner.artifact_client).await;
 
         result
     }

--- a/crates/prover/src/worker/node/full/mod.rs
+++ b/crates/prover/src/worker/node/full/mod.rs
@@ -236,11 +236,11 @@ impl SP1LocalNode {
             tracing::warn!("failed to release task bookkeeping for proof {proof_id}: {e}");
         }
 
-        // Delete every artifact the worker client recorded for this proof - the
-        // top-level inputs/outputs plus any intermediates the controller left
-        // behind (e.g. on an error path). Best-effort; most are already deleted
-        // inline during proving, so this is the backstop that bounds growth.
-        self.inner.worker_client.cleanup(&self.inner.artifact_client).await;
+        // Delete whatever artifacts this proof leaked - the index has already
+        // been pruned of everything deleted inline during proving, so this only
+        // hits the leftovers (e.g. on an error path). The backstop that bounds
+        // growth across proofs.
+        self.inner.worker_client.cleanup(&proof_id, &self.inner.artifact_client).await;
 
         result
     }

--- a/crates/prover/src/worker/node/full/mod.rs
+++ b/crates/prover/src/worker/node/full/mod.rs
@@ -12,7 +12,7 @@ use sp1_hypercube::{SP1PcsProofOuter, SP1VerifyingKey, SP1WrapProof};
 use sp1_primitives::{io::SP1PublicValues, SP1OuterGlobalContext};
 use sp1_prover_types::{
     network_base_types::ProofMode, Artifact, ArtifactClient, ArtifactType, InMemoryArtifactClient,
-    TaskStatus, TaskType,
+    ProofRequestStatus, TaskStatus, TaskType,
 };
 pub use sp1_verifier::{ProofFromNetwork, SP1Proof};
 use tokio::task::JoinSet;
@@ -172,69 +172,86 @@ impl SP1LocalNode {
         context: SP1Context<'static>,
         mode: ProofMode,
     ) -> anyhow::Result<ProofFromNetwork> {
+        // Allocate the per-proof artifacts and id up front so the cleanup below
+        // can always reach them, regardless of how the proving body exits.
         let elf_artifact = self.inner.artifact_client.create_artifact()?;
-        self.inner.artifact_client.upload_program(&elf_artifact, elf.to_vec()).await?;
-
         let proof_nonce_artifact = self.inner.artifact_client.create_artifact()?;
-        self.inner
-            .artifact_client
-            .upload::<[u32; 4]>(&proof_nonce_artifact, context.proof_nonce)
-            .await?;
-
         let stdin_artifact = self.inner.artifact_client.create_artifact()?;
-        self.inner
-            .artifact_client
-            .upload_with_type(&stdin_artifact, ArtifactType::Stdin, stdin)
-            .await?;
-
-        let mode_artifact = Artifact((mode as i32).to_string());
-
-        // Create an artifact for the output
         let output_artifact = self.inner.artifact_client.create_artifact()?;
-
         let proof_id = ProofId::new("proof".create_type_id::<V7>().to_string());
-        let request = RawTaskRequest {
-            inputs: vec![
-                elf_artifact.clone(),
-                stdin_artifact.clone(),
-                mode_artifact.clone(),
-                proof_nonce_artifact.clone(),
-            ],
-            outputs: vec![output_artifact.clone()],
-            context: TaskContext {
-                proof_id: proof_id.clone(),
-                parent_id: None,
-                parent_context: None,
-                requester_id: RequesterId::new(format!("local-node-{}", std::process::id())),
-            },
-        };
 
-        let task_id = self.inner.worker_client.submit_task(TaskType::Controller, request).await?;
-        let subscriber = self.inner.worker_client.subscriber(proof_id).await?.per_task();
-        let status = subscriber.wait_task(task_id).await?;
-        if status != TaskStatus::Succeeded {
-            return Err(anyhow::anyhow!("controller task failed"));
+        // Run the actual proving. `?` inside only short-circuits this block; the
+        // cleanup afterwards always runs (on both success and failure).
+        let result = async {
+            self.inner.artifact_client.upload_program(&elf_artifact, elf.to_vec()).await?;
+            self.inner
+                .artifact_client
+                .upload::<[u32; 4]>(&proof_nonce_artifact, context.proof_nonce)
+                .await?;
+            self.inner
+                .artifact_client
+                .upload_with_type(&stdin_artifact, ArtifactType::Stdin, stdin)
+                .await?;
+
+            let mode_artifact = Artifact((mode as i32).to_string());
+            let request = RawTaskRequest {
+                inputs: vec![
+                    elf_artifact.clone(),
+                    stdin_artifact.clone(),
+                    mode_artifact,
+                    proof_nonce_artifact.clone(),
+                ],
+                outputs: vec![output_artifact.clone()],
+                context: TaskContext {
+                    proof_id: proof_id.clone(),
+                    parent_id: None,
+                    parent_context: None,
+                    requester_id: RequesterId::new(format!("local-node-{}", std::process::id())),
+                },
+            };
+
+            let task_id =
+                self.inner.worker_client.submit_task(TaskType::Controller, request).await?;
+            let subscriber =
+                self.inner.worker_client.subscriber(proof_id.clone()).await?.per_task();
+            let status = subscriber.wait_task(task_id).await?;
+            if status != TaskStatus::Succeeded {
+                return Err(anyhow::anyhow!("controller task failed"));
+            }
+
+            // Download the output proof.
+            self.inner.artifact_client.download::<ProofFromNetwork>(&output_artifact).await
+        }
+        .await;
+
+        // Always release this proof's task bookkeeping. The node (and its
+        // worker_client) is reused across proofs, and `submit_task` records every
+        // task in the worker client's `db`/`proof_index`; `complete_proof` is the
+        // only thing that prunes them, so it must run for every proof.
+        let status =
+            if result.is_ok() { ProofRequestStatus::Completed } else { ProofRequestStatus::Failed };
+        if let Err(e) =
+            self.inner.worker_client.complete_proof(proof_id.clone(), None, status, "").await
+        {
+            tracing::warn!("failed to release task bookkeeping for proof {proof_id}: {e}");
         }
 
-        // Clean up the input artifacts
-        self.inner.artifact_client.try_delete(&elf_artifact, ArtifactType::Program).await?;
-        self.inner.artifact_client.try_delete(&stdin_artifact, ArtifactType::Stdin).await?;
-
-        // Download the output proof and return it.
-        let proof =
-            self.inner.artifact_client.download::<ProofFromNetwork>(&output_artifact).await?;
-        // Clean up the output artifact
-        self.inner
+        // Always delete the per-proof input/output artifacts (best-effort), so a
+        // failed proof does not leave its ELF/stdin/output in the artifact store.
+        let _ = self.inner.artifact_client.try_delete(&elf_artifact, ArtifactType::Program).await;
+        let _ = self.inner.artifact_client.try_delete(&stdin_artifact, ArtifactType::Stdin).await;
+        let _ = self
+            .inner
             .artifact_client
             .try_delete(&output_artifact, ArtifactType::UnspecifiedArtifactType)
-            .await?;
-
-        self.inner
+            .await;
+        let _ = self
+            .inner
             .artifact_client
             .try_delete(&proof_nonce_artifact, ArtifactType::UnspecifiedArtifactType)
-            .await?;
+            .await;
 
-        Ok(proof)
+        result
     }
 
     pub fn verify(&self, vk: &SP1VerifyingKey, proof: &SP1Proof) -> anyhow::Result<()> {


### PR DESCRIPTION
`SP1LocalNode` is built once and reused across proofs (e.g. by the persistent
CUDA `sp1-gpu-server`), so anything its `worker_client` / `artifact_client`
retains per proof accumulates for the node's whole lifetime. Two such leaks:

1. **Task bookkeeping.** `WorkerClient::submit_task` records every task in the
   local client's `db` (a per-task `watch` channel) and `proof_index`
   (`proof_id -> {task_ids}`). The only remover, `complete_proof`, had **no
   callers** — so both grew unboundedly, one entry per task per proof.
2. **Artifacts.** The in-memory artifact store was cleaned by hand-built lists
   at the success-end of `controller::run` / `prove_with_mode`, skipped on any
   early-return, with no per-proof grouping.

Fixes:

- `prove_with_mode` now runs its body in an inner block and a cleanup section
  that **always** runs (success or failure): it calls `complete_proof` (pruning
  `db`/`proof_index`) and then `worker_client.cleanup(&artifact_client)`.
- The local worker client gains a per-proof artifact index: `submit_task`
  records each task's input/output artifact ids under its `proof_id`,
  `complete_proof` stashes them into a pending set, and the new
  `LocalWorkerClient::cleanup` drains it via a client the node passes in (the
  worker client holds no artifact-client handle). Intermediates are still freed
  inline during proving, so peak memory is unchanged — this is the backstop that
  bounds growth across proofs.

Scope: in-memory/local path only (the CUDA `sp1-gpu-server`). The Redis/S3
artifact backends in `sp1-cluster` already bound growth via TTL / capacity; a
shared cross-backend mechanism is left for a follow-up.

`cargo check -p sp1-prover` passes.