### PR TITLE
chore: bump SP1 version to v6.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1679,7 +1679,7 @@ dependencies = [
  "hex",
  "pairing",
  "rand_core 0.6.4",
- "sp1-lib 6.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp1-lib 6.2.4",
  "subtle",
 ]
 
@@ -3935,7 +3935,7 @@ dependencies = [
  "elliptic-curve",
  "hex",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp1-lib 6.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp1-lib 6.2.4",
 ]
 
 [[package]]
@@ -4057,7 +4057,7 @@ dependencies = [
 
 [[package]]
 name = "libzkevm"
-version = "6.2.4"
+version = "6.3.1"
 dependencies = [
  "bls12_381",
  "hex",
@@ -4631,7 +4631,7 @@ dependencies = [
  "hex",
  "primeorder 0.13.1",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp1-lib 6.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp1-lib 6.2.4",
 ]
 
 [[package]]
@@ -6460,19 +6460,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slop-air"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "p3-air",
-]
-
-[[package]]
-name = "slop-algebra"
-version = "6.3.0"
-dependencies = [
- "itertools 0.14.0",
- "p3-field",
- "serde",
- "slop-baby-bear",
 ]
 
 [[package]]
@@ -6487,43 +6477,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "slop-algebra"
+version = "6.3.1"
+dependencies = [
+ "itertools 0.14.0",
+ "p3-field",
+ "serde",
+ "slop-baby-bear",
+]
+
+[[package]]
 name = "slop-alloc"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "serde",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.3.1",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "slop-baby-bear"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "lazy_static",
  "p3-baby-bear",
  "serde",
- "slop-algebra 6.2.4",
- "slop-challenger 6.2.4",
- "slop-poseidon2 6.2.4",
- "slop-symmetric 6.2.4",
+ "slop-algebra 6.3.1",
+ "slop-challenger 6.3.1",
+ "slop-poseidon2 6.3.1",
+ "slop-symmetric 6.3.1",
 ]
 
 [[package]]
 name = "slop-basefold"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
  "serde",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.3.1",
  "slop-alloc",
  "slop-baby-bear",
- "slop-bn254 6.2.4",
- "slop-challenger 6.2.4",
- "slop-koala-bear 6.2.4",
+ "slop-bn254 6.3.1",
+ "slop-challenger 6.3.1",
+ "slop-koala-bear 6.3.1",
  "slop-merkle-tree",
  "slop-multilinear",
- "slop-primitives 6.2.4",
+ "slop-primitives 6.3.1",
  "slop-tensor",
  "slop-utils",
  "thiserror 1.0.69",
@@ -6531,41 +6531,28 @@ dependencies = [
 
 [[package]]
 name = "slop-basefold-prover"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "derive-where",
  "futures",
  "itertools 0.14.0",
  "rand 0.8.6",
  "serde",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.3.1",
  "slop-alloc",
  "slop-baby-bear",
  "slop-basefold",
- "slop-bn254 6.2.4",
- "slop-challenger 6.2.4",
+ "slop-bn254 6.3.1",
+ "slop-challenger 6.3.1",
  "slop-commit",
  "slop-dft",
  "slop-fri",
  "slop-futures",
- "slop-koala-bear 6.2.4",
+ "slop-koala-bear 6.3.1",
  "slop-merkle-tree",
  "slop-multilinear",
  "slop-tensor",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "slop-bn254"
-version = "6.3.0"
-dependencies = [
- "ff",
- "p3-bn254-fr",
- "serde",
- "slop-algebra 6.2.4",
- "slop-challenger 6.2.4",
- "slop-poseidon2 6.2.4",
- "slop-symmetric 6.2.4",
 ]
 
 [[package]]
@@ -6577,21 +6564,23 @@ dependencies = [
  "ff",
  "p3-bn254-fr",
  "serde",
- "slop-algebra 6.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-challenger 6.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-poseidon2 6.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-symmetric 6.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slop-algebra 6.2.4",
+ "slop-challenger 6.2.4",
+ "slop-poseidon2 6.2.4",
+ "slop-symmetric 6.2.4",
 ]
 
 [[package]]
-name = "slop-challenger"
-version = "6.3.0"
+name = "slop-bn254"
+version = "6.3.1"
 dependencies = [
- "futures",
- "p3-challenger",
+ "ff",
+ "p3-bn254-fr",
  "serde",
- "slop-algebra 6.2.4",
- "slop-symmetric 6.2.4",
+ "slop-algebra 6.3.1",
+ "slop-challenger 6.3.1",
+ "slop-poseidon2 6.3.1",
+ "slop-symmetric 6.3.1",
 ]
 
 [[package]]
@@ -6603,13 +6592,24 @@ dependencies = [
  "futures",
  "p3-challenger",
  "serde",
- "slop-algebra 6.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-symmetric 6.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slop-algebra 6.2.4",
+ "slop-symmetric 6.2.4",
+]
+
+[[package]]
+name = "slop-challenger"
+version = "6.3.1"
+dependencies = [
+ "futures",
+ "p3-challenger",
+ "serde",
+ "slop-algebra 6.3.1",
+ "slop-symmetric 6.3.1",
 ]
 
 [[package]]
 name = "slop-commit"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "p3-commit",
  "serde",
@@ -6618,11 +6618,11 @@ dependencies = [
 
 [[package]]
 name = "slop-dft"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "p3-dft",
  "serde",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.3.1",
  "slop-alloc",
  "slop-matrix",
  "slop-tensor",
@@ -6630,14 +6630,14 @@ dependencies = [
 
 [[package]]
 name = "slop-fri"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "p3-fri",
 ]
 
 [[package]]
 name = "slop-futures"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "crossbeam",
  "futures",
@@ -6651,7 +6651,7 @@ dependencies = [
 
 [[package]]
 name = "slop-jagged"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "derive-where",
  "futures",
@@ -6660,21 +6660,21 @@ dependencies = [
  "rand 0.8.6",
  "rayon",
  "serde",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.3.1",
  "slop-alloc",
  "slop-baby-bear",
  "slop-basefold",
  "slop-basefold-prover",
- "slop-bn254 6.2.4",
- "slop-challenger 6.2.4",
+ "slop-bn254 6.3.1",
+ "slop-challenger 6.3.1",
  "slop-commit",
  "slop-futures",
- "slop-koala-bear 6.2.4",
+ "slop-koala-bear 6.3.1",
  "slop-merkle-tree",
  "slop-multilinear",
  "slop-stacked",
  "slop-sumcheck",
- "slop-symmetric 6.2.4",
+ "slop-symmetric 6.3.1",
  "slop-tensor",
  "slop-utils",
  "thiserror 1.0.69",
@@ -6683,22 +6683,9 @@ dependencies = [
 
 [[package]]
 name = "slop-keccak-air"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "p3-keccak-air",
-]
-
-[[package]]
-name = "slop-koala-bear"
-version = "6.3.0"
-dependencies = [
- "lazy_static",
- "p3-koala-bear",
- "serde",
- "slop-algebra 6.2.4",
- "slop-challenger 6.2.4",
- "slop-poseidon2 6.2.4",
- "slop-symmetric 6.2.4",
 ]
 
 [[package]]
@@ -6710,46 +6697,59 @@ dependencies = [
  "lazy_static",
  "p3-koala-bear",
  "serde",
- "slop-algebra 6.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-challenger 6.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-poseidon2 6.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-symmetric 6.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slop-algebra 6.2.4",
+ "slop-challenger 6.2.4",
+ "slop-poseidon2 6.2.4",
+ "slop-symmetric 6.2.4",
+]
+
+[[package]]
+name = "slop-koala-bear"
+version = "6.3.1"
+dependencies = [
+ "lazy_static",
+ "p3-koala-bear",
+ "serde",
+ "slop-algebra 6.3.1",
+ "slop-challenger 6.3.1",
+ "slop-poseidon2 6.3.1",
+ "slop-symmetric 6.3.1",
 ]
 
 [[package]]
 name = "slop-matrix"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "p3-matrix",
 ]
 
 [[package]]
 name = "slop-maybe-rayon"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "p3-maybe-rayon",
 ]
 
 [[package]]
 name = "slop-merkle-tree"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
  "p3-merkle-tree",
  "rand 0.8.6",
  "serde",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.3.1",
  "slop-alloc",
  "slop-baby-bear",
- "slop-bn254 6.2.4",
- "slop-challenger 6.2.4",
+ "slop-bn254 6.3.1",
+ "slop-challenger 6.3.1",
  "slop-commit",
  "slop-futures",
- "slop-koala-bear 6.2.4",
+ "slop-koala-bear 6.3.1",
  "slop-matrix",
- "slop-poseidon2 6.2.4",
- "slop-symmetric 6.2.4",
+ "slop-poseidon2 6.3.1",
+ "slop-symmetric 6.3.1",
  "slop-tensor",
  "slop-utils",
  "thiserror 1.0.69",
@@ -6757,7 +6757,7 @@ dependencies = [
 
 [[package]]
 name = "slop-multilinear"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "derive-where",
  "futures",
@@ -6766,10 +6766,10 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.3.1",
  "slop-alloc",
  "slop-baby-bear",
- "slop-challenger 6.2.4",
+ "slop-challenger 6.3.1",
  "slop-commit",
  "slop-futures",
  "slop-matrix",
@@ -6778,27 +6778,20 @@ dependencies = [
 
 [[package]]
 name = "slop-pgspcs"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "futures",
  "rand 0.8.6",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.3.1",
  "slop-alloc",
  "slop-baby-bear",
  "slop-basefold",
  "slop-basefold-prover",
- "slop-challenger 6.2.4",
+ "slop-challenger 6.3.1",
  "slop-commit",
  "slop-merkle-tree",
  "slop-multilinear",
  "slop-sumcheck",
-]
-
-[[package]]
-name = "slop-poseidon2"
-version = "6.3.0"
-dependencies = [
- "p3-poseidon2",
 ]
 
 [[package]]
@@ -6811,10 +6804,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "slop-primitives"
-version = "6.3.0"
+name = "slop-poseidon2"
+version = "6.3.1"
 dependencies = [
- "slop-algebra 6.2.4",
+ "p3-poseidon2",
 ]
 
 [[package]]
@@ -6823,20 +6816,27 @@ version = "6.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62cc9b1ba7261571e853287064780a6e7f489f024d544e6344d6004f243cdf81"
 dependencies = [
- "slop-algebra 6.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slop-algebra 6.2.4",
+]
+
+[[package]]
+name = "slop-primitives"
+version = "6.3.1"
+dependencies = [
+ "slop-algebra 6.3.1",
 ]
 
 [[package]]
 name = "slop-spartan"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "futures",
  "itertools 0.14.0",
  "rand 0.8.6",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.3.1",
  "slop-alloc",
  "slop-baby-bear",
- "slop-challenger 6.2.4",
+ "slop-challenger 6.3.1",
  "slop-merkle-tree",
  "slop-multilinear",
  "slop-pgspcs",
@@ -6846,19 +6846,19 @@ dependencies = [
 
 [[package]]
 name = "slop-stacked"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "derive-where",
  "futures",
  "itertools 0.14.0",
  "rand 0.8.6",
  "serde",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.3.1",
  "slop-alloc",
  "slop-baby-bear",
  "slop-basefold",
  "slop-basefold-prover",
- "slop-challenger 6.2.4",
+ "slop-challenger 6.3.1",
  "slop-commit",
  "slop-futures",
  "slop-merkle-tree",
@@ -6869,26 +6869,19 @@ dependencies = [
 
 [[package]]
 name = "slop-sumcheck"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "futures",
  "itertools 0.14.0",
  "rand 0.8.6",
  "rayon",
  "serde",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.3.1",
  "slop-alloc",
  "slop-baby-bear",
- "slop-challenger 6.2.4",
+ "slop-challenger 6.3.1",
  "slop-multilinear",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "slop-symmetric"
-version = "6.3.0"
-dependencies = [
- "p3-symmetric",
 ]
 
 [[package]]
@@ -6901,8 +6894,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "slop-symmetric"
+version = "6.3.1"
+dependencies = [
+ "p3-symmetric",
+]
+
+[[package]]
 name = "slop-tensor"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "arrayvec",
  "derive-where",
@@ -6911,7 +6911,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.3.1",
  "slop-alloc",
  "slop-baby-bear",
  "slop-futures",
@@ -6922,14 +6922,14 @@ dependencies = [
 
 [[package]]
 name = "slop-uni-stark"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "p3-uni-stark",
 ]
 
 [[package]]
 name = "slop-utils"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "p3-util",
  "tracing-forest",
@@ -6938,7 +6938,7 @@ dependencies = [
 
 [[package]]
 name = "slop-veil"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "bincode",
  "derive-where",
@@ -6948,23 +6948,23 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rayon",
  "serde",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.3.1",
  "slop-alloc",
  "slop-basefold",
  "slop-basefold-prover",
- "slop-challenger 6.2.4",
+ "slop-challenger 6.3.1",
  "slop-commit",
  "slop-dft",
  "slop-futures",
  "slop-jagged",
- "slop-koala-bear 6.2.4",
+ "slop-koala-bear 6.3.1",
  "slop-matrix",
  "slop-merkle-tree",
  "slop-multilinear",
- "slop-poseidon2 6.2.4",
+ "slop-poseidon2 6.3.1",
  "slop-stacked",
  "slop-sumcheck",
- "slop-symmetric 6.2.4",
+ "slop-symmetric 6.3.1",
  "slop-tensor",
  "slop-utils",
  "thiserror 1.0.69",
@@ -6973,7 +6973,7 @@ dependencies = [
 
 [[package]]
 name = "slop-whir"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "bincode",
  "derive-where",
@@ -6982,15 +6982,15 @@ dependencies = [
  "rand 0.8.6",
  "rayon",
  "serde",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.3.1",
  "slop-alloc",
  "slop-baby-bear",
  "slop-basefold",
- "slop-challenger 6.2.4",
+ "slop-challenger 6.3.1",
  "slop-commit",
  "slop-dft",
  "slop-jagged",
- "slop-koala-bear 6.2.4",
+ "slop-koala-bear 6.3.1",
  "slop-matrix",
  "slop-merkle-tree",
  "slop-multilinear",
@@ -7042,19 +7042,19 @@ dependencies = [
 
 [[package]]
 name = "sp1-build"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
  "chrono",
  "clap",
  "dirs",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.3.1",
 ]
 
 [[package]]
 name = "sp1-cli"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -7075,19 +7075,19 @@ dependencies = [
 
 [[package]]
 name = "sp1-constraint-compiler"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "clap",
  "serde_json",
  "slop-air",
  "sp1-core-machine",
  "sp1-hypercube",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.3.1",
 ]
 
 [[package]]
 name = "sp1-core-executor"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -7111,13 +7111,13 @@ dependencies = [
  "serde_arrays",
  "serde_json",
  "slop-air",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.3.1",
  "slop-maybe-rayon",
- "slop-symmetric 6.2.4",
+ "slop-symmetric 6.3.1",
  "sp1-curves",
  "sp1-hypercube",
  "sp1-jit",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.3.1",
  "sp1-zkvm",
  "strum",
  "subenum",
@@ -7131,7 +7131,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor-runner"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -7144,7 +7144,7 @@ dependencies = [
  "sp1-core-executor-runner-binary",
  "sp1-core-machine",
  "sp1-jit",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.3.1",
  "sysinfo 0.30.13",
  "test-artifacts",
  "tracing",
@@ -7153,7 +7153,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor-runner-binary"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "bincode",
  "crash-handler",
@@ -7166,7 +7166,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-machine"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "bincode",
  "cfg-if",
@@ -7184,10 +7184,10 @@ dependencies = [
  "serde",
  "serde_json",
  "slop-air",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.3.1",
  "slop-alloc",
  "slop-basefold",
- "slop-challenger 6.2.4",
+ "slop-challenger 6.3.1",
  "slop-futures",
  "slop-keccak-air",
  "slop-matrix",
@@ -7202,7 +7202,7 @@ dependencies = [
  "sp1-derive",
  "sp1-hypercube",
  "sp1-jit",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.3.1",
  "static_assertions",
  "struct-reflection",
  "strum",
@@ -7220,7 +7220,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cuda"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "bincode",
  "bytes",
@@ -7230,7 +7230,7 @@ dependencies = [
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-hypercube",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.3.1",
  "sp1-prover",
  "sp1-prover-types",
  "thiserror 1.0.69",
@@ -7240,7 +7240,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -7253,15 +7253,15 @@ dependencies = [
  "rand 0.8.6",
  "rug",
  "serde",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.3.1",
  "snowbridge-amcl",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.3.1",
  "typenum",
 ]
 
 [[package]]
 name = "sp1-derive"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7270,42 +7270,42 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-air"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "lazy_static",
  "slop-air",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.3.1",
  "slop-matrix",
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-hypercube",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.3.1",
 ]
 
 [[package]]
 name = "sp1-gpu-basefold"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "futures",
  "itertools 0.14.0",
  "rand 0.8.6",
  "serde",
  "serial_test",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.3.1",
  "slop-alloc",
  "slop-basefold",
  "slop-basefold-prover",
- "slop-bn254 6.2.4",
- "slop-challenger 6.2.4",
+ "slop-bn254 6.3.1",
+ "slop-challenger 6.3.1",
  "slop-commit",
  "slop-dft",
  "slop-futures",
- "slop-koala-bear 6.2.4",
+ "slop-koala-bear 6.3.1",
  "slop-merkle-tree",
  "slop-multilinear",
- "slop-poseidon2 6.2.4",
+ "slop-poseidon2 6.3.1",
  "slop-stacked",
- "slop-symmetric 6.2.4",
+ "slop-symmetric 6.3.1",
  "slop-tensor",
  "sp1-core-machine",
  "sp1-gpu-challenger",
@@ -7317,7 +7317,7 @@ dependencies = [
  "sp1-gpu-tracegen",
  "sp1-gpu-utils",
  "sp1-hypercube",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.3.1",
  "sp1-recursion-circuit",
  "sp1-recursion-compiler",
  "sp1-sdk",
@@ -7329,38 +7329,38 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-challenger"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
- "slop-algebra 6.2.4",
+ "slop-algebra 6.3.1",
  "slop-alloc",
- "slop-challenger 6.2.4",
- "slop-koala-bear 6.2.4",
- "slop-poseidon2 6.2.4",
- "slop-symmetric 6.2.4",
+ "slop-challenger 6.3.1",
+ "slop-koala-bear 6.3.1",
+ "slop-poseidon2 6.3.1",
+ "slop-symmetric 6.3.1",
  "sp1-gpu-cudart",
  "sp1-hypercube",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.3.1",
  "tokio",
 ]
 
 [[package]]
 name = "sp1-gpu-commit"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "criterion",
  "itertools 0.14.0",
  "rand 0.8.6",
  "serial_test",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.3.1",
  "slop-alloc",
- "slop-challenger 6.2.4",
+ "slop-challenger 6.3.1",
  "slop-dft",
  "slop-futures",
  "slop-jagged",
- "slop-koala-bear 6.2.4",
+ "slop-koala-bear 6.3.1",
  "slop-merkle-tree",
  "slop-stacked",
- "slop-symmetric 6.2.4",
+ "slop-symmetric 6.3.1",
  "slop-tensor",
  "sp1-core-machine",
  "sp1-gpu-basefold",
@@ -7372,7 +7372,7 @@ dependencies = [
  "sp1-gpu-tracegen",
  "sp1-gpu-utils",
  "sp1-hypercube",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.3.1",
  "sp1-recursion-circuit",
  "sp1-recursion-compiler",
  "sp1-sdk",
@@ -7384,28 +7384,28 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-cudart"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "crossbeam",
  "futures",
  "itertools 0.14.0",
  "pin-project",
  "rand 0.8.6",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.3.1",
  "slop-alloc",
  "slop-basefold",
- "slop-challenger 6.2.4",
+ "slop-challenger 6.3.1",
  "slop-commit",
  "slop-futures",
  "slop-jagged",
- "slop-koala-bear 6.2.4",
+ "slop-koala-bear 6.3.1",
  "slop-multilinear",
  "slop-stacked",
  "slop-sumcheck",
  "slop-tensor",
  "sp1-gpu-sys",
  "sp1-hypercube",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.3.1",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -7413,28 +7413,28 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-jagged-assist"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "futures",
  "itertools 0.14.0",
  "rand 0.8.6",
  "serde",
  "serial_test",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.3.1",
  "slop-alloc",
  "slop-basefold",
- "slop-bn254 6.2.4",
- "slop-challenger 6.2.4",
+ "slop-bn254 6.3.1",
+ "slop-challenger 6.3.1",
  "slop-commit",
  "slop-jagged",
- "slop-koala-bear 6.2.4",
+ "slop-koala-bear 6.3.1",
  "slop-multilinear",
  "slop-sumcheck",
  "slop-tensor",
  "sp1-gpu-challenger",
  "sp1-gpu-cudart",
  "sp1-gpu-tracing",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.3.1",
  "sp1-prover",
  "tokio",
  "tracing",
@@ -7442,7 +7442,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-jagged-sumcheck"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "criterion",
  "futures",
@@ -7451,9 +7451,9 @@ dependencies = [
  "rand 0.8.6",
  "rayon",
  "serial_test",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.3.1",
  "slop-alloc",
- "slop-challenger 6.2.4",
+ "slop-challenger 6.3.1",
  "slop-futures",
  "slop-jagged",
  "slop-multilinear",
@@ -7476,7 +7476,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-jagged-tracegen"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "criterion",
  "futures",
@@ -7487,9 +7487,9 @@ dependencies = [
  "serde_json",
  "serial_test",
  "slop-air",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.3.1",
  "slop-alloc",
- "slop-challenger 6.2.4",
+ "slop-challenger 6.3.1",
  "slop-futures",
  "slop-jagged",
  "slop-multilinear",
@@ -7516,7 +7516,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-logup-gkr"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "criterion",
  "futures",
@@ -7527,19 +7527,19 @@ dependencies = [
  "serde_json",
  "serial_test",
  "slop-air",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.3.1",
  "slop-alloc",
  "slop-basefold-prover",
- "slop-bn254 6.2.4",
- "slop-challenger 6.2.4",
+ "slop-bn254 6.3.1",
+ "slop-challenger 6.3.1",
  "slop-commit",
  "slop-dft",
  "slop-futures",
- "slop-koala-bear 6.2.4",
+ "slop-koala-bear 6.3.1",
  "slop-merkle-tree",
  "slop-multilinear",
  "slop-sumcheck",
- "slop-symmetric 6.2.4",
+ "slop-symmetric 6.3.1",
  "slop-tensor",
  "sp1-core-executor",
  "sp1-core-machine",
@@ -7549,7 +7549,7 @@ dependencies = [
  "sp1-gpu-utils",
  "sp1-gpu-zerocheck",
  "sp1-hypercube",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.3.1",
  "sp1-recursion-circuit",
  "sp1-sdk",
  "test-artifacts",
@@ -7562,20 +7562,20 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-merkle-tree"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "serial_test",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.3.1",
  "slop-alloc",
- "slop-bn254 6.2.4",
- "slop-challenger 6.2.4",
+ "slop-bn254 6.3.1",
+ "slop-challenger 6.3.1",
  "slop-commit",
  "slop-futures",
- "slop-koala-bear 6.2.4",
+ "slop-koala-bear 6.3.1",
  "slop-merkle-tree",
  "slop-multilinear",
  "slop-stacked",
- "slop-symmetric 6.2.4",
+ "slop-symmetric 6.3.1",
  "slop-tensor",
  "sp1-core-machine",
  "sp1-gpu-cudart",
@@ -7584,7 +7584,7 @@ dependencies = [
  "sp1-gpu-tracegen",
  "sp1-gpu-utils",
  "sp1-hypercube",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.3.1",
  "sp1-recursion-circuit",
  "sp1-recursion-compiler",
  "test-artifacts",
@@ -7595,7 +7595,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-perf"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "bincode",
  "clap",
@@ -7609,7 +7609,7 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "serde_json",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.3.1",
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-gpu-cudart",
@@ -7617,7 +7617,7 @@ dependencies = [
  "sp1-gpu-shard-prover",
  "sp1-gpu-tracing",
  "sp1-hypercube",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.3.1",
  "sp1-prover",
  "sp1-prover-types",
  "sp1-recursion-circuit",
@@ -7635,18 +7635,18 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-prover"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "clap",
  "serde",
  "slop-air",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.3.1",
  "slop-basefold",
- "slop-bn254 6.2.4",
- "slop-challenger 6.2.4",
+ "slop-bn254 6.3.1",
+ "slop-challenger 6.3.1",
  "slop-futures",
  "slop-jagged",
- "slop-koala-bear 6.2.4",
+ "slop-koala-bear 6.3.1",
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-gpu-air",
@@ -7660,7 +7660,7 @@ dependencies = [
  "sp1-gpu-shard-prover",
  "sp1-gpu-tracegen",
  "sp1-hypercube",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.3.1",
  "sp1-prover",
  "sp1-prover-types",
  "sysinfo 0.31.4",
@@ -7669,7 +7669,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-server"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "bincode",
  "clap",
@@ -7679,7 +7679,7 @@ dependencies = [
  "sp1-cuda",
  "sp1-gpu-cudart",
  "sp1-gpu-prover",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.3.1",
  "sp1-prover",
  "sp1-prover-types",
  "sp1-recursion-gnark-ffi",
@@ -7691,17 +7691,17 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-shard-prover"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "criterion",
  "rand 0.8.6",
  "serde_json",
  "serial_test",
  "slop-air",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.3.1",
  "slop-alloc",
  "slop-basefold",
- "slop-challenger 6.2.4",
+ "slop-challenger 6.3.1",
  "slop-commit",
  "slop-futures",
  "slop-jagged",
@@ -7724,7 +7724,7 @@ dependencies = [
  "sp1-gpu-utils",
  "sp1-gpu-zerocheck",
  "sp1-hypercube",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.3.1",
  "sp1-recursion-circuit",
  "sp1-recursion-compiler",
  "test-artifacts",
@@ -7736,39 +7736,39 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-sys"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "cbindgen",
  "cmake",
  "pathdiff",
- "slop-koala-bear 6.2.4",
+ "slop-koala-bear 6.3.1",
  "sp1-core-executor",
  "sp1-core-machine",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.3.1",
  "sp1-recursion-executor",
  "sp1-recursion-machine",
 ]
 
 [[package]]
 name = "sp1-gpu-tracegen"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "futures",
  "rand 0.8.6",
  "rayon",
  "slop-air",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.3.1",
  "slop-alloc",
  "slop-futures",
- "slop-koala-bear 6.2.4",
+ "slop-koala-bear 6.3.1",
  "slop-multilinear",
- "slop-symmetric 6.2.4",
+ "slop-symmetric 6.3.1",
  "slop-tensor",
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-gpu-cudart",
  "sp1-hypercube",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.3.1",
  "sp1-recursion-executor",
  "sp1-recursion-machine",
  "tokio",
@@ -7777,7 +7777,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-tracing"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "sp1-gpu-cudart",
  "tracing",
@@ -7786,18 +7786,18 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-utils"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "rand 0.8.6",
  "serial_test",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.3.1",
  "slop-alloc",
- "slop-koala-bear 6.2.4",
+ "slop-koala-bear 6.3.1",
  "slop-stacked",
  "slop-tensor",
  "sp1-gpu-cudart",
  "sp1-gpu-prover",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.3.1",
  "sp1-recursion-circuit",
  "sp1-recursion-compiler",
  "sp1-sdk",
@@ -7806,19 +7806,19 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-zerocheck"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "criterion",
  "itertools 0.14.0",
  "rand 0.8.6",
  "serial_test",
  "slop-air",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.3.1",
  "slop-alloc",
- "slop-challenger 6.2.4",
+ "slop-challenger 6.3.1",
  "slop-commit",
  "slop-futures",
- "slop-koala-bear 6.2.4",
+ "slop-koala-bear 6.3.1",
  "slop-matrix",
  "slop-multilinear",
  "slop-stacked",
@@ -7834,7 +7834,7 @@ dependencies = [
  "sp1-gpu-tracegen",
  "sp1-gpu-utils",
  "sp1-hypercube",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.3.1",
  "sp1-recursion-circuit",
  "sp1-recursion-compiler",
  "sp1-sdk",
@@ -7847,14 +7847,14 @@ dependencies = [
 
 [[package]]
 name = "sp1-helper"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "sp1-build",
 ]
 
 [[package]]
 name = "sp1-hypercube"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "arrayref",
  "deepsize2",
@@ -7870,28 +7870,28 @@ dependencies = [
  "rayon-scan",
  "serde",
  "slop-air",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.3.1",
  "slop-alloc",
  "slop-basefold",
  "slop-basefold-prover",
- "slop-bn254 6.2.4",
- "slop-challenger 6.2.4",
+ "slop-bn254 6.3.1",
+ "slop-challenger 6.3.1",
  "slop-commit",
  "slop-futures",
  "slop-jagged",
- "slop-koala-bear 6.2.4",
+ "slop-koala-bear 6.3.1",
  "slop-matrix",
  "slop-merkle-tree",
  "slop-multilinear",
- "slop-poseidon2 6.2.4",
+ "slop-poseidon2 6.3.1",
  "slop-stacked",
  "slop-sumcheck",
- "slop-symmetric 6.2.4",
+ "slop-symmetric 6.3.1",
  "slop-tensor",
  "slop-uni-stark",
  "slop-whir",
  "sp1-derive",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.3.1",
  "sp1-zkvm",
  "struct-reflection",
  "strum",
@@ -7903,7 +7903,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-jit"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "bincode",
  "dynasmrt",
@@ -7912,19 +7912,9 @@ dependencies = [
  "memfd",
  "memmap2",
  "serde",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.3.1",
  "tracing",
  "uuid",
-]
-
-[[package]]
-name = "sp1-lib"
-version = "6.3.0"
-dependencies = [
- "bincode",
- "elliptic-curve",
- "serde",
- "sp1-primitives 6.2.4",
 ]
 
 [[package]]
@@ -7936,12 +7926,22 @@ dependencies = [
  "bincode",
  "elliptic-curve",
  "serde",
- "sp1-primitives 6.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp1-primitives 6.2.4",
+]
+
+[[package]]
+name = "sp1-lib"
+version = "6.3.1"
+dependencies = [
+ "bincode",
+ "elliptic-curve",
+ "serde",
+ "sp1-primitives 6.3.1",
 ]
 
 [[package]]
 name = "sp1-perf"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -7951,12 +7951,12 @@ dependencies = [
  "dotenv",
  "rand 0.8.6",
  "rustyline",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.3.1",
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-cuda",
  "sp1-hypercube",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.3.1",
  "sp1-prover",
  "sp1-prover-types",
  "sp1-sdk",
@@ -7968,7 +7968,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.3.0"
+version = "6.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd38fbc3cf2e151b1d899919def510c80e7f6ca7b8fe7fdaac0e6614cd2bd286"
 dependencies = [
  "bincode",
  "blake3",
@@ -7990,9 +7992,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd38fbc3cf2e151b1d899919def510c80e7f6ca7b8fe7fdaac0e6614cd2bd286"
+version = "6.3.1"
 dependencies = [
  "bincode",
  "blake3",
@@ -8003,18 +8003,18 @@ dependencies = [
  "num-bigint 0.4.6",
  "serde",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-algebra 6.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-bn254 6.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-challenger 6.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-koala-bear 6.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-poseidon2 6.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-primitives 6.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-symmetric 6.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slop-algebra 6.3.1",
+ "slop-bn254 6.3.1",
+ "slop-challenger 6.3.1",
+ "slop-koala-bear 6.3.1",
+ "slop-poseidon2 6.3.1",
+ "slop-primitives 6.3.1",
+ "slop-symmetric 6.3.1",
 ]
 
 [[package]]
 name = "sp1-prover"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8040,22 +8040,22 @@ dependencies = [
  "serial_test",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "slop-air",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.3.1",
  "slop-basefold",
- "slop-bn254 6.2.4",
- "slop-challenger 6.2.4",
+ "slop-bn254 6.3.1",
+ "slop-challenger 6.3.1",
  "slop-futures",
  "slop-jagged",
  "slop-multilinear",
  "slop-stacked",
- "slop-symmetric 6.2.4",
+ "slop-symmetric 6.3.1",
  "sp1-core-executor",
  "sp1-core-executor-runner",
  "sp1-core-machine",
  "sp1-derive",
  "sp1-hypercube",
  "sp1-jit",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.3.1",
  "sp1-prover-types",
  "sp1-recursion-circuit",
  "sp1-recursion-compiler",
@@ -8077,7 +8077,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover-types"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -8090,7 +8090,7 @@ dependencies = [
  "serde",
  "sp1-core-machine",
  "sp1-hypercube",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.3.1",
  "tokio",
  "tonic 0.12.3",
  "tonic-build",
@@ -8099,7 +8099,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-circuit"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "bincode",
  "futures",
@@ -8108,29 +8108,29 @@ dependencies = [
  "rayon",
  "serde",
  "slop-air",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.3.1",
  "slop-alloc",
  "slop-basefold",
  "slop-basefold-prover",
- "slop-bn254 6.2.4",
- "slop-challenger 6.2.4",
+ "slop-bn254 6.3.1",
+ "slop-challenger 6.3.1",
  "slop-commit",
  "slop-dft",
  "slop-jagged",
- "slop-koala-bear 6.2.4",
+ "slop-koala-bear 6.3.1",
  "slop-matrix",
  "slop-merkle-tree",
  "slop-multilinear",
  "slop-stacked",
  "slop-sumcheck",
- "slop-symmetric 6.2.4",
+ "slop-symmetric 6.3.1",
  "slop-tensor",
  "slop-whir",
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-derive",
  "sp1-hypercube",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.3.1",
  "sp1-recursion-compiler",
  "sp1-recursion-executor",
  "sp1-recursion-gnark-ffi",
@@ -8142,19 +8142,19 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-compiler"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "backtrace",
  "cfg-if",
  "itertools 0.14.0",
  "rand 0.8.6",
  "serde",
- "slop-algebra 6.2.4",
- "slop-bn254 6.2.4",
- "slop-symmetric 6.2.4",
+ "slop-algebra 6.3.1",
+ "slop-bn254 6.3.1",
+ "slop-symmetric 6.3.1",
  "sp1-core-machine",
  "sp1-hypercube",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.3.1",
  "sp1-recursion-executor",
  "tracing",
  "vec_map",
@@ -8162,7 +8162,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-executor"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -8170,10 +8170,10 @@ dependencies = [
  "itertools 0.14.0",
  "range-set-blaze",
  "serde",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.3.1",
  "slop-maybe-rayon",
- "slop-poseidon2 6.2.4",
- "slop-symmetric 6.2.4",
+ "slop-poseidon2 6.3.1",
+ "slop-symmetric 6.3.1",
  "smallvec",
  "sp1-derive",
  "sp1-hypercube",
@@ -8184,7 +8184,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-cli"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "bincode",
  "clap",
@@ -8193,7 +8193,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-ffi"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8204,10 +8204,10 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-algebra 6.2.4",
- "slop-symmetric 6.2.4",
+ "slop-algebra 6.3.1",
+ "slop-symmetric 6.3.1",
  "sp1-hypercube",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.3.1",
  "sp1-recursion-compiler",
  "sp1-verifier",
  "tempfile",
@@ -8216,21 +8216,21 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-machine"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.6",
  "slop-air",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.3.1",
  "slop-basefold",
- "slop-challenger 6.2.4",
+ "slop-challenger 6.3.1",
  "slop-matrix",
  "slop-maybe-rayon",
- "slop-symmetric 6.2.4",
+ "slop-symmetric 6.3.1",
  "sp1-core-machine",
  "sp1-derive",
  "sp1-hypercube",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.3.1",
  "sp1-recursion-executor",
  "strum",
  "tokio",
@@ -8239,7 +8239,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-sdk"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -8273,7 +8273,7 @@ dependencies = [
  "sp1-core-machine",
  "sp1-cuda",
  "sp1-hypercube",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.3.1",
  "sp1-prover",
  "sp1-prover-types",
  "sp1-recursion-executor",
@@ -8293,7 +8293,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-verifier"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -8310,12 +8310,12 @@ dependencies = [
  "serde",
  "serial_test",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-algebra 6.2.4",
- "slop-challenger 6.2.4",
- "slop-primitives 6.2.4",
- "slop-symmetric 6.2.4",
+ "slop-algebra 6.3.1",
+ "slop-challenger 6.3.1",
+ "slop-primitives 6.3.1",
+ "slop-symmetric 6.3.1",
  "sp1-hypercube",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.3.1",
  "sp1-recursion-executor",
  "sp1-recursion-machine",
  "sp1-sdk",
@@ -8328,7 +8328,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "blake3",
  "cfg-if",
@@ -8340,9 +8340,9 @@ dependencies = [
  "libm",
  "rand 0.8.6",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-algebra 6.2.4",
- "sp1-lib 6.2.4",
- "sp1-primitives 6.2.4",
+ "slop-algebra 6.3.1",
+ "sp1-lib 6.3.1",
+ "sp1-primitives 6.3.1",
 ]
 
 [[package]]
@@ -8451,7 +8451,7 @@ dependencies = [
  "num-bigint 0.4.6",
  "rand 0.8.6",
  "rustc-hex",
- "sp1-lib 6.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp1-lib 6.2.4",
 ]
 
 [[package]]
@@ -8622,7 +8622,7 @@ dependencies = [
 
 [[package]]
 name = "test-artifacts"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "sp1-build",
 ]
@@ -8760,7 +8760,7 @@ source = "git+https://github.com/sp1-patches/tiny-keccak?tag=patch-2.0.2-sp1-6.2
 dependencies = [
  "cfg-if",
  "crunchy",
- "sp1-lib 6.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp1-lib 6.2.4",
 ]
 
 [[package]]
@@ -10298,7 +10298,7 @@ dependencies = [
 
 [[package]]
 name = "zkevm-build-sdk"
-version = "6.2.4"
+version = "6.3.1"
 dependencies = [
  "sp1-build",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "6.3.0"
+version = "6.3.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/succinctlabs/sp1"
@@ -118,53 +118,53 @@ debug = true
 debug-assertions = true
 
 [workspace.dependencies]
-sp1-build = { version = "6.3.0", path = "crates/build" }
-sp1-cli = { version = "6.3.0", path = "crates/cli", default-features = false }
-sp1-core-executor = { version = "6.3.0", path = "crates/core/executor" }
-sp1-core-executor-runner = { version = "6.3.0", path = "crates/core/runner" }
-sp1-core-executor-runner-binary = { version = "6.3.0", path = "crates/core/runner-binary" }
-sp1-core-machine = { version = "6.3.0", path = "crates/core/machine" }
-sp1-cuda = { version = "6.3.0", path = "crates/cuda" }
-sp1-curves = { version = "6.3.0", path = "crates/curves" }
-sp1-derive = { version = "6.3.0", path = "crates/derive" }
-# sp1-eval = { version = "6.3.0", path = "crates/eval" }
-sp1-helper = { version = "6.3.0", path = "crates/helper", default-features = false }
-sp1-hypercube = { version = "6.3.0", path = "crates/hypercube" }
-sp1-jit = { version = "6.3.0", path = "crates/core/jit" }
-sp1-lib = { version = "6.3.0", path = "crates/zkvm/lib", default-features = false }
-sp1-primitives = { version = "6.3.0", path = "crates/primitives" }
-sp1-prover = { version = "6.3.0", path = "crates/prover" }
-sp1-prover-types = { version = "6.3.0", path = "crates/prover-types" }
-sp1-recursion-circuit = { version = "6.3.0", path = "crates/recursion/circuit", default-features = false }
-sp1-recursion-compiler = { version = "6.3.0", path = "crates/recursion/compiler" }
-sp1-recursion-executor = { version = "6.3.0", path = "crates/recursion/executor", default-features = false }
-sp1-recursion-gnark-ffi = { version = "6.3.0", path = "crates/recursion/gnark-ffi", default-features = false }
-sp1-recursion-machine = { version = "6.3.0", path = "crates/recursion/machine", default-features = false }
-sp1-sdk = { version = "6.3.0", path = "crates/sdk", default-features = false }
-sp1-verifier = { version = "6.3.0", path = "crates/verifier", default-features = false }
-sp1-zkvm = { version = "6.3.0", path = "crates/zkvm/entrypoint", default-features = false }
+sp1-build = { version = "6.3.1", path = "crates/build" }
+sp1-cli = { version = "6.3.1", path = "crates/cli", default-features = false }
+sp1-core-executor = { version = "6.3.1", path = "crates/core/executor" }
+sp1-core-executor-runner = { version = "6.3.1", path = "crates/core/runner" }
+sp1-core-executor-runner-binary = { version = "6.3.1", path = "crates/core/runner-binary" }
+sp1-core-machine = { version = "6.3.1", path = "crates/core/machine" }
+sp1-cuda = { version = "6.3.1", path = "crates/cuda" }
+sp1-curves = { version = "6.3.1", path = "crates/curves" }
+sp1-derive = { version = "6.3.1", path = "crates/derive" }
+# sp1-eval = { version = "6.3.1", path = "crates/eval" }
+sp1-helper = { version = "6.3.1", path = "crates/helper", default-features = false }
+sp1-hypercube = { version = "6.3.1", path = "crates/hypercube" }
+sp1-jit = { version = "6.3.1", path = "crates/core/jit" }
+sp1-lib = { version = "6.3.1", path = "crates/zkvm/lib", default-features = false }
+sp1-primitives = { version = "6.3.1", path = "crates/primitives" }
+sp1-prover = { version = "6.3.1", path = "crates/prover" }
+sp1-prover-types = { version = "6.3.1", path = "crates/prover-types" }
+sp1-recursion-circuit = { version = "6.3.1", path = "crates/recursion/circuit", default-features = false }
+sp1-recursion-compiler = { version = "6.3.1", path = "crates/recursion/compiler" }
+sp1-recursion-executor = { version = "6.3.1", path = "crates/recursion/executor", default-features = false }
+sp1-recursion-gnark-ffi = { version = "6.3.1", path = "crates/recursion/gnark-ffi", default-features = false }
+sp1-recursion-machine = { version = "6.3.1", path = "crates/recursion/machine", default-features = false }
+sp1-sdk = { version = "6.3.1", path = "crates/sdk", default-features = false }
+sp1-verifier = { version = "6.3.1", path = "crates/verifier", default-features = false }
+sp1-zkvm = { version = "6.3.1", path = "crates/zkvm/entrypoint", default-features = false }
 test-artifacts = { path = "crates/test-artifacts" }
 
 # sp1-gpu crates
-sp1-gpu-air = { version = "6.3.0", path = "sp1-gpu/crates/air" }
-sp1-gpu-basefold = { version = "6.3.0", path = "sp1-gpu/crates/basefold" }
-sp1-gpu-challenger = { version = "6.3.0", path = "sp1-gpu/crates/challenger" }
-sp1-gpu-commit = { version = "6.3.0", path = "sp1-gpu/crates/commit" }
-sp1-gpu-cudart = { version = "6.3.0", path = "sp1-gpu/crates/cuda" }
-sp1-gpu-jagged-assist = { version = "6.3.0", path = "sp1-gpu/crates/jagged_assist" }
-sp1-gpu-jagged-sumcheck = { version = "6.3.0", path = "sp1-gpu/crates/jagged_sumcheck" }
-sp1-gpu-jagged-tracegen = { version = "6.3.0", path = "sp1-gpu/crates/jagged_tracegen" }
-sp1-gpu-logup-gkr = { version = "6.3.0", path = "sp1-gpu/crates/logup_gkr" }
-sp1-gpu-merkle-tree = { version = "6.3.0", path = "sp1-gpu/crates/merkle_tree" }
-sp1-gpu-perf = { version = "6.3.0", path = "sp1-gpu/crates/perf" }
-sp1-gpu-prover = { version = "6.3.0", path = "sp1-gpu/crates/prover_components" }
-sp1-gpu-server = { version = "6.3.0", path = "sp1-gpu/crates/server" }
-sp1-gpu-shard-prover = { version = "6.3.0", path = "sp1-gpu/crates/shard_prover" }
-sp1-gpu-sys = { version = "6.3.0", path = "sp1-gpu/crates/sys" }
-sp1-gpu-tracegen = { version = "6.3.0", path = "sp1-gpu/crates/tracegen" }
-sp1-gpu-tracing = { version = "6.3.0", path = "sp1-gpu/crates/tracing" }
-sp1-gpu-utils = { version = "6.3.0", path = "sp1-gpu/crates/utils" }
-sp1-gpu-zerocheck = { version = "6.3.0", path = "sp1-gpu/crates/zerocheck" }
+sp1-gpu-air = { version = "6.3.1", path = "sp1-gpu/crates/air" }
+sp1-gpu-basefold = { version = "6.3.1", path = "sp1-gpu/crates/basefold" }
+sp1-gpu-challenger = { version = "6.3.1", path = "sp1-gpu/crates/challenger" }
+sp1-gpu-commit = { version = "6.3.1", path = "sp1-gpu/crates/commit" }
+sp1-gpu-cudart = { version = "6.3.1", path = "sp1-gpu/crates/cuda" }
+sp1-gpu-jagged-assist = { version = "6.3.1", path = "sp1-gpu/crates/jagged_assist" }
+sp1-gpu-jagged-sumcheck = { version = "6.3.1", path = "sp1-gpu/crates/jagged_sumcheck" }
+sp1-gpu-jagged-tracegen = { version = "6.3.1", path = "sp1-gpu/crates/jagged_tracegen" }
+sp1-gpu-logup-gkr = { version = "6.3.1", path = "sp1-gpu/crates/logup_gkr" }
+sp1-gpu-merkle-tree = { version = "6.3.1", path = "sp1-gpu/crates/merkle_tree" }
+sp1-gpu-perf = { version = "6.3.1", path = "sp1-gpu/crates/perf" }
+sp1-gpu-prover = { version = "6.3.1", path = "sp1-gpu/crates/prover_components" }
+sp1-gpu-server = { version = "6.3.1", path = "sp1-gpu/crates/server" }
+sp1-gpu-shard-prover = { version = "6.3.1", path = "sp1-gpu/crates/shard_prover" }
+sp1-gpu-sys = { version = "6.3.1", path = "sp1-gpu/crates/sys" }
+sp1-gpu-tracegen = { version = "6.3.1", path = "sp1-gpu/crates/tracegen" }
+sp1-gpu-tracing = { version = "6.3.1", path = "sp1-gpu/crates/tracing" }
+sp1-gpu-utils = { version = "6.3.1", path = "sp1-gpu/crates/utils" }
+sp1-gpu-zerocheck = { version = "6.3.1", path = "sp1-gpu/crates/zerocheck" }
 
 p3-air = "=0.4.3-succinct"
 p3-baby-bear = "=0.4.3-succinct"
@@ -184,37 +184,37 @@ p3-symmetric = "=0.4.3-succinct"
 p3-uni-stark = "=0.4.3-succinct"
 p3-util = "=0.4.3-succinct"
 
-slop-air = { version = "6.3.0", path = "./slop/crates/air" }
-slop-algebra = { version = "6.3.0", path = "./slop/crates/algebra" }
-slop-alloc = { version = "6.3.0", path = "./slop/crates/alloc" }
-slop-baby-bear = { version = "6.3.0", path = "./slop/crates/baby-bear" }
-slop-basefold = { version = "6.3.0", path = "./slop/crates/basefold" }
-slop-basefold-prover = { version = "6.3.0", path = "./slop/crates/basefold-prover" }
-slop-bn254 = { version = "6.3.0", path = "./slop/crates/bn254" }
-slop-challenger = { version = "6.3.0", path = "./slop/crates/challenger" }
-slop-commit = { version = "6.3.0", path = "./slop/crates/commit" }
-slop-dft = { version = "6.3.0", path = "./slop/crates/dft" }
-slop-fri = { version = "6.3.0", path = "./slop/crates/fri" }
-slop-futures = { version = "6.3.0", path = "./slop/crates/futures" }
-slop-jagged = { version = "6.3.0", path = "./slop/crates/jagged" }
-slop-keccak-air = { version = "6.3.0", path = "./slop/crates/keccak-air" }
-slop-koala-bear = { version = "6.3.0", path = "./slop/crates/koala-bear" }
-slop-matrix = { version = "6.3.0", path = "./slop/crates/matrix" }
-slop-maybe-rayon = { version = "6.3.0", path = "./slop/crates/maybe-rayon" }
-slop-merkle-tree = { version = "6.3.0", path = "./slop/crates/merkle-tree" }
-slop-multilinear = { version = "6.3.0", path = "./slop/crates/multilinear" }
-slop-pgspcs = { version = "6.3.0", path = "./slop/crates/pgspcs" }
-slop-primitives = { version = "6.3.0", path = "./slop/crates/primitives" }
-slop-poseidon2 = { version = "6.3.0", path = "./slop/crates/poseidon2" }
-slop-spartan = { version = "6.3.0", path = "./slop/crates/spartan" }
-slop-stacked = { version = "6.3.0", path = "./slop/crates/stacked" }
-slop-sumcheck = { version = "6.3.0", path = "./slop/crates/sumcheck" }
-slop-symmetric = { version = "6.3.0", path = "./slop/crates/symmetric" }
-slop-tensor = { version = "6.3.0", path = "./slop/crates/tensor" }
-slop-uni-stark = { version = "6.3.0", path = "./slop/crates/uni-stark" }
-slop-utils = { version = "6.3.0", path = "./slop/crates/utils" }
-slop-veil = { version = "6.3.0", path = "./slop/crates/veil" }
-slop-whir = { version = "6.3.0", path = "./slop/crates/whir" }
+slop-air = { version = "6.3.1", path = "./slop/crates/air" }
+slop-algebra = { version = "6.3.1", path = "./slop/crates/algebra" }
+slop-alloc = { version = "6.3.1", path = "./slop/crates/alloc" }
+slop-baby-bear = { version = "6.3.1", path = "./slop/crates/baby-bear" }
+slop-basefold = { version = "6.3.1", path = "./slop/crates/basefold" }
+slop-basefold-prover = { version = "6.3.1", path = "./slop/crates/basefold-prover" }
+slop-bn254 = { version = "6.3.1", path = "./slop/crates/bn254" }
+slop-challenger = { version = "6.3.1", path = "./slop/crates/challenger" }
+slop-commit = { version = "6.3.1", path = "./slop/crates/commit" }
+slop-dft = { version = "6.3.1", path = "./slop/crates/dft" }
+slop-fri = { version = "6.3.1", path = "./slop/crates/fri" }
+slop-futures = { version = "6.3.1", path = "./slop/crates/futures" }
+slop-jagged = { version = "6.3.1", path = "./slop/crates/jagged" }
+slop-keccak-air = { version = "6.3.1", path = "./slop/crates/keccak-air" }
+slop-koala-bear = { version = "6.3.1", path = "./slop/crates/koala-bear" }
+slop-matrix = { version = "6.3.1", path = "./slop/crates/matrix" }
+slop-maybe-rayon = { version = "6.3.1", path = "./slop/crates/maybe-rayon" }
+slop-merkle-tree = { version = "6.3.1", path = "./slop/crates/merkle-tree" }
+slop-multilinear = { version = "6.3.1", path = "./slop/crates/multilinear" }
+slop-pgspcs = { version = "6.3.1", path = "./slop/crates/pgspcs" }
+slop-primitives = { version = "6.3.1", path = "./slop/crates/primitives" }
+slop-poseidon2 = { version = "6.3.1", path = "./slop/crates/poseidon2" }
+slop-spartan = { version = "6.3.1", path = "./slop/crates/spartan" }
+slop-stacked = { version = "6.3.1", path = "./slop/crates/stacked" }
+slop-sumcheck = { version = "6.3.1", path = "./slop/crates/sumcheck" }
+slop-symmetric = { version = "6.3.1", path = "./slop/crates/symmetric" }
+slop-tensor = { version = "6.3.1", path = "./slop/crates/tensor" }
+slop-uni-stark = { version = "6.3.1", path = "./slop/crates/uni-stark" }
+slop-utils = { version = "6.3.1", path = "./slop/crates/utils" }
+slop-veil = { version = "6.3.1", path = "./slop/crates/veil" }
+slop-whir = { version = "6.3.1", path = "./slop/crates/whir" }
 
 # For testing.
 tokio-test = "0.4.4"

--- a/crates/test-artifacts/programs/fibonacci-blake3/Cargo.lock
+++ b/crates/test-artifacts/programs/fibonacci-blake3/Cargo.lock
@@ -754,7 +754,7 @@ checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "slop-algebra"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -763,7 +763,7 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "ff",
  "p3-bn254-fr",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "futures",
  "p3-challenger",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -800,28 +800,28 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "p3-poseidon2",
 ]
 
 [[package]]
 name = "slop-primitives"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "slop-algebra",
 ]
 
 [[package]]
 name = "slop-symmetric"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "p3-symmetric",
 ]
 
 [[package]]
 name = "sp1-lib"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "bincode",
  "serde",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "bincode",
  "blake3",
@@ -852,7 +852,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "blake3",
  "cfg-if",

--- a/crates/test-artifacts/programs/trap-exec/Cargo.lock
+++ b/crates/test-artifacts/programs/trap-exec/Cargo.lock
@@ -756,7 +756,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slop-algebra"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "ff",
  "p3-bn254-fr",
@@ -778,7 +778,7 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "futures",
  "p3-challenger",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -802,28 +802,28 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "p3-poseidon2",
 ]
 
 [[package]]
 name = "slop-primitives"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "slop-algebra",
 ]
 
 [[package]]
 name = "slop-symmetric"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "p3-symmetric",
 ]
 
 [[package]]
 name = "sp1-derive"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "bincode",
  "serde",
@@ -841,7 +841,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "bincode",
  "blake3",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "cfg-if",
  "critical-section",

--- a/crates/test-artifacts/programs/trap-load-store/Cargo.lock
+++ b/crates/test-artifacts/programs/trap-load-store/Cargo.lock
@@ -756,7 +756,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slop-algebra"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "ff",
  "p3-bn254-fr",
@@ -778,7 +778,7 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "futures",
  "p3-challenger",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -802,28 +802,28 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "p3-poseidon2",
 ]
 
 [[package]]
 name = "slop-primitives"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "slop-algebra",
 ]
 
 [[package]]
 name = "slop-symmetric"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "p3-symmetric",
 ]
 
 [[package]]
 name = "sp1-derive"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "bincode",
  "serde",
@@ -841,7 +841,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "bincode",
  "blake3",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "cfg-if",
  "critical-section",

--- a/zkevm/libzkevm-cabi/Cargo.lock
+++ b/zkevm/libzkevm-cabi/Cargo.lock
@@ -786,7 +786,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libzkevm"
-version = "6.2.4"
+version = "6.3.1"
 dependencies = [
  "bls12_381 0.8.0",
  "k256",
@@ -1537,7 +1537,7 @@ dependencies = [
 
 [[package]]
 name = "slop-algebra"
-version = "6.2.4"
+version = "6.3.1"
 dependencies = [
  "itertools 0.14.0",
  "p3-field 0.4.3-succinct",
@@ -1562,15 +1562,15 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.2.4"
+version = "6.3.1"
 dependencies = [
  "ff 0.13.1",
  "p3-bn254-fr 0.4.3-succinct",
  "serde",
- "slop-algebra 6.2.4",
- "slop-challenger 6.2.4",
- "slop-poseidon2 6.2.4",
- "slop-symmetric 6.2.4",
+ "slop-algebra 6.3.1",
+ "slop-challenger 6.3.1",
+ "slop-poseidon2 6.3.1",
+ "slop-symmetric 6.3.1",
 ]
 
 [[package]]
@@ -1588,13 +1588,13 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.2.4"
+version = "6.3.1"
 dependencies = [
  "futures",
  "p3-challenger 0.4.3-succinct",
  "serde",
- "slop-algebra 6.2.4",
- "slop-symmetric 6.2.4",
+ "slop-algebra 6.3.1",
+ "slop-symmetric 6.3.1",
 ]
 
 [[package]]
@@ -1614,15 +1614,15 @@ dependencies = [
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.2.4"
+version = "6.3.1"
 dependencies = [
  "lazy_static",
  "p3-koala-bear 0.4.3-succinct",
  "serde",
- "slop-algebra 6.2.4",
- "slop-challenger 6.2.4",
- "slop-poseidon2 6.2.4",
- "slop-symmetric 6.2.4",
+ "slop-algebra 6.3.1",
+ "slop-challenger 6.3.1",
+ "slop-poseidon2 6.3.1",
+ "slop-symmetric 6.3.1",
 ]
 
 [[package]]
@@ -1636,7 +1636,7 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.2.4"
+version = "6.3.1"
 dependencies = [
  "p3-poseidon2 0.4.3-succinct",
 ]
@@ -1652,9 +1652,9 @@ dependencies = [
 
 [[package]]
 name = "slop-primitives"
-version = "6.2.4"
+version = "6.3.1"
 dependencies = [
- "slop-algebra 6.2.4",
+ "slop-algebra 6.3.1",
 ]
 
 [[package]]
@@ -1668,7 +1668,7 @@ dependencies = [
 
 [[package]]
 name = "slop-symmetric"
-version = "6.2.4"
+version = "6.3.1"
 dependencies = [
  "p3-symmetric 0.4.3-succinct",
 ]
@@ -1717,7 +1717,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.2.4"
+version = "6.3.1"
 dependencies = [
  "bincode",
  "blake3",
@@ -1728,18 +1728,18 @@ dependencies = [
  "num-bigint 0.4.6",
  "serde",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-algebra 6.2.4",
- "slop-bn254 6.2.4",
- "slop-challenger 6.2.4",
- "slop-koala-bear 6.2.4",
- "slop-poseidon2 6.2.4",
- "slop-primitives 6.2.4",
- "slop-symmetric 6.2.4",
+ "slop-algebra 6.3.1",
+ "slop-bn254 6.3.1",
+ "slop-challenger 6.3.1",
+ "slop-koala-bear 6.3.1",
+ "slop-poseidon2 6.3.1",
+ "slop-primitives 6.3.1",
+ "slop-symmetric 6.3.1",
 ]
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.2.4"
+version = "6.3.1"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -1749,7 +1749,7 @@ dependencies = [
  "lazy_static",
  "rand",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.3.1",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Bump the SP1 workspace version `6.3.0` → `6.3.1` via `set-version.sh`.

This release includes #2850 (`GetClusterComponentInfo` + `OpenRequest` build fields) and #2855 (drop `ClusterComponentInfo.instance_id` + renumber its build fields to 1..4) — both merged into `main` but not in the published `v6.3.0` crates.

Needed so downstream **succinctlabs/sp1-cluster#146** can stop pinning a post-`v6.3.0` git rev and depend on released crates instead.

No runtime behavior change beyond the already-merged #2850/#2855 — this is version metadata only.

## Changes

- `set-version.sh 6.3.1`: root `Cargo.toml` workspace version + member path-dep versions, and the lockfiles it could resolve offline (root `Cargo.lock` + the cached guest/test sublockfiles).

## Note on test-workspace lockfiles

`set-version.sh` (offline `cargo update`) could not refresh a few separate test-workspace lockfiles (`examples/`, `patch-testing/`, `crates/verifier/guest-verify-programs/`, `crates/test-artifacts/programs/`) because they pull git patch deps that weren't cached locally. These reference SP1 by path, so they reconcile on the next build/CI and don't affect the crates.io publish (which uses the root workspace). They can be refreshed with network access before/at release if a fully in-sync diff is wanted (as in the v6.3.0 bump).

## Release

crates.io publish happens **after** this PR merges and the release action runs — not in this PR. No tags are created here.

