### PR TITLE
feat(prover-types): expose cluster component build info

### DIFF
--- a/crates/prover-types/proto/worker.proto
+++ b/crates/prover-types/proto/worker.proto
@@ -120,11 +120,10 @@ message OpenRequest {
     WorkerType worker_type = 2;
     uint32 max_weight = 3;
     // Self-reported build identity of this worker, so the coordinator can expose it via
-    // GetClusterComponentInfo. These are additive and optional; older workers leave them empty.
+    // GetClusterComponentInfo. Additive fields; workers that do not report leave them empty.
     string version = 4;
     string git_sha = 5;
     string image_tag = 6;
-    string build_timestamp = 7;
 }
 
 message ServerMessage {
@@ -304,7 +303,6 @@ message ClusterComponentInfo {
     string version = 3;
     string git_sha = 4;
     string image_tag = 5;
-    string build_timestamp = 6;
 }
 
 message GetClusterComponentInfoRequest {}

--- a/crates/prover-types/proto/worker.proto
+++ b/crates/prover-types/proto/worker.proto
@@ -56,6 +56,9 @@ service WorkerService {
     // Get stats about the coordinator.
     rpc GetStats(google.protobuf.Empty) returns (GetStatsResponse);
 
+    // Get the self-reported build identity of the coordinator and every connected worker.
+    rpc GetClusterComponentInfo(GetClusterComponentInfoRequest) returns (GetClusterComponentInfoResponse);
+
     // Subscribe to a task's message stream.
     rpc SubscribeTaskMessages(SubscribeTaskMessagesRequest) returns (stream MessageStreamResponse);
 
@@ -116,6 +119,12 @@ message OpenRequest {
     string worker_id = 1;
     WorkerType worker_type = 2;
     uint32 max_weight = 3;
+    // Self-reported build identity of this worker, so the coordinator can expose it via
+    // GetClusterComponentInfo. These are additive and optional; older workers leave them empty.
+    string version = 4;
+    string git_sha = 5;
+    string image_tag = 6;
+    string build_timestamp = 7;
 }
 
 message ServerMessage {
@@ -282,6 +291,27 @@ message GetStatsResponse {
     uint32 cpu_queue = 12;
     uint32 gpu_queue = 13;
     uint32 active_subscribers = 14;
+}
+
+// Self-reported build identity of a single cluster component (the coordinator or a worker).
+// Field names and semantics mirror the network-side prover component report so the fulfiller
+// can forward these entries without remapping.
+message ClusterComponentInfo {
+    // The component kind: "coordinator", "gpu-node", or "cpu-node".
+    string component = 1;
+    // The component instance identifier: "" for the coordinator, worker id for nodes.
+    string instance_id = 2;
+    string version = 3;
+    string git_sha = 4;
+    string image_tag = 5;
+    string build_timestamp = 6;
+}
+
+message GetClusterComponentInfoRequest {}
+
+message GetClusterComponentInfoResponse {
+    // The coordinator's own build followed by one entry per connected worker.
+    repeated ClusterComponentInfo components = 1;
 }
 
 // Message channel RPCs


### PR DESCRIPTION
## Summary

Adds an additive worker proto surface for reporting cluster component build identity.

This is Phase 3 of the prover component build reporting chain:

- succinctlabs/network#232: network wire contract
- succinctlabs/network-services#1199: SPN receive/store handler
- this PR: SP1 worker proto surface
- follow-up sp1-cluster PR: collect and report the data

## What Changed

- Adds build identity fields to `OpenRequest`: `version`, `git_sha`, `image_tag`.
- Adds `GetClusterComponentInfo` to `WorkerService`.
- Adds `ClusterComponentInfo`, `GetClusterComponentInfoRequest`, and `GetClusterComponentInfoResponse`.

All fields/RPCs are additive. Existing `OpenRequest` tags `1-3` are unchanged.

## Why

The follow-up `sp1-cluster` PR needs a proto surface for the coordinator to expose its own build identity plus the build identity reported by connected workers, so the fulfiller can report per-component runtime build info to SPN.

Field names mirror the network-side `ComponentInfo` so the follow-up can forward entries without remapping.

## Scope

Proto surface only. It does not implement coordinator storage/serving, populate worker clients, report to SPN, or touch network/network-services/sp1-cluster/infra/Docker/SDK.

## Validation

- `cargo check -p sp1-prover-types --release`
- `cargo fmt -p sp1-prover-types -- --check`
- `git diff --check`

Generated Rust is emitted to `OUT_DIR` by the crate build and is not committed.

## Review updates

- Dropped `build_timestamp`: it is not a stable identity signal (the same `git_sha` can be rebuilt); the meaningful time is server-owned observation time downstream.
- Removed the word "optional" from the docstring rather than making the fields proto3 `optional` — an empty string is the natural "unknown" for self-reported telemetry, so field presence buys nothing.
