### PR TITLE
fix(executor): make chunk-threshold gas test robust to per-chunk rounding

### DIFF
--- a/crates/core/executor/src/estimating.rs
+++ b/crates/core/executor/src/estimating.rs
@@ -598,6 +598,16 @@ impl<'a> GasEstimatingVMEnum<'a> {
         }
     }
 
+    /// The raw `(complexity, trace_area)` accumulated by the gas calculator, before the
+    /// integer divisions of the gas formula round them down.
+    #[must_use]
+    pub fn costs(&self) -> (u64, u64) {
+        match self {
+            Self::Supervisor(vm) => vm.gas_calculator.get_costs(),
+            Self::User(vm) => vm.gas_calculator.get_costs(),
+        }
+    }
+
     /// Check if the VM has completed execution.
     #[must_use]
     pub fn is_done(&self) -> bool {

--- a/crates/core/runner/src/tests.rs
+++ b/crates/core/runner/src/tests.rs
@@ -90,12 +90,21 @@ fn test_clks_should_be_available_while_running() {
 /// The gas estimator treats each trace chunk as a "shard": `shard_start_clk` is reset to the
 /// chunk start, so every address whose previous access predates the chunk is re-counted as a
 /// "first read this shard" (1 `MemoryLocal` + 2 `Global` rows). Smaller chunks => more chunk
-/// boundaries => the carried working set is re-counted more often => higher gas. Real proving
+/// boundaries => the carried working set is re-counted more often => higher cost. Real proving
 /// cost is unaffected because real shards are cut by the (unchanged) sharding thresholds, not the
 /// chunk threshold. PR #2793 cut the chunk threshold 8x (134_217_728 -> 16_777_216), inflating
 /// gas above the value #2786 calibrated against v6.1.0.
+///
+/// The assertions compare the raw per-chunk cost `3 * trace_area + complexity`, not the rounded
+/// gas: gas floors that quantity twice per chunk (`/ 10`, then `* 10 / 191`), so summing per-chunk
+/// gas loses up to ~1 gas unit per chunk and the summed gas of a many-chunk run can dip below a
+/// fewer-chunk run even though the underlying cost is monotonic. The raw cost has no such
+/// rounding. Chunked runs are also only compared against the single-chunk baseline (not pairwise):
+/// two chunked runs cut boundaries at unrelated positions, so their re-counted working sets are
+/// not supersets of each other, while every chunked run only *adds* re-counted rows relative to
+/// the boundary-free baseline.
 #[test]
-#[allow(clippy::print_stdout)] // prints a gas-vs-chunk-count table under `--nocapture`
+#[allow(clippy::print_stdout)] // prints a cost-vs-chunk-count table under `--nocapture`
 fn test_gas_depends_on_chunk_threshold() {
     use bincode::serialize;
     use sp1_core_executor::{GasEstimatingVMEnum, SP1CoreOpts};
@@ -115,7 +124,8 @@ fn test_gas_depends_on_chunk_threshold() {
 
     let opts = SP1CoreOpts::default();
 
-    let gas_for_threshold = |threshold: u64| -> (u64, usize) {
+    // Total raw cost (the gas formula's numerator, before rounding) and chunk count.
+    let cost_for_threshold = |threshold: u64| -> (u64, usize) {
         let mut runner = MinimalExecutorRunner::new(
             program.clone(),
             false,
@@ -126,45 +136,46 @@ fn test_gas_depends_on_chunk_threshold() {
         for input in &inputs {
             runner.with_input(input);
         }
-        let mut total_gas = 0u64;
+        let mut total_cost = 0u64;
         let mut num_chunks = 0usize;
         while let Some(chunk) = runner.try_execute_chunk().expect("execute chunk") {
             num_chunks += 1;
             let mut vm = GasEstimatingVMEnum::new(&chunk, program.clone(), [0u32; 4], opts.clone());
-            let report = vm.execute().expect("gas execute");
-            total_gas += report.gas().expect("gas present");
+            vm.execute().expect("gas execute");
+            let (complexity, trace_area) = vm.costs();
+            total_cost += 3 * trace_area + complexity;
         }
-        (total_gas, num_chunks)
+        (total_cost, num_chunks)
     };
 
     // A large threshold (single chunk = calibrated baseline) versus progressively smaller ones
     // that force more chunk boundaries. The exact 134M->16M head-to-head needs a multi-GiB
-    // workload to straddle those cadences; here we keep it fast and assert the same monotonic
-    // coupling that drives the #2793 regression.
+    // workload to straddle those cadences; here we keep it fast and assert the same coupling
+    // that drives the #2793 regression.
     let thresholds = [1u64 << 22, 1 << 18, 1 << 16, 1 << 14];
     let mut results = Vec::new();
     for t in thresholds {
-        let (gas, chunks) = gas_for_threshold(t);
-        println!("threshold={t:>12}  chunks={chunks:>5}  gas={gas}");
-        results.push((t, gas, chunks));
+        let (cost, chunks) = cost_for_threshold(t);
+        println!("threshold={t:>12}  chunks={chunks:>5}  cost={cost}");
+        results.push((t, cost, chunks));
     }
 
     // The large (pre-#2793) threshold is a single chunk here: the calibrated baseline.
-    let baseline = results[0].1;
-    // Smaller thresholds produce more chunks and strictly more gas (monotonic inflation).
-    for w in results.windows(2) {
-        let (t_big, gas_big, _) = w[0];
-        let (t_small, gas_small, _) = w[1];
+    let (_, baseline, baseline_chunks) = results[0];
+    assert_eq!(baseline_chunks, 1, "baseline threshold did not produce a single chunk");
+    // Chunked runs re-count the carried working set at every boundary, so each costs at least as
+    // much as the boundary-free baseline.
+    for &(t, cost, _) in &results[1..] {
         assert!(
-            gas_small >= gas_big,
-            "gas should be monotonic in chunk count: threshold {t_small} gave {gas_small} < threshold {t_big} gave {gas_big}",
+            cost >= baseline,
+            "cost should not drop below the single-chunk baseline: threshold {t} gave {cost} < baseline {baseline}",
         );
     }
-    // And the smallest threshold must inflate gas above the calibrated baseline.
-    let (_, smallest_gas, smallest_chunks) = *results.last().unwrap();
+    // And the smallest threshold must inflate the cost strictly above the calibrated baseline.
+    let (_, smallest_cost, smallest_chunks) = *results.last().unwrap();
     assert!(smallest_chunks > 1, "test workload did not span multiple chunks");
     assert!(
-        smallest_gas > baseline,
-        "expected gas inflation: smallest-threshold gas {smallest_gas} !> baseline {baseline}",
+        smallest_cost > baseline,
+        "expected cost inflation: smallest-threshold cost {smallest_cost} !> baseline {baseline}",
     );
 }


### PR DESCRIPTION
## Problem

`test_gas_depends_on_chunk_threshold` (added in #2836) asserted that the *sum of rounded per-chunk gas* is monotonic in chunk count. That inequality is not actually guaranteed: gas floors the raw cost twice per chunk — `(3 * trace_area + complexity) / 10` and then `* 10 / 191` — so a many-chunk run loses up to ~1 gas unit per chunk to rounding. When the true cost inflation across boundaries is small (observed: only 32 trace units over 4 chunks), the rounding loss dominates and the inequality flips. This was hit in practice while rebasing.

## Fix

- Assert on the raw pre-rounding cost `3 * trace_area + complexity`, which is the quantity that genuinely grows with chunk boundaries. Exposed via a new `GasEstimatingVMEnum::costs()` accessor (delegates to the existing `ReportGenerator::get_costs()`).
- Compare each chunked run against the single-chunk baseline only, instead of pairwise between chunked runs: two chunked runs cut boundaries at unrelated positions, so their re-counted working sets are not supersets of each other and pairwise monotonicity is not a theorem either. Relative to the boundary-free baseline, chunking can only *add* re-counted rows, so `cost >= baseline` (and strictly `>` for the multi-chunk smallest threshold) is guaranteed.

The test still documents the same #2793 coupling — chunk boundaries inflate the gas estimator's cost — just on the quantity where the claim actually holds.

## Testing

- `cargo test --release -p sp1-core-executor-runner test_gas_depends_on_chunk_threshold` passes (1 chunk → cost 147420538; 4 chunks → 149077064; 14 chunks → 154483592).
- `cargo fmt --check` and `clippy -D warnings` clean on `sp1-core-executor` and `sp1-core-executor-runner`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)