### PR TITLE
fix: handle patch-testing comment runs without PR context

### DIFF
--- a/.github/workflows/patch-testing-cycles-comment.yml
+++ b/.github/workflows/patch-testing-cycles-comment.yml
@@ -33,12 +33,18 @@ jobs:
         id: pr
         run: |
           # Get the PR number from the workflow run
-          PR_NUMBER=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }} --jq '.pull_requests[0].number')
+          PR_NUMBER=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }} --jq 'first(.pull_requests[].number) // empty')
           echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: "Skip when no PR is attached to the workflow run"
+        if: steps.pr.outputs.number == ''
+        run: |
+          echo "No PR attached to workflow run ${{ github.event.workflow_run.id }}; skipping patch testing comment."
+
       - name: "Post comment to PR"
+        if: steps.pr.outputs.number != ''
         run: |
           cd ./patch-testing
           RUST_BACKTRACE=full cargo run --bin post-to-github

--- a/patch-testing/sp1-test/bin/post_to_github.rs
+++ b/patch-testing/sp1-test/bin/post_to_github.rs
@@ -3,6 +3,13 @@ use sp1_test::{
     BenchEntry,
 };
 
+fn normalize_pr_number(pr_number: Option<String>) -> Option<String> {
+    pr_number.and_then(|pr_number| {
+        let pr_number = pr_number.trim();
+        (!pr_number.is_empty()).then(|| pr_number.to_string())
+    })
+}
+
 pub fn main() {
     let old_path =
         std::env::var("OLD_CYCLE_STATS").unwrap_or_else(|_| "../old_cycle_stats.json".to_string());
@@ -19,10 +26,33 @@ pub fn main() {
 
     println!("{comparison}");
 
-    let pr_number = std::env::var("PR_NUMBER").unwrap();
+    let Some(pr_number) = normalize_pr_number(std::env::var("PR_NUMBER").ok()) else {
+        eprintln!("PR_NUMBER is missing or empty; skipping PR comment.");
+        return;
+    };
     let token = std::env::var("GITHUB_TOKEN").unwrap();
     let github_repo = std::env::var("GITHUB_REPOSITORY").unwrap();
     let (owner, repo) = github_repo.split_once('/').unwrap();
 
     post_to_github_pr_sync(owner, repo, &pr_number, &token, &comparison).unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_pr_number;
+
+    #[test]
+    fn normalize_pr_number_rejects_missing_value() {
+        assert_eq!(normalize_pr_number(None), None);
+    }
+
+    #[test]
+    fn normalize_pr_number_rejects_whitespace_only_value() {
+        assert_eq!(normalize_pr_number(Some("   ".to_string())), None);
+    }
+
+    #[test]
+    fn normalize_pr_number_keeps_trimmed_pr_number() {
+        assert_eq!(normalize_pr_number(Some(" 2821 ".to_string())), Some("2821".to_string()));
+    }
 }


### PR DESCRIPTION
This fixes Patch Testing Cycles Comment runs that do not have a PR attached in the workflow_run payload.

The failure showed up in run 27173224829. GitHub returned pull_requests: [] for that run, but the workflow still tried to read .pull_requests[0].number and passed the result into post-to-github. The posting binary then unwrapped PR_NUMBER and panicked while decoding the GitHub comments response.

This change adds the guard in both places that assume PR context:
- the workflow now reads the first PR number with a null-safe jq expression and skips the posting step when no PR is attached
- post-to-github now treats a missing or blank PR_NUMBER as a no-op instead of panicking

The benchmark comparison path stays the same. If the run has a real PR, the workflow still posts the generated comparison comment through the existing code path.

Testing:
- cargo test -p sp1-test --bin post-to-github -- --nocapture
- cargo run --bin post-to-github with PR_NUMBER='' and empty cycle stats now exits 0 after printing the comparison table and a skip message
