### PR TITLE
feat(executor): capture bounded guest stderr tail in ExecutionReport

### DIFF
--- a/crates/core/executor/src/minimal.rs
+++ b/crates/core/executor/src/minimal.rs
@@ -157,6 +157,15 @@ impl MinimalExecutorEnum {
         }
     }
 
+    /// Calls `stderr_tail` to respective `MinimalExecutor`.
+    #[must_use]
+    pub fn stderr_tail(&self) -> Option<String> {
+        match self {
+            Self::Supervisor(e) => e.stderr_tail(),
+            Self::User(e) => e.stderr_tail(),
+        }
+    }
+
     /// Calls `public_value_digest` to respective `MinimalExecutor`.
     #[must_use]
     pub fn public_value_digest(&self) -> [u32; sp1_jit::PUBLIC_VALUE_DIGEST_WORDS] {

--- a/crates/core/executor/src/minimal/arch/portable/mod.rs
+++ b/crates/core/executor/src/minimal/arch/portable/mod.rs
@@ -4,8 +4,8 @@
 
 use sp1_jit::{
     debug::{self, DebugState},
-    trace_capacity, Interrupt, MemValue, PageProtValue, RiscRegister, SyscallContext,
-    TraceChunkRaw, PUBLIC_VALUE_DIGEST_WORDS,
+    push_stderr_tail, trace_capacity, Interrupt, MemValue, PageProtValue, RiscRegister,
+    SyscallContext, TraceChunkRaw, PUBLIC_VALUE_DIGEST_WORDS,
 };
 use sp1_primitives::consts::{
     LOG_PAGE_SIZE, PROT_EXEC, PROT_FAILURE_EXEC, PROT_FAILURE_READ, PROT_FAILURE_WRITE, PROT_READ,
@@ -63,6 +63,8 @@ pub struct MinimalExecutor<M: ExecutionMode> {
     exit_code: u32,
     max_trace_size: Option<u64>,
     public_values_stream: Vec<u8>,
+    /// Bounded tail of guest `fd=2` (stderr) output, captured for panic debugging.
+    stderr_tail: Vec<u8>,
     public_value_digest: [u32; PUBLIC_VALUE_DIGEST_WORDS],
     hints: Vec<(u64, Vec<u8>)>,
     maybe_unconstrained: Option<UnconstrainedCtx>,
@@ -253,6 +255,10 @@ impl<M: ExecutionMode> SyscallContext for MinimalExecutor<M> {
 
     fn public_values_stream(&mut self) -> &mut Vec<u8> {
         &mut self.public_values_stream
+    }
+
+    fn record_stderr(&mut self, bytes: &[u8]) {
+        push_stderr_tail(&mut self.stderr_tail, bytes);
     }
 
     fn enter_unconstrained(&mut self) -> io::Result<()> {
@@ -449,6 +455,7 @@ impl<M: ExecutionMode> MinimalExecutor<M> {
             traces: None,
             max_trace_size,
             public_values_stream: Vec::new(),
+            stderr_tail: Vec::new(),
             public_value_digest: [0; PUBLIC_VALUE_DIGEST_WORDS],
             hints: Vec::new(),
             maybe_unconstrained: None,
@@ -595,6 +602,14 @@ impl<M: ExecutionMode> MinimalExecutor<M> {
     #[must_use]
     pub fn into_public_values_stream(self) -> Vec<u8> {
         self.public_values_stream
+    }
+
+    /// The bounded guest `fd=2` (stderr) tail captured during execution, as lossy UTF-8.
+    /// `None` when the guest wrote nothing to stderr. Untrusted, guest-controlled text.
+    #[must_use]
+    pub fn stderr_tail(&self) -> Option<String> {
+        (!self.stderr_tail.is_empty())
+            .then(|| String::from_utf8_lossy(&self.stderr_tail).into_owned())
     }
 
     /// Get the public value digest words committed by the guest via `COMMIT` syscalls.

--- a/crates/core/executor/src/minimal/arch/x86_64/mod.rs
+++ b/crates/core/executor/src/minimal/arch/x86_64/mod.rs
@@ -233,6 +233,14 @@ impl<M: ExecutionMode> MinimalExecutor<M> {
         self.compiled.public_values_stream
     }
 
+    /// The bounded guest `fd=2` (stderr) tail captured during execution, as lossy UTF-8.
+    /// `None` when the guest wrote nothing to stderr. Untrusted, guest-controlled text.
+    #[must_use]
+    pub fn stderr_tail(&self) -> Option<String> {
+        (!self.compiled.stderr_tail.is_empty())
+            .then(|| String::from_utf8_lossy(&self.compiled.stderr_tail).into_owned())
+    }
+
     /// Get the public value digest words committed by the guest via `COMMIT` syscalls.
     #[must_use]
     pub fn public_value_digest(&self) -> [u32; PUBLIC_VALUE_DIGEST_WORDS] {

--- a/crates/core/executor/src/minimal/write.rs
+++ b/crates/core/executor/src/minimal/write.rs
@@ -113,6 +113,11 @@ pub(crate) unsafe fn write(ctx: &mut impl SyscallContext, arg1: u64, arg2: u64) 
 
     let slice = bytes.as_slice();
     if fd == 1 || fd == 2 {
+        // Capture a bounded stderr tail (panic message + location) for debugging; stdout is
+        // not captured. The existing host-stderr printing below is preserved.
+        if fd == 2 {
+            ctx.record_stderr(slice);
+        }
         handle_output(ctx, fd, &String::from_utf8_lossy(slice));
         return None;
     } else if fd as u32 == FD_PUBLIC_VALUES {

--- a/crates/core/executor/src/report.rs
+++ b/crates/core/executor/src/report.rs
@@ -37,6 +37,14 @@ pub struct ExecutionReport {
     pub exit_code: u64,
     /// The unnormalized gas, if it was calculated. Should not be accessed directly. Use `gas()` instead.
     pub(crate) gas: Option<u64>,
+    /// A bounded, lossy-UTF-8 tail of the guest program's `fd=2` (stderr) output captured
+    /// during execution. A guest panic writes its message and source location to stderr
+    /// before halting, so this carries debuggable context beyond a bare non-zero exit code.
+    /// `None` when the guest wrote nothing to stderr or on paths that do not capture it.
+    /// This is guest-controlled, untrusted text — bounded here, and must be sanitized and
+    /// re-bounded before any storage or display.
+    #[serde(default)]
+    pub stderr_tail: Option<String>,
 }
 
 impl ExecutionReport {
@@ -114,6 +122,12 @@ impl AddAssign for ExecutionReport {
 
         // The exit code value must either be `0` or the final exit code, so taking an `OR` works.
         self.exit_code |= rhs.exit_code;
+
+        // Keep the latest non-empty stderr tail; a guest panic is written in the final
+        // chunk before the halt.
+        if rhs.stderr_tail.is_some() {
+            self.stderr_tail = rhs.stderr_tail;
+        }
     }
 }
 

--- a/crates/core/executor/src/vm/gas.rs
+++ b/crates/core/executor/src/vm/gas.rs
@@ -105,6 +105,9 @@ impl ReportGenerator {
             touched_memory_addresses: 0,
             gas: Some(gas),
             exit_code: self.exit_code,
+            // Populated by the execute-only driver from the executor's captured stderr, not
+            // by gas estimation.
+            stderr_tail: None,
         }
     }
 

--- a/crates/core/jit/src/context.rs
+++ b/crates/core/jit/src/context.rs
@@ -9,6 +9,22 @@ use std::{collections::VecDeque, io, os::fd::RawFd, ptr::NonNull, sync::mpsc};
 /// pulling `sp1-hypercube` into the JIT crate's dependency graph.
 pub const PUBLIC_VALUE_DIGEST_WORDS: usize = 8;
 
+/// Maximum number of guest `fd=2` (stderr) bytes retained as a tail for panic debugging.
+pub const STDERR_TAIL_MAX: usize = 2048;
+
+/// Append `bytes` to `buf`, keeping only the last [`STDERR_TAIL_MAX`] bytes.
+///
+/// Guest stderr is unbounded and attacker-controlled, so only a bounded tail is retained.
+/// A panic writes its message and location to stderr immediately before halting, so the
+/// tail preserves the most relevant output while older bytes are dropped.
+pub fn push_stderr_tail(buf: &mut Vec<u8>, bytes: &[u8]) {
+    buf.extend_from_slice(bytes);
+    let len = buf.len();
+    if len > STDERR_TAIL_MAX {
+        buf.drain(0..len - STDERR_TAIL_MAX);
+    }
+}
+
 pub trait SyscallContext {
     /// Read a value from a register.
     fn rr(&self, reg: RiscRegister) -> u64;
@@ -70,6 +86,12 @@ pub trait SyscallContext {
     fn input_buffer(&mut self) -> &mut VecDeque<Vec<u8>>;
     /// Get the public values stream.
     fn public_values_stream(&mut self) -> &mut Vec<u8>;
+    /// Record bytes written by the guest to `fd=2` (stderr).
+    ///
+    /// Default is a no-op; executors that surface a bounded stderr tail (for panic
+    /// debugging) override this. The bytes are guest-controlled and untrusted; implementors
+    /// must bound what they retain.
+    fn record_stderr(&mut self, _bytes: &[u8]) {}
     /// Enter the unconstrained context.
     fn enter_unconstrained(&mut self) -> io::Result<()>;
     /// Exit the unconstrained context.
@@ -260,6 +282,13 @@ impl SyscallContext for JitContext {
         unsafe { self.public_values_stream() }
     }
 
+    fn record_stderr(&mut self, bytes: &[u8]) {
+        // SAFETY: `stderr_tail` points to the owning `JitFunction`'s `Vec`, which is valid
+        // for the duration of the call (same invariant as `public_values_stream`).
+        let buf = unsafe { self.stderr_tail.as_mut() };
+        push_stderr_tail(buf, bytes);
+    }
+
     fn enter_unconstrained(&mut self) -> io::Result<()> {
         self.enter_unconstrained()
     }
@@ -380,6 +409,8 @@ pub struct JitContext {
     pub(crate) input_buffer: NonNull<VecDeque<Vec<u8>>>,
     /// A stream of public values from the program (global to entire program).
     pub(crate) public_values_stream: NonNull<Vec<u8>>,
+    /// Bounded tail of guest `fd=2` (stderr) output, captured for panic debugging.
+    pub(crate) stderr_tail: NonNull<Vec<u8>>,
     /// The hints read by the program, with their corresponding start address.
     pub(crate) hints: NonNull<Vec<(u64, Vec<u8>)>>,
     /// The memory file descriptor, this is used to create the COW memory at runtime.
@@ -730,5 +761,31 @@ impl<'a> ContextMemory<'a> {
 
         let new_entry = MemValue { value: val, clk: 0 };
         unsafe { std::ptr::write(ptr, new_entry) };
+    }
+}
+
+#[cfg(test)]
+mod stderr_tail_tests {
+    use super::{push_stderr_tail, STDERR_TAIL_MAX};
+
+    #[test]
+    fn keeps_last_bytes_when_over_cap() {
+        let mut buf = Vec::new();
+        // Write more than the cap; only the last STDERR_TAIL_MAX bytes are retained.
+        let head = vec![b'a'; STDERR_TAIL_MAX];
+        let tail = b"panicked at src/main.rs:9:5: boom";
+        push_stderr_tail(&mut buf, &head);
+        push_stderr_tail(&mut buf, tail);
+        assert_eq!(buf.len(), STDERR_TAIL_MAX);
+        // The most recent bytes (the panic) survive; the oldest are dropped.
+        assert!(buf.ends_with(tail));
+        assert!(!buf.starts_with(&head));
+    }
+
+    #[test]
+    fn keeps_all_bytes_when_under_cap() {
+        let mut buf = Vec::new();
+        push_stderr_tail(&mut buf, b"short panic");
+        assert_eq!(buf, b"short panic");
     }
 }

--- a/crates/core/jit/src/lib.rs
+++ b/crates/core/jit/src/lib.rs
@@ -210,6 +210,9 @@ pub struct JitFunction<M> {
     /// A stream of public values from the program (global to entire program).
     pub public_values_stream: Vec<u8>,
 
+    /// Bounded tail of guest `fd=2` (stderr) output, captured for panic debugging.
+    pub stderr_tail: Vec<u8>,
+
     /// Memory structure,
     pub memory: M,
 
@@ -259,6 +262,7 @@ impl<M: JitMemory> JitFunction<M> {
             input_buffer: VecDeque::new(),
             hints: Vec::new(),
             public_values_stream: Vec::new(),
+            stderr_tail: Vec::new(),
             debug_sender: None,
             exit_code: 0,
             public_value_digest: [0; context::PUBLIC_VALUE_DIGEST_WORDS],
@@ -344,6 +348,7 @@ impl<M: JitMemory> JitFunction<M> {
             hints: NonNull::new_unchecked(&mut self.hints),
             maybe_unconstrained: None,
             public_values_stream: NonNull::new_unchecked(&mut self.public_values_stream),
+            stderr_tail: NonNull::new_unchecked(&mut self.stderr_tail),
             memory_fd: self.memory.as_raw_fd(),
             registers: self.registers,
             pc: self.pc,
@@ -406,6 +411,7 @@ impl<M: JitResetableMemory> JitFunction<M> {
         self.input_buffer = VecDeque::new();
         self.hints = Vec::new();
         self.public_values_stream = Vec::new();
+        self.stderr_tail = Vec::new();
         self.public_value_digest = [0; context::PUBLIC_VALUE_DIGEST_WORDS];
         self.memory.reset();
 

--- a/crates/core/runner/src/native.rs
+++ b/crates/core/runner/src/native.rs
@@ -6,6 +6,7 @@ use sp1_core_executor::{
 use sp1_core_executor_runner_binary::{Input, Output};
 use sp1_jit::{
     memory::SharedMemory,
+    push_stderr_tail,
     shm::{ShmTraceRing, TraceResult},
     trace_capacity, MemValue, MinimalTrace, TraceChunkRaw,
 };
@@ -18,7 +19,7 @@ use std::{
     ptr::NonNull,
     sync::{
         atomic::{AtomicBool, Ordering},
-        Arc,
+        Arc, Mutex,
     },
     thread::{self, JoinHandle},
     time::Duration,
@@ -39,6 +40,10 @@ pub struct MinimalExecutorRunner {
     // budget, so that kill can be told apart from an external (OOM-killer) one.
     process: Option<(Child, JoinHandle<()>, Arc<AtomicBool>)>,
     output: Option<Result<Output, ExecutionError>>,
+
+    /// Bounded tail of the guest's `fd=2` (stderr) output, accumulated by the stderr-drain
+    /// thread for execute-only panic debugging. Untrusted, guest-controlled text.
+    stderr_tail: Arc<Mutex<Vec<u8>>>,
 
     global_clk: u64,
     clk: u64,
@@ -76,7 +81,16 @@ impl MinimalExecutorRunner {
         };
         let (memory, consumer) = create(&input);
 
-        Self { input, consumer, memory, process: None, output: None, global_clk: 0, clk: 0 }
+        Self {
+            input,
+            consumer,
+            memory,
+            process: None,
+            output: None,
+            stderr_tail: Arc::new(Mutex::new(Vec::new())),
+            global_clk: 0,
+            clk: 0,
+        }
     }
 
     /// Create a new minimal executor with no tracing or debugging.
@@ -145,9 +159,20 @@ impl MinimalExecutorRunner {
             // from the start also preserves its diagnostics if it dies before reading input.
             let stderr = child.stderr.take().expect("open stderr");
             let id = self.input.id.clone();
+            let stderr_tail = Arc::clone(&self.stderr_tail);
             let log_handle = thread::spawn(move || {
                 let reader = BufReader::new(stderr);
                 for l in reader.lines().map_while(Result::ok) {
+                    // The in-process executor prefixes guest `fd=2` writes with "stderr: "
+                    // (see `minimal::write::handle_output`). Capture a bounded tail of those
+                    // lines so a guest panic's message and location survive; other child
+                    // diagnostics are logged but not captured.
+                    if let Some(guest) = l.strip_prefix("stderr: ") {
+                        if let Ok(mut buf) = stderr_tail.lock() {
+                            push_stderr_tail(&mut buf, guest.as_bytes());
+                            push_stderr_tail(&mut buf, b"\n");
+                        }
+                    }
                     tracing::debug!("CHILD {}: {}", id, l);
                 }
             });
@@ -357,6 +382,14 @@ impl MinimalExecutorRunner {
     #[must_use]
     pub fn into_public_values_stream(self) -> Vec<u8> {
         self.take_output().public_values_stream
+    }
+
+    /// The bounded guest `fd=2` (stderr) tail captured by the drain thread, as lossy UTF-8.
+    /// `None` when the guest wrote nothing to stderr. Untrusted, guest-controlled text.
+    #[must_use]
+    pub fn stderr_tail(&self) -> Option<String> {
+        let buf = self.stderr_tail.lock().ok()?;
+        (!buf.is_empty()).then(|| String::from_utf8_lossy(&buf).into_owned())
     }
 
     /// Get the public value digest words committed by the guest via `COMMIT` syscalls.

--- a/crates/core/runner/src/portable.rs
+++ b/crates/core/runner/src/portable.rs
@@ -161,6 +161,14 @@ impl MinimalExecutorRunner {
         self.inner.into_public_values_stream()
     }
 
+    /// The bounded guest `fd=2` (stderr) tail captured during execution, as lossy UTF-8.
+    /// `None` when the guest wrote nothing to stderr. Untrusted, guest-controlled text.
+    #[must_use]
+    #[inline]
+    pub fn stderr_tail(&self) -> Option<String> {
+        self.inner.stderr_tail()
+    }
+
     /// Get the public value digest words committed by the guest via `COMMIT` syscalls.
     #[must_use]
     #[inline]

--- a/crates/prover/src/worker/prover/execute.rs
+++ b/crates/prover/src/worker/prover/execute.rs
@@ -168,6 +168,7 @@ pub async fn execute_with_options_and_machine(
         PublicValues {
             public_values: SP1PublicValues,
             public_value_digest: [u32; PV_DIGEST_NUM_WORDS],
+            stderr_tail: Option<String>,
             #[cfg(feature = "profiling")]
             cycle_tracker: hashbrown::HashMap<String, u64>,
             #[cfg(feature = "profiling")]
@@ -285,6 +286,8 @@ pub async fn execute_with_options_and_machine(
         let invocation_tracker = minimal_executor.take_invocation_tracker();
 
         let public_value_digest = minimal_executor.public_value_digest();
+        // Capture the guest stderr tail before consuming the executor.
+        let stderr_tail = minimal_executor.stderr_tail();
         let public_value_stream = minimal_executor.into_public_values_stream();
         let public_values = SP1PublicValues::from(&public_value_stream);
 
@@ -292,6 +295,7 @@ pub async fn execute_with_options_and_machine(
         Ok::<_, anyhow::Error>(ExecutorOutput::PublicValues {
             public_values,
             public_value_digest,
+            stderr_tail,
             #[cfg(feature = "profiling")]
             cycle_tracker,
             #[cfg(feature = "profiling")]
@@ -303,6 +307,7 @@ pub async fn execute_with_options_and_machine(
     let mut final_report = ExecutionReport::default();
     let mut public_values = SP1PublicValues::default();
     let mut minimal_executor_digest: Option<[u32; PV_DIGEST_NUM_WORDS]> = None;
+    let mut stderr_tail_data: Option<String> = None;
     #[cfg(feature = "profiling")]
     let mut cycle_tracker_data: Option<(
         hashbrown::HashMap<String, u64>,
@@ -315,6 +320,7 @@ pub async fn execute_with_options_and_machine(
                 ExecutorOutput::PublicValues {
                     public_values: pv,
                     public_value_digest: pvd,
+                    stderr_tail,
                     #[cfg(feature = "profiling")]
                     cycle_tracker,
                     #[cfg(feature = "profiling")]
@@ -322,6 +328,7 @@ pub async fn execute_with_options_and_machine(
                 } => {
                     public_values = pv;
                     minimal_executor_digest = Some(pvd);
+                    stderr_tail_data = stderr_tail;
                     #[cfg(feature = "profiling")]
                     {
                         cycle_tracker_data = Some((cycle_tracker, invocation_tracker));
@@ -348,6 +355,10 @@ pub async fn execute_with_options_and_machine(
         final_report.cycle_tracker = cycle_tracker;
         final_report.invocation_tracker = invocation_tracker;
     }
+
+    // Attach the bounded guest stderr tail (panic message + location) captured by the
+    // executor, for execute-only failure debugging.
+    final_report.stderr_tail = stderr_tail_data;
 
     // Extract the public value digest. Prefer the value tracked by the gas-estimating VM (set when
     // `calculate_gas` is enabled), and fall back to the digest captured by the minimal executor

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -108,6 +108,11 @@ mod tests {
         stdin.write(&10usize);
         let (_, report) = client.execute(elf, stdin).await.unwrap();
         assert_eq!(report.exit_code, 1);
+        // The guest panics via `assert_eq!`; its stderr (panic message + source location)
+        // is captured into the bounded `stderr_tail`.
+        let stderr_tail = report.stderr_tail.expect("panic should capture a stderr tail");
+        assert!(stderr_tail.contains("panicked at"), "stderr_tail={stderr_tail}");
+        assert!(stderr_tail.contains("main.rs"), "stderr_tail={stderr_tail}");
     }
 
     // TODO: reimplement the cycle limit logic and revive this test.


### PR DESCRIPTION
## Summary
Captures the last **2048 bytes** of the guest program's `fd=2` (stderr) during execution and exposes it as `ExecutionReport::stderr_tail: Option<String>`.

## Why
A guest panic writes its message **and source location** (`panicked at <file>:<line>:<col>`) to stderr right before halting non-zero, but SP1 printed that to the host and discarded it — so execute-only failures collapse to a bare `HaltWithNonZeroExitCode`, losing the panic detail before sp1-cluster can attach it to `error_trace`.

## Scope
SP1-only. No sp1-cluster/network/infra wiring. No SDK or public-explorer printing; the existing host-stderr printing is preserved. `fd=1` (stdout) is not captured.

## Safety
Guest stderr is untrusted, attacker-controlled text. It's bounded here (keep-last 2048 bytes, lossy UTF-8) and is observability-only/additive (fail-safe to `None`). Downstream storage/display must sanitize and keep it internal.

## Tests
`cargo test -p sp1-jit stderr_tail` (bounded-tail unit tests); `cargo test -p sp1-sdk --features slow-tests test_execute_panic` (e2e: tail contains panic message + location); `cargo check -p sp1-core-executor`; `cargo fmt --all --check`; clippy on touched crates.

## Follow-up
sp1-cluster must read `report.stderr_tail` into the execute-only `extra_data.failure_message` before this is live in `error_trace`.
