### PR TITLE
feat(prover-types): add ClusterService component manifest RPCs

### DIFF
--- a/crates/prover-types/proto/cluster.proto
+++ b/crates/prover-types/proto/cluster.proto
@@ -4,6 +4,7 @@ syntax = "proto3";
 package cluster;
 
 import "google/protobuf/empty.proto";
+import "worker.proto";
 
 service ClusterService {
   rpc ProofRequestCreate(ProofRequestCreateRequest) returns (google.protobuf.Empty) {}
@@ -12,7 +13,35 @@ service ClusterService {
   rpc ProofRequestGet(ProofRequestGetRequest) returns (ProofRequestGetResponse) {}
   rpc ProofRequestList(ProofRequestListRequest) returns (ProofRequestListResponse) {}
 
+  // Cluster component build manifest (component / version / git_sha / image_tag).
+  // The coordinator periodically writes its full manifest (its own build + one entry
+  // per connected worker) via SetClusterComponentInfo; the fulfiller reads the latest
+  // via GetClusterComponentInfo and forwards it to the SPN. This is the
+  // topology-agnostic replacement for the fulfiller connecting to the coordinator's
+  // WorkerService directly. Cluster-internal only; unrelated to the SPN
+  // ReportProverInfo wire types.
+  rpc SetClusterComponentInfo(SetClusterComponentInfoRequest) returns (google.protobuf.Empty) {}
+  rpc GetClusterComponentInfo(google.protobuf.Empty) returns (ClusterComponentManifest) {}
+
   rpc Healthcheck(google.protobuf.Empty) returns (google.protobuf.Empty);
+}
+
+// Full cluster component build manifest written by the coordinator: its own build
+// followed by one entry per connected worker. Reuses worker.ClusterComponentInfo
+// (component / version / git_sha / image_tag; no instance_id). A write replaces the
+// previous manifest (full snapshot).
+message SetClusterComponentInfoRequest {
+  repeated worker.ClusterComponentInfo components = 1;
+}
+
+// The latest manifest as held by the API, with the server-owned time it was last
+// written. Empty `components` with `updated_at = 0` means no coordinator has pushed a
+// manifest yet; a caller compares `updated_at` against a freshness window to reject a
+// stale manifest instead of forwarding a partial snapshot.
+message ClusterComponentManifest {
+  repeated worker.ClusterComponentInfo components = 1;
+  // Unix seconds when the API last stored a manifest (server-owned).
+  uint64 updated_at = 2;
 }
 
 message ProofRequestCreateRequest {

--- a/crates/prover-types/proto/worker.proto
+++ b/crates/prover-types/proto/worker.proto
@@ -56,9 +56,6 @@ service WorkerService {
     // Get stats about the coordinator.
     rpc GetStats(google.protobuf.Empty) returns (GetStatsResponse);
 
-    // Get the self-reported build identity of the coordinator and every connected worker.
-    rpc GetClusterComponentInfo(GetClusterComponentInfoRequest) returns (GetClusterComponentInfoResponse);
-
     // Subscribe to a task's message stream.
     rpc SubscribeTaskMessages(SubscribeTaskMessagesRequest) returns (stream MessageStreamResponse);
 
@@ -119,8 +116,9 @@ message OpenRequest {
     string worker_id = 1;
     WorkerType worker_type = 2;
     uint32 max_weight = 3;
-    // Self-reported build identity of this worker, so the coordinator can expose it via
-    // GetClusterComponentInfo. Additive fields; workers that do not report leave them empty.
+    // Self-reported build identity of this worker, included in the cluster component
+    // manifest the coordinator publishes (cluster.SetClusterComponentInfo). Additive
+    // fields; workers that do not report leave them empty.
     string version = 4;
     string git_sha = 5;
     string image_tag = 6;
@@ -303,12 +301,6 @@ message ClusterComponentInfo {
     string image_tag = 4;
 }
 
-message GetClusterComponentInfoRequest {}
-
-message GetClusterComponentInfoResponse {
-    // The coordinator's own build followed by one entry per connected worker.
-    repeated ClusterComponentInfo components = 1;
-}
 
 // Message channel RPCs
 


### PR DESCRIPTION
## What

Adds two cluster-internal `ClusterService` RPCs in `crates/prover-types/proto/cluster.proto`:

- `SetClusterComponentInfo` — coordinator writes its full component manifest.
- `GetClusterComponentInfo` — fulfiller reads the latest manifest.

The manifest reuses `worker.ClusterComponentInfo` (`component`, `version`, `git_sha`, `image_tag`; no `instance_id`) and includes server-owned `updated_at` so stale/missing manifests can be rejected by the producer.

## Why

Follow-up to `sp1-cluster#146`: route the manifest through the existing ClusterService/API path instead of requiring `FULFILLER_COORDINATOR_RPC`.

This is only the cluster-internal proto surface. SPN `ReportProverInfo` wire types, receiver storage, and DB semantics are unchanged.

## Validation

- `cargo build -p sp1-prover-types`
- `cargo +nightly fmt --all --check`
- `git diff --check`

## Follow-up

Wire `sp1-cluster` so coordinator pushes the manifest to API, fulfiller reads it via `cluster_rpc`, and `FULFILLER_COORDINATOR_RPC` is removed.
