### PR TITLE
fix(sdk): enforce expected exit status in MockProver::verify

### DIFF
--- a/crates/sdk/src/blocking/mock/mod.rs
+++ b/crates/sdk/src/blocking/mock/mod.rs
@@ -19,7 +19,7 @@ use crate::{
         cpu::CPUProverError,
         prover::{BaseProveRequest, ProveRequest, Prover},
     },
-    proof::verify_mock_public_inputs,
+    proof::{verify_mock_exit_code, verify_mock_public_inputs},
     SP1Proof, SP1ProofWithPublicValues, SP1ProvingKey, SP1VerificationError, StatusCode,
 };
 
@@ -79,18 +79,22 @@ impl Prover for MockProver {
         &self,
         proof: &SP1ProofWithPublicValues,
         vkey: &SP1VerifyingKey,
-        _status_code: Option<StatusCode>,
+        status_code: Option<StatusCode>,
     ) -> Result<(), SP1VerificationError> {
         match &proof.proof {
             SP1Proof::Plonk(PlonkBn254Proof { public_inputs, .. }) => {
                 // Verify the mock Plonk proof by checking public inputs match.
                 verify_mock_public_inputs(vkey, &proof.public_values, public_inputs)
-                    .map_err(SP1VerificationError::Plonk)
+                    .map_err(SP1VerificationError::Plonk)?;
+                // Enforce the expected exit status, mirroring the real verifier.
+                verify_mock_exit_code(public_inputs, status_code)
             }
             SP1Proof::Groth16(Groth16Bn254Proof { public_inputs, .. }) => {
                 // Verify the mock Groth16 proof by checking public inputs match.
                 verify_mock_public_inputs(vkey, &proof.public_values, public_inputs)
-                    .map_err(SP1VerificationError::Groth16)
+                    .map_err(SP1VerificationError::Groth16)?;
+                // Enforce the expected exit status, mirroring the real verifier.
+                verify_mock_exit_code(public_inputs, status_code)
             }
             _ => Ok(()),
         }
@@ -112,12 +116,13 @@ impl<'a> ProveRequest<'a, MockProver> for MockProveRequest<'a> {
         tracing::info!(mode = ?mode, "generating mock proof");
         let mut req = prover.execute(pk.elf.clone(), stdin);
         req.context_builder = context_builder;
-        let (public_values, _) = req.run()?;
+        let (public_values, report) = req.run()?;
         Ok(SP1ProofWithPublicValues::create_mock_proof(
             &pk.vk,
             public_values,
             mode,
             prover.version(),
+            report.exit_code,
         ))
     }
 }
@@ -127,7 +132,7 @@ mod tests {
     use crate::{
         blocking::prover::{ProveRequest, Prover},
         utils::setup_logger,
-        SP1Stdin,
+        SP1Stdin, StatusCode,
     };
 
     use super::MockProver;
@@ -280,5 +285,53 @@ mod tests {
         // Verification should fail because public_values hash won't match.
         let result = prover.verify(&proof, &pk.vk, None);
         assert!(result.is_err(), "Verification should fail with tampered public values");
+    }
+
+    /// Regression test for #2817: a successful program's mock Plonk proof must verify as `SUCCESS`
+    /// (and under the `None` default) but be rejected when `PANIC` is expected, so the same proof
+    /// cannot satisfy two different exit statuses.
+    #[test]
+    fn test_mock_plonk_proof_enforces_exit_status() {
+        setup_logger();
+        let prover = MockProver::new();
+        let pk = prover.setup(test_artifacts::FIBONACCI_ELF).expect("failed to setup proving key");
+        let mut stdin = SP1Stdin::new();
+        stdin.write(&10usize);
+        let proof =
+            prover.prove(&pk, stdin).plonk().run().expect("failed to create mock Plonk proof");
+
+        // The program exits successfully (exit code 0).
+        prover.verify(&proof, &pk.vk, None).expect("default verify should accept exit code 0");
+        prover
+            .verify(&proof, &pk.vk, Some(StatusCode::SUCCESS))
+            .expect("SUCCESS verify should accept exit code 0");
+
+        // The same proof must NOT verify when PANIC is expected.
+        assert!(
+            prover.verify(&proof, &pk.vk, Some(StatusCode::PANIC)).is_err(),
+            "a SUCCESS mock proof must not verify under expected PANIC status"
+        );
+    }
+
+    /// Regression test for #2817: same as the Plonk case, for Groth16 mock proofs.
+    #[test]
+    fn test_mock_groth16_proof_enforces_exit_status() {
+        setup_logger();
+        let prover = MockProver::new();
+        let pk = prover.setup(test_artifacts::FIBONACCI_ELF).expect("failed to setup proving key");
+        let mut stdin = SP1Stdin::new();
+        stdin.write(&10usize);
+        let proof =
+            prover.prove(&pk, stdin).groth16().run().expect("failed to create mock Groth16 proof");
+
+        prover.verify(&proof, &pk.vk, None).expect("default verify should accept exit code 0");
+        prover
+            .verify(&proof, &pk.vk, Some(StatusCode::SUCCESS))
+            .expect("SUCCESS verify should accept exit code 0");
+
+        assert!(
+            prover.verify(&proof, &pk.vk, Some(StatusCode::PANIC)).is_err(),
+            "a SUCCESS mock proof must not verify under expected PANIC status"
+        );
     }
 }

--- a/crates/sdk/src/mock/mod.rs
+++ b/crates/sdk/src/mock/mod.rs
@@ -16,7 +16,7 @@ use sp1_prover::{
 };
 
 use crate::{
-    proof::verify_mock_public_inputs,
+    proof::{verify_mock_exit_code, verify_mock_public_inputs},
     prover::{BaseProveRequest, ProveRequest},
     Prover, SP1Proof, SP1ProofWithPublicValues, SP1ProvingKey, SP1VerificationError, StatusCode,
 };
@@ -89,20 +89,24 @@ impl Prover for MockProver {
         &self,
         proof: &SP1ProofWithPublicValues,
         vkey: &SP1VerifyingKey,
-        _status_code: Option<StatusCode>,
+        status_code: Option<StatusCode>,
     ) -> Result<(), SP1VerificationError> {
         match &proof.proof {
             SP1Proof::Plonk(PlonkBn254Proof { public_inputs, .. }) => {
                 // Verify the mock Plonk proof by checking public inputs match.
                 // For mock proofs, the encoded_proof is empty, so we only verify the public inputs.
                 verify_mock_public_inputs(vkey, &proof.public_values, public_inputs)
-                    .map_err(SP1VerificationError::Plonk)
+                    .map_err(SP1VerificationError::Plonk)?;
+                // Enforce the expected exit status, mirroring the real verifier.
+                verify_mock_exit_code(public_inputs, status_code)
             }
             SP1Proof::Groth16(Groth16Bn254Proof { public_inputs, .. }) => {
                 // Verify the mock Groth16 proof by checking public inputs match.
                 // For mock proofs, the encoded_proof is empty, so we only verify the public inputs.
                 verify_mock_public_inputs(vkey, &proof.public_values, public_inputs)
-                    .map_err(SP1VerificationError::Groth16)
+                    .map_err(SP1VerificationError::Groth16)?;
+                // Enforce the expected exit status, mirroring the real verifier.
+                verify_mock_exit_code(public_inputs, status_code)
             }
             _ => Ok(()),
         }
@@ -134,13 +138,14 @@ impl<'a> IntoFuture for MockProveRequest<'a> {
             req.context_builder = context_builder;
 
             // Spawn blocking under the hood.
-            let (public_values, _) = req.await?;
+            let (public_values, report) = req.await?;
 
             Ok(SP1ProofWithPublicValues::create_mock_proof(
                 &pk.vk,
                 public_values,
                 mode,
                 prover.version(),
+                report.exit_code,
             ))
         })
     }
@@ -148,7 +153,9 @@ impl<'a> IntoFuture for MockProveRequest<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{prover::ProveRequest, utils::setup_logger, MockProver, Prover, SP1Stdin};
+    use crate::{
+        prover::ProveRequest, utils::setup_logger, MockProver, Prover, SP1Stdin, StatusCode,
+    };
 
     /// Test mock proof creation and verification for all proof types.
     #[tokio::test]
@@ -310,5 +317,55 @@ mod tests {
         // Verification should fail because public_values hash won't match.
         let result = prover.verify(&proof, &pk.vk, None);
         assert!(result.is_err(), "Verification should fail with tampered public values");
+    }
+
+    /// Regression test for #2817: a successful program's mock Plonk proof must verify as `SUCCESS`
+    /// (and under the `None` default) but be rejected when `PANIC` is expected, so the same proof
+    /// cannot satisfy two different exit statuses.
+    #[tokio::test]
+    async fn test_mock_plonk_proof_enforces_exit_status() {
+        setup_logger();
+        let prover = MockProver::new().await;
+        let pk =
+            prover.setup(test_artifacts::FIBONACCI_ELF).await.expect("failed to setup proving key");
+        let mut stdin = SP1Stdin::new();
+        stdin.write(&10usize);
+        let proof =
+            prover.prove(&pk, stdin).plonk().await.expect("failed to create mock Plonk proof");
+
+        // The program exits successfully (exit code 0).
+        prover.verify(&proof, &pk.vk, None).expect("default verify should accept exit code 0");
+        prover
+            .verify(&proof, &pk.vk, Some(StatusCode::SUCCESS))
+            .expect("SUCCESS verify should accept exit code 0");
+
+        // The same proof must NOT verify when PANIC is expected.
+        assert!(
+            prover.verify(&proof, &pk.vk, Some(StatusCode::PANIC)).is_err(),
+            "a SUCCESS mock proof must not verify under expected PANIC status"
+        );
+    }
+
+    /// Regression test for #2817: same as the Plonk case, for Groth16 mock proofs.
+    #[tokio::test]
+    async fn test_mock_groth16_proof_enforces_exit_status() {
+        setup_logger();
+        let prover = MockProver::new().await;
+        let pk =
+            prover.setup(test_artifacts::FIBONACCI_ELF).await.expect("failed to setup proving key");
+        let mut stdin = SP1Stdin::new();
+        stdin.write(&10usize);
+        let proof =
+            prover.prove(&pk, stdin).groth16().await.expect("failed to create mock Groth16 proof");
+
+        prover.verify(&proof, &pk.vk, None).expect("default verify should accept exit code 0");
+        prover
+            .verify(&proof, &pk.vk, Some(StatusCode::SUCCESS))
+            .expect("SUCCESS verify should accept exit code 0");
+
+        assert!(
+            prover.verify(&proof, &pk.vk, Some(StatusCode::PANIC)).is_err(),
+            "a SUCCESS mock proof must not verify under expected PANIC status"
+        );
     }
 }

--- a/crates/sdk/src/proof.rs
+++ b/crates/sdk/src/proof.rs
@@ -4,13 +4,16 @@
 #![allow(missing_docs)]
 #![allow(clippy::double_parens)] // For some reason we need this to use EnumTryAs
 
-use std::{fmt::Debug, fs::File, path::Path};
+use std::{fmt::Debug, fs::File, path::Path, str::FromStr};
 
 use anyhow::{Context, Result};
+use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 use sp1_hypercube::create_dummy_recursion_proof;
 use sp1_primitives::io::SP1PublicValues;
 use sp1_prover::{Groth16Bn254Proof, HashableKey, PlonkBn254Proof, SP1VerifyingKey};
+
+use crate::{SP1VerificationError, StatusCode};
 
 // Re-export the types from the verifier crate in order to avoid importing the verifier crate
 // for downstream dependencies.
@@ -44,6 +47,28 @@ pub(crate) fn verify_mock_public_inputs(
         );
     }
 
+    Ok(())
+}
+
+/// Enforce the requested exit status against a mock Plonk/Groth16 proof's encoded exit code.
+///
+/// Mock Plonk and Groth16 proofs encode the program's exit code in `public_inputs[2]`. The real
+/// verifier checks this against the caller's expected [`StatusCode`] (defaulting to
+/// [`StatusCode::SUCCESS`] when `None`); this mirrors that check so a mock proof cannot satisfy an
+/// exit status it does not actually encode (e.g. the same proof verifying as both `SUCCESS` and
+/// `PANIC`).
+pub(crate) fn verify_mock_exit_code(
+    public_inputs: &[String; 5],
+    status_code: Option<StatusCode>,
+) -> Result<(), SP1VerificationError> {
+    let status_code = status_code.unwrap_or(StatusCode::SUCCESS);
+    let exit_code = BigUint::from_str(&public_inputs[2])
+        .map_err(|_| SP1VerificationError::InvalidPublicValues)?;
+    let exit_code =
+        u32::try_from(&exit_code).map_err(|_| SP1VerificationError::InvalidPublicValues)?;
+    if !status_code.is_accepted_code(exit_code) {
+        return Err(SP1VerificationError::UnexpectedExitCode(exit_code));
+    }
     Ok(())
 }
 
@@ -201,7 +226,7 @@ impl SP1ProofWithPublicValues {
     ///
     ///     let client = ProverClient::builder().cpu().build().await;
     ///     let pk = client.setup(elf.clone()).await.unwrap();
-    ///     let (public_values, _) = client.execute(elf, stdin).await.unwrap();
+    ///     let (public_values, report) = client.execute(elf, stdin).await.unwrap();
     ///
     ///     // Create a mock Plonk proof.
     ///     let mock_proof = SP1ProofWithPublicValues::create_mock_proof(
@@ -209,6 +234,7 @@ impl SP1ProofWithPublicValues {
     ///         public_values,
     ///         SP1ProofMode::Plonk,
     ///         SP1_CIRCUIT_VERSION,
+    ///         report.exit_code,
     ///     );
     /// });
     /// ```
@@ -219,6 +245,7 @@ impl SP1ProofWithPublicValues {
         public_values: SP1PublicValues,
         mode: SP1ProofMode,
         sp1_version: &str,
+        exit_code: u64,
     ) -> Self {
         let sp1_version = sp1_version.to_string();
         match mode {
@@ -242,7 +269,7 @@ impl SP1ProofWithPublicValues {
                 // Create mock Plonk proof with correct public inputs.
                 // public_inputs[0]: vkey_hash
                 // public_inputs[1]: committed_values_digest (public_values hash)
-                // public_inputs[2]: exit_code (0 for success)
+                // public_inputs[2]: exit_code (the program's real exit code from execution)
                 // public_inputs[3]: vk_root (0 for mock)
                 // public_inputs[4]: proof_nonce (0 for mock)
                 let vkey_hash = vk.hash_bn254().to_string();
@@ -252,9 +279,9 @@ impl SP1ProofWithPublicValues {
                         public_inputs: [
                             vkey_hash,
                             committed_values_digest,
-                            "0".to_string(), // exit_code
-                            "0".to_string(), // vk_root (mock)
-                            "0".to_string(), // proof_nonce (mock)
+                            exit_code.to_string(), // exit_code (from execution)
+                            "0".to_string(),       // vk_root (mock)
+                            "0".to_string(),       // proof_nonce (mock)
                         ],
                         encoded_proof: String::new(),
                         raw_proof: String::new(),
@@ -269,7 +296,7 @@ impl SP1ProofWithPublicValues {
                 // Create mock Groth16 proof with correct public inputs.
                 // public_inputs[0]: vkey_hash
                 // public_inputs[1]: committed_values_digest (public_values hash)
-                // public_inputs[2]: exit_code (0 for success)
+                // public_inputs[2]: exit_code (the program's real exit code from execution)
                 // public_inputs[3]: vk_root (0 for mock)
                 // public_inputs[4]: proof_nonce (0 for mock)
                 let vkey_hash = vk.hash_bn254().to_string();
@@ -279,9 +306,9 @@ impl SP1ProofWithPublicValues {
                         public_inputs: [
                             vkey_hash,
                             committed_values_digest,
-                            "0".to_string(), // exit_code
-                            "0".to_string(), // vk_root (mock)
-                            "0".to_string(), // proof_nonce (mock)
+                            exit_code.to_string(), // exit_code (from execution)
+                            "0".to_string(),       // vk_root (mock)
+                            "0".to_string(),       // proof_nonce (mock)
                         ],
                         encoded_proof: String::new(),
                         raw_proof: String::new(),


### PR DESCRIPTION
## Motivation

`MockProver::verify` takes a `status_code: Option<StatusCode>` argument (part of the shared `Prover::verify` contract) but ignored it, so the mock verifier did not enforce the program's expected exit status the way the real verifier (`verify_proof`) does.

As reported in #2817, this means a single mock proof verifies under *any* expected status, e.g. a successful program's proof verifies as both `SUCCESS` and `PANIC`.  Separately, mock Plonk/Groth16 proofs hardcoded the encoded exit code (`public_inputs[2]`) to `"0"` regardless of the real execution result, so even an enforced check would not have reflected a panicking program.

## Solution

- `create_mock_proof` now records the real execution exit code into the mock Plonk/Groth16 `public_inputs[2]` (previously hardcoded `"0"`).  The exit code comes from the `ExecutionReport` that mock proving already produces but was discarding.
- Both the async (`mock`) and blocking (`blocking::mock`) `MockProver::verify` now enforce `status_code.unwrap_or(StatusCode::SUCCESS)` against the encoded exit code via a shared `verify_mock_exit_code` helper that mirrors `verify_proof`'s Plonk/Groth16 arms exactly (same `BigUint` parse + `StatusCode::is_accepted_code` check + `UnexpectedExitCode` error).
- Added regression tests (async + blocking, Plonk + Groth16) asserting that a successful program's mock proof verifies under `None`/`SUCCESS` but is rejected under `PANIC`, so one proof can no longer satisfy two different expected statuses.

### Scope

This PR covers the Plonk and Groth16 mock modes, which carry the exit code in `public_inputs[2]` (the slot the real verifier reads).  Mock `Core`/`Compressed` proofs are intentionally hollow (`Core(vec![])` / a dummy recursion proof with empty public values), so enforcing status for those modes requires giving them an exit-code-bearing field and is left as a focused follow-up.  **Towards #2817.**

### Note

`create_mock_proof` gains an `exit_code` parameter (the execution exit code to encode).  This is a small breaking change to that public helper; the two in-tree callers (async + blocking mock provers) and the doc example are updated.

### Verification

Locally, on `main`:
- `cargo +nightly fmt -p sp1-sdk -- --check` — clean
- `cargo check -p sp1-sdk --features blocking --tests` — clean
- `cargo test -p sp1-sdk --features blocking` — 6 mock tests pass (4 new + the existing `test_mock_proof_all_types` for both async and blocking)
- `cargo clippy -p sp1-sdk --features blocking` — clean

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] Breaking changes
