### PR TITLE
refactor(proto): drop ClusterComponentInfo.instance_id

### DIFF
--- a/crates/prover-types/proto/worker.proto
+++ b/crates/prover-types/proto/worker.proto
@@ -293,16 +293,14 @@ message GetStatsResponse {
 }
 
 // Self-reported build identity of a single cluster component (the coordinator or a worker).
-// Field names and semantics mirror the network-side prover component report so the fulfiller
-// can forward these entries without remapping.
+// Keyed by build identity (component + version/git_sha/image_tag); per-instance identity is not
+// reported here (the coordinator tracks workers by OpenRequest.worker_id internally).
 message ClusterComponentInfo {
     // The component kind: "coordinator", "gpu-node", or "cpu-node".
     string component = 1;
-    // The component instance identifier: "" for the coordinator, worker id for nodes.
-    string instance_id = 2;
-    string version = 3;
-    string git_sha = 4;
-    string image_tag = 5;
+    string version = 2;
+    string git_sha = 3;
+    string image_tag = 4;
 }
 
 message GetClusterComponentInfoRequest {}


### PR DESCRIPTION
## Summary

Drops the never-shipped `ClusterComponentInfo.instance_id` from `crates/prover-types/proto/worker.proto` (replaces the earlier doc-only comment tweak with the real cleanup, per Farhad).

The cluster component manifest (`GetClusterComponentInfo`) is keyed by build identity — `component` + `version`/`git_sha`/`image_tag`. Per-instance identity is not reported: the coordinator still tracks workers internally by `OpenRequest.worker_id` (untouched). The build fields are renumbered contiguously (`version=2`, `git_sha=3`, `image_tag=4`), no `reserved` marker, matching the public `ComponentInfo` (succinctlabs/network#234).

## Notes

- `OpenRequest.worker_id`, `GetClusterComponentInfo`, and the build fields (`version`, `git_sha`, `image_tag`) are unchanged.
- No producer traffic has shipped, so removing the field (rather than reserving it) is safe.
- Should land before `v6.3.1` is cut so the released crates carry the slimmed message.

