### PR TITLE
chore: add struct reflection for `AluX0` chip

### DIFF
--- a/crates/core/machine/src/alu/alu_x0.rs
+++ b/crates/core/machine/src/alu/alu_x0.rs
@@ -16,6 +16,7 @@ use sp1_core_executor::{
 };
 use sp1_derive::AlignedBorrow;
 use sp1_hypercube::air::MachineAir;
+use struct_reflection::{StructReflection, StructReflectionHelper};
 
 use crate::{
     adapter::{
@@ -44,7 +45,7 @@ pub struct AluX0Chip<M: TrustMode> {
 }
 
 /// The column layout for `AluX0Chip`.
-#[derive(AlignedBorrow, Default, Clone, Copy)]
+#[derive(AlignedBorrow, StructReflection, Default, Clone, Copy)]
 #[repr(C)]
 pub struct AluX0Cols<T, M: TrustMode> {
     /// The current shard, timestamp, program counter of the CPU.


### PR DESCRIPTION
PR to derive `StructReflection` for `AluX0Cols`. Needed for `sp1-lean` in proving trace-level soundness.