### PR TITLE
perf: zerocheck lookahead

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -122,6 +122,14 @@ runs:
         echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
         echo "CARGO_INCREMENTAL=0" >> $GITHUB_ENV
 
+    # `rustup override set` (below) persists the override in ~/.rustup/settings.toml, which is
+    # cached with a key shared by ALL jobs. A job that restores a cache saved by a job that set
+    # an override (e.g. nightly) would silently run that toolchain instead of the one pinned in
+    # rust-toolchain.toml. Clear any override inherited from the cache before proceeding.
+    - name: Clear stale rustup override restored from cache
+      shell: bash
+      run: rustup override unset 2>/dev/null || true
+
     - name: Override toolchain
       if: inputs.rustup_override != null
       shell: bash

--- a/crates/core/machine/src/utils/zerocheck_unit_test.rs
+++ b/crates/core/machine/src/utils/zerocheck_unit_test.rs
@@ -195,7 +195,7 @@ mod tests {
     use sp1_hypercube::{
         air::MachineAir,
         debug_constraints,
-        prover::{zerocheck_reduce_sumcheck_to_evaluation, ZeroCheckPoly, ZerocheckCpuProverData},
+        prover::{ZeroCheckPoly, ZerocheckCpuProverData},
         AirOpenedValues, Chip, ChipOpenedValues, ConstraintSumcheckFolder, InnerSC, ShardVerifier,
         PROOF_MAX_NUM_PVS,
     };
@@ -557,6 +557,9 @@ mod tests {
         for (num_variables, heights) in cases {
             let zeta = Point::<EF>::rand(&mut rng, num_variables as u32);
             let lambda = rng.gen::<EF>();
+            // The lookahead depth of the fused prover; traces with a single variable only
+            // support the plain first round.
+            let lookahead = num_variables.min(2);
 
             let (add_polys, add_claims): (Vec<_>, Vec<_>) = heights
                 .iter()
@@ -586,10 +589,11 @@ mod tests {
             );
 
             let mut challenger_fused = SP1GlobalContext::default_challenger();
-            let (add_proof_fused, add_evals_fused) = zerocheck_reduce_sumcheck_to_evaluation(
+            let (add_proof_fused, add_evals_fused) = reduce_sumcheck_to_evaluation(
                 add_polys,
                 &mut challenger_fused,
                 add_claims,
+                lookahead,
                 lambda,
             );
 
@@ -620,10 +624,11 @@ mod tests {
             );
 
             let mut challenger_fused = SP1GlobalContext::default_challenger();
-            let (cube_proof_fused, cube_evals_fused) = zerocheck_reduce_sumcheck_to_evaluation(
+            let (cube_proof_fused, cube_evals_fused) = reduce_sumcheck_to_evaluation(
                 cube_polys,
                 &mut challenger_fused,
                 cube_claims,
+                lookahead,
                 lambda,
             );
 

--- a/crates/core/machine/src/utils/zerocheck_unit_test.rs
+++ b/crates/core/machine/src/utils/zerocheck_unit_test.rs
@@ -3,7 +3,7 @@ use core::{
     mem::size_of,
 };
 
-use slop_air::{Air, BaseAir};
+use slop_air::{Air, BaseAir, PairBuilder};
 use slop_algebra::{AbstractField, PrimeField32};
 use slop_matrix::{dense::RowMajorMatrix, Matrix};
 use slop_maybe_rayon::prelude::{ParallelBridge, ParallelIterator};
@@ -109,6 +109,73 @@ impl std::fmt::Debug for MinimalAddChip {
     }
 }
 
+/// A minimal chip with a preprocessed column, used to exercise the zerocheck prover on chips
+/// with preprocessed traces. The constraint `a^3 = p + 1` is cubic in the trace and does not
+/// hold on zero-padded rows.
+#[derive(Default, Clone)]
+pub struct MinimalCubeChip;
+
+impl<F> BaseAir<F> for MinimalCubeChip {
+    fn width(&self) -> usize {
+        1
+    }
+}
+
+impl<F: PrimeField32> MachineAir<F> for MinimalCubeChip {
+    type Record = Vec<(u32, u32, u32)>;
+
+    type Program = Program;
+
+    fn name(&self) -> &'static str {
+        "MinimalCube"
+    }
+
+    fn preprocessed_width(&self) -> usize {
+        1
+    }
+
+    fn num_rows(&self, input: &Self::Record) -> Option<usize> {
+        Some(input.len())
+    }
+
+    fn generate_trace_into(
+        &self,
+        _input: &Self::Record,
+        _output: &mut Self::Record,
+        _buffer: &mut [std::mem::MaybeUninit<F>],
+    ) {
+        unimplemented!();
+    }
+
+    fn generate_trace(&self, _input: &Self::Record, _: &mut Self::Record) -> RowMajorMatrix<F> {
+        unimplemented!();
+    }
+
+    fn included(&self, shard: &Self::Record) -> bool {
+        !shard.is_empty()
+    }
+}
+
+impl<AB> Air<AB> for MinimalCubeChip
+where
+    AB: SP1AirBuilder + PairBuilder,
+{
+    fn eval(&self, builder: &mut AB) {
+        let main = builder.main();
+        let a = main.row_slice(0)[0];
+        let preprocessed = builder.preprocessed();
+        let p = preprocessed.row_slice(0)[0];
+
+        builder.assert_eq(a * a * a, p.into() + AB::Expr::one());
+    }
+}
+
+impl std::fmt::Debug for MinimalCubeChip {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "MinimalCubeChip")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::print_stdout)]
@@ -128,7 +195,7 @@ mod tests {
     use sp1_hypercube::{
         air::MachineAir,
         debug_constraints,
-        prover::{ZeroCheckPoly, ZerocheckCpuProverData},
+        prover::{zerocheck_reduce_sumcheck_to_evaluation, ZeroCheckPoly, ZerocheckCpuProverData},
         AirOpenedValues, Chip, ChipOpenedValues, ConstraintSumcheckFolder, InnerSC, ShardVerifier,
         PROOF_MAX_NUM_PVS,
     };
@@ -136,8 +203,187 @@ mod tests {
 
     use crate::utils::{setup_logger, MinimalAddChip, NUM_MINIMAL_ADD_COLS};
 
+    use super::MinimalCubeChip;
+
     type F = sp1_primitives::SP1Field;
     type EF = BinomialExtensionField<F, 4>;
+
+    /// Builds a zerocheck polynomial and its sumcheck claim for a `MinimalAddChip` trace with
+    /// the given number of real rows, mirroring the setup done by the shard prover.
+    fn make_minimal_add_zerocheck_poly(
+        rng: &mut impl Rng,
+        zeta: &Point<EF>,
+        num_real_entries: usize,
+        num_variables: u32,
+    ) -> (ZeroCheckPoly<F, F, EF, MinimalAddChip>, EF) {
+        let air = MinimalAddChip;
+
+        let mut shard = Vec::new();
+        for _ in 0..num_real_entries {
+            let operand_1 = rng.gen_range(0..(u16::MAX as u32));
+            let operand_2 = rng.gen_range(0..(u16::MAX as u32));
+            let result = operand_1.wrapping_add(operand_2) + 1;
+            shard.push((result, operand_1, operand_2));
+        }
+
+        let main_trace = if num_real_entries == 0 {
+            PaddedMle::zeros(NUM_MINIMAL_ADD_COLS, num_variables)
+        } else {
+            let trace = MinimalAddChip::generate_trace(&air, &shard, &mut Vec::new());
+            PaddedMle::new(
+                Some(Arc::new(trace.into())),
+                num_variables,
+                Padding::Constant((F::zero(), NUM_MINIMAL_ADD_COLS, CpuBackend)),
+            )
+        };
+
+        let alpha = rng.gen::<EF>();
+        let gkr_power = rng.gen::<EF>();
+
+        let num_constraints = get_symbolic_constraints::<F, _>(&air, 0, PROOF_MAX_NUM_PVS).len();
+        let mut alpha_powers = alpha.powers().take(num_constraints).collect::<Vec<_>>();
+        alpha_powers.reverse();
+        let gkr_powers = gkr_power.powers().take(NUM_MINIMAL_ADD_COLS).collect::<Vec<_>>();
+
+        let public_values = vec![F::zero(); PROOF_MAX_NUM_PVS];
+        let dummy_main = vec![F::zero(); NUM_MINIMAL_ADD_COLS];
+        let mut folder = ConstraintSumcheckFolder {
+            preprocessed: RowMajorMatrixView::new_row(&[]),
+            main: RowMajorMatrixView::new_row(&dummy_main),
+            accumulator: EF::zero(),
+            public_values: &public_values,
+            constraint_index: 0,
+            powers_of_alpha: &alpha_powers,
+        };
+        air.eval(&mut folder);
+        let padded_row_adjustment = folder.accumulator;
+
+        let gkr_openings: MleEval<EF> = main_trace.eval_at(zeta);
+        let claim = gkr_openings
+            .evaluations()
+            .as_slice()
+            .iter()
+            .zip_eq(gkr_powers.iter())
+            .map(|(opening, power)| *opening * *power)
+            .sum::<EF>();
+
+        let air_data = ZerocheckCpuProverData::round_prover(
+            Arc::new(air),
+            Arc::new(public_values),
+            Arc::new(alpha_powers),
+            Arc::new(gkr_powers),
+        );
+
+        let virtual_geq =
+            VirtualGeq::new(num_real_entries as u32, F::one(), F::zero(), num_variables);
+        let geq_value = if num_real_entries > 0 { EF::zero() } else { EF::one() };
+
+        let poly = ZeroCheckPoly::new(
+            air_data,
+            zeta.clone(),
+            None,
+            main_trace,
+            EF::one(),
+            geq_value,
+            padded_row_adjustment,
+            virtual_geq,
+        );
+        (poly, claim)
+    }
+
+    /// Builds a zerocheck polynomial and its sumcheck claim for a `MinimalCubeChip` trace,
+    /// which exercises the preprocessed trace handling of the zerocheck prover.
+    fn make_minimal_cube_zerocheck_poly(
+        rng: &mut impl Rng,
+        zeta: &Point<EF>,
+        num_real_entries: usize,
+        num_variables: u32,
+    ) -> (ZeroCheckPoly<F, F, EF, MinimalCubeChip>, EF) {
+        let air = MinimalCubeChip;
+
+        let mut main_values = Vec::with_capacity(num_real_entries);
+        let mut preprocessed_values = Vec::with_capacity(num_real_entries);
+        for _ in 0..num_real_entries {
+            let a = rng.gen::<F>();
+            main_values.push(a);
+            preprocessed_values.push(a * a * a - F::one());
+        }
+
+        let (main_trace, preprocessed_trace) = if num_real_entries == 0 {
+            (PaddedMle::zeros(1, num_variables), PaddedMle::zeros(1, num_variables))
+        } else {
+            let padding = || Padding::Constant((F::zero(), 1, CpuBackend));
+            (
+                PaddedMle::new(
+                    Some(Arc::new(RowMajorMatrix::new(main_values, 1).into())),
+                    num_variables,
+                    padding(),
+                ),
+                PaddedMle::new(
+                    Some(Arc::new(RowMajorMatrix::new(preprocessed_values, 1).into())),
+                    num_variables,
+                    padding(),
+                ),
+            )
+        };
+
+        let alpha = rng.gen::<EF>();
+        let gkr_power = rng.gen::<EF>();
+
+        let num_constraints = get_symbolic_constraints::<F, _>(&air, 1, PROOF_MAX_NUM_PVS).len();
+        let mut alpha_powers = alpha.powers().take(num_constraints).collect::<Vec<_>>();
+        alpha_powers.reverse();
+        // One power for the main column, one for the preprocessed column.
+        let gkr_powers = gkr_power.powers().take(2).collect::<Vec<_>>();
+
+        let public_values = vec![F::zero(); PROOF_MAX_NUM_PVS];
+        let dummy_row = vec![F::zero(); 1];
+        let mut folder = ConstraintSumcheckFolder {
+            preprocessed: RowMajorMatrixView::new_row(&dummy_row),
+            main: RowMajorMatrixView::new_row(&dummy_row),
+            accumulator: EF::zero(),
+            public_values: &public_values,
+            constraint_index: 0,
+            powers_of_alpha: &alpha_powers,
+        };
+        air.eval(&mut folder);
+        let padded_row_adjustment = folder.accumulator;
+
+        // The openings are batched in the order main columns, then preprocessed columns.
+        let main_openings: MleEval<EF> = main_trace.eval_at(zeta);
+        let preprocessed_openings: MleEval<EF> = preprocessed_trace.eval_at(zeta);
+        let claim = main_openings
+            .evaluations()
+            .as_slice()
+            .iter()
+            .chain(preprocessed_openings.evaluations().as_slice().iter())
+            .zip_eq(gkr_powers.iter())
+            .map(|(opening, power)| *opening * *power)
+            .sum::<EF>();
+
+        let air_data = ZerocheckCpuProverData::round_prover(
+            Arc::new(air),
+            Arc::new(public_values),
+            Arc::new(alpha_powers),
+            Arc::new(gkr_powers),
+        );
+
+        let virtual_geq =
+            VirtualGeq::new(num_real_entries as u32, F::one(), F::zero(), num_variables);
+        let geq_value = if num_real_entries > 0 { EF::zero() } else { EF::one() };
+
+        let poly = ZeroCheckPoly::new(
+            air_data,
+            zeta.clone(),
+            Some(preprocessed_trace),
+            main_trace,
+            EF::one(),
+            geq_value,
+            padded_row_adjustment,
+            virtual_geq,
+        );
+        (poly, claim)
+    }
 
     #[test]
     fn test_zerocheck() {
@@ -287,6 +533,117 @@ mod tests {
         partially_verify_sumcheck_proof(&proof, &mut challenger, num_variables as usize, 4)
             .unwrap();
         assert_eq!(chip_eval_claim, zerocheck_eq_val * (constraint_eval + openings_batch));
+    }
+
+    /// Checks that the zerocheck prover with fused first two rounds produces exactly the same
+    /// proof as the generic round-by-round sumcheck prover, and that the proof verifies.
+    #[test]
+    fn test_zerocheck_fused_first_two_rounds() {
+        setup_logger();
+        let mut rng = rand::thread_rng();
+
+        // Chip heights covering all residues mod 4, full traces, single rows, fully padded
+        // chips, and the minimum numbers of variables.
+        let cases: Vec<(usize, Vec<usize>)> = vec![
+            (7, vec![65]),
+            (7, vec![128, 1, 67]),
+            (7, vec![2, 66]),
+            (7, vec![3, 0, 64]),
+            (7, vec![4, 5]),
+            (2, vec![1, 2, 3, 4]),
+            (1, vec![1, 2]),
+        ];
+
+        for (num_variables, heights) in cases {
+            let zeta = Point::<EF>::rand(&mut rng, num_variables as u32);
+            let lambda = rng.gen::<EF>();
+
+            let (add_polys, add_claims): (Vec<_>, Vec<_>) = heights
+                .iter()
+                .map(|&height| {
+                    make_minimal_add_zerocheck_poly(&mut rng, &zeta, height, num_variables as u32)
+                })
+                .unzip();
+
+            // A chip with a preprocessed trace always has a non-empty one in production, so only
+            // non-zero heights are exercised for the cube chip.
+            let (cube_polys, cube_claims): (Vec<_>, Vec<_>) = heights
+                .iter()
+                .filter(|&&height| height > 0)
+                .map(|&height| {
+                    make_minimal_cube_zerocheck_poly(&mut rng, &zeta, height, num_variables as u32)
+                })
+                .unzip();
+
+            // Run the generic and the fused prover on identical inputs and transcripts.
+            let mut challenger_generic = SP1GlobalContext::default_challenger();
+            let (add_proof_generic, add_evals_generic) = reduce_sumcheck_to_evaluation(
+                add_polys.clone(),
+                &mut challenger_generic,
+                add_claims.clone(),
+                1,
+                lambda,
+            );
+
+            let mut challenger_fused = SP1GlobalContext::default_challenger();
+            let (add_proof_fused, add_evals_fused) = zerocheck_reduce_sumcheck_to_evaluation(
+                add_polys,
+                &mut challenger_fused,
+                add_claims,
+                lambda,
+            );
+
+            assert_eq!(
+                add_proof_generic.univariate_polys, add_proof_fused.univariate_polys,
+                "add chip messages differ for {num_variables} variables, heights {heights:?}"
+            );
+            assert_eq!(add_proof_generic.claimed_sum, add_proof_fused.claimed_sum);
+            assert_eq!(add_proof_generic.point_and_eval, add_proof_fused.point_and_eval);
+            assert_eq!(add_evals_generic, add_evals_fused);
+
+            let mut challenger_verify = SP1GlobalContext::default_challenger();
+            partially_verify_sumcheck_proof(
+                &add_proof_fused,
+                &mut challenger_verify,
+                num_variables,
+                4,
+            )
+            .unwrap();
+
+            let mut challenger_generic = SP1GlobalContext::default_challenger();
+            let (cube_proof_generic, cube_evals_generic) = reduce_sumcheck_to_evaluation(
+                cube_polys.clone(),
+                &mut challenger_generic,
+                cube_claims.clone(),
+                1,
+                lambda,
+            );
+
+            let mut challenger_fused = SP1GlobalContext::default_challenger();
+            let (cube_proof_fused, cube_evals_fused) = zerocheck_reduce_sumcheck_to_evaluation(
+                cube_polys,
+                &mut challenger_fused,
+                cube_claims,
+                lambda,
+            );
+
+            assert_eq!(
+                cube_proof_generic.univariate_polys, cube_proof_fused.univariate_polys,
+                "cube chip messages differ for {num_variables} variables, heights {heights:?}"
+            );
+            assert_eq!(cube_proof_generic.claimed_sum, cube_proof_fused.claimed_sum);
+            assert_eq!(cube_proof_generic.point_and_eval, cube_proof_fused.point_and_eval);
+            assert_eq!(cube_evals_generic, cube_evals_fused);
+
+            let mut challenger_verify = SP1GlobalContext::default_challenger();
+            partially_verify_sumcheck_proof(
+                &cube_proof_fused,
+                &mut challenger_verify,
+                num_variables,
+                4,
+            )
+            .unwrap();
+        }
     }
 
     #[test]

--- a/crates/hypercube/src/prover/shard.rs
+++ b/crates/hypercube/src/prover/shard.rs
@@ -11,7 +11,7 @@ use slop_matrix::dense::RowMajorMatrixView;
 use slop_multilinear::{
     Evaluations, MleEval, MultilinearPcsProver, MultilinearPcsVerifier, Point, VirtualGeq,
 };
-use slop_sumcheck::PartialSumcheckProof;
+use slop_sumcheck::{reduce_sumcheck_to_evaluation, PartialSumcheckProof};
 use slop_tensor::Tensor;
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -26,8 +26,8 @@ use tracing::Instrument;
 use crate::{
     air::{MachineAir, MachineProgram},
     prover::{
-        zerocheck_reduce_sumcheck_to_evaluation, DefaultTraceGenerator, Program, ProverPermit,
-        ProverSemaphore, Record, ZeroCheckPoly, ZerocheckCpuProverData,
+        DefaultTraceGenerator, Program, ProverPermit, ProverSemaphore, Record, ZeroCheckPoly,
+        ZerocheckCpuProverData,
     },
     septic_digest::SepticDigest,
     AirOpenedValues, Chip, ChipEvaluation, ChipOpenedValues, ChipStatistics,
@@ -598,15 +598,17 @@ impl<GC: IopCtx, SC: ShardContext<GC>, C: DefaultJaggedProver<GC, SC::Config>>
         // Same lambda for the RLC of the zerocheck polynomials.
         let lambda = challenger.sample_ext_element::<GC::EF>();
 
-        // Compute the sumcheck proof for the zerocheck polynomials, proving the first two rounds
-        // together from a single pass over the base-field traces.
-        let (partial_sumcheck_proof, component_poly_evals) =
-            zerocheck_reduce_sumcheck_to_evaluation(
-                zerocheck_polys,
-                challenger,
-                chip_sumcheck_claims,
-                lambda,
-            );
+        // Compute the sumcheck proof for the zerocheck polynomials with a two-round lookahead:
+        // the first two round messages are computed together from a single pass over the
+        // base-field traces (unless the traces are too short for two rounds).
+        let lookahead = self.inner.pcs_prover.max_log_row_count.clamp(1, 2);
+        let (partial_sumcheck_proof, component_poly_evals) = reduce_sumcheck_to_evaluation(
+            zerocheck_polys,
+            challenger,
+            chip_sumcheck_claims,
+            lookahead,
+            lambda,
+        );
 
         let mut point_extended = partial_sumcheck_proof.point_and_eval.0.clone();
         point_extended.add_dimension(GC::EF::zero());

--- a/crates/hypercube/src/prover/shard.rs
+++ b/crates/hypercube/src/prover/shard.rs
@@ -11,7 +11,7 @@ use slop_matrix::dense::RowMajorMatrixView;
 use slop_multilinear::{
     Evaluations, MleEval, MultilinearPcsProver, MultilinearPcsVerifier, Point, VirtualGeq,
 };
-use slop_sumcheck::{reduce_sumcheck_to_evaluation, PartialSumcheckProof};
+use slop_sumcheck::PartialSumcheckProof;
 use slop_tensor::Tensor;
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -26,8 +26,8 @@ use tracing::Instrument;
 use crate::{
     air::{MachineAir, MachineProgram},
     prover::{
-        DefaultTraceGenerator, Program, ProverPermit, ProverSemaphore, Record, ZeroCheckPoly,
-        ZerocheckCpuProverData,
+        zerocheck_reduce_sumcheck_to_evaluation, DefaultTraceGenerator, Program, ProverPermit,
+        ProverSemaphore, Record, ZeroCheckPoly, ZerocheckCpuProverData,
     },
     septic_digest::SepticDigest,
     AirOpenedValues, Chip, ChipEvaluation, ChipOpenedValues, ChipStatistics,
@@ -598,14 +598,15 @@ impl<GC: IopCtx, SC: ShardContext<GC>, C: DefaultJaggedProver<GC, SC::Config>>
         // Same lambda for the RLC of the zerocheck polynomials.
         let lambda = challenger.sample_ext_element::<GC::EF>();
 
-        // Compute the sumcheck proof for the zerocheck polynomials.
-        let (partial_sumcheck_proof, component_poly_evals) = reduce_sumcheck_to_evaluation(
-            zerocheck_polys,
-            challenger,
-            chip_sumcheck_claims,
-            1,
-            lambda,
-        );
+        // Compute the sumcheck proof for the zerocheck polynomials, proving the first two rounds
+        // together from a single pass over the base-field traces.
+        let (partial_sumcheck_proof, component_poly_evals) =
+            zerocheck_reduce_sumcheck_to_evaluation(
+                zerocheck_polys,
+                challenger,
+                chip_sumcheck_claims,
+                lambda,
+            );
 
         let mut point_extended = partial_sumcheck_proof.point_and_eval.0.clone();
         point_extended.add_dimension(GC::EF::zero());

--- a/crates/hypercube/src/prover/zerocheck/first_two_rounds.rs
+++ b/crates/hypercube/src/prover/zerocheck/first_two_rounds.rs
@@ -18,18 +18,19 @@
 //! `X, Y ∈ {0, 1}` (on real rows they hold, and on padded rows their value is cancelled exactly
 //! by the geq correction), so those nodes only require the GKR opening batch, which is linear in
 //! the trace and hence bilinear in `(X, Y)`.
+//!
+//! The fused rounds are proven by [`slop_sumcheck::reduce_sumcheck_to_evaluation`] with a
+//! lookahead depth of `t = 2`: [`ZeroCheckPoly`]'s first-round implementation computes the grid
+//! (and the first message) in [`zerocheck_sum_as_poly_in_last_two_variables`], and
+//! [`zerocheck_fix_last_variable_with_lookahead`] hands the second message over to the
+//! next-round polynomial.
 
 use itertools::Itertools;
 use slop_algebra::{
-    interpolate_univariate_polynomial, rlc_univariate_polynomials, AbstractExtensionField,
-    ExtensionField, Field, UnivariatePolynomial,
+    interpolate_univariate_polynomial, ExtensionField, Field, UnivariatePolynomial,
 };
-use slop_challenger::{FieldChallenger, VariableLengthChallenger};
 use slop_multilinear::Mle;
-use slop_sumcheck::{
-    reduce_sumcheck_to_evaluation, ComponentPoly, PartialSumcheckProof, SumcheckPoly,
-    SumcheckPolyBase,
-};
+use slop_sumcheck::SumcheckPolyBase;
 
 use super::{zerocheck_fix_last_variable, ZeroCheckPoly, ZerocheckAir};
 
@@ -62,6 +63,7 @@ pub const ZEROCHECK_CONSTRAINT_NODES: [(usize, usize); 12] = [
 ///
 /// `grid[ix][iy]` is the evaluation at `(ZEROCHECK_NODE_XS[ix], ZEROCHECK_NODE_XS[iy])`, where
 /// the first coordinate corresponds to the second-to-last variable.
+#[derive(Clone)]
 pub struct ZerocheckBivariateEvals<EF> {
     grid: [[EF; 4]; 4],
 }
@@ -267,128 +269,49 @@ where
     )
 }
 
-/// Proves the zerocheck sumcheck, reducing it to a claim about the evaluations of the trace
-/// columns at a point.
+/// The first-round message of the zerocheck sumcheck with a two-round lookahead (`t = 2`).
 ///
-/// This produces exactly the same transcript and proof as
-/// [`slop_sumcheck::reduce_sumcheck_to_evaluation`] applied to the zerocheck polynomials, but
-/// computes the first two round messages together from a single pass over the base-field traces.
-///
-/// # Panics
-/// Panics if `polys` is empty or if the polynomials do not all have the same number of variables.
-pub fn zerocheck_reduce_sumcheck_to_evaluation<F, EF, A, Challenger>(
-    polys: Vec<ZeroCheckPoly<F, F, EF, A>>,
-    challenger: &mut Challenger,
-    claims: Vec<EF>,
-    lambda: EF,
-) -> (PartialSumcheckProof<EF>, Vec<Vec<EF>>)
+/// Computes the bivariate grid evaluations in a single pass over the base-field traces and
+/// caches them on the polynomial, from where [`zerocheck_fix_last_variable_with_lookahead`]
+/// interpolates the second-round message once the first challenge is known.
+pub(crate) fn zerocheck_sum_as_poly_in_last_two_variables<F, EF, A>(
+    poly: &ZeroCheckPoly<F, F, EF, A>,
+    claim: Option<EF>,
+) -> UnivariatePolynomial<EF>
 where
     F: Field,
-    EF: ExtensionField<F> + Send + Sync,
+    EF: ExtensionField<F>,
     A: ZerocheckAir<F, EF>,
-    Challenger: FieldChallenger<F>,
 {
-    assert!(!polys.is_empty());
-    let num_variables = polys[0].num_variables();
-    assert!(polys.iter().all(|poly| poly.num_variables() == num_variables));
-
-    // The fused first two rounds require at least two variables.
-    if num_variables < 2 {
-        return reduce_sumcheck_to_evaluation(polys, challenger, claims, 1, lambda);
-    }
-
-    // The point at which the reduced sumcheck proof should be evaluated.
-    let mut point = vec![];
-
-    // The univariate poly messages.  This will be a rlc of the polys' univariate polys.
-    let mut univariate_poly_msgs: Vec<UnivariatePolynomial<EF>> = vec![];
-
-    // Evaluate the bivariate round polynomial of each chip on the interpolation grid.
-    let bivariate_evals = polys.iter().map(zerocheck_bivariate_evals).collect::<Vec<_>>();
-
-    // First round message.
-    let mut uni_polys: Vec<_> = polys
-        .iter()
-        .zip(bivariate_evals.iter())
-        .map(|(poly, evals)| zerocheck_first_round_message(poly, evals.as_ref()))
-        .collect();
-
-    #[cfg(debug_assertions)]
-    for (uni_poly, claim) in uni_polys.iter().zip_eq(claims.iter()) {
+    let evals = poly.bivariate_evals.get_or_init(|| zerocheck_bivariate_evals(poly));
+    let message = zerocheck_first_round_message(poly, evals.as_ref());
+    if let Some(claim) = claim {
         debug_assert_eq!(
-            uni_poly.eval_one_plus_eval_zero(),
-            *claim,
+            message.eval_one_plus_eval_zero(),
+            claim,
             "first round message inconsistent with the claim"
         );
     }
+    message
+}
 
-    let mut rlc_uni_poly = rlc_univariate_polynomials(&uni_polys, lambda);
-    let coefficients = rlc_uni_poly
-        .coefficients
-        .iter()
-        .flat_map(AbstractExtensionField::as_base_slice)
-        .copied()
-        .collect_vec();
-    challenger.observe_constant_length_slice(&coefficients);
-    univariate_poly_msgs.push(rlc_uni_poly);
-
-    let alpha: EF = challenger.sample_ext_element();
-    point.insert(0, alpha);
-
-    // Second round message, obtained from the stored grid without a pass over the traces.
-    uni_polys = polys
-        .iter()
-        .zip(bivariate_evals.iter())
-        .map(|(poly, evals)| zerocheck_second_round_message(poly, evals.as_ref(), alpha))
-        .collect();
-
-    rlc_uni_poly = rlc_univariate_polynomials(&uni_polys, lambda);
-    challenger.observe_constant_length_extension_slice(&rlc_uni_poly.coefficients);
-    univariate_poly_msgs.push(rlc_uni_poly);
-
-    let alpha_2: EF = challenger.sample_ext_element();
-    point.insert(0, alpha_2);
-
-    // Fix the last two variables to the sampled challenges.
-    let mut polys_cursor: Vec<_> = polys
-        .into_iter()
-        .map(|poly| zerocheck_fix_last_variable(zerocheck_fix_last_variable(poly, alpha), alpha_2))
-        .collect();
-
-    // The remaining rounds proceed exactly as in the generic sumcheck prover.
-    for _ in 2..num_variables as usize {
-        let round_claims = uni_polys.iter().map(|poly| poly.eval_at_point(*point.first().unwrap()));
-
-        uni_polys = polys_cursor
-            .iter()
-            .zip_eq(round_claims)
-            .map(|(poly, round_claim)| poly.sum_as_poly_in_last_variable(Some(round_claim)))
-            .collect();
-        let rlc_uni_poly = rlc_univariate_polynomials(&uni_polys, lambda);
-        challenger.observe_constant_length_extension_slice(&rlc_uni_poly.coefficients);
-
-        univariate_poly_msgs.push(rlc_uni_poly);
-
-        let alpha: EF = challenger.sample_ext_element();
-        point.insert(0, alpha);
-        polys_cursor = polys_cursor.into_iter().map(|poly| poly.fix_last_variable(alpha)).collect();
-    }
-
-    let evals =
-        uni_polys.iter().map(|poly| poly.eval_at_point(*point.first().unwrap())).collect_vec();
-
-    let component_poly_evals: Vec<_> =
-        polys_cursor.iter().map(ComponentPoly::get_component_poly_evals).collect();
-
-    (
-        PartialSumcheckProof {
-            univariate_polys: univariate_poly_msgs,
-            claimed_sum: claims.into_iter().fold(EF::zero(), |acc, x| acc * lambda + x),
-            point_and_eval: (
-                point.into(),
-                evals.into_iter().fold(EF::zero(), |acc, x| acc * lambda + x),
-            ),
-        },
-        component_poly_evals,
-    )
+/// Fixes the last variable to the first-round challenge under a two-round lookahead (`t = 2`).
+///
+/// The second-round message `h(X) = p(X, alpha)` is interpolated from the grid cached by
+/// [`zerocheck_sum_as_poly_in_last_two_variables`] and carried over to the folded polynomial,
+/// so the second round requires no pass over the trace.
+pub(crate) fn zerocheck_fix_last_variable_with_lookahead<F, EF, A>(
+    mut poly: ZeroCheckPoly<F, F, EF, A>,
+    alpha: EF,
+) -> ZeroCheckPoly<EF, F, EF, A>
+where
+    F: Field,
+    EF: ExtensionField<F>,
+    A: ZerocheckAir<F, EF>,
+{
+    let evals = poly.bivariate_evals.take().unwrap_or_else(|| zerocheck_bivariate_evals(&poly));
+    let message = zerocheck_second_round_message(&poly, evals.as_ref(), alpha);
+    let mut folded = zerocheck_fix_last_variable(poly, alpha);
+    folded.lookahead_message = Some(message);
+    folded
 }

--- a/crates/hypercube/src/prover/zerocheck/first_two_rounds.rs
+++ b/crates/hypercube/src/prover/zerocheck/first_two_rounds.rs
@@ -1,0 +1,394 @@
+//! A fused implementation of the first two rounds of the zerocheck sumcheck.
+//!
+//! Instead of computing the first-round message from the full trace and the second-round message
+//! from the trace folded by the first challenge, the prover evaluates the *bivariate* polynomial
+//!
+//! `p(X, Y) = sum_i eq_zeta(i || X || Y) * F(i || X || Y)`,
+//!
+//! where `F` is the constraint polynomial plus the GKR opening batch (with the padded row
+//! correction), on a 4x4 grid of interpolation nodes in a single pass over the base-field traces.
+//! The first-round message is `g(Y) = p(0, Y) + p(1, Y)` and, after sampling the challenge
+//! `alpha`, the second-round message `h(X) = p(X, alpha)` is obtained from the stored grid by
+//! interpolation, without a second pass over the trace. Both messages are identical to the ones
+//! produced by the round-by-round prover, so the protocol and the verifier are unchanged.
+//!
+//! The benefit is that the second round's constraint evaluations happen on interpolations of
+//! *base-field* rows, instead of on rows of the extension-field trace obtained by folding with
+//! the first-round challenge. Moreover, the constraints vanish at the four grid nodes with
+//! `X, Y ∈ {0, 1}` (on real rows they hold, and on padded rows their value is cancelled exactly
+//! by the geq correction), so those nodes only require the GKR opening batch, which is linear in
+//! the trace and hence bilinear in `(X, Y)`.
+
+use itertools::Itertools;
+use slop_algebra::{
+    interpolate_univariate_polynomial, rlc_univariate_polynomials, AbstractExtensionField,
+    ExtensionField, Field, UnivariatePolynomial,
+};
+use slop_challenger::{FieldChallenger, VariableLengthChallenger};
+use slop_multilinear::Mle;
+use slop_sumcheck::{
+    reduce_sumcheck_to_evaluation, ComponentPoly, PartialSumcheckProof, SumcheckPoly,
+    SumcheckPolyBase,
+};
+
+use super::{zerocheck_fix_last_variable, ZeroCheckPoly, ZerocheckAir};
+
+/// The interpolation nodes used in each of the last two variables. Together with the known root
+/// of the eq term, they determine the degree-4 round messages. The non-boolean nodes are chosen
+/// so that the row interpolations only require additions and doublings.
+pub const ZEROCHECK_NODE_XS: [u32; 4] = [0, 1, 2, 4];
+
+/// The grid indices `(ix, iy)` into [`ZEROCHECK_NODE_XS`] of the nodes at which the constraint
+/// polynomial must be evaluated, i.e. all nodes outside the boolean square `{0, 1}^2`. The order
+/// matches the node rows produced by the interpolation in the zerocheck kernels.
+pub const ZEROCHECK_CONSTRAINT_NODES: [(usize, usize); 12] = [
+    (0, 2),
+    (0, 3),
+    (1, 2),
+    (1, 3),
+    (2, 0),
+    (2, 1),
+    (2, 2),
+    (2, 3),
+    (3, 0),
+    (3, 1),
+    (3, 2),
+    (3, 3),
+];
+
+/// The evaluations, on the grid [`ZEROCHECK_NODE_XS`]`^2` of the last two variables, of the
+/// zerocheck sumcheck polynomial with all other variables summed over the boolean hypercube,
+/// excluding the eq factors in the last two variables and the `eq_adjustment`.
+///
+/// `grid[ix][iy]` is the evaluation at `(ZEROCHECK_NODE_XS[ix], ZEROCHECK_NODE_XS[iy])`, where
+/// the first coordinate corresponds to the second-to-last variable.
+pub struct ZerocheckBivariateEvals<EF> {
+    grid: [[EF; 4]; 4],
+}
+
+/// The evaluations of `eq(z, .)` at the grid nodes [`ZEROCHECK_NODE_XS`].
+fn eq_at_nodes<F: Field, EF: ExtensionField<F>>(z: EF) -> [EF; 4] {
+    [
+        EF::one() - z,
+        z,
+        z * F::from_canonical_usize(3) - EF::one(),
+        z * F::from_canonical_usize(7) - F::from_canonical_usize(3),
+    ]
+}
+
+/// The root of `eq(z, .)`, at which the round message is known to vanish.
+fn eq_root<F: Field, EF: ExtensionField<F>>(z: EF) -> EF {
+    (EF::one() - z) / (EF::one() - z.double())
+}
+
+/// Computes the bivariate grid evaluations for the first two zerocheck rounds, in a single pass
+/// over the trace. Returns `None` for a fully padded chip, whose round messages are zero.
+fn zerocheck_bivariate_evals<F, EF, A>(
+    poly: &ZeroCheckPoly<F, F, EF, A>,
+) -> Option<ZerocheckBivariateEvals<EF>>
+where
+    F: Field,
+    EF: ExtensionField<F>,
+    A: ZerocheckAir<F, EF>,
+{
+    let num_real_entries = poly.main_columns.num_real_entries();
+    if num_real_entries == 0 {
+        return None;
+    }
+    debug_assert!(poly.num_variables() >= 2);
+
+    let (rest_point, _) = poly.zeta.split_at(poly.zeta.dimension() - 2);
+
+    let partial_lagrange: Mle<EF> = Mle::partial_lagrange(&rest_point);
+
+    let (constraint_sums, gkr_sums) = poly.air_data.sum_as_poly_in_last_two_variables(
+        &partial_lagrange,
+        poly.preprocessed_columns.as_ref(),
+        &poly.main_columns,
+    );
+
+    // The GKR opening batch is linear in the trace values, hence bilinear in the last two
+    // variables: its values at the four boolean nodes determine it on the whole grid.
+    let [gkr_00, gkr_01, gkr_10, gkr_11] = gkr_sums;
+    let gkr_x = gkr_10 - gkr_00;
+    let gkr_y = gkr_01 - gkr_00;
+    let gkr_xy = gkr_11 - gkr_10 - gkr_01 + gkr_00;
+
+    // Quadruples of fully padded rows cancel exactly against the geq correction and are not
+    // summed; the only quadruple needing a correction is the one straddling the padding boundary.
+    let threshold_quad = num_real_entries.div_ceil(4) - 1;
+    let lagrange_threshold_eval = partial_lagrange.guts().as_buffer().as_slice()[threshold_quad];
+
+    let mut grid = [[EF::zero(); 4]; 4];
+    grid[0][0] = gkr_00;
+    grid[0][1] = gkr_01;
+    grid[1][0] = gkr_10;
+    grid[1][1] = gkr_11;
+
+    for (&(ix, iy), constraint_sum) in ZEROCHECK_CONSTRAINT_NODES.iter().zip_eq(constraint_sums) {
+        let x = EF::from_canonical_u32(ZEROCHECK_NODE_XS[ix]);
+        let y = EF::from_canonical_u32(ZEROCHECK_NODE_XS[iy]);
+        let gkr_eval = gkr_00 + gkr_x * x + gkr_y * y + gkr_xy * (x * y);
+        // The geq polynomial with its last two variables fixed to the node, at the straddling
+        // quadruple.
+        let geq_eval = poly
+            .virtual_geq
+            .fix_last_variable(y)
+            .fix_last_variable(x)
+            .eval_at_usize(threshold_quad);
+        grid[ix][iy] = constraint_sum + gkr_eval
+            - poly.padded_row_adjustment * lagrange_threshold_eval * geq_eval;
+    }
+
+    Some(ZerocheckBivariateEvals { grid })
+}
+
+/// The first-round message `g(Y) = p(0, Y) + p(1, Y)` computed from the bivariate grid
+/// evaluations `grid[ix][iy]` (see [`ZerocheckBivariateEvals`]), where `z_a` and `z_b` are the
+/// second-to-last and last coordinates of the zerocheck point.
+///
+/// This is shared with the GPU prover, which assembles the same grid from its kernels' outputs
+/// (RLC'ed over the shard's chips, which is fine since the assembly is linear in the grid).
+pub fn zerocheck_first_round_message_from_grid<F, EF>(
+    grid: &[[EF; 4]; 4],
+    z_a: EF,
+    z_b: EF,
+    eq_adjustment: EF,
+) -> UnivariatePolynomial<EF>
+where
+    F: Field,
+    EF: ExtensionField<F>,
+{
+    let eq_y = eq_at_nodes::<F, EF>(z_b);
+
+    let mut xs = ZEROCHECK_NODE_XS.iter().map(|&v| EF::from_canonical_u32(v)).collect::<Vec<_>>();
+    let mut ys = (0..4)
+        .map(|iy| {
+            // Summing `X` over `{0, 1}` leaves the linear eq factor in `X` evaluated at `z_a`.
+            let summed = (EF::one() - z_a) * grid[0][iy] + z_a * grid[1][iy];
+            eq_adjustment * eq_y[iy] * summed
+        })
+        .collect::<Vec<_>>();
+
+    xs.push(eq_root::<F, EF>(z_b));
+    ys.push(EF::zero());
+
+    interpolate_univariate_polynomial(&xs, &ys)
+}
+
+/// The second-round message `h(X) = p(X, alpha)` computed from the bivariate grid evaluations,
+/// where `alpha` is the challenge sampled after the first round. See
+/// [`zerocheck_first_round_message_from_grid`] for the arguments.
+pub fn zerocheck_second_round_message_from_grid<F, EF>(
+    grid: &[[EF; 4]; 4],
+    z_a: EF,
+    z_b: EF,
+    eq_adjustment: EF,
+    alpha: EF,
+) -> UnivariatePolynomial<EF>
+where
+    F: Field,
+    EF: ExtensionField<F>,
+{
+    // Lagrange interpolation weights for evaluating a cubic given at the grid nodes at `alpha`.
+    let node_points = ZEROCHECK_NODE_XS.map(EF::from_canonical_u32);
+    let weights: [EF; 4] = std::array::from_fn(|k| {
+        let (numerator, denominator) =
+            (0..4).filter(|&j| j != k).fold((EF::one(), EF::one()), |(num, denom), j| {
+                (num * (alpha - node_points[j]), denom * (node_points[k] - node_points[j]))
+            });
+        numerator * denominator.inverse()
+    });
+
+    let eq_x = eq_at_nodes::<F, EF>(z_a);
+    let eq_y_at_alpha = z_b * alpha + (EF::one() - z_b) * (EF::one() - alpha);
+
+    let mut xs = node_points.to_vec();
+    let mut ys = (0..4)
+        .map(|ix| {
+            let bivariate_at_alpha = (0..4).map(|iy| weights[iy] * grid[ix][iy]).sum::<EF>();
+            eq_adjustment * eq_y_at_alpha * eq_x[ix] * bivariate_at_alpha
+        })
+        .collect::<Vec<_>>();
+
+    xs.push(eq_root::<F, EF>(z_a));
+    ys.push(EF::zero());
+
+    interpolate_univariate_polynomial(&xs, &ys)
+}
+
+/// The first-round message `g(Y) = p(0, Y) + p(1, Y)` obtained from the grid evaluations.
+fn zerocheck_first_round_message<F, EF, A>(
+    poly: &ZeroCheckPoly<F, F, EF, A>,
+    evals: Option<&ZerocheckBivariateEvals<EF>>,
+) -> UnivariatePolynomial<EF>
+where
+    F: Field,
+    EF: ExtensionField<F>,
+{
+    let Some(evals) = evals else {
+        // NOTE: We hard-code the degree of the zerocheck to be three here. This is important to
+        // get the correct shape of a dummy proof.
+        return UnivariatePolynomial::zero(4);
+    };
+
+    let (_, last_two) = poly.zeta.split_at(poly.zeta.dimension() - 2);
+    let z_a = *last_two[0];
+    let z_b = *last_two[1];
+
+    zerocheck_first_round_message_from_grid::<F, EF>(&evals.grid, z_a, z_b, poly.eq_adjustment)
+}
+
+/// The second-round message `h(X) = p(X, alpha)` obtained from the grid evaluations, where
+/// `alpha` is the challenge sampled after the first round.
+fn zerocheck_second_round_message<F, EF, A>(
+    poly: &ZeroCheckPoly<F, F, EF, A>,
+    evals: Option<&ZerocheckBivariateEvals<EF>>,
+    alpha: EF,
+) -> UnivariatePolynomial<EF>
+where
+    F: Field,
+    EF: ExtensionField<F>,
+{
+    let Some(evals) = evals else {
+        return UnivariatePolynomial::zero(4);
+    };
+
+    let (_, last_two) = poly.zeta.split_at(poly.zeta.dimension() - 2);
+    let z_a = *last_two[0];
+    let z_b = *last_two[1];
+
+    zerocheck_second_round_message_from_grid::<F, EF>(
+        &evals.grid,
+        z_a,
+        z_b,
+        poly.eq_adjustment,
+        alpha,
+    )
+}
+
+/// Proves the zerocheck sumcheck, reducing it to a claim about the evaluations of the trace
+/// columns at a point.
+///
+/// This produces exactly the same transcript and proof as
+/// [`slop_sumcheck::reduce_sumcheck_to_evaluation`] applied to the zerocheck polynomials, but
+/// computes the first two round messages together from a single pass over the base-field traces.
+///
+/// # Panics
+/// Panics if `polys` is empty or if the polynomials do not all have the same number of variables.
+pub fn zerocheck_reduce_sumcheck_to_evaluation<F, EF, A, Challenger>(
+    polys: Vec<ZeroCheckPoly<F, F, EF, A>>,
+    challenger: &mut Challenger,
+    claims: Vec<EF>,
+    lambda: EF,
+) -> (PartialSumcheckProof<EF>, Vec<Vec<EF>>)
+where
+    F: Field,
+    EF: ExtensionField<F> + Send + Sync,
+    A: ZerocheckAir<F, EF>,
+    Challenger: FieldChallenger<F>,
+{
+    assert!(!polys.is_empty());
+    let num_variables = polys[0].num_variables();
+    assert!(polys.iter().all(|poly| poly.num_variables() == num_variables));
+
+    // The fused first two rounds require at least two variables.
+    if num_variables < 2 {
+        return reduce_sumcheck_to_evaluation(polys, challenger, claims, 1, lambda);
+    }
+
+    // The point at which the reduced sumcheck proof should be evaluated.
+    let mut point = vec![];
+
+    // The univariate poly messages.  This will be a rlc of the polys' univariate polys.
+    let mut univariate_poly_msgs: Vec<UnivariatePolynomial<EF>> = vec![];
+
+    // Evaluate the bivariate round polynomial of each chip on the interpolation grid.
+    let bivariate_evals = polys.iter().map(zerocheck_bivariate_evals).collect::<Vec<_>>();
+
+    // First round message.
+    let mut uni_polys: Vec<_> = polys
+        .iter()
+        .zip(bivariate_evals.iter())
+        .map(|(poly, evals)| zerocheck_first_round_message(poly, evals.as_ref()))
+        .collect();
+
+    #[cfg(debug_assertions)]
+    for (uni_poly, claim) in uni_polys.iter().zip_eq(claims.iter()) {
+        debug_assert_eq!(
+            uni_poly.eval_one_plus_eval_zero(),
+            *claim,
+            "first round message inconsistent with the claim"
+        );
+    }
+
+    let mut rlc_uni_poly = rlc_univariate_polynomials(&uni_polys, lambda);
+    let coefficients = rlc_uni_poly
+        .coefficients
+        .iter()
+        .flat_map(AbstractExtensionField::as_base_slice)
+        .copied()
+        .collect_vec();
+    challenger.observe_constant_length_slice(&coefficients);
+    univariate_poly_msgs.push(rlc_uni_poly);
+
+    let alpha: EF = challenger.sample_ext_element();
+    point.insert(0, alpha);
+
+    // Second round message, obtained from the stored grid without a pass over the traces.
+    uni_polys = polys
+        .iter()
+        .zip(bivariate_evals.iter())
+        .map(|(poly, evals)| zerocheck_second_round_message(poly, evals.as_ref(), alpha))
+        .collect();
+
+    rlc_uni_poly = rlc_univariate_polynomials(&uni_polys, lambda);
+    challenger.observe_constant_length_extension_slice(&rlc_uni_poly.coefficients);
+    univariate_poly_msgs.push(rlc_uni_poly);
+
+    let alpha_2: EF = challenger.sample_ext_element();
+    point.insert(0, alpha_2);
+
+    // Fix the last two variables to the sampled challenges.
+    let mut polys_cursor: Vec<_> = polys
+        .into_iter()
+        .map(|poly| zerocheck_fix_last_variable(zerocheck_fix_last_variable(poly, alpha), alpha_2))
+        .collect();
+
+    // The remaining rounds proceed exactly as in the generic sumcheck prover.
+    for _ in 2..num_variables as usize {
+        let round_claims = uni_polys.iter().map(|poly| poly.eval_at_point(*point.first().unwrap()));
+
+        uni_polys = polys_cursor
+            .iter()
+            .zip_eq(round_claims)
+            .map(|(poly, round_claim)| poly.sum_as_poly_in_last_variable(Some(round_claim)))
+            .collect();
+        let rlc_uni_poly = rlc_univariate_polynomials(&uni_polys, lambda);
+        challenger.observe_constant_length_extension_slice(&rlc_uni_poly.coefficients);
+
+        univariate_poly_msgs.push(rlc_uni_poly);
+
+        let alpha: EF = challenger.sample_ext_element();
+        point.insert(0, alpha);
+        polys_cursor = polys_cursor.into_iter().map(|poly| poly.fix_last_variable(alpha)).collect();
+    }
+
+    let evals =
+        uni_polys.iter().map(|poly| poly.eval_at_point(*point.first().unwrap())).collect_vec();
+
+    let component_poly_evals: Vec<_> =
+        polys_cursor.iter().map(ComponentPoly::get_component_poly_evals).collect();
+
+    (
+        PartialSumcheckProof {
+            univariate_polys: univariate_poly_msgs,
+            claimed_sum: claims.into_iter().fold(EF::zero(), |acc, x| acc * lambda + x),
+            point_and_eval: (
+                point.into(),
+                evals.into_iter().fold(EF::zero(), |acc, x| acc * lambda + x),
+            ),
+        },
+        component_poly_evals,
+    )
+}

--- a/crates/hypercube/src/prover/zerocheck/mod.rs
+++ b/crates/hypercube/src/prover/zerocheck/mod.rs
@@ -1,10 +1,12 @@
 //! Zerocheck Sumcheck polynomial.
 
+mod first_two_rounds;
 mod fix_last_variable;
 mod sum_as_poly;
 
 use std::fmt::Debug;
 
+pub use first_two_rounds::*;
 pub use fix_last_variable::*;
 use slop_air::Air;
 use slop_algebra::{ExtensionField, Field, UnivariatePolynomial};

--- a/crates/hypercube/src/prover/zerocheck/mod.rs
+++ b/crates/hypercube/src/prover/zerocheck/mod.rs
@@ -4,7 +4,7 @@ mod first_two_rounds;
 mod fix_last_variable;
 mod sum_as_poly;
 
-use std::fmt::Debug;
+use std::{fmt::Debug, sync::OnceLock};
 
 pub use first_two_rounds::*;
 pub use fix_last_variable::*;
@@ -47,6 +47,14 @@ pub struct ZeroCheckPoly<K, F, EF, A> {
     /// A virtual materialization keeping track the geq polynomial which is used to adjust the sums
     /// for airs in which the zero row doesn't satisfy the constraints.
     pub virtual_geq: VirtualGeq<K>,
+
+    /// The bivariate grid evaluations backing the fused first two rounds (lookahead `t = 2`),
+    /// computed lazily by the first-round message and consumed when the first challenge is fixed.
+    /// `None` inside the lock marks a fully padded chip, whose round messages are zero.
+    pub(crate) bivariate_evals: OnceLock<Option<ZerocheckBivariateEvals<EF>>>,
+    /// The round message interpolated ahead of time from the bivariate grid, making the second
+    /// round of a lookahead sumcheck free of any pass over the trace.
+    pub(crate) lookahead_message: Option<UnivariatePolynomial<EF>>,
 }
 
 impl<K: Field, F: Field, EF: ExtensionField<F>, AirData> ZeroCheckPoly<K, F, EF, AirData> {
@@ -72,6 +80,8 @@ impl<K: Field, F: Field, EF: ExtensionField<F>, AirData> ZeroCheckPoly<K, F, EF,
             geq_value,
             padded_row_adjustment,
             virtual_geq,
+            bivariate_evals: OnceLock::new(),
+            lookahead_message: None,
         }
     }
 }
@@ -132,8 +142,11 @@ where
         alpha: EF,
         t: usize,
     ) -> Self::NextRoundPoly {
-        debug_assert_eq!(t, 1);
-        zerocheck_fix_last_variable(poly, alpha)
+        match t {
+            1 => zerocheck_fix_last_variable(poly, alpha),
+            2 => zerocheck_fix_last_variable_with_lookahead(poly, alpha),
+            _ => panic!("the zerocheck polynomial supports a lookahead of at most two rounds"),
+        }
     }
 
     #[inline]
@@ -142,9 +155,12 @@ where
         claim: Option<EF>,
         t: usize,
     ) -> UnivariatePolynomial<EF> {
-        debug_assert_eq!(t, 1);
-        debug_assert!(poly.num_variables() > 0);
-        zerocheck_sum_as_poly_in_last_variable::<F, F, EF, A, true>(poly, claim)
+        debug_assert!(poly.num_variables() >= t as u32);
+        match t {
+            1 => zerocheck_sum_as_poly_in_last_variable::<F, F, EF, A, true>(poly, claim),
+            2 => zerocheck_sum_as_poly_in_last_two_variables(poly, claim),
+            _ => panic!("the zerocheck polynomial supports a lookahead of at most two rounds"),
+        }
     }
 }
 
@@ -168,6 +184,17 @@ where
         claim: Option<EF>,
     ) -> UnivariatePolynomial<EF> {
         debug_assert!(poly.num_variables() > 0);
+        // A polynomial produced with a lookahead already carries this round's message.
+        if let Some(message) = &poly.lookahead_message {
+            if let Some(claim) = claim {
+                debug_assert_eq!(
+                    message.eval_one_plus_eval_zero(),
+                    claim,
+                    "lookahead round message inconsistent with the claim"
+                );
+            }
+            return message.clone();
+        }
         zerocheck_sum_as_poly_in_last_variable::<EF, F, EF, A, false>(poly, claim)
     }
 }

--- a/crates/hypercube/src/prover/zerocheck/sum_as_poly.rs
+++ b/crates/hypercube/src/prover/zerocheck/sum_as_poly.rs
@@ -181,6 +181,186 @@ where
     }
 }
 
+impl<F, EF, A> ZerocheckCpuProver<F, EF, A>
+where
+    F: Field,
+    EF: ExtensionField<F>,
+{
+    /// Computes the sums needed to evaluate the bivariate polynomial obtained by summing all
+    /// variables other than the last two over the boolean hypercube, on the grid
+    /// [`super::ZEROCHECK_NODE_XS`]`^2` of the last two variables.
+    ///
+    /// Returns:
+    /// - the eq-weighted sums of the constraint polynomial evaluations at the 12 non-boolean grid
+    ///   nodes (see [`super::ZEROCHECK_CONSTRAINT_NODES`] for the node order), and
+    /// - the eq-weighted sums of the GKR opening batch at the 4 boolean grid nodes, in the order
+    ///   `(0, 0), (0, 1), (1, 0), (1, 1)` where the first coordinate is the second-to-last
+    ///   variable.
+    ///
+    /// The constraint polynomial is not evaluated at the boolean nodes: on real rows the
+    /// constraints vanish there, and on padded rows their value is cancelled exactly by the geq
+    /// correction applied by the caller.
+    pub(crate) fn sum_as_poly_in_last_two_variables<K>(
+        &self,
+        partial_lagrange: &Mle<EF>,
+        preprocessed_values: Option<&PaddedMle<K>>,
+        main_values: &PaddedMle<K>,
+    ) -> ([EF; 12], [EF; 4])
+    where
+        K: ExtensionField<F>,
+        EF: ExtensionField<K>,
+        A: for<'b> Air<ConstraintSumcheckFolder<'b, F, K, EF>> + MachineAir<F>,
+    {
+        let air = self.air.clone();
+        let public_values = self.public_values.clone();
+        let powers_of_alpha = self.powers_of_alpha.clone();
+        let gkr_powers = self.gkr_powers.clone();
+
+        let num_quads = main_values.num_real_entries().div_ceil(4);
+        let eq_chunk_size = std::cmp::max(num_quads / num_cpus::get(), 1);
+        let values_chunk_size = eq_chunk_size * 4;
+
+        let eq_guts = partial_lagrange.guts().as_buffer().as_slice();
+        let eq_guts = &eq_guts[0..num_quads];
+
+        let num_main_columns = main_values.num_polynomials();
+        let num_preprocessed_columns =
+            preprocessed_values.map_or(0, slop_multilinear::PaddedMle::num_polynomials);
+
+        let main_values = main_values.inner().as_ref().unwrap().guts().as_buffer().as_slice();
+        let preprocessed_values = preprocessed_values
+            .as_ref()
+            .map_or([].as_slice(), |p| p.inner().as_ref().unwrap().guts().as_buffer().as_slice());
+
+        // Zero rows standing in for the virtually padded rows of a partially real quadruple.
+        let zero_main_row = vec![K::zero(); num_main_columns];
+        let zero_preprocessed_row = vec![K::zero(); num_preprocessed_columns];
+
+        let cumul_sums = eq_guts
+            .chunks(eq_chunk_size)
+            .zip(main_values.chunks(values_chunk_size * num_main_columns))
+            .enumerate()
+            .par_bridge()
+            .map(|(i, (eq_chunk, main_chunk))| {
+                let mut constraint_sums = [EF::zero(); 12];
+                let mut gkr_sums = [EF::zero(); 4];
+
+                let mut main_node_rows = vec![vec![K::zero(); num_main_columns]; 12];
+                let mut preprocessed_node_rows =
+                    vec![vec![K::zero(); num_preprocessed_columns]; 12];
+
+                for (j, (eq, main_quad)) in
+                    eq_chunk.iter().zip(main_chunk.chunks(num_main_columns * 4)).enumerate()
+                {
+                    // The four rows of the quadruple, padding with zero rows past the real ones.
+                    let main_rows: [&[K]; 4] = std::array::from_fn(|k| {
+                        if main_quad.len() >= (k + 1) * num_main_columns {
+                            &main_quad[k * num_main_columns..(k + 1) * num_main_columns]
+                        } else {
+                            zero_main_row.as_slice()
+                        }
+                    });
+
+                    let quad_start_idx = (i * values_chunk_size + 4 * j) * num_preprocessed_columns;
+                    let preprocessed_rows: [&[K]; 4] = std::array::from_fn(|k| {
+                        let start = quad_start_idx + k * num_preprocessed_columns;
+                        let end = start + num_preprocessed_columns;
+                        if preprocessed_values.len() >= end {
+                            &preprocessed_values[start..end]
+                        } else {
+                            zero_preprocessed_row.as_slice()
+                        }
+                    });
+
+                    interpolate_last_two_vars_rows(&main_rows, &mut main_node_rows);
+                    interpolate_last_two_vars_rows(&preprocessed_rows, &mut preprocessed_node_rows);
+
+                    // The GKR opening batch at the boolean nodes. Node (x, y) is row `2x + y`.
+                    for k in 0..4 {
+                        let gkr_row_sum = main_rows[k]
+                            .iter()
+                            .copied()
+                            .chain(preprocessed_rows[k].iter().copied())
+                            .zip(gkr_powers.iter().copied())
+                            .map(|(val, power)| power * val)
+                            .sum::<EF>();
+                        gkr_sums[k] += gkr_row_sum * *eq;
+                    }
+
+                    // The constraint polynomial at the non-boolean nodes.
+                    for t in 0..12 {
+                        let mut folder = ConstraintSumcheckFolder {
+                            preprocessed: RowMajorMatrixView::new_row(&preprocessed_node_rows[t]),
+                            main: RowMajorMatrixView::new_row(&main_node_rows[t]),
+                            accumulator: EF::zero(),
+                            public_values: &public_values,
+                            constraint_index: 0,
+                            powers_of_alpha: &powers_of_alpha,
+                        };
+                        air.eval(&mut folder);
+                        constraint_sums[t] += folder.accumulator * *eq;
+                    }
+                }
+                (constraint_sums, gkr_sums)
+            })
+            .collect::<Vec<_>>();
+
+        cumul_sums.into_iter().fold(
+            ([EF::zero(); 12], [EF::zero(); 4]),
+            |(mut constraint_acc, mut gkr_acc), (constraint_sums, gkr_sums)| {
+                for (acc, sum) in constraint_acc.iter_mut().zip(constraint_sums) {
+                    *acc += sum;
+                }
+                for (acc, sum) in gkr_acc.iter_mut().zip(gkr_sums) {
+                    *acc += sum;
+                }
+                (constraint_acc, gkr_acc)
+            },
+        )
+    }
+}
+
+/// This function calculates the column values of a quadruple of rows at the 12 non-boolean grid
+/// nodes of the last two variables, in the order of [`super::ZEROCHECK_CONSTRAINT_NODES`].
+///
+/// `rows[2x + y]` is the row at the boolean point `(x, y)` where `x` is the second-to-last
+/// variable. Since the grid coordinates `{0, 1, 2, 4}` and their pairwise products are all powers
+/// of two, the interpolation only requires additions and doublings.
+fn interpolate_last_two_vars_rows<K: Field>(rows: &[&[K]; 4], node_rows: &mut [Vec<K>]) {
+    debug_assert_eq!(node_rows.len(), 12);
+    let [row_00, row_01, row_10, row_11] = rows;
+    for (i, (((a, r01), r10), r11)) in
+        row_00.iter().zip_eq(row_01.iter()).zip_eq(row_10.iter()).zip_eq(row_11.iter()).enumerate()
+    {
+        let a = *a;
+        let dy = *r01 - a;
+        let dx = *r10 - a;
+        let dxy = *r11 - *r10 - *r01 + a;
+
+        let dy2 = dy.double();
+        let dy4 = dy2.double();
+        let dx2 = dx.double();
+        let dx4 = dx2.double();
+        let dxy2 = dxy.double();
+        let dxy4 = dxy2.double();
+        let dxy8 = dxy4.double();
+        let dxy16 = dxy8.double();
+
+        node_rows[0][i] = a + dy2; // (0, 2)
+        node_rows[1][i] = a + dy4; // (0, 4)
+        node_rows[2][i] = a + dx + dy2 + dxy2; // (1, 2)
+        node_rows[3][i] = a + dx + dy4 + dxy4; // (1, 4)
+        node_rows[4][i] = a + dx2; // (2, 0)
+        node_rows[5][i] = a + dx2 + dy + dxy2; // (2, 1)
+        node_rows[6][i] = a + dx2 + dy2 + dxy4; // (2, 2)
+        node_rows[7][i] = a + dx2 + dy4 + dxy8; // (2, 4)
+        node_rows[8][i] = a + dx4; // (4, 0)
+        node_rows[9][i] = a + dx4 + dy + dxy4; // (4, 1)
+        node_rows[10][i] = a + dx4 + dy2 + dxy8; // (4, 2)
+        node_rows[11][i] = a + dx4 + dy4 + dxy16; // (4, 4)
+    }
+}
+
 /// This function will calculate the univariate polynomial where all variables other than the last
 /// are summed on the boolean hypercube and the last variable is left as a free variable.
 /// TODO:  Add flexibility to support degree 2 and degree 3 constraint polynomials.

--- a/crates/verifier/guest-verify-programs/Cargo.lock
+++ b/crates/verifier/guest-verify-programs/Cargo.lock
@@ -14,57 +14,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "addr2line"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
-name = "aho-corasick"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,22 +30,6 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "backtrace"
-version = "0.3.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "serde",
- "windows-link",
-]
 
 [[package]]
 name = "base16ct"
@@ -239,62 +172,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
-name = "crossbeam"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -323,27 +200,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "deepsize2"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b5184084af9beed35eecbf4c36baf6e26b9dc47b61b74e02f930c72a58e71b"
-dependencies = [
- "deepsize_derive2",
- "hashbrown",
-]
-
-[[package]]
-name = "deepsize_derive2"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f8817865cacf3b93b943ca06b0fc5fd8e99eabfdb7ea5d296efcbc4afc4f69"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,17 +207,6 @@ checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
  "zeroize",
-]
-
-[[package]]
-name = "derive-where"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -393,7 +238,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -574,12 +419,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d758ba1b47b00caf47f24925c0074ecb20d6dfcffe7f6d53395c0465674841a"
 
 [[package]]
-name = "gen_ops"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "304de19db7028420975a296ab0fcbbc8e69438c4ed254a1e41e2a7f37d5f0e0a"
-
-[[package]]
 name = "generic-array"
 version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -614,12 +453,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
-
-[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -637,29 +470,6 @@ dependencies = [
  "sp1-verifier",
  "sp1-zkvm",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
- "serde",
-]
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -740,43 +550,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b23ac50abb8261cb38c6e2a7192d3302e0836dac1628f6a93b82b4fad185897"
 
 [[package]]
-name = "log"
-version = "0.4.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
-
-[[package]]
-name = "matchers"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
-dependencies = [
- "regex-automata",
-]
-
-[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
-]
-
-[[package]]
-name = "nu-ansi-term"
-version = "0.50.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
-dependencies = [
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "num-bigint"
@@ -818,25 +595,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
-name = "object"
-version = "0.37.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -847,34 +605,6 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "p3-air"
-version = "0.4.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3a5de20a2301bf2530de1ceb13768ec3a80f729fbf8b72f813e30bc54c5bce2"
-dependencies = [
- "p3-field",
- "p3-matrix",
- "serde",
-]
-
-[[package]]
-name = "p3-baby-bear"
-version = "0.4.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d69e6e9af4eaaaa60f7bb9f0e0f73ebcbaefe7e00974d97ad0fa542d6a4f0890"
-dependencies = [
- "cfg-if",
- "num-bigint 0.4.6",
- "p3-field",
- "p3-mds",
- "p3-poseidon2",
- "p3-symmetric",
- "rand",
- "rustc_version",
- "serde",
-]
 
 [[package]]
 name = "p3-bn254-fr"
@@ -906,20 +636,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "p3-commit"
-version = "0.4.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50acacc7219fce6c01db938f82c1b21b5e7133990b7fff861f91534aeb569419"
-dependencies = [
- "itertools 0.12.1",
- "p3-challenger",
- "p3-field",
- "p3-matrix",
- "p3-util",
- "serde",
-]
-
-[[package]]
 name = "p3-dft"
 version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -944,36 +660,6 @@ dependencies = [
  "p3-util",
  "rand",
  "serde",
-]
-
-[[package]]
-name = "p3-fri"
-version = "0.4.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cbc4965ee488f3247867b7ec4bb005b8afa72cb0d461a4dcb1387ecab6426d5"
-dependencies = [
- "itertools 0.12.1",
- "p3-challenger",
- "p3-commit",
- "p3-dft",
- "p3-field",
- "p3-interpolation",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-util",
- "serde",
- "tracing",
-]
-
-[[package]]
-name = "p3-interpolation"
-version = "0.4.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ad7e9f08c336d7ea39d12e11951188473542565323bac2a6535e536b58487d"
-dependencies = [
- "p3-field",
- "p3-matrix",
- "p3-util",
 ]
 
 [[package]]
@@ -1013,9 +699,6 @@ name = "p3-maybe-rayon"
 version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0641952b42da45e1dfa2d4a2a3163e330f944ad9740942f35026c0a71a605f1"
-dependencies = [
- "rayon",
-]
 
 [[package]]
 name = "p3-mds"
@@ -1030,23 +713,6 @@ dependencies = [
  "p3-symmetric",
  "p3-util",
  "rand",
-]
-
-[[package]]
-name = "p3-merkle-tree"
-version = "0.4.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5703d9229d52a8c09970e4d722c3a8b4d37e688c306c3a1c03b872efcd204e6"
-dependencies = [
- "itertools 0.12.1",
- "p3-commit",
- "p3-field",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-symmetric",
- "p3-util",
- "serde",
- "tracing",
 ]
 
 [[package]]
@@ -1075,51 +741,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "p3-uni-stark"
-version = "0.4.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc3dfdeba14d8db621c4e52dd63973384ff35f353fd750154ff88397f4ea5adf"
-dependencies = [
- "itertools 0.12.1",
- "p3-air",
- "p3-challenger",
- "p3-commit",
- "p3-dft",
- "p3-field",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-util",
- "serde",
- "tracing",
-]
-
-[[package]]
 name = "p3-util"
 version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cff962f8eaa5f36e0447cee7c241f6b4b475fadf3ee61f154327a26bb4e009ba"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "pin-project"
-version = "1.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -1198,47 +825,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "range-set-blaze"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8421b5d459262eabbe49048d362897ff3e3830b44eac6cfe341d6acb2f0f13d2"
-dependencies = [
- "gen_ops",
- "itertools 0.12.1",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "rayon"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "rayon-scan"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f87cc11a0140b4b0da0ffc889885760c61b13672d80a908920b2c0df078fa14"
-dependencies = [
- "rayon",
-]
-
-[[package]]
 name = "redox_users"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1248,23 +834,6 @@ dependencies = [
  "libredox",
  "thiserror 1.0.69",
 ]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rlsf"
@@ -1278,12 +847,6 @@ dependencies = [
  "rustversion",
  "svgbobdoc",
 ]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hex"
@@ -1367,15 +930,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sharded-slab"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
-dependencies = [
- "lazy_static",
-]
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1388,87 +942,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
-name = "slop-air"
-version = "6.3.1"
-dependencies = [
- "p3-air",
-]
-
-[[package]]
 name = "slop-algebra"
 version = "6.3.1"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
  "serde",
-]
-
-[[package]]
-name = "slop-alloc"
-version = "6.3.1"
-dependencies = [
- "serde",
- "slop-algebra",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "slop-baby-bear"
-version = "6.3.1"
-dependencies = [
- "lazy_static",
- "p3-baby-bear",
- "serde",
- "slop-algebra",
- "slop-challenger",
- "slop-poseidon2",
- "slop-symmetric",
-]
-
-[[package]]
-name = "slop-basefold"
-version = "6.3.1"
-dependencies = [
- "derive-where",
- "itertools 0.14.0",
- "serde",
- "slop-algebra",
- "slop-alloc",
- "slop-baby-bear",
- "slop-bn254",
- "slop-challenger",
- "slop-koala-bear",
- "slop-merkle-tree",
- "slop-multilinear",
- "slop-primitives",
- "slop-tensor",
- "slop-utils",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "slop-basefold-prover"
-version = "6.3.1"
-dependencies = [
- "derive-where",
- "itertools 0.14.0",
- "rand",
- "serde",
- "slop-algebra",
- "slop-alloc",
- "slop-baby-bear",
- "slop-basefold",
- "slop-bn254",
- "slop-challenger",
- "slop-commit",
- "slop-dft",
- "slop-fri",
- "slop-futures",
- "slop-koala-bear",
- "slop-merkle-tree",
- "slop-multilinear",
- "slop-tensor",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1496,79 +975,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "slop-commit"
-version = "6.3.1"
-dependencies = [
- "p3-commit",
- "serde",
- "slop-alloc",
-]
-
-[[package]]
-name = "slop-dft"
-version = "6.3.1"
-dependencies = [
- "p3-dft",
- "serde",
- "slop-algebra",
- "slop-alloc",
- "slop-matrix",
- "slop-tensor",
-]
-
-[[package]]
-name = "slop-fri"
-version = "6.3.1"
-dependencies = [
- "p3-fri",
-]
-
-[[package]]
-name = "slop-futures"
-version = "6.3.1"
-dependencies = [
- "crossbeam",
- "futures",
- "pin-project",
- "rayon",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "slop-jagged"
-version = "6.3.1"
-dependencies = [
- "derive-where",
- "futures",
- "itertools 0.14.0",
- "num_cpus",
- "rand",
- "rayon",
- "serde",
- "slop-algebra",
- "slop-alloc",
- "slop-baby-bear",
- "slop-basefold",
- "slop-basefold-prover",
- "slop-bn254",
- "slop-challenger",
- "slop-commit",
- "slop-futures",
- "slop-koala-bear",
- "slop-merkle-tree",
- "slop-multilinear",
- "slop-stacked",
- "slop-sumcheck",
- "slop-symmetric",
- "slop-tensor",
- "slop-utils",
- "thiserror 1.0.69",
- "tracing",
-]
-
-[[package]]
 name = "slop-koala-bear"
 version = "6.3.1"
 dependencies = [
@@ -1579,63 +985,6 @@ dependencies = [
  "slop-challenger",
  "slop-poseidon2",
  "slop-symmetric",
-]
-
-[[package]]
-name = "slop-matrix"
-version = "6.3.1"
-dependencies = [
- "p3-matrix",
-]
-
-[[package]]
-name = "slop-maybe-rayon"
-version = "6.3.1"
-dependencies = [
- "p3-maybe-rayon",
-]
-
-[[package]]
-name = "slop-merkle-tree"
-version = "6.3.1"
-dependencies = [
- "derive-where",
- "itertools 0.14.0",
- "p3-merkle-tree",
- "serde",
- "slop-algebra",
- "slop-alloc",
- "slop-baby-bear",
- "slop-bn254",
- "slop-challenger",
- "slop-commit",
- "slop-futures",
- "slop-koala-bear",
- "slop-matrix",
- "slop-poseidon2",
- "slop-symmetric",
- "slop-tensor",
- "slop-utils",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "slop-multilinear"
-version = "6.3.1"
-dependencies = [
- "derive-where",
- "futures",
- "num_cpus",
- "rand",
- "rayon",
- "serde",
- "slop-algebra",
- "slop-alloc",
- "slop-challenger",
- "slop-commit",
- "slop-futures",
- "slop-matrix",
- "slop-tensor",
 ]
 
 [[package]]
@@ -1653,174 +1002,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "slop-stacked"
-version = "6.3.1"
-dependencies = [
- "derive-where",
- "futures",
- "itertools 0.14.0",
- "serde",
- "slop-algebra",
- "slop-alloc",
- "slop-basefold",
- "slop-basefold-prover",
- "slop-challenger",
- "slop-commit",
- "slop-futures",
- "slop-merkle-tree",
- "slop-multilinear",
- "slop-tensor",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "slop-sumcheck"
-version = "6.3.1"
-dependencies = [
- "futures",
- "itertools 0.14.0",
- "rayon",
- "serde",
- "slop-algebra",
- "slop-alloc",
- "slop-baby-bear",
- "slop-challenger",
- "slop-multilinear",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "slop-symmetric"
 version = "6.3.1"
 dependencies = [
  "p3-symmetric",
-]
-
-[[package]]
-name = "slop-tensor"
-version = "6.3.1"
-dependencies = [
- "arrayvec",
- "derive-where",
- "itertools 0.14.0",
- "rand",
- "rayon",
- "serde",
- "slop-algebra",
- "slop-alloc",
- "slop-futures",
- "slop-matrix",
- "thiserror 1.0.69",
- "transpose",
-]
-
-[[package]]
-name = "slop-uni-stark"
-version = "6.3.1"
-dependencies = [
- "p3-uni-stark",
-]
-
-[[package]]
-name = "slop-utils"
-version = "6.3.1"
-dependencies = [
- "p3-util",
- "tracing-forest",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "slop-whir"
-version = "6.3.1"
-dependencies = [
- "derive-where",
- "futures",
- "itertools 0.14.0",
- "rand",
- "rayon",
- "serde",
- "slop-algebra",
- "slop-alloc",
- "slop-baby-bear",
- "slop-basefold",
- "slop-challenger",
- "slop-commit",
- "slop-dft",
- "slop-jagged",
- "slop-koala-bear",
- "slop-matrix",
- "slop-merkle-tree",
- "slop-multilinear",
- "slop-stacked",
- "slop-tensor",
- "slop-utils",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "smallvec"
-version = "1.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "sp1-derive"
-version = "6.3.1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "sp1-hypercube"
-version = "6.3.1"
-dependencies = [
- "arrayref",
- "deepsize2",
- "derive-where",
- "futures",
- "hashbrown",
- "itertools 0.14.0",
- "num-bigint 0.4.6",
- "num-traits",
- "num_cpus",
- "rayon",
- "rayon-scan",
- "serde",
- "slop-air",
- "slop-algebra",
- "slop-alloc",
- "slop-basefold",
- "slop-basefold-prover",
- "slop-bn254",
- "slop-challenger",
- "slop-commit",
- "slop-futures",
- "slop-jagged",
- "slop-koala-bear",
- "slop-matrix",
- "slop-merkle-tree",
- "slop-multilinear",
- "slop-poseidon2",
- "slop-stacked",
- "slop-sumcheck",
- "slop-symmetric",
- "slop-tensor",
- "slop-uni-stark",
- "slop-whir",
- "sp1-derive",
- "sp1-primitives",
- "struct-reflection",
- "strum",
- "thiserror 1.0.69",
- "thousands",
- "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -1856,68 +1041,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp1-recursion-executor"
-version = "6.3.1"
-dependencies = [
- "backtrace",
- "cfg-if",
- "hashbrown",
- "itertools 0.14.0",
- "range-set-blaze",
- "serde",
- "slop-algebra",
- "slop-maybe-rayon",
- "slop-poseidon2",
- "slop-symmetric",
- "smallvec",
- "sp1-derive",
- "sp1-hypercube",
- "static_assertions",
- "thiserror 1.0.69",
- "tracing",
-]
-
-[[package]]
-name = "sp1-recursion-machine"
-version = "6.3.1"
-dependencies = [
- "itertools 0.14.0",
- "rand",
- "slop-air",
- "slop-algebra",
- "slop-basefold",
- "slop-matrix",
- "slop-maybe-rayon",
- "slop-symmetric",
- "sp1-derive",
- "sp1-hypercube",
- "sp1-primitives",
- "sp1-recursion-executor",
- "strum",
- "tracing",
-]
-
-[[package]]
 name = "sp1-verifier"
 version = "6.3.1"
 dependencies = [
- "bincode",
  "blake3",
  "cfg-if",
  "dirs",
  "hex",
  "lazy_static",
- "serde",
  "sha2",
- "slop-algebra",
- "slop-challenger",
- "slop-primitives",
- "slop-symmetric",
- "sp1-hypercube",
- "sp1-primitives",
- "sp1-recursion-executor",
- "sp1-recursion-machine",
- "strum",
  "substrate-bn-succinct-rs",
  "thiserror 2.0.18",
 ]
@@ -1945,59 +1077,6 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "strength_reduce"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
-
-[[package]]
-name = "struct-reflection"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "701b671d1ad68e250e05718f95dae3014a17f4e69cbe51842531c30495ff3301"
-dependencies = [
- "struct-reflection-derive",
-]
-
-[[package]]
-name = "struct-reflection-derive"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ab74230a0592602e361bd63c645413fa8cbe4500d10274e849179e5c72548f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "strum"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
-dependencies = [
- "strum_macros",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "substrate-bn-succinct-rs"
@@ -2103,30 +1182,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thousands"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
-
-[[package]]
-name = "thread_local"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "tokio"
-version = "1.52.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
-dependencies = [
- "pin-project-lite",
-]
-
-[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2155,59 +1210,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-forest"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee40835db14ddd1e3ba414292272eddde9dad04d3d4b65509656414d1c42592f"
-dependencies = [
- "ansi_term",
- "smallvec",
- "thiserror 1.0.69",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
-dependencies = [
- "matchers",
- "nu-ansi-term",
- "once_cell",
- "regex-automata",
- "sharded-slab",
- "smallvec",
- "thread_local",
- "tracing",
- "tracing-core",
- "tracing-log",
-]
-
-[[package]]
-name = "transpose"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
-dependencies = [
- "num-integer",
- "strength_reduce",
 ]
 
 [[package]]
@@ -2227,12 +1229,6 @@ name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
-
-[[package]]
-name = "valuable"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"
@@ -2256,49 +1252,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-link"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
 name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
-dependencies = [
- "windows-link",
 ]
 
 [[package]]

--- a/slop/crates/sumcheck/src/backend.rs
+++ b/slop/crates/sumcheck/src/backend.rs
@@ -28,7 +28,7 @@ where
 /// A trait to enable backend implementations of sumcheck polynomials for the first round.
 ///
 /// An implementation of this trait for a type will imply a [crate::SumcheckPolyFirstRound]
-/// implementation for that type.
+/// implementation for that type. See that trait for the meaning of the lookahead depth `t`.
 pub trait SumCheckPolyFirstRoundBackend<P, K>: Backend
 where
     K: Field,

--- a/slop/crates/sumcheck/src/poly.rs
+++ b/slop/crates/sumcheck/src/poly.rs
@@ -9,11 +9,26 @@ pub trait ComponentPoly<K: Field> {
     fn get_component_poly_evals(&self) -> Vec<K>;
 }
 
-/// The fix_first_variable function applied to a sumcheck's first round's polynomial.
+/// A sumcheck polynomial that can prove the first rounds of a sumcheck, typically holding data
+/// in a smaller field than `K`.
+///
+/// The parameter `t` is a lookahead depth: an implementation supporting `t > 1` computes the
+/// messages of the first `t` rounds together in
+/// [`Self::sum_as_poly_in_last_t_variables`], typically from a single pass over its data. The
+/// transcript is unaffected by `t` — the prover still sends one message and samples one
+/// challenge per variable.
 pub trait SumcheckPolyFirstRound<K: Field>: SumcheckPolyBase {
     type NextRoundPoly: SumcheckPoly<K>;
+
+    /// Fixes the last variable to `alpha`, producing the polynomial used from the second round
+    /// onwards. `t` must match the value passed to [`Self::sum_as_poly_in_last_t_variables`], so
+    /// that the prepared messages of rounds `2..=t` can be carried over to the next-round
+    /// polynomial.
     fn fix_t_variables(self, alpha: K, t: usize) -> Self::NextRoundPoly;
 
+    /// The first round message: the univariate polynomial obtained by summing all variables but
+    /// the last over the boolean hypercube. With `t > 1`, the implementation also prepares the
+    /// messages of rounds `2..=t` from the same pass over the data.
     fn sum_as_poly_in_last_t_variables(
         &self,
         claim: Option<K>,

--- a/slop/crates/sumcheck/src/prover.rs
+++ b/slop/crates/sumcheck/src/prover.rs
@@ -8,6 +8,11 @@ use crate::{ComponentPoly, PartialSumcheckProof, SumcheckPoly, SumcheckPolyFirst
 /// Proves a sumcheck for any sumcheckable polynomial, by reducing it to a claim about the
 /// evaluation of the polynomial at a point.
 ///
+/// `t` is the lookahead depth of the first round (see [`SumcheckPolyFirstRound`]): the messages
+/// of the first `t` rounds are computed together by the first-round polynomials, typically from
+/// a single pass over their data. The transcript is independent of `t` — one message is sent and
+/// one challenge is sampled per variable.
+///
 ///  # Panics
 ///  Will panic if the polynomial has zero variables.
 pub fn reduce_sumcheck_to_evaluation<
@@ -29,8 +34,8 @@ pub fn reduce_sumcheck_to_evaluation<
     // Check that all the polynomials have the same number of variables.
     assert!(polys.iter().all(|poly| poly.num_variables() == num_variables));
 
-    // The first round will process the first t variables, so we need to ensure that there are at
-    // least t variables.
+    // The first-round polynomials compute the first t round messages together, so we need to
+    // ensure that there are at least t variables.
     assert!(num_variables >= t as u32);
 
     // The point at which the reduced sumcheck proof should be evaluated.
@@ -57,7 +62,7 @@ pub fn reduce_sumcheck_to_evaluation<
     let mut polys_cursor: Vec<_> =
         polys.into_iter().map(|poly| poly.fix_t_variables(alpha, t)).collect();
     // The multi-variate polynomial used at the start of each sumcheck round.
-    for _ in t..num_variables as usize {
+    for _ in 1..num_variables as usize {
         // Get the round claims from the last round's univariate poly messages.
         let round_claims = uni_polys.iter().map(|poly| poly.eval_at_point(*point.first().unwrap()));
 

--- a/sp1-gpu/crates/sys/build.rs
+++ b/sp1-gpu/crates/sys/build.rs
@@ -230,7 +230,11 @@ fn main() {
     println!("cargo:rustc-link-search=native={}/lib", dst.display());
     println!("cargo:rustc-link-lib=static=sys-cuda");
 
-    // Add CUDA library search paths
+    // Add CUDA library search paths. Track the env var so switching
+    // `CUDA_PATH` re-emits the link-search lines — otherwise a stale cached
+    // path (e.g. `/usr/local/cuda` pointing at a newer toolkit than nvcc)
+    // fails to link with undefined cudart symbols.
+    println!("cargo:rerun-if-env-changed=CUDA_PATH");
     if let Ok(cuda_path) = env::var("CUDA_PATH") {
         println!("cargo:rustc-link-search=native={cuda_path}/lib64");
         println!("cargo:rustc-link-search=native={cuda_path}/lib");

--- a/sp1-gpu/crates/sys/include/tracegen/jagged_tracegen/jagged.cuh
+++ b/sp1-gpu/crates/sys/include/tracegen/jagged_tracegen/jagged.cuh
@@ -89,6 +89,67 @@ struct JaggedMle {
         return restrictedIndex;
     }
 
+    // Folds the last TWO variables in one pass: `q` enumerates input
+    // QUADRUPLES (pairs 2q, 2q+1; elements 4q .. 4q+3), each producing one
+    // output element — exactly the composition of two `fixLastVariableTwoPadding`
+    // folds, without materializing the intermediate.
+    //
+    // Requires every column's pair-height to be EVEN (equivalently, element
+    // heights ≡ 0 mod 4 — the invariant the jagged trace layout maintains).
+    // Then no quadruple straddles a column boundary, the first fold needs no
+    // padding at all, and the second fold's out-of-range inputs are the
+    // intermediate's zero pads, so the output for `j ≥ h/2` is exactly zero.
+    // The last quadruple of each column writes the trailing zero pads for the
+    // region `[h/2, 2·hp2)` (hp2 = the twice-folded pair height, matching the
+    // `h.div_ceil(4)*2` metadata recurrence applied twice) and the output
+    // colIndex entries the padded pairs need.
+    __forceinline__ __device__ void fixLastTwoVariablesTwoPadding(
+        JaggedMle<OutputDenseData>& output, size_t q, ext_t alpha_1, ext_t alpha_2) const {
+        size_t pairIdx = q << 1;
+        size_t colIdx = this->colIndex[pairIdx];
+        size_t startIdx = this->startIndices[colIdx];
+        size_t interactionHeight = this->startIndices[colIdx + 1] - startIdx;
+
+        // Fail loudly if the even-pair-height invariant is broken — the quad
+        // enumeration below would silently mix columns otherwise.
+        if (interactionHeight & 1) {
+            __trap();
+        }
+
+        size_t pairRow = pairIdx - startIdx;
+        size_t quadRow = pairRow >> 1;
+
+        size_t outStartElems = output.startIndices[colIdx] << 1;
+        size_t restrictedIndex = outStartElems + quadRow;
+        this->denseData.fixLastTwoVariables(
+            output.denseData, restrictedIndex, pairIdx << 1, alpha_1, alpha_2);
+
+        // Mirrors the single fold's rule: the writer completing an output
+        // pair records its column. `outStartElems` is even, so the parity of
+        // `restrictedIndex` is the parity of `quadRow`.
+        if (quadRow & 1) {
+            output.colIndex[restrictedIndex >> 1] = colIdx;
+        }
+
+        // The last quadruple writes the zero tail: the second fold's outputs
+        // over the intermediate's pads (j in [h/2, hp1)) plus the second
+        // fold's own pads (j in [hp1, 2·hp2)), and the colIndex entries for
+        // every output pair the tail completes.
+        size_t realQuads = interactionHeight >> 1;
+        bool isLast = quadRow == realQuads - 1;
+        if (isLast) {
+            size_t hp1 = ((interactionHeight + 3) >> 2) << 1;
+            size_t hp2 = ((hp1 + 3) >> 2) << 1;
+            size_t totalElems = hp2 << 1;
+            for (size_t t = realQuads; t < totalElems; t++) {
+                this->denseData.pad(output.denseData, outStartElems + t);
+                if ((outStartElems + t) & 1) {
+                    output.colIndex[(outStartElems + t) >> 1] = colIdx;
+                }
+            }
+        }
+    }
+
     __forceinline__ __device__ size_t
     fixLastVariableTwoPaddingInfo(JaggedMle<OutputDenseData>& output, size_t i) const {
         size_t colIdx = this->colIndex[i];

--- a/sp1-gpu/crates/sys/include/zerocheck/aggregate.cuh
+++ b/sp1-gpu/crates/sys/include/zerocheck/aggregate.cuh
@@ -20,3 +20,8 @@
 // Reduces `total_slots / 3` block triples in `partials` into `totals[0..3]`.
 // `total_slots` must be a multiple of 3.
 extern "C" void* zerocheck_aggregate_partials_kernel();
+
+// Strided variant for the fused first-two-rounds partials buffers: reduces
+// `total_slots / stride` groups of `stride` slots into `totals[0..stride]`.
+// Launched with gridDim.x == stride; `total_slots` must be a multiple of it.
+extern "C" void* zerocheck_aggregate_partials_strided_kernel();

--- a/sp1-gpu/crates/sys/include/zerocheck/bivariate.cuh
+++ b/sp1-gpu/crates/sys/include/zerocheck/bivariate.cuh
@@ -1,0 +1,91 @@
+// Shared helpers for the fused first-two-rounds ("bivariate") zerocheck.
+//
+// The first two sumcheck rounds are proven from a single pass over the
+// base-field trace: the round polynomial is evaluated as a *bivariate* in the
+// last two variables `(X, Y)` on the grid `{0, 1, 2, 4}^2`. Rows are consumed
+// in quadruples (element index `4·quad + 2·X + Y`); the four boolean nodes
+// `X, Y ∈ {0, 1}` need no constraint evaluation (constraints vanish on real
+// rows and the padded-row values cancel exactly against the geq correction),
+// leaving the 12 non-boolean nodes below.
+//
+// The node order MUST match `sp1_hypercube::prover::ZEROCHECK_CONSTRAINT_NODES`
+// (with `ZEROCHECK_NODE_XS = [0, 1, 2, 4]`), which the host uses to assemble
+// the grid and interpolate the two round messages.
+
+#pragma once
+
+#include "config.cuh"
+#include <cstdint>
+
+// Number of non-boolean grid nodes evaluated by the constraint kernels; also
+// the output stride of every bivariate partials buffer.
+constexpr int BIVARIATE_NUM_NODES = 12;
+
+// Number of boolean corner nodes swept by the GKR corner kernel.
+constexpr int BIVARIATE_NUM_CORNERS = 4;
+
+// The `(x, y, x·y)` coordinates of node `e`. All coordinates are powers of
+// two (or zero/one), so interpolation multiplies reduce to doublings.
+struct BivariateNode {
+    uint32_t cx;
+    uint32_t cy;
+    uint32_t cxy;
+};
+
+// Node table — must match ZEROCHECK_CONSTRAINT_NODES:
+//   [(0,2),(0,4),(1,2),(1,4),(2,0),(2,1),(2,2),(2,4),(4,0),(4,1),(4,2),(4,4)]
+// `e` is uniform per block (blockIdx.z), so the switch never diverges.
+__device__ __forceinline__ BivariateNode bivariate_node(int e) {
+    switch (e) {
+    case 0:  return {0u, 2u, 0u};
+    case 1:  return {0u, 4u, 0u};
+    case 2:  return {1u, 2u, 2u};
+    case 3:  return {1u, 4u, 4u};
+    case 4:  return {2u, 0u, 0u};
+    case 5:  return {2u, 1u, 2u};
+    case 6:  return {2u, 2u, 4u};
+    case 7:  return {2u, 4u, 8u};
+    case 8:  return {4u, 0u, 0u};
+    case 9:  return {4u, 1u, 4u};
+    case 10: return {4u, 2u, 8u};
+    default: return {4u, 4u, 16u};
+    }
+}
+
+// `v * c` for `c ∈ {0, 1, 2, 4, 8, 16}` via doublings. `c` is uniform per
+// block (derived from blockIdx.z), so the switch costs nothing.
+template <typename K>
+__device__ __forceinline__ K mul_small_pow2(K v, uint32_t c) {
+    switch (c) {
+    case 0: return K::zero();
+    case 1: return v;
+    case 2: return v + v;
+    case 4: {
+        K d = v + v;
+        return d + d;
+    }
+    case 8: {
+        K d = v + v;
+        d = d + d;
+        return d + d;
+    }
+    default: {  // 16
+        K d = v + v;
+        d = d + d;
+        d = d + d;
+        return d + d;
+    }
+    }
+}
+
+// Bilinear interpolation of a quadruple's corner values at node `nd`:
+//   value = r00 + x·(r10 − r00) + y·(r01 − r00) + x·y·(r11 − r10 − r01 + r00)
+// where `r[2x + y]` is the value at boolean point `(x, y)`.
+template <typename K>
+__device__ __forceinline__ K bivariate_interp(K r00, K r01, K r10, K r11, BivariateNode nd) {
+    K dy = r01 - r00;
+    K dx = r10 - r00;
+    K dxy = (r11 - r10) - dy;
+    return r00 + mul_small_pow2(dx, nd.cx) + mul_small_pow2(dy, nd.cy)
+        + mul_small_pow2(dxy, nd.cxy);
+}

--- a/sp1-gpu/crates/sys/include/zerocheck/bivariate.cuh
+++ b/sp1-gpu/crates/sys/include/zerocheck/bivariate.cuh
@@ -89,3 +89,30 @@ __device__ __forceinline__ K bivariate_interp(K r00, K r01, K r10, K r11, Bivari
     return r00 + mul_small_pow2(dx, nd.cx) + mul_small_pow2(dy, nd.cy)
         + mul_small_pow2(dxy, nd.cxy);
 }
+
+// Load one column's row quadruple `4·quad .. 4·quad + 3` and bilinearly
+// interpolate it at grid node `nd`. `full_quad` guards rows 2 and 3, which
+// can be missing from a chip's last quadruple (heights are even but not
+// necessarily multiples of four); the missing rows are zero, matching the
+// virtual zero padding of the trace MLE — an unguarded load would land in
+// the next column's data.
+//
+// The column-stride math is 64-bit: with u32 × u32 the product wraps for
+// chips approaching `2^32 / height` columns. See review #6.
+template <typename K>
+__device__ __forceinline__ K interp_load_quad(
+    const K* trace_data, size_t base, uint32_t col, uint32_t height,
+    uint32_t quad_idx, bool full_quad, BivariateNode nd)
+{
+    const size_t col_off = (size_t)col * (size_t)height;
+    const size_t quad_base = base + col_off + ((size_t)quad_idx << 2);
+    K r00 = K::load(trace_data, quad_base);
+    K r01 = K::load(trace_data, quad_base + 1);
+    K r10 = K::zero();
+    K r11 = K::zero();
+    if (full_quad) {
+        r10 = K::load(trace_data, quad_base + 2);
+        r11 = K::load(trace_data, quad_base + 3);
+    }
+    return bivariate_interp(r00, r01, r10, r11, nd);
+}

--- a/sp1-gpu/crates/sys/include/zerocheck/geq_corrections.cuh
+++ b/sp1-gpu/crates/sys/include/zerocheck/geq_corrections.cuh
@@ -45,3 +45,7 @@ extern "C" void* zerocheck_fix_geq_state_kernel();
 
 // Per-chip geq corrections kernel. See file banner for the I/O contract.
 extern "C" void* zerocheck_geq_corrections_kernel();
+
+// Bivariate variant for the fused first-two-rounds: 12 partials per geq chip,
+// one per non-boolean grid node. See zerocheck/bivariate.cuh for node order.
+extern "C" void* zerocheck_geq_corrections_bivariate_kernel();

--- a/sp1-gpu/crates/sys/include/zerocheck/gkr_sweep.cuh
+++ b/sp1-gpu/crates/sys/include/zerocheck/gkr_sweep.cuh
@@ -43,3 +43,8 @@ constexpr int GKR_SWEEP_WARPS_PER_BLOCK = GKR_SWEEP_BLOCK_SIZE / 32;
 
 extern "C" void* zerocheck_gkr_sweep_kb_kernel();
 extern "C" void* zerocheck_gkr_sweep_ext_kernel();
+
+// Corner sweep for the fused first-two-rounds: the GKR opening batch at the
+// four boolean grid corners (raw rows `4·quad + c`, no interpolation).
+// Round 0 only — base-field trace. Output stride 4.
+extern "C" void* zerocheck_gkr_corner_sweep_kb_kernel();

--- a/sp1-gpu/crates/sys/include/zerocheck/jagged_mle.cuh
+++ b/sp1-gpu/crates/sys/include/zerocheck/jagged_mle.cuh
@@ -29,6 +29,29 @@ struct DenseBuffer {
         ext_t::store(other.data, restrictedIdx, ext_t::zero());
     }
 
+    /// The composition of two `fixLastVariable` folds on one quadruple:
+    ///   out1[k] = in[2k]  + alpha_1 · (in[2k+1] − in[2k])
+    ///   out2[j] = out1[2j] + alpha_2 · (out1[2j+1] − out1[2j])
+    /// evaluated on elements `baseIdx .. baseIdx+3`, without materializing
+    /// the intermediate.
+    __forceinline__ __device__ void fixLastTwoVariables(
+        DenseBuffer<ext_t>& other,
+        size_t restrictedIdx,
+        size_t baseIdx,
+        ext_t alpha_1,
+        ext_t alpha_2) const {
+
+        F v0 = F::load(data, baseIdx);
+        F v1 = F::load(data, baseIdx + 1);
+        F v2 = F::load(data, baseIdx + 2);
+        F v3 = F::load(data, baseIdx + 3);
+
+        ext_t lo = alpha_1 * (v1 - v0) + v0;
+        ext_t hi = alpha_1 * (v3 - v2) + v2;
+        ext_t result = alpha_2 * (hi - lo) + lo;
+        ext_t::store(other.data, restrictedIdx, result);
+    }
+
     __forceinline__ __device__ ext_t evaluate(uint32_t index, ext_t coef) const {
         return coef * data[index];
     }
@@ -59,6 +82,7 @@ struct InfoBuffer {
 extern "C" void* initialize_jagged_info();
 extern "C" void* fix_last_variable_jagged_felt();
 extern "C" void* fix_last_variable_jagged_ext();
+extern "C" void* fix_last_two_variables_jagged_felt();
 extern "C" void* fix_last_variable_jagged_info();
 extern "C" void* jagged_eval_kernel_chunked_felt();
 extern "C" void* jagged_eval_kernel_chunked_ext();

--- a/sp1-gpu/crates/sys/include/zerocheck/sequential.cuh
+++ b/sp1-gpu/crates/sys/include/zerocheck/sequential.cuh
@@ -91,6 +91,32 @@ struct BlockDispatch {
     uint32_t n_rows;                   // 4
 };
 
+// Load one column's row pair `(2·row, 2·row + 1)` and interpolate the last
+// variable at eval point `e` — the univariate round-message nodes {0, 2, 4}.
+// Diff-doubling: `z + ep * (o - z)` is rewritten as `z + d2 (+ d2)` with
+// `d2 = 2·(o − z)`, so we never multiply by a felt; `e == 0` skips the
+// second load entirely. `e` is uniform per block, so the branches never
+// diverge. Shared by the univariate constraint and GKR sweep kernels.
+//
+// The column-stride math is 64-bit: with u32 × u32 the product wraps for
+// chips approaching `2^32 / height` columns, silently reading from the
+// wrong column. See review #6.
+template <typename K>
+__device__ __forceinline__ K interp_load_pair(
+    const K* trace_data, size_t base, uint32_t col, uint32_t height,
+    uint32_t row_idx, int e)
+{
+    const size_t col_off = (size_t)col * (size_t)height;
+    K z = K::load(trace_data, base + col_off + (row_idx << 1));
+    if (e == 0) {
+        return z;
+    }
+    K o = K::load(trace_data, base + col_off + (row_idx << 1 | 1));
+    K diff = o - z;
+    K d2 = diff + diff;
+    return (e == 1) ? (z + d2) : (z + d2 + d2);
+}
+
 // Fused dispatch kernel. One launch handles every Sequential chunk tile
 // produced by the host-side dispatch builder. Each block reads its
 // `BlockDispatch` once at block init — no per-row binary search.

--- a/sp1-gpu/crates/sys/include/zerocheck/sequential.cuh
+++ b/sp1-gpu/crates/sys/include/zerocheck/sequential.cuh
@@ -111,3 +111,13 @@ extern "C" void* zerocheck_fused_sequential_ext_128_kernel();
 extern "C" void* zerocheck_fused_sequential_ext_256_kernel();
 extern "C" void* zerocheck_fused_sequential_ext_512_kernel();
 extern "C" void* zerocheck_fused_sequential_ext_1024_kernel();
+
+// Bivariate (fused first-two-rounds) variants: eval nodes on blockIdx.z
+// (12 nodes), quadruple row consumption, output stride 12. Round 0 only —
+// base-field trace, so no ext instantiations. See zerocheck/bivariate.cuh.
+extern "C" void* zerocheck_fused_sequential_bivariate_kb_32_kernel();
+extern "C" void* zerocheck_fused_sequential_bivariate_kb_64_kernel();
+extern "C" void* zerocheck_fused_sequential_bivariate_kb_128_kernel();
+extern "C" void* zerocheck_fused_sequential_bivariate_kb_256_kernel();
+extern "C" void* zerocheck_fused_sequential_bivariate_kb_512_kernel();
+extern "C" void* zerocheck_fused_sequential_bivariate_kb_1024_kernel();

--- a/sp1-gpu/crates/sys/lib/zerocheck/aggregate.cu
+++ b/sp1-gpu/crates/sys/lib/zerocheck/aggregate.cu
@@ -47,8 +47,40 @@ __global__ void zerocheck_aggregate_partials(
     }
 }
 
+// Strided variant for the fused first-two-rounds buffers: every producer
+// writes `stride` consecutive slots per group ([group][e] layout), and block
+// `e` of this kernel sums slot `e` of every group into `totals[e]`. Launched
+// with gridDim.x == stride.
+__global__ void zerocheck_aggregate_partials_strided(
+    const ext_t* __restrict__ partials,
+    uint32_t total_slots,
+    uint32_t stride,
+    ext_t* __restrict__ totals  // `stride` ext_t outputs
+) {
+    const uint32_t e = blockIdx.x;
+    const uint32_t n_groups = total_slots / stride;
+    ext_t acc = ext_t::zero();
+    for (uint32_t b = threadIdx.x; b < n_groups; b += blockDim.x) {
+        acc += ext_t::load(partials, b * stride + e);
+    }
+
+    extern __shared__ unsigned char smem[];
+    ext_t* shared = reinterpret_cast<ext_t*>(smem);
+    auto block = cg::this_thread_block();
+    auto tile = cg::tiled_partition<32>(block);
+
+    ext_t total = partialBlockReduce(block, tile, acc, shared);
+    if (threadIdx.x == 0) {
+        ext_t::store(totals, e, total);
+    }
+}
+
 }  // namespace
 
 extern "C" void* zerocheck_aggregate_partials_kernel() {
     return (void*)zerocheck_aggregate_partials;
+}
+
+extern "C" void* zerocheck_aggregate_partials_strided_kernel() {
+    return (void*)zerocheck_aggregate_partials_strided;
 }

--- a/sp1-gpu/crates/sys/lib/zerocheck/geq_corrections.cu
+++ b/sp1-gpu/crates/sys/lib/zerocheck/geq_corrections.cu
@@ -7,6 +7,7 @@
 // doesn't matter).
 
 #include "zerocheck/geq_corrections.cuh"
+#include "zerocheck/bivariate.cuh"
 #include "zerocheck/sequential.cuh"
 #include "config.cuh"
 #include "sum_and_reduce/reduce.cuh"
@@ -138,6 +139,100 @@ __global__ void zerocheck_geq_corrections(
     }
 }
 
+// ============================================================================
+// geq_corrections_bivariate — the padded-row correction for the fused
+// first-two-rounds evaluation.
+//
+// Rows are consumed in quadruples; the geq indicator restricted to a
+// quadruple is bilinear in the last two variables, so its eq-weighted sum is
+// determined by the four corner sums
+//   A_c = Σ_quad eq[quad] · g(4·quad + c),   c = 2X + Y ∈ {0, 1, 2, 3},
+// where `g(idx)` is the VirtualGeq vector value (0 below the threshold,
+// eq+geq at it, geq above it). Thread 0 bilinearly extends the corner sums
+// to the 12 non-boolean grid nodes and writes `−λ · pad_adj · S(node)`,
+// aligned with the constraint kernel's node order. The boolean corners get
+// NO correction: there the padded rows' constraint values are not summed by
+// any kernel, and the two cancel exactly.
+// ============================================================================
+__global__ void zerocheck_geq_corrections_bivariate(
+    const uint32_t* __restrict__ geq_chip_indices,
+    uint32_t n_geq_chips,
+    const VirtualGeqState* __restrict__ geq_state,
+    const ext_t* __restrict__ chip_pad_adj,
+    const ext_t* __restrict__ powers_of_lambda,
+    const ChipLayout* __restrict__ chip_layouts,
+    const ext_t* __restrict__ partial_lagrange,
+    uint32_t rest_point_dim,
+    ext_t* __restrict__ partials  // 12 slots per geq chip, laid out as [idx][e]
+) {
+    (void)n_geq_chips;
+    const uint32_t out_idx = blockIdx.x;
+    const uint32_t chip_idx = geq_chip_indices[out_idx];
+    const VirtualGeqState s = geq_state[chip_idx];
+    const ext_t pad_adj = ext_t::load(chip_pad_adj, chip_idx);
+    const ext_t lambda = ext_t::load(powers_of_lambda, chip_idx);
+    const ChipLayout lay = chip_layouts[chip_idx];
+
+    // Effective quadruple span for this chip — must match the constraint
+    // kernel's dispatch (ceil(height / 4) quadruples). Fully virtual
+    // quadruples beyond it cancel identically and are summed by neither.
+    const uint32_t quad_limit = 1u << rest_point_dim;
+    const uint32_t chip_quad_count = (lay.height + 3u) / 4u;
+    const uint32_t in_limit = chip_quad_count < quad_limit ? chip_quad_count : quad_limit;
+
+    ext_t t00 = ext_t::zero();
+    ext_t t01 = ext_t::zero();
+    ext_t t10 = ext_t::zero();
+    ext_t t11 = ext_t::zero();
+    for (uint32_t quad_idx = threadIdx.x; quad_idx < in_limit; quad_idx += blockDim.x) {
+        ext_t lagr = ext_t::load(partial_lagrange, quad_idx);
+        const uint32_t base_idx = quad_idx << 2;
+#pragma unroll
+        for (uint32_t c = 0; c < 4u; c++) {
+            const uint32_t idx = base_idx | c;
+            ext_t contrib = ext_t::zero();
+            if (idx > s.threshold) {
+                contrib = lagr * s.geq_coefficient;
+            } else if (idx == s.threshold) {
+                contrib = lagr * (s.geq_coefficient + s.eq_coefficient);
+            }
+            switch (c) {
+            case 0: t00 += contrib; break;
+            case 1: t01 += contrib; break;
+            case 2: t10 += contrib; break;
+            default: t11 += contrib; break;
+            }
+        }
+    }
+
+    extern __shared__ unsigned char smem[];
+    ext_t* shared = reinterpret_cast<ext_t*>(smem);
+    auto block = cg::this_thread_block();
+    auto tile = cg::tiled_partition<32>(block);
+
+    ext_t a00 = partialBlockReduce(block, tile, t00, shared);
+    block.sync();
+    ext_t a01 = partialBlockReduce(block, tile, t01, shared);
+    block.sync();
+    ext_t a10 = partialBlockReduce(block, tile, t10, shared);
+    block.sync();
+    ext_t a11 = partialBlockReduce(block, tile, t11, shared);
+
+    if (threadIdx.x == 0) {
+        const ext_t coeff = lambda * pad_adj;
+        const ext_t ax = a10 - a00;
+        const ext_t ay = a01 - a00;
+        const ext_t axy = (a11 - a10) - ay;
+        const uint32_t base = out_idx * (uint32_t)BIVARIATE_NUM_NODES;
+        for (int e = 0; e < BIVARIATE_NUM_NODES; e++) {
+            const BivariateNode nd = bivariate_node(e);
+            ext_t S = a00 + mul_small_pow2(ax, nd.cx) + mul_small_pow2(ay, nd.cy)
+                + mul_small_pow2(axy, nd.cxy);
+            ext_t::store(partials, base + (uint32_t)e, ext_t::zero() - coeff * S);
+        }
+    }
+}
+
 }  // namespace
 
 extern "C" void* zerocheck_fix_geq_state_kernel() {
@@ -146,4 +241,8 @@ extern "C" void* zerocheck_fix_geq_state_kernel() {
 
 extern "C" void* zerocheck_geq_corrections_kernel() {
     return (void*)zerocheck_geq_corrections;
+}
+
+extern "C" void* zerocheck_geq_corrections_bivariate_kernel() {
+    return (void*)zerocheck_geq_corrections_bivariate;
 }

--- a/sp1-gpu/crates/sys/lib/zerocheck/gkr_sweep.cu
+++ b/sp1-gpu/crates/sys/lib/zerocheck/gkr_sweep.cu
@@ -16,28 +16,6 @@ namespace cg = cooperative_groups;
 
 namespace {
 
-// Per-row interp helper — `z + ep_v * (o - z)` rewritten with the standard
-// diff-doubling trick (see sequential.cu banner). `e` is uniform across the
-// block.
-template <typename K>
-__device__ __forceinline__ K interp_load(
-    const K* trace_data, size_t base, uint32_t col, uint32_t height,
-    uint32_t row_idx, int e)
-{
-    // Cast one operand to size_t so the column-stride math is 64-bit; with
-    // u32 × u32 the product wraps for chips approaching `2^32 / height`
-    // columns, silently reading from the wrong column. See review #6.
-    const size_t col_off = (size_t)col * (size_t)height;
-    K z = K::load(trace_data, base + col_off + (row_idx << 1));
-    if (e == 0) {
-        return z;
-    }
-    K o = K::load(trace_data, base + col_off + (row_idx << 1 | 1));
-    K diff = o - z;
-    K d2 = diff + diff;
-    return (e == 1) ? (z + d2) : (z + d2 + d2);
-}
-
 template <typename K>
 __global__ void zerocheck_gkr_sweep(
     const BlockDispatch* __restrict__ dispatch,
@@ -85,11 +63,11 @@ __global__ void zerocheck_gkr_sweep(
         {
             ext_t acc = ext_t::zero();
             for (uint32_t i = 0; i < gkr.main_width; i++) {
-                K v = interp_load(trace_data, lay.main_ptr, i, lay.height, row_idx, e);
+                K v = interp_load_pair(trace_data, lay.main_ptr, i, lay.height, row_idx, e);
                 acc += ext_t::load(gkr_powers, i) * v;
             }
             for (uint32_t i = 0; i < gkr.prep_width; i++) {
-                K v = interp_load(trace_data, lay.preprocessed_ptr, i, lay.height, row_idx, e);
+                K v = interp_load_pair(trace_data, lay.preprocessed_ptr, i, lay.height, row_idx, e);
                 acc += ext_t::load(gkr_powers, gkr.main_width + i) * v;
             }
             if (row_idx < row_limit) {
@@ -107,11 +85,12 @@ __global__ void zerocheck_gkr_sweep(
         {
             ext_t lane_sum = ext_t::zero();
             for (uint32_t col = (uint32_t)lane; col < gkr.main_width; col += WARP_SIZE) {
-                K v = interp_load(trace_data, lay.main_ptr, col, lay.height, row_idx, e);
+                K v = interp_load_pair(trace_data, lay.main_ptr, col, lay.height, row_idx, e);
                 lane_sum += ext_t::load(gkr_powers, col) * v;
             }
             for (uint32_t col = (uint32_t)lane; col < gkr.prep_width; col += WARP_SIZE) {
-                K v = interp_load(trace_data, lay.preprocessed_ptr, col, lay.height, row_idx, e);
+                K v = interp_load_pair(
+                    trace_data, lay.preprocessed_ptr, col, lay.height, row_idx, e);
                 lane_sum += ext_t::load(gkr_powers, gkr.main_width + col) * v;
             }
             ext_t row_total = cg::reduce(warp, lane_sum, cg::plus<ext_t>());

--- a/sp1-gpu/crates/sys/lib/zerocheck/gkr_sweep.cu
+++ b/sp1-gpu/crates/sys/lib/zerocheck/gkr_sweep.cu
@@ -4,6 +4,7 @@
 // rounds 1+ use the ext-field folded trace, matching the constraint kernel.
 
 #include "zerocheck/gkr_sweep.cuh"
+#include "zerocheck/bivariate.cuh"
 #include "zerocheck/sequential.cuh"
 #include "config.cuh"
 #include "sum_and_reduce/reduce.cuh"
@@ -132,6 +133,143 @@ __global__ void zerocheck_gkr_sweep(
     }
 }
 
+// ============================================================================
+// Corner sweep — the GKR opening batch for the fused first-two-rounds.
+//
+// The bivariate round polynomial's four boolean grid corners `(X, Y) ∈
+// {0, 1}^2` need only the GKR opening batch (constraints vanish there); the
+// corner value of row-quadruple `q` at corner `c = 2X + Y` is simply the raw
+// trace row `4q + c` — no interpolation. Each block computes ALL four corner
+// sums in one pass: per (quad, column), the four consecutive elements are
+// loaded once (one cache line) and accumulated into their per-corner sums.
+// Guarded against the column height: the last quadruple of a chip may have
+// only two physical rows, and the missing rows are zero (which contribute
+// zero to the sweep anyway, but an unguarded load would read the next
+// column's data).
+//
+// One block per (chip, quad-tile); grid is (n_blocks, 1, 1); output stride 4.
+// Runs for EVERY chip with non-zero width in the fused round — the inline
+// carrier-chunk sweep is disabled there.
+// ============================================================================
+
+// Accumulate `gkr_power · element` into the four per-corner sums for one
+// (quad, column) pair. The guard only fires on the chip's last quadruple.
+template <typename K>
+__device__ __forceinline__ void corner_accumulate(
+    const K* trace_data, size_t base, uint32_t col, uint32_t height,
+    uint32_t quad_idx, ext_t power, ext_t acc[BIVARIATE_NUM_CORNERS])
+{
+    const size_t col_off = (size_t)col * (size_t)height;
+    const size_t quad_base = base + col_off + ((size_t)quad_idx << 2);
+    const uint32_t elem0 = quad_idx << 2;
+#pragma unroll
+    for (int c = 0; c < BIVARIATE_NUM_CORNERS; c++) {
+        if ((elem0 | (uint32_t)c) < height) {
+            acc[c] += power * K::load(trace_data, quad_base + c);
+        }
+    }
+}
+
+template <typename K>
+__global__ void zerocheck_gkr_corner_sweep(
+    const BlockDispatch* __restrict__ dispatch,
+    const ChipLayout* __restrict__ chip_layouts,
+    const ChipGkrInfo* __restrict__ chip_gkr,
+    const K* __restrict__ trace_data,
+    const ext_t* __restrict__ gkr_powers,
+    const ext_t* __restrict__ partial_lagrange,
+    const ext_t* __restrict__ powers_of_lambda,
+    uint32_t rest_point_dim,
+    ext_t* __restrict__ partials
+) {
+    BlockDispatch disp = dispatch[blockIdx.x];
+    uint32_t chip_idx = disp.chunk_id;
+    ChipLayout lay = chip_layouts[chip_idx];
+    ChipGkrInfo gkr = chip_gkr[chip_idx];
+
+    const uint32_t quad_limit = 1u << rest_point_dim;
+    const uint32_t quad_end = disp.row_offset + disp.n_rows;
+    const ext_t lambda = ext_t::load(powers_of_lambda, chip_idx);
+
+    constexpr int WARP_SIZE = 32;
+    constexpr int WARPS_PER_BLOCK = GKR_SWEEP_BLOCK_SIZE / WARP_SIZE;
+    auto block = cg::this_thread_block();
+
+    const uint32_t total_width = gkr.main_width + gkr.prep_width;
+    ext_t thread_acc[BIVARIATE_NUM_CORNERS] = {
+        ext_t::zero(), ext_t::zero(), ext_t::zero(), ext_t::zero()};
+    if (total_width <= (uint32_t)WARP_SIZE) {
+        // ---- Narrow path: thread-per-quad, columns in inner loop ----
+        for (uint32_t quad_idx = disp.row_offset + threadIdx.x;
+             quad_idx < quad_end;
+             quad_idx += blockDim.x)
+        {
+            if (quad_idx >= quad_limit) {
+                continue;
+            }
+            ext_t acc[BIVARIATE_NUM_CORNERS] = {
+                ext_t::zero(), ext_t::zero(), ext_t::zero(), ext_t::zero()};
+            for (uint32_t i = 0; i < gkr.main_width; i++) {
+                ext_t power = ext_t::load(gkr_powers, i);
+                corner_accumulate(trace_data, lay.main_ptr, i, lay.height, quad_idx, power, acc);
+            }
+            for (uint32_t i = 0; i < gkr.prep_width; i++) {
+                ext_t power = ext_t::load(gkr_powers, gkr.main_width + i);
+                corner_accumulate(
+                    trace_data, lay.preprocessed_ptr, i, lay.height, quad_idx, power, acc);
+            }
+            const ext_t w = ext_t::load(partial_lagrange, quad_idx) * lambda;
+#pragma unroll
+            for (int c = 0; c < BIVARIATE_NUM_CORNERS; c++) {
+                thread_acc[c] += acc[c] * w;
+            }
+        }
+    } else {
+        // ---- Wide path: warp-per-quad, lane-strided columns ----
+        const int warp_id = threadIdx.x / WARP_SIZE;
+        const int lane = threadIdx.x % WARP_SIZE;
+        auto warp = cg::tiled_partition<WARP_SIZE>(block);
+        for (uint32_t quad_idx = disp.row_offset + warp_id; quad_idx < quad_end;
+             quad_idx += WARPS_PER_BLOCK)
+        {
+            if (quad_idx >= quad_limit) {
+                continue;
+            }
+            ext_t lane_sum[BIVARIATE_NUM_CORNERS] = {
+                ext_t::zero(), ext_t::zero(), ext_t::zero(), ext_t::zero()};
+            for (uint32_t col = (uint32_t)lane; col < gkr.main_width; col += WARP_SIZE) {
+                ext_t power = ext_t::load(gkr_powers, col);
+                corner_accumulate(
+                    trace_data, lay.main_ptr, col, lay.height, quad_idx, power, lane_sum);
+            }
+            for (uint32_t col = (uint32_t)lane; col < gkr.prep_width; col += WARP_SIZE) {
+                ext_t power = ext_t::load(gkr_powers, gkr.main_width + col);
+                corner_accumulate(
+                    trace_data, lay.preprocessed_ptr, col, lay.height, quad_idx, power, lane_sum);
+            }
+            const ext_t w = ext_t::load(partial_lagrange, quad_idx) * lambda;
+#pragma unroll
+            for (int c = 0; c < BIVARIATE_NUM_CORNERS; c++) {
+                ext_t row_total = cg::reduce(warp, lane_sum[c], cg::plus<ext_t>());
+                if (lane == 0) {
+                    thread_acc[c] += row_total * w;
+                }
+            }
+        }
+    }
+
+    extern __shared__ unsigned char smem[];
+    ext_t* shared = reinterpret_cast<ext_t*>(smem);
+    auto tile_warp = cg::tiled_partition<32>(block);
+    for (int c = 0; c < BIVARIATE_NUM_CORNERS; c++) {
+        ext_t block_sum = partialBlockReduce(block, tile_warp, thread_acc[c], shared);
+        if (threadIdx.x == 0) {
+            ext_t::store(partials, blockIdx.x * BIVARIATE_NUM_CORNERS + (uint32_t)c, block_sum);
+        }
+        block.sync();
+    }
+}
+
 }  // namespace
 
 extern "C" void* zerocheck_gkr_sweep_kb_kernel() {
@@ -139,4 +277,7 @@ extern "C" void* zerocheck_gkr_sweep_kb_kernel() {
 }
 extern "C" void* zerocheck_gkr_sweep_ext_kernel() {
     return (void*)zerocheck_gkr_sweep<ext_t>;
+}
+extern "C" void* zerocheck_gkr_corner_sweep_kb_kernel() {
+    return (void*)zerocheck_gkr_corner_sweep<felt_t>;
 }

--- a/sp1-gpu/crates/sys/lib/zerocheck/jagged_mle.cu
+++ b/sp1-gpu/crates/sys/lib/zerocheck/jagged_mle.cu
@@ -15,6 +15,24 @@ __global__ void fixLastVariableJagged(
     }
 }
 
+// Folds the last two variables in one pass over the input (see
+// `fixLastTwoVariablesTwoPadding`); `n_quads` is the input pair count / 2.
+// Used by the zerocheck fused first-two-rounds, whose two challenges are
+// both known before any fold happens.
+template <typename F>
+__global__ void fixLastTwoVariablesJagged(
+    const JaggedMle<DenseBuffer<F>> inputJaggedMle,
+    JaggedMle<DenseBuffer<ext_t>> outputJaggedMle,
+    uint32_t n_quads,
+    ext_t alpha_1,
+    ext_t alpha_2) {
+
+    for (size_t q = blockIdx.x * blockDim.x + threadIdx.x; q < n_quads;
+         q += blockDim.x * gridDim.x) {
+        inputJaggedMle.fixLastTwoVariablesTwoPadding(outputJaggedMle, q, alpha_1, alpha_2);
+    }
+}
+
 __global__ void initializeJaggedInfo(
     JaggedMle<InfoBuffer> jaggedMle,
     const uint64_t* values,
@@ -55,6 +73,9 @@ extern "C" void* initialize_jagged_info() { return (void*)initializeJaggedInfo; 
 
 extern "C" void* fix_last_variable_jagged_felt() { return (void*)fixLastVariableJagged<felt_t>; }
 extern "C" void* fix_last_variable_jagged_ext() { return (void*)fixLastVariableJagged<ext_t>; }
+extern "C" void* fix_last_two_variables_jagged_felt() {
+    return (void*)fixLastTwoVariablesJagged<felt_t>;
+}
 extern "C" void* fix_last_variable_jagged_info() { return (void*)fixLastVariableJaggedInfo; }
 
 extern "C" void* jagged_eval_kernel_chunked_felt() { return (void*)jaggedEvalChunked<felt_t>; }

--- a/sp1-gpu/crates/sys/lib/zerocheck/sequential.cu
+++ b/sp1-gpu/crates/sys/lib/zerocheck/sequential.cu
@@ -41,6 +41,72 @@ namespace cg = cooperative_groups;
 
 namespace {
 
+// Run one chunk's DAG bytecode for a single row position, then batch the
+// assertion registers by their alpha powers, returning the chunk's
+// constraint accumulator. Shared by the univariate and bivariate kernels,
+// which differ only in how a leaf's trace value is interpolated —
+// `load_leaf(LeafRef) -> K` supplies it.
+template <typename K, int MAX_REGS, typename LoadLeaf>
+__device__ __forceinline__ ext_t run_chunk_bytecode(
+    const ChunkStatic& stc,
+    const felt_t* consts,
+    const felt_t* public_values,
+    const ext_t* powers_of_alpha,
+    K (&regs)[MAX_REGS],
+    LoadLeaf load_leaf)
+{
+    for (uint32_t i = 0; i < stc.n_instrs; i++) {
+        DagInstr instr = stc.instrs[i];
+        switch (instr.opcode) {
+        case BC_LOAD_LEAF: {
+            regs[instr.out] = load_leaf(stc.leaves[instr.a]);
+            break;
+        }
+        case BC_LOAD_CONST: {
+            regs[instr.out] = K(consts[instr.a]);
+            break;
+        }
+        case BC_LOAD_PUBLIC: {
+            uint32_t pv_idx = stc.publics[instr.a];
+            regs[instr.out] = K(felt_t::load(public_values, pv_idx));
+            break;
+        }
+        case BC_ADD_F: {
+            regs[instr.out] = regs[instr.a] + regs[instr.b];
+            break;
+        }
+        case BC_SUB_F: {
+            regs[instr.out] = regs[instr.a] - regs[instr.b];
+            break;
+        }
+        case BC_MUL_F: {
+            regs[instr.out] = regs[instr.a] * regs[instr.b];
+            break;
+        }
+        case BC_NEG_F: {
+            regs[instr.out] = K::zero() - regs[instr.a];
+            break;
+        }
+        default:
+            // Unknown opcode = Rust↔CUDA bytecode drift; fail loudly
+            // rather than leaving `regs[instr.out]` stale and silently
+            // producing the wrong constraint value downstream.
+            __trap();
+        }
+    }
+
+    ext_t acc = ext_t::zero();
+    for (uint32_t i = 0; i < stc.n_asserts; i++) {
+        uint16_t reg = stc.assert_regs[i];
+        // Bytecode stores chip-relative alpha indices; shift into the
+        // cluster's powers_of_alpha table here.
+        uint32_t alpha_idx = stc.chip_alpha_offset + stc.assert_alphas[i];
+        ext_t alpha = ext_t::load(powers_of_alpha, alpha_idx);
+        acc += alpha * regs[reg];
+    }
+    return acc;
+}
+
 template <typename K, int MAX_REGS>
 __global__ void zerocheck_fused_sequential(
     const BlockDispatch* __restrict__ dispatch,
@@ -62,9 +128,8 @@ __global__ void zerocheck_fused_sequential(
     ChipLayout lay = chip_layouts[stc.chip_idx];
     const felt_t* consts = reinterpret_cast<const felt_t*>(stc.consts);
 
-    // Eval point index. Diff-doubling: eval points are {0, 2, 4}; the leaf
-    // interpolation `z + ep * (o - z)` is rewritten as `z + d2 (+ d2)` with
-    // `d2 = diff + diff` so we never multiply by a felt.
+    // Eval point index into the univariate nodes {0, 2, 4}; see
+    // `interp_load_pair` for the diff-doubling interpolation.
     const int e = blockIdx.z;
 
     K regs[MAX_REGS];
@@ -80,72 +145,13 @@ __global__ void zerocheck_fused_sequential(
          row_idx < row_end;
          row_idx += blockDim.x)
     {
-        ext_t acc = ext_t::zero();
-
-        for (uint32_t i = 0; i < stc.n_instrs; i++) {
-            DagInstr instr = stc.instrs[i];
-            switch (instr.opcode) {
-            case BC_LOAD_LEAF: {
-                LeafRef leaf = stc.leaves[instr.a];
+        ext_t acc = run_chunk_bytecode(
+            stc, consts, public_values, powers_of_alpha, regs, [&](LeafRef leaf) {
                 size_t base = (leaf.source == LEAF_SOURCE_MAIN_LOCAL)
                                   ? lay.main_ptr
                                   : lay.preprocessed_ptr;
-                // 64-bit column stride math; u32 × u32 wraps near the
-                // 2^32 / height column count. See review #6.
-                size_t col_off = (size_t)leaf.col * (size_t)lay.height;
-                K z = K::load(trace_data, base + col_off + (row_idx << 1));
-                if (e == 0) {
-                    regs[instr.out] = z;
-                } else {
-                    K o = K::load(trace_data, base + col_off + (row_idx << 1 | 1));
-                    K diff = o - z;
-                    K d2 = diff + diff;          // 2 * diff
-                    regs[instr.out] = (e == 1) ? (z + d2)            // z + 2*diff
-                                               : (z + d2 + d2);      // z + 4*diff
-                }
-                break;
-            }
-            case BC_LOAD_CONST: {
-                regs[instr.out] = K(consts[instr.a]);
-                break;
-            }
-            case BC_LOAD_PUBLIC: {
-                uint32_t pv_idx = stc.publics[instr.a];
-                regs[instr.out] = K(felt_t::load(public_values, pv_idx));
-                break;
-            }
-            case BC_ADD_F: {
-                regs[instr.out] = regs[instr.a] + regs[instr.b];
-                break;
-            }
-            case BC_SUB_F: {
-                regs[instr.out] = regs[instr.a] - regs[instr.b];
-                break;
-            }
-            case BC_MUL_F: {
-                regs[instr.out] = regs[instr.a] * regs[instr.b];
-                break;
-            }
-            case BC_NEG_F: {
-                regs[instr.out] = K::zero() - regs[instr.a];
-                break;
-            }
-            default:
-                // Unknown opcode = Rust↔CUDA bytecode drift; fail loudly
-                // rather than leaving `regs[instr.out]` stale and silently
-                // producing the wrong constraint value downstream.
-                __trap();
-            }
-        }
-
-        for (uint32_t i = 0; i < stc.n_asserts; i++) {
-            uint16_t reg = stc.assert_regs[i];
-            // Bytecode stores chip-relative alpha indices; shift into the
-            // cluster's powers_of_alpha table here.
-            uint32_t alpha_idx = stc.chip_alpha_offset + stc.assert_alphas[i];
-            ext_t alpha = ext_t::load(powers_of_alpha, alpha_idx);
-            acc += alpha * regs[reg];
-        }
+                return interp_load_pair(trace_data, base, leaf.col, lay.height, row_idx, e);
+            });
 
         // Inline GKR column sweep for the carrier chunk of NARROW chips
         // (the launcher zeroes these widths for wide chips, which get GKR
@@ -155,37 +161,13 @@ __global__ void zerocheck_fused_sequential(
         //
         // Geq correction is always out-of-band (`zerocheck_geq_corrections`).
         if (stc.gkr_main_width != 0 || stc.gkr_prep_width != 0) {
-            // 64-bit column stride math; u32 × u32 wraps near
-            // `2^32 / height` columns. See review #6.
-            const size_t height_64 = (size_t)lay.height;
             for (uint32_t i = 0; i < stc.gkr_main_width; i++) {
-                size_t col_off = (size_t)i * height_64;
-                K z = K::load(trace_data, lay.main_ptr + col_off + (row_idx << 1));
-                K v;
-                if (e == 0) {
-                    v = z;
-                } else {
-                    K o = K::load(trace_data,
-                                  lay.main_ptr + col_off + (row_idx << 1 | 1));
-                    K diff = o - z;
-                    K d2 = diff + diff;
-                    v = (e == 1) ? (z + d2) : (z + d2 + d2);
-                }
+                K v = interp_load_pair(trace_data, lay.main_ptr, i, lay.height, row_idx, e);
                 acc += ext_t::load(gkr_powers, i) * v;
             }
             for (uint32_t i = 0; i < stc.gkr_prep_width; i++) {
-                size_t col_off = (size_t)i * height_64;
-                K z = K::load(trace_data, lay.preprocessed_ptr + col_off + (row_idx << 1));
-                K v;
-                if (e == 0) {
-                    v = z;
-                } else {
-                    K o = K::load(trace_data,
-                                  lay.preprocessed_ptr + col_off + (row_idx << 1 | 1));
-                    K diff = o - z;
-                    K d2 = diff + diff;
-                    v = (e == 1) ? (z + d2) : (z + d2 + d2);
-                }
+                K v = interp_load_pair(
+                    trace_data, lay.preprocessed_ptr, i, lay.height, row_idx, e);
                 acc += ext_t::load(gkr_powers, stc.gkr_main_width + i) * v;
             }
         }
@@ -283,69 +265,14 @@ __global__ void zerocheck_fused_sequential_bivariate(
 
         for (int e = 0; e < BIVARIATE_NUM_NODES; e++) {
             const BivariateNode node = bivariate_node(e);
-            ext_t acc = ext_t::zero();
-
-            for (uint32_t i = 0; i < stc.n_instrs; i++) {
-                DagInstr instr = stc.instrs[i];
-                switch (instr.opcode) {
-                case BC_LOAD_LEAF: {
-                    LeafRef leaf = stc.leaves[instr.a];
+            ext_t acc = run_chunk_bytecode(
+                stc, consts, public_values, powers_of_alpha, regs, [&](LeafRef leaf) {
                     size_t base = (leaf.source == LEAF_SOURCE_MAIN_LOCAL)
                                       ? lay.main_ptr
                                       : lay.preprocessed_ptr;
-                    // 64-bit column stride math; u32 × u32 wraps near the
-                    // 2^32 / height column count.
-                    size_t col_off = (size_t)leaf.col * (size_t)lay.height;
-                    size_t quad_base = base + col_off + ((size_t)quad_idx << 2);
-                    K r00 = K::load(trace_data, quad_base);
-                    K r01 = K::load(trace_data, quad_base + 1);
-                    K r10, r11;
-                    if (full_quad) {
-                        r10 = K::load(trace_data, quad_base + 2);
-                        r11 = K::load(trace_data, quad_base + 3);
-                    } else {
-                        r10 = K::zero();
-                        r11 = K::zero();
-                    }
-                    regs[instr.out] = bivariate_interp(r00, r01, r10, r11, node);
-                    break;
-                }
-                case BC_LOAD_CONST: {
-                    regs[instr.out] = K(consts[instr.a]);
-                    break;
-                }
-                case BC_LOAD_PUBLIC: {
-                    uint32_t pv_idx = stc.publics[instr.a];
-                    regs[instr.out] = K(felt_t::load(public_values, pv_idx));
-                    break;
-                }
-                case BC_ADD_F: {
-                    regs[instr.out] = regs[instr.a] + regs[instr.b];
-                    break;
-                }
-                case BC_SUB_F: {
-                    regs[instr.out] = regs[instr.a] - regs[instr.b];
-                    break;
-                }
-                case BC_MUL_F: {
-                    regs[instr.out] = regs[instr.a] * regs[instr.b];
-                    break;
-                }
-                case BC_NEG_F: {
-                    regs[instr.out] = K::zero() - regs[instr.a];
-                    break;
-                }
-                default:
-                    __trap();
-                }
-            }
-
-            for (uint32_t i = 0; i < stc.n_asserts; i++) {
-                uint16_t reg = stc.assert_regs[i];
-                uint32_t alpha_idx = stc.chip_alpha_offset + stc.assert_alphas[i];
-                ext_t alpha = ext_t::load(powers_of_alpha, alpha_idx);
-                acc += alpha * regs[reg];
-            }
+                    return interp_load_quad(
+                        trace_data, base, leaf.col, lay.height, quad_idx, full_quad, node);
+                });
 
             thread_acc[e] += acc * w;
         }

--- a/sp1-gpu/crates/sys/lib/zerocheck/sequential.cu
+++ b/sp1-gpu/crates/sys/lib/zerocheck/sequential.cu
@@ -30,6 +30,7 @@
 // and lets the GPU run all three eval points concurrently.
 
 #include "zerocheck/sequential.cuh"
+#include "zerocheck/bivariate.cuh"
 #include "config.cuh"
 #include "sum_and_reduce/reduce.cuh"
 
@@ -209,6 +210,162 @@ __global__ void zerocheck_fused_sequential(
     }
 }
 
+// ============================================================================
+// Bivariate variant — the fused first-two-rounds evaluation.
+//
+// Rows are consumed in QUADRUPLES (element index `4·quad + 2·X + Y`), and each
+// block computes ALL 12 non-boolean grid nodes of `{0, 1, 2, 4}^2`: per row,
+// the node loop re-runs the chunk's bytecode once per node, so the trace is
+// pulled from DRAM once and the 11 repeat passes hit L1/L2 (per-thread
+// temporal locality on the same quadruple). This trades compute (the
+// interpreter runs 12× per row either way) for a single pass over memory —
+// the round-message cost is pass-count-bound, not compute-bound.
+// Only run for round 0, so only the felt_t instantiations are exported.
+//
+// Differences from the univariate kernel above:
+//   - No blockIdx.z: the launcher's grid is (n_blocks, 1, 1).
+//   - No inline GKR sweep: the boolean corner nodes are handled by the
+//     dedicated `zerocheck_gkr_corner_sweep` kernel for every chip.
+//   - Loads are guarded against the column height: heights are even but not
+//     necessarily multiples of four, so the last quadruple of a chip may have
+//     only two physical rows; the missing rows are zero (matching the virtual
+//     zero padding of the trace MLE). Reading past `lay.height` would land in
+//     the next column's data.
+//   - Output stride is 12: each block writes nodes e = 0..12 at
+//     (block.x * 12 + e).
+// ============================================================================
+
+template <typename K, int MAX_REGS>
+__global__ void zerocheck_fused_sequential_bivariate(
+    const BlockDispatch* __restrict__ dispatch,
+    const ChunkStatic* __restrict__ chunk_static,
+    const ChipLayout* __restrict__ chip_layouts,
+    const K* __restrict__ trace_data,
+    const felt_t* __restrict__ public_values,
+    const ext_t* __restrict__ powers_of_alpha,
+    const ext_t* __restrict__ partial_lagrange,
+    const ext_t* __restrict__ powers_of_lambda,
+    uint32_t rest_point_dim,
+    ext_t* __restrict__ partials
+) {
+    BlockDispatch disp = dispatch[blockIdx.x];
+    ChunkStatic stc = chunk_static[disp.chunk_id];
+    ChipLayout lay = chip_layouts[stc.chip_idx];
+    const felt_t* consts = reinterpret_cast<const felt_t*>(stc.consts);
+    const ext_t lambda = ext_t::load(powers_of_lambda, stc.chip_idx);
+
+    K regs[MAX_REGS];
+    // One accumulator per grid node. Indexed by the (non-unrolled) node loop,
+    // so it lives in L1-cached local memory rather than bloating the register
+    // file on top of `regs[]`.
+    ext_t thread_acc[BIVARIATE_NUM_NODES];
+    for (int e = 0; e < BIVARIATE_NUM_NODES; e++) {
+        thread_acc[e] = ext_t::zero();
+    }
+
+    const uint32_t quad_limit = 1u << rest_point_dim;
+    const uint32_t quad_end = disp.row_offset + disp.n_rows;
+
+    for (uint32_t quad_idx = disp.row_offset + threadIdx.x;
+         quad_idx < quad_end;
+         quad_idx += blockDim.x)
+    {
+        // Rows at or above the eq range contribute nothing (their true
+        // contribution is zero); skip the bytecode entirely.
+        if (quad_idx >= quad_limit) {
+            continue;
+        }
+        const ext_t w = ext_t::load(partial_lagrange, quad_idx) * lambda;
+        // Heights are even, so only rows 2 and 3 of the chip's last
+        // quadruple can be missing; uniform across the block except at the
+        // chip's boundary quad.
+        const bool full_quad = ((quad_idx << 2) | 3u) < lay.height;
+
+        for (int e = 0; e < BIVARIATE_NUM_NODES; e++) {
+            const BivariateNode node = bivariate_node(e);
+            ext_t acc = ext_t::zero();
+
+            for (uint32_t i = 0; i < stc.n_instrs; i++) {
+                DagInstr instr = stc.instrs[i];
+                switch (instr.opcode) {
+                case BC_LOAD_LEAF: {
+                    LeafRef leaf = stc.leaves[instr.a];
+                    size_t base = (leaf.source == LEAF_SOURCE_MAIN_LOCAL)
+                                      ? lay.main_ptr
+                                      : lay.preprocessed_ptr;
+                    // 64-bit column stride math; u32 × u32 wraps near the
+                    // 2^32 / height column count.
+                    size_t col_off = (size_t)leaf.col * (size_t)lay.height;
+                    size_t quad_base = base + col_off + ((size_t)quad_idx << 2);
+                    K r00 = K::load(trace_data, quad_base);
+                    K r01 = K::load(trace_data, quad_base + 1);
+                    K r10, r11;
+                    if (full_quad) {
+                        r10 = K::load(trace_data, quad_base + 2);
+                        r11 = K::load(trace_data, quad_base + 3);
+                    } else {
+                        r10 = K::zero();
+                        r11 = K::zero();
+                    }
+                    regs[instr.out] = bivariate_interp(r00, r01, r10, r11, node);
+                    break;
+                }
+                case BC_LOAD_CONST: {
+                    regs[instr.out] = K(consts[instr.a]);
+                    break;
+                }
+                case BC_LOAD_PUBLIC: {
+                    uint32_t pv_idx = stc.publics[instr.a];
+                    regs[instr.out] = K(felt_t::load(public_values, pv_idx));
+                    break;
+                }
+                case BC_ADD_F: {
+                    regs[instr.out] = regs[instr.a] + regs[instr.b];
+                    break;
+                }
+                case BC_SUB_F: {
+                    regs[instr.out] = regs[instr.a] - regs[instr.b];
+                    break;
+                }
+                case BC_MUL_F: {
+                    regs[instr.out] = regs[instr.a] * regs[instr.b];
+                    break;
+                }
+                case BC_NEG_F: {
+                    regs[instr.out] = K::zero() - regs[instr.a];
+                    break;
+                }
+                default:
+                    __trap();
+                }
+            }
+
+            for (uint32_t i = 0; i < stc.n_asserts; i++) {
+                uint16_t reg = stc.assert_regs[i];
+                uint32_t alpha_idx = stc.chip_alpha_offset + stc.assert_alphas[i];
+                ext_t alpha = ext_t::load(powers_of_alpha, alpha_idx);
+                acc += alpha * regs[reg];
+            }
+
+            thread_acc[e] += acc * w;
+        }
+    }
+
+    extern __shared__ unsigned char smem[];
+    ext_t* shared = reinterpret_cast<ext_t*>(smem);
+
+    auto block = cg::this_thread_block();
+    auto tile_warp = cg::tiled_partition<32>(block);
+
+    for (int e = 0; e < BIVARIATE_NUM_NODES; e++) {
+        ext_t block_sum = partialBlockReduce(block, tile_warp, thread_acc[e], shared);
+        if (threadIdx.x == 0) {
+            ext_t::store(partials, blockIdx.x * BIVARIATE_NUM_NODES + (uint32_t)e, block_sum);
+        }
+        block.sync();
+    }
+}
+
 } // namespace
 
 // Fused dispatch entry points, tiered by MAX_REGS so the per-thread local
@@ -250,4 +407,25 @@ extern "C" void* zerocheck_fused_sequential_ext_512_kernel() {
 }
 extern "C" void* zerocheck_fused_sequential_ext_1024_kernel() {
     return (void*)zerocheck_fused_sequential<ext_t, 1024>;
+}
+
+// Bivariate (fused first-two-rounds) entry points. Round 0 only, so only the
+// base-field instantiations exist.
+extern "C" void* zerocheck_fused_sequential_bivariate_kb_32_kernel() {
+    return (void*)zerocheck_fused_sequential_bivariate<felt_t, 32>;
+}
+extern "C" void* zerocheck_fused_sequential_bivariate_kb_64_kernel() {
+    return (void*)zerocheck_fused_sequential_bivariate<felt_t, 64>;
+}
+extern "C" void* zerocheck_fused_sequential_bivariate_kb_128_kernel() {
+    return (void*)zerocheck_fused_sequential_bivariate<felt_t, 128>;
+}
+extern "C" void* zerocheck_fused_sequential_bivariate_kb_256_kernel() {
+    return (void*)zerocheck_fused_sequential_bivariate<felt_t, 256>;
+}
+extern "C" void* zerocheck_fused_sequential_bivariate_kb_512_kernel() {
+    return (void*)zerocheck_fused_sequential_bivariate<felt_t, 512>;
+}
+extern "C" void* zerocheck_fused_sequential_bivariate_kb_1024_kernel() {
+    return (void*)zerocheck_fused_sequential_bivariate<felt_t, 1024>;
 }

--- a/sp1-gpu/crates/sys/src/kernels.rs
+++ b/sp1-gpu/crates/sys/src/kernels.rs
@@ -47,6 +47,17 @@ extern "C" {
     pub fn zerocheck_fused_sequential_ext_512_kernel() -> KernelPtr;
     pub fn zerocheck_fused_sequential_ext_1024_kernel() -> KernelPtr;
 
+    // zerocheck (DAG-native): bivariate variants for the fused
+    // first-two-rounds evaluation. Eval nodes on blockIdx.z (12 non-boolean
+    // grid nodes of {0,1,2,4}^2), quadruple row consumption, output stride
+    // 12. Round 0 only — base-field trace.
+    pub fn zerocheck_fused_sequential_bivariate_kb_32_kernel() -> KernelPtr;
+    pub fn zerocheck_fused_sequential_bivariate_kb_64_kernel() -> KernelPtr;
+    pub fn zerocheck_fused_sequential_bivariate_kb_128_kernel() -> KernelPtr;
+    pub fn zerocheck_fused_sequential_bivariate_kb_256_kernel() -> KernelPtr;
+    pub fn zerocheck_fused_sequential_bivariate_kb_512_kernel() -> KernelPtr;
+    pub fn zerocheck_fused_sequential_bivariate_kb_1024_kernel() -> KernelPtr;
+
     // zerocheck (DAG-native): ColumnTile lowering kernels.
     pub fn zerocheck_column_tile_kb_kernel() -> KernelPtr;
     pub fn zerocheck_column_tile_ext_kernel() -> KernelPtr;
@@ -55,6 +66,11 @@ extern "C" {
     // writes 3 ext_t partials per chip (one per eval point) that the host
     // aggregation sums into the round's totals.
     pub fn zerocheck_geq_corrections_kernel() -> KernelPtr;
+
+    // zerocheck (DAG-native): bivariate geq correction for the fused
+    // first-two-rounds. One block per geq chip, 12 ext_t partials per chip
+    // (one per non-boolean grid node).
+    pub fn zerocheck_geq_corrections_bivariate_kernel() -> KernelPtr;
 
     // zerocheck (DAG-native): apply `VirtualGeq::fix_last_variable(alpha)`
     // in place to each chip's geq state. One thread per chip.
@@ -65,11 +81,21 @@ extern "C" {
     // host then only downloads the 3 totals instead of the full partials.
     pub fn zerocheck_aggregate_partials_kernel() -> KernelPtr;
 
+    // zerocheck (DAG-native): strided aggregation for the fused
+    // first-two-rounds partials ([group][e] layout with `stride` slots per
+    // group). Launched with gridDim.x == stride.
+    pub fn zerocheck_aggregate_partials_strided_kernel() -> KernelPtr;
+
     // zerocheck (DAG-native): per-chip GKR column sweep. Decoupled from the
     // sequential constraint kernel so wide chips can parallelise the column
     // reduction across a warp's lanes. One block per (chip, row-tile).
     pub fn zerocheck_gkr_sweep_kb_kernel() -> KernelPtr;
     pub fn zerocheck_gkr_sweep_ext_kernel() -> KernelPtr;
+
+    // zerocheck (DAG-native): GKR corner sweep for the fused
+    // first-two-rounds — the opening batch at the four boolean grid corners
+    // (raw rows of each quadruple, no interpolation). Output stride 4.
+    pub fn zerocheck_gkr_corner_sweep_kb_kernel() -> KernelPtr;
 
     // zerocheck (DAG-native): per-chunk padded_row_adjustment via the
     // bytecode interpreter at the all-zero trace. One thread per chunk;

--- a/sp1-gpu/crates/sys/src/kernels.rs
+++ b/sp1-gpu/crates/sys/src/kernels.rs
@@ -31,6 +31,10 @@ extern "C" {
     pub fn fix_last_variable_jagged_felt() -> KernelPtr;
     pub fn fix_last_variable_jagged_ext() -> KernelPtr;
 
+    // Fused two-variable jagged fold (base trace → twice-folded ext trace in
+    // one pass), used by the zerocheck fused first-two-rounds.
+    pub fn fix_last_two_variables_jagged_felt() -> KernelPtr;
+
     // Fused dispatch: one launch per non-empty tier handles every
     // Sequential chunk in a round. The launcher's per-block dispatch
     // descriptor maps each block to its `(chunk_id, row_offset, n_rows)`.

--- a/sp1-gpu/crates/zerocheck/src/lib.rs
+++ b/sp1-gpu/crates/zerocheck/src/lib.rs
@@ -1576,9 +1576,7 @@ pub mod tests {
         run_zerocheck_and_verify(&chips, machine_compiled, &[1 << 16], &[], 16);
     }
 
-    #[test]
-    #[serial]
-    fn test_zerocheck_function_verify() {
+    fn zerocheck_function_verify_with_sizes(input_size: Vec<u32>) {
         let mut chips: BTreeSet<Chip<Felt, _>> = BTreeSet::new();
         chips.insert(Chip::new(ZerocheckTestChip::Chip1(ZerocheckTestChip1)));
         chips.insert(Chip::new(ZerocheckTestChip::Chip2(ZerocheckTestChip2)));
@@ -1598,7 +1596,6 @@ pub mod tests {
             let mut superset = vec![fake];
             superset.append(&mut machine_compiled);
             let machine_bytecode = Arc::new(upload_compiled_bytecode(superset, &t));
-            let input_size = get_input_sizes();
             let mut rng = rand::thread_rng();
             let public_values = vec![random_felt(&mut rng), random_felt(&mut rng)];
 
@@ -1679,6 +1676,24 @@ pub mod tests {
             );
         })
         .unwrap();
+    }
+
+    #[test]
+    #[serial]
+    fn test_zerocheck_function_verify() {
+        zerocheck_function_verify_with_sizes(get_input_sizes());
+    }
+
+    /// A tiny chip alongside large ones: exercises the fused
+    /// first-two-rounds dispatch with a quadruple count far below the tile
+    /// size and a small geq threshold. (Heights stay ≡ 0 mod 4 — a
+    /// pipeline-wide invariant of the jagged trace layout that the test
+    /// harness's `evaluate_jagged_columns` also relies on; the bivariate
+    /// kernels additionally guard partial quadruples defensively.)
+    #[test]
+    #[serial]
+    fn test_zerocheck_function_verify_tiny_chip() {
+        zerocheck_function_verify_with_sizes(vec![1456084, 1665180, 36]);
     }
 
     /// Zerocheck on real RISC-V traces. Builds the machine bytecode from the

--- a/sp1-gpu/crates/zerocheck/src/primitives.rs
+++ b/sp1-gpu/crates/zerocheck/src/primitives.rs
@@ -5,7 +5,9 @@ use slop_commit::Rounds;
 use slop_multilinear::{MleEval, Point};
 use slop_tensor::{Tensor, TensorView};
 
-use sp1_gpu_cudart::sys::kernels::{fix_last_variable_jagged_ext, fix_last_variable_jagged_felt};
+use sp1_gpu_cudart::sys::kernels::{
+    fix_last_two_variables_jagged_felt, fix_last_variable_jagged_ext, fix_last_variable_jagged_felt,
+};
 use sp1_gpu_cudart::sys::runtime::KernelPtr;
 use sp1_gpu_cudart::{
     args, dot_along_dim_view, DeviceBuffer, DevicePoint, DeviceTensor, TaskScope,
@@ -36,6 +38,77 @@ pub struct FoldMetadataScratch<'a> {
     pub block_counter: &'a mut Buffer<u32, TaskScope>,
     pub flags: &'a mut Buffer<u32, TaskScope>,
     pub scan_values: &'a mut Buffer<u32, TaskScope>,
+}
+
+/// Runs the fold-metadata kernel: reads `input_heights` (device pointer to
+/// `n_columns` pair-unit heights), returns freshly allocated folded
+/// `column_heights` and `start_indices` buffers.
+///
+/// Single launch — fully on device, no host round-trip. The kernel uses a
+/// multi-block decoupled-lookback inclusive scan with the `h.div_ceil(4)*2`
+/// transform fused into the load and the exclusive-prefix shift fused into
+/// the store. The caller-owned scan scratch is reset in place per the
+/// contract in `fold_metadata.cuh`; since `n_columns` is invariant across
+/// folds, the same capacity suffices every round.
+fn launch_fold_metadata(
+    input_heights: *const u32,
+    n_columns: usize,
+    scratch: &mut FoldMetadataScratch<'_>,
+    backend: &TaskScope,
+) -> (Buffer<u32, TaskScope>, Buffer<u32, TaskScope>) {
+    let section_size =
+        unsafe { sp1_gpu_cudart::sys::kernels::jagged_fold_metadata_section_size() } as usize;
+    let block_dim = unsafe { sp1_gpu_cudart::sys::kernels::jagged_fold_metadata_block_dim() };
+    let n_blocks: usize = n_columns.div_ceil(section_size).max(1);
+
+    let mut output_heights_dev =
+        Buffer::<u32, TaskScope>::with_capacity_in(n_columns, backend.clone());
+    let mut output_start_idx =
+        Buffer::<u32, TaskScope>::with_capacity_in(n_columns + 1, backend.clone());
+    // SAFETY: the fold-metadata kernel writes all `n_columns` + `n_columns+1`
+    // slots before any downstream read.
+    unsafe {
+        output_heights_dev.assume_init();
+        output_start_idx.assume_init();
+    }
+
+    // Reset the cached scan bookkeeping in place — no per-fold allocation.
+    // `block_counter[0] = 0`, `flags[0]` set non-zero so the first block
+    // doesn't wait, `flags[1..n_blocks+1] = 0` and `scan_values[0..n_blocks+1]
+    // = 0` so the decoupled-lookback chain starts from a clean state.
+    let u32_bytes = std::mem::size_of::<u32>();
+    unsafe {
+        scratch.block_counter.set_len(0);
+        scratch.flags.set_len(0);
+        scratch.scan_values.set_len(0);
+    }
+    scratch.block_counter.write_bytes(0, u32_bytes).unwrap();
+    scratch.flags.write_bytes(1, u32_bytes).unwrap();
+    scratch.flags.write_bytes(0, n_blocks * u32_bytes).unwrap();
+    scratch.scan_values.write_bytes(0, (n_blocks + 1) * u32_bytes).unwrap();
+
+    unsafe {
+        let args = args!(
+            input_heights,
+            n_columns as u32,
+            output_heights_dev.as_mut_ptr(),
+            output_start_idx.as_mut_ptr(),
+            scratch.block_counter.as_mut_ptr(),
+            scratch.flags.as_mut_ptr(),
+            scratch.scan_values.as_mut_ptr()
+        );
+        backend
+            .launch_kernel(
+                sp1_gpu_cudart::sys::kernels::jagged_fold_metadata_kernel(),
+                (n_blocks as u32, 1u32, 1u32),
+                (block_dim, 1u32, 1u32),
+                &args,
+                0,
+            )
+            .unwrap();
+    }
+
+    (output_heights_dev, output_start_idx)
 }
 
 /// Folds the trace MLE against `value`, returning the next-round MLE.
@@ -92,69 +165,10 @@ where
         update_offset(&jagged_mle.dense_data.main_table_index, next_preprocessed_offset);
 
     // ---- Device-side fold metadata ----
-    //
-    // Single launch reads `column_heights`, writes new `column_heights` and
-    // new `start_indices` — fully on device, no host round-trip. The kernel
-    // uses a multi-block decoupled-lookback inclusive scan with the
-    // `h.div_ceil(4)*2` transform fused into the load and the exclusive-
-    // prefix shift fused into the store. Caller pre-zeroes the
-    // bookkeeping buffers `block_counter`, `flags`, `scan_values` per the
-    // contract in `fold_metadata.cuh`.
     let n_columns = jagged_mle.column_heights.len();
-    let section_size =
-        unsafe { sp1_gpu_cudart::sys::kernels::jagged_fold_metadata_section_size() } as usize;
-    let block_dim = unsafe { sp1_gpu_cudart::sys::kernels::jagged_fold_metadata_block_dim() };
-    let n_blocks: usize = n_columns.div_ceil(section_size).max(1);
-
-    let mut output_heights_dev =
-        Buffer::<u32, TaskScope>::with_capacity_in(n_columns, backend.clone());
-    let mut output_start_idx =
-        Buffer::<u32, TaskScope>::with_capacity_in(n_columns + 1, backend.clone());
-    // SAFETY: the fold-metadata kernel writes all `n_columns` + `n_columns+1`
-    // slots before any downstream read.
-    unsafe {
-        output_heights_dev.assume_init();
-        output_start_idx.assume_init();
-    }
-
-    // Reset the cached scan bookkeeping in place — no per-fold allocation.
-    // `block_counter[0] = 0`, `flags[0]` set non-zero so the first block
-    // doesn't wait, `flags[1..n_blocks+1] = 0` and `scan_values[0..n_blocks+1]
-    // = 0` so the decoupled-lookback chain starts from a clean state. The
-    // caller-owned buffers were allocated once for this shard's
-    // `n_blocks = ceil(n_columns / SECTION_SIZE)`; since `n_columns` is
-    // invariant across folds, the same capacity suffices every round.
-    let u32_bytes = std::mem::size_of::<u32>();
-    unsafe {
-        scratch.block_counter.set_len(0);
-        scratch.flags.set_len(0);
-        scratch.scan_values.set_len(0);
-    }
-    scratch.block_counter.write_bytes(0, u32_bytes).unwrap();
-    scratch.flags.write_bytes(1, u32_bytes).unwrap();
-    scratch.flags.write_bytes(0, n_blocks * u32_bytes).unwrap();
-    scratch.scan_values.write_bytes(0, (n_blocks + 1) * u32_bytes).unwrap();
-
-    unsafe {
-        let args = args!(
-            jagged_mle.column_heights.as_ptr(),
-            n_columns as u32,
-            output_heights_dev.as_mut_ptr(),
-            output_start_idx.as_mut_ptr(),
-            scratch.block_counter.as_mut_ptr(),
-            scratch.flags.as_mut_ptr(),
-            scratch.scan_values.as_mut_ptr()
-        );
-        backend
-            .launch_kernel(
-                sp1_gpu_cudart::sys::kernels::jagged_fold_metadata_kernel(),
-                (n_blocks as u32, 1u32, 1u32),
-                (block_dim, 1u32, 1u32),
-                &args,
-                0,
-            )
-            .unwrap();
-    }
+    let mut scratch = scratch;
+    let (output_heights_dev, output_start_idx) =
+        launch_fold_metadata(jagged_mle.column_heights.as_ptr(), n_columns, &mut scratch, backend);
 
     let new_data =
         Buffer::<Ext, TaskScope>::with_capacity_in(new_total_length as usize, backend.clone());
@@ -199,6 +213,116 @@ where
         backend
             .launch_kernel(
                 <TaskScope as JaggedFixLastVariableKernel<F>>::jagged_fix_last_variable_kernel(),
+                grid_size,
+                block_dim_fold,
+                &args,
+                0,
+            )
+            .unwrap();
+    }
+
+    next_jagged_mle
+}
+
+/// Folds the trace MLE against two challenges in a single pass over the
+/// input, returning the twice-folded MLE — byte-identical to two chained
+/// [`evaluate_jagged_fix_last_variable`] calls, but the intermediate
+/// (half-size, extension-field) trace is never written or re-read.
+///
+/// `alpha_1` folds the last variable, `alpha_2` the second-to-last.
+/// `input_length` is the input pair count; `new_total_length` the
+/// twice-folded element count. Base-field input only: the caller is the
+/// zerocheck fused first-two-rounds, whose two challenges are both known
+/// before any fold happens.
+#[inline(always)]
+pub(crate) fn evaluate_jagged_fix_last_two_variables(
+    jagged_mle: &JaggedTraceMle<Felt, TaskScope>,
+    alpha_1: Ext,
+    alpha_2: Ext,
+    input_length: u32,
+    new_total_length: u32,
+    scratch: FoldMetadataScratch<'_>,
+) -> JaggedTraceMle<Ext, TaskScope> {
+    let backend = jagged_mle.dense().backend();
+
+    // Adjusts offsets for each chip — the single-fold recurrence applied
+    // twice.
+    fn update_offset_twice(
+        old_map: &BTreeMap<String, TraceOffset>,
+        starting_offset: usize,
+    ) -> (BTreeMap<String, TraceOffset>, usize) {
+        let mut current_offset = starting_offset;
+        let mut next_table_index = BTreeMap::new();
+        for (chip, old_offset) in old_map.iter() {
+            let once_poly_size = old_offset.poly_size.div_ceil(4) * 2;
+            let next_poly_size = once_poly_size.div_ceil(4) * 2;
+            let upper = current_offset + next_poly_size * old_offset.num_polys;
+            let next_offset = TraceOffset {
+                dense_offset: current_offset..upper,
+                poly_size: next_poly_size,
+                num_polys: old_offset.num_polys,
+            };
+            next_table_index.insert(chip.clone(), next_offset.clone());
+            current_offset = upper;
+        }
+        (next_table_index, current_offset)
+    }
+    let (next_preprocessed_table_index, next_preprocessed_offset) =
+        update_offset_twice(&jagged_mle.dense_data.preprocessed_table_index, 0);
+    let (next_main_table_index, _next_main_offset) =
+        update_offset_twice(&jagged_mle.dense_data.main_table_index, next_preprocessed_offset);
+
+    // ---- Device-side fold metadata, applied twice ----
+    //
+    // The intermediate metadata is only an input to the second launch; its
+    // start indices are never consumed.
+    let n_columns = jagged_mle.column_heights.len();
+    let mut scratch = scratch;
+    let (mid_heights, _mid_starts) =
+        launch_fold_metadata(jagged_mle.column_heights.as_ptr(), n_columns, &mut scratch, backend);
+    let (output_heights_dev, output_start_idx) =
+        launch_fold_metadata(mid_heights.as_ptr(), n_columns, &mut scratch, backend);
+
+    let new_data =
+        Buffer::<Ext, TaskScope>::with_capacity_in(new_total_length as usize, backend.clone());
+    let new_cols =
+        Buffer::<u32, TaskScope>::with_capacity_in(new_total_length as usize / 2, backend.clone());
+
+    let next_trace_data = TraceDenseData {
+        dense: new_data,
+        preprocessed_offset: next_preprocessed_offset,
+        preprocessed_cols: jagged_mle.dense_data.preprocessed_cols,
+        preprocessed_table_index: next_preprocessed_table_index,
+        main_table_index: next_main_table_index,
+        main_padding: 0,
+        preprocessed_padding: 0,
+        prep_padding_col_count: jagged_mle.dense_data.prep_padding_col_count,
+        main_padding_col_count: jagged_mle.dense_data.main_padding_col_count,
+    };
+
+    let mut next_jagged_mle =
+        JaggedTraceMle::new(next_trace_data, new_cols, output_start_idx, output_heights_dev);
+
+    const BLOCK_SIZE: usize = 256;
+    const CHUNK_SIZE: usize = 1 << 16;
+    let n_quads = input_length / 2;
+    let grid_size_x = (n_quads as usize).div_ceil(CHUNK_SIZE).max(256);
+    let grid_size = (grid_size_x, 1, 1);
+    let block_dim_fold = BLOCK_SIZE;
+
+    // SAFETY: `next_jagged_mle` is freshly allocated with capacity sized to
+    // `new_total_length`; the kernel below writes every element (real
+    // outputs plus the per-column zero tails) before any later reader. The
+    // `args!` tuple matches `fix_last_two_variables_jagged_felt`'s C
+    // signature in `sys/include/zerocheck/jagged_mle.cuh`.
+    unsafe {
+        next_jagged_mle.dense_data.dense.assume_init();
+        next_jagged_mle.col_index.assume_init();
+        let args =
+            args!(jagged_mle.as_raw(), next_jagged_mle.as_mut_raw(), n_quads, alpha_1, alpha_2);
+        backend
+            .launch_kernel(
+                fix_last_two_variables_jagged_felt(),
                 grid_size,
                 block_dim_fold,
                 &args,

--- a/sp1-gpu/crates/zerocheck/src/prover.rs
+++ b/sp1-gpu/crates/zerocheck/src/prover.rs
@@ -58,7 +58,10 @@ use sp1_hypercube::{
 };
 
 use crate::challenger_update;
-use crate::primitives::{evaluate_jagged_fix_last_variable, JaggedFixLastVariableKernel};
+use crate::primitives::{
+    evaluate_jagged_fix_last_two_variables, evaluate_jagged_fix_last_variable,
+    JaggedFixLastVariableKernel,
+};
 
 // ============================================================================
 // Compiled per-chip data — built once per session, reused across all rounds
@@ -2280,6 +2283,108 @@ where
     }
 }
 
+/// Fixes the last TWO variables in a single pass over the base-field trace —
+/// used by the fused first-two-rounds driver, which holds both challenges
+/// before any fold happens. Equivalent to two chained
+/// [`zerocheck_fix_last_variable`] calls without materializing the
+/// intermediate half-size extension trace.
+///
+/// `alpha_1` folds the last variable, `alpha_2` the second-to-last; `claim`
+/// is the round-2 claim (the second round message evaluated at `alpha_2`).
+pub(crate) fn zerocheck_fix_last_two_variables<'b>(
+    input: ZeroCheckJaggedPoly<'b, Felt>,
+    alpha_1: Ext,
+    alpha_2: Ext,
+    claim: Ext,
+) -> ZeroCheckJaggedPoly<'b, Ext> {
+    let (rest, last_two) = input.zeta.split_at(input.zeta.dimension() - 2);
+    let z_a = *last_two[0];
+    let z_b = *last_two[1];
+
+    let input_length = input.layout_tracker.total_length_pair();
+    let mut layout_tracker = input.layout_tracker;
+    layout_tracker.fold();
+    layout_tracker.fold();
+    let new_total_length = layout_tracker.total_length_pair() * 2;
+
+    let mut scan_block_counter = input.scan_block_counter;
+    let mut scan_flags = input.scan_flags;
+    let mut scan_values = input.scan_values;
+    let new_data = evaluate_jagged_fix_last_two_variables(
+        &input.data,
+        alpha_1,
+        alpha_2,
+        input_length,
+        new_total_length,
+        crate::primitives::FoldMetadataScratch {
+            block_counter: &mut scan_block_counter,
+            flags: &mut scan_flags,
+            scan_values: &mut scan_values,
+        },
+    );
+    // Both fixed eq factors, in fold order: the last coordinate against
+    // `alpha_1`, then the second-to-last against `alpha_2`.
+    let eq_1 = (Ext::one() - z_b) * (Ext::one() - alpha_1) + z_b * alpha_1;
+    let eq_2 = (Ext::one() - z_a) * (Ext::one() - alpha_2) + z_a * alpha_2;
+    let eq_adjustment = input.eq_adjustment * eq_1 * eq_2;
+
+    // Mutate the device-resident per-chip geq state in place, once per
+    // fixed variable (the recurrence is sequential in the challenges).
+    let n_chips = input.compiled.len() as u32;
+    if n_chips > 0 {
+        const BS: u32 = 128;
+        let n_blocks = n_chips.div_ceil(BS);
+        let scope = new_data.dense().backend();
+        for alpha in [alpha_1, alpha_2] {
+            unsafe {
+                let args = args!(input.chip_geq_state_dev.as_ptr(), n_chips, alpha);
+                scope
+                    .launch_kernel(
+                        zerocheck_fix_geq_state_kernel(),
+                        (n_blocks, 1, 1),
+                        (BS, 1, 1),
+                        &args,
+                        0,
+                    )
+                    .unwrap();
+            }
+        }
+    }
+
+    let mut chip_layouts_dev = input.chip_layouts_dev;
+    launch_chip_layouts_kernel(&new_data, &input.chip_column_layouts_dev, &mut chip_layouts_dev);
+
+    ZeroCheckJaggedPoly {
+        data: Cow::Owned(new_data),
+        compiled: input.compiled,
+        machine_bytecode: input.machine_bytecode,
+        eq_adjustment,
+        zeta: rest,
+        claim,
+        padded_row_adjustment_host: input.padded_row_adjustment_host,
+        public_values: input.public_values,
+        powers_of_alpha: input.powers_of_alpha,
+        gkr_powers: input.gkr_powers,
+        powers_of_lambda: input.powers_of_lambda,
+        layout_tracker,
+        chip_column_layouts_dev: input.chip_column_layouts_dev,
+        chip_layouts_dev,
+        chip_alpha_offset: input.chip_alpha_offset,
+        seq_tiers: input.seq_tiers,
+        chip_geq_state_dev: input.chip_geq_state_dev,
+        chip_pad_adj_dev: input.chip_pad_adj_dev,
+        geq_chip_indices_dev: input.geq_chip_indices_dev,
+        n_geq_chips: input.n_geq_chips,
+        chip_gkr_info_dev: input.chip_gkr_info_dev,
+        gkr_active_chips: input.gkr_active_chips,
+        cached_seq_dispatch: input.cached_seq_dispatch,
+        cached_gkr_dispatch: input.cached_gkr_dispatch,
+        scan_block_counter,
+        scan_flags,
+        scan_values,
+    }
+}
+
 // ============================================================================
 // Outer driver — parallel to v1's `zerocheck`.
 // ============================================================================
@@ -2476,7 +2581,7 @@ where
             main_poly.claim,
             "fused first round message inconsistent with the claim"
         );
-        let (alpha, claim_1) = challenger_update(&first_msg, challenger);
+        let (alpha, _claim_1) = challenger_update(&first_msg, challenger);
         univariate_polys.push(first_msg);
         jagged_point.add_dimension(alpha);
 
@@ -2495,16 +2600,15 @@ where
         }
 
         let t = std::time::Instant::now();
-        let mid_poly = zerocheck_fix_last_variable(main_poly, alpha, claim_1);
-        let next_poly = zerocheck_fix_last_variable(mid_poly, alpha_2, claim_2);
+        let next_poly = zerocheck_fix_last_two_variables(main_poly, alpha, alpha_2, claim_2);
         if debug_timing {
             total_fold += t.elapsed();
         }
         if round_timing {
-            // Drain the two async folds so their cost is attributed here
+            // Drain the async double-fold so its cost is attributed here
             // rather than to the next round's eval window.
             next_poly.data.backend().synchronize_blocking().unwrap();
-            tracing::info!("zerocheck folds 0+1 (fused): drain={:?}", t.elapsed());
+            tracing::info!("zerocheck folds 0+1 (fused double-fold): drain={:?}", t.elapsed());
         }
         (next_poly, claim_2, max_log_row_count - 2)
     } else {

--- a/sp1-gpu/crates/zerocheck/src/prover.rs
+++ b/sp1-gpu/crates/zerocheck/src/prover.rs
@@ -26,24 +26,33 @@ use sp1_gpu_air::ir::{
     lower_sequential, ChunkBudget, ChunkBytecode, ColumnTileBytecode, DagBuilder, Lowering,
 };
 use sp1_gpu_cudart::sys::kernels::{
-    zerocheck_aggregate_partials_kernel, zerocheck_column_tile_ext_kernel,
-    zerocheck_column_tile_kb_kernel, zerocheck_fix_geq_state_kernel,
-    zerocheck_fused_sequential_ext_1024_kernel, zerocheck_fused_sequential_ext_128_kernel,
-    zerocheck_fused_sequential_ext_256_kernel, zerocheck_fused_sequential_ext_32_kernel,
-    zerocheck_fused_sequential_ext_512_kernel, zerocheck_fused_sequential_ext_64_kernel,
-    zerocheck_fused_sequential_kb_1024_kernel, zerocheck_fused_sequential_kb_128_kernel,
-    zerocheck_fused_sequential_kb_256_kernel, zerocheck_fused_sequential_kb_32_kernel,
-    zerocheck_fused_sequential_kb_512_kernel, zerocheck_fused_sequential_kb_64_kernel,
-    zerocheck_geq_corrections_kernel, zerocheck_gkr_sweep_ext_kernel,
-    zerocheck_gkr_sweep_kb_kernel, zerocheck_pad_adj_1024_kernel, zerocheck_pad_adj_128_kernel,
-    zerocheck_pad_adj_256_kernel, zerocheck_pad_adj_32_kernel, zerocheck_pad_adj_512_kernel,
-    zerocheck_pad_adj_64_kernel,
+    zerocheck_aggregate_partials_kernel, zerocheck_aggregate_partials_strided_kernel,
+    zerocheck_column_tile_ext_kernel, zerocheck_column_tile_kb_kernel,
+    zerocheck_fix_geq_state_kernel, zerocheck_fused_sequential_bivariate_kb_1024_kernel,
+    zerocheck_fused_sequential_bivariate_kb_128_kernel,
+    zerocheck_fused_sequential_bivariate_kb_256_kernel,
+    zerocheck_fused_sequential_bivariate_kb_32_kernel,
+    zerocheck_fused_sequential_bivariate_kb_512_kernel,
+    zerocheck_fused_sequential_bivariate_kb_64_kernel, zerocheck_fused_sequential_ext_1024_kernel,
+    zerocheck_fused_sequential_ext_128_kernel, zerocheck_fused_sequential_ext_256_kernel,
+    zerocheck_fused_sequential_ext_32_kernel, zerocheck_fused_sequential_ext_512_kernel,
+    zerocheck_fused_sequential_ext_64_kernel, zerocheck_fused_sequential_kb_1024_kernel,
+    zerocheck_fused_sequential_kb_128_kernel, zerocheck_fused_sequential_kb_256_kernel,
+    zerocheck_fused_sequential_kb_32_kernel, zerocheck_fused_sequential_kb_512_kernel,
+    zerocheck_fused_sequential_kb_64_kernel, zerocheck_geq_corrections_bivariate_kernel,
+    zerocheck_geq_corrections_kernel, zerocheck_gkr_corner_sweep_kb_kernel,
+    zerocheck_gkr_sweep_ext_kernel, zerocheck_gkr_sweep_kb_kernel, zerocheck_pad_adj_1024_kernel,
+    zerocheck_pad_adj_128_kernel, zerocheck_pad_adj_256_kernel, zerocheck_pad_adj_32_kernel,
+    zerocheck_pad_adj_512_kernel, zerocheck_pad_adj_64_kernel,
 };
 use sp1_gpu_cudart::sys::runtime::KernelPtr;
 use sp1_gpu_cudart::{args, DeviceBuffer, DeviceCopy, DevicePoint, TaskScope};
 use sp1_gpu_utils::{Ext, Felt, JaggedTraceMle};
 use sp1_hypercube::air::MachineAir;
-use sp1_hypercube::prover::ZerocheckAir;
+use sp1_hypercube::prover::{
+    zerocheck_first_round_message_from_grid, zerocheck_second_round_message_from_grid,
+    ZerocheckAir, ZEROCHECK_CONSTRAINT_NODES, ZEROCHECK_NODE_XS,
+};
 use sp1_hypercube::{
     AirOpenedValues, Chip, ChipEvaluation, ChipOpenedValues, LogUpEvaluations, ShardOpenedValues,
 };
@@ -1857,6 +1866,319 @@ fn launch_chunk_into<K: Field>(
 }
 
 // ============================================================================
+// Fused first-two-rounds ("bivariate") evaluation.
+// ============================================================================
+
+/// The tiered bivariate fused-sequential kernel for the first round's base-field trace.
+fn bivariate_sequential_kernel_for(max_reg_in_tier: u16) -> KernelPtr {
+    unsafe {
+        if max_reg_in_tier <= 32 {
+            zerocheck_fused_sequential_bivariate_kb_32_kernel()
+        } else if max_reg_in_tier <= 64 {
+            zerocheck_fused_sequential_bivariate_kb_64_kernel()
+        } else if max_reg_in_tier <= 128 {
+            zerocheck_fused_sequential_bivariate_kb_128_kernel()
+        } else if max_reg_in_tier <= 256 {
+            zerocheck_fused_sequential_bivariate_kb_256_kernel()
+        } else if max_reg_in_tier <= 512 {
+            zerocheck_fused_sequential_bivariate_kb_512_kernel()
+        } else {
+            zerocheck_fused_sequential_bivariate_kb_1024_kernel()
+        }
+    }
+}
+
+/// Evaluates the bivariate round polynomial of the fused first two rounds on the interpolation
+/// grid `{0, 1, 2, 4}^2` of the last two variables, in a single pass over the base-field trace.
+///
+/// Returns `grid[ix][iy]` — the eq-weighted, lambda-RLC'ed sums over the trace quadruples at node
+/// `(ZEROCHECK_NODE_XS[ix], ZEROCHECK_NODE_XS[iy])`, excluding the eq factors in the last two
+/// variables and the `eq_adjustment` (which the message assembly applies). The four boolean
+/// corners hold only the GKR opening batch: constraint values vanish on real rows there and the
+/// padded rows' values cancel exactly against the geq correction, so neither is computed. The 12
+/// non-boolean nodes hold constraint sums (via the bivariate bytecode kernel), the bilinearly
+/// extended GKR batch, and the geq corrections.
+///
+/// The caller must ensure no active chip has a ColumnTile chunk — those only have a univariate
+/// kernel — and that the poly has at least two variables.
+pub(crate) fn evaluate_zerocheck_bivariate(
+    poly: &mut ZeroCheckJaggedPoly<'_, Felt>,
+) -> [[Ext; 4]; 4] {
+    let backend = poly.data.backend();
+    // The 12 non-boolean grid nodes evaluated by the constraint + geq kernels, and the 4 boolean
+    // corners swept by the GKR corner kernel. Must match `bivariate.cuh`.
+    const NUM_NODES: usize = 12;
+    const NUM_CORNERS: usize = 4;
+    const BLOCK_SIZE_LOW_REG: u32 = 256;
+    const BLOCK_SIZE_HIGH_REG: u32 = 64;
+    // One quadruple per thread: unlike the univariate kernels, the bivariate
+    // kernels have no eval-point grid dimension (each block computes all
+    // nodes), so smaller tiles restore the block-level parallelism that
+    // small chips would otherwise lose.
+    const ROWS_PER_THREAD: u32 = 1;
+
+    debug_assert!(poly.zeta.dimension() >= 2);
+    let (rest, _) = poly.zeta.split_at(poly.zeta.dimension() - 2);
+    let rest_point = DevicePoint::from_host(&rest, backend).unwrap();
+    let partial_lagrange = rest_point.partial_lagrange();
+    let rest_point_dim = rest.dimension() as u32;
+
+    let trace_ptr = poly.data.as_ref().dense_data.dense.as_ptr();
+    let chip_layouts_ptr = poly.chip_layouts_dev.as_ptr();
+
+    let block_size_for = |tier: usize| -> u32 {
+        if poly.seq_tiers[tier].max_reg > 128 {
+            BLOCK_SIZE_HIGH_REG
+        } else {
+            BLOCK_SIZE_LOW_REG
+        }
+    };
+
+    // ---- Per-tier dispatch tables over row QUADRUPLES ----
+    let mut dispatch_tiers: [Vec<BlockDispatchC>; 2] = [Vec::new(), Vec::new()];
+    for (t, tier) in poly.seq_tiers.iter().enumerate() {
+        let tile = block_size_for(t) * ROWS_PER_THREAD;
+        for (chunk_idx_in_tier, &chip_idx) in tier.chip_indices.iter().enumerate() {
+            let quad_count =
+                poly.layout_tracker.chip_height_elements(chip_idx as usize).div_ceil(4);
+            if quad_count == 0 {
+                continue;
+            }
+            let mut row_offset = 0u32;
+            while row_offset < quad_count {
+                let n_rows = (quad_count - row_offset).min(tile);
+                dispatch_tiers[t].push(BlockDispatchC {
+                    chunk_id: chunk_idx_in_tier as u32,
+                    row_offset,
+                    n_rows,
+                });
+                row_offset += tile;
+            }
+        }
+    }
+
+    // ---- GKR corner-sweep dispatch: EVERY chip with non-zero width ----
+    //
+    // The bivariate sequential kernel has no inline GKR path, so the corner
+    // sweep covers narrow and wide chips uniformly.
+    const GKR_BLOCK_SIZE: u32 = 256;
+    let gkr_tile: u32 = GKR_BLOCK_SIZE * ROWS_PER_THREAD;
+    let mut corner_dispatch: Vec<BlockDispatchC> = Vec::new();
+    for chip in poly.compiled.iter() {
+        if chip.main_width + chip.prep_width == 0 {
+            continue;
+        }
+        let quad_count =
+            poly.layout_tracker.chip_height_elements(chip.chip_idx as usize).div_ceil(4);
+        if quad_count == 0 {
+            continue;
+        }
+        let mut row_offset = 0u32;
+        while row_offset < quad_count {
+            let n_rows = (quad_count - row_offset).min(gkr_tile);
+            corner_dispatch.push(BlockDispatchC { chunk_id: chip.chip_idx, row_offset, n_rows });
+            row_offset += gkr_tile;
+        }
+    }
+
+    // ---- Slot allocation ----
+    //
+    // Two shared buffers by output stride: the node buffer ([group][e] with
+    // 12 slots per group — sequential tiers + geq chips) and the corner
+    // buffer (4 slots per corner-sweep block).
+    let mut tier_slot: [usize; 2] = [0, 0];
+    let mut node_slots: usize = 0;
+    for t in 0..2 {
+        tier_slot[t] = node_slots;
+        node_slots += dispatch_tiers[t].len() * NUM_NODES;
+    }
+    let geq_slot = node_slots;
+    node_slots += poly.n_geq_chips * NUM_NODES;
+    let corner_slots = corner_dispatch.len() * NUM_CORNERS;
+
+    let mut node_partials: Tensor<Ext, TaskScope> =
+        Tensor::with_sizes_in([node_slots.max(1)], backend.clone());
+    let mut corner_partials: Tensor<Ext, TaskScope> =
+        Tensor::with_sizes_in([corner_slots.max(1)], backend.clone());
+    unsafe {
+        node_partials.assume_init();
+        corner_partials.assume_init();
+    }
+    let node_partials_ptr = node_partials.as_mut_ptr();
+    let corner_partials_ptr = corner_partials.as_mut_ptr();
+
+    // ---- Launch one bivariate fused kernel per non-empty tier ----
+    for t in 0..2 {
+        if dispatch_tiers[t].is_empty() {
+            continue;
+        }
+        let bs = block_size_for(t);
+        let dispatch_ptr =
+            refill_buffer(&mut poly.cached_seq_dispatch[t], &dispatch_tiers[t], backend).as_ptr();
+        let static_ptr = poly.seq_tiers[t].static_buf.as_ref().unwrap().as_ptr();
+        let max_reg = poly.seq_tiers[t].max_reg;
+        let out_ptr = unsafe { node_partials_ptr.add(tier_slot[t]) };
+        let shmem_bytes = (bs as usize / 32).max(1) * std::mem::size_of::<Ext>();
+        unsafe {
+            let args = args!(
+                dispatch_ptr,
+                static_ptr,
+                chip_layouts_ptr,
+                trace_ptr,
+                poly.public_values.as_ptr(),
+                poly.powers_of_alpha.as_ptr(),
+                partial_lagrange.as_ptr(),
+                poly.powers_of_lambda.as_ptr(),
+                rest_point_dim,
+                out_ptr
+            );
+            backend
+                .launch_kernel(
+                    bivariate_sequential_kernel_for(max_reg),
+                    (dispatch_tiers[t].len() as u32, 1, 1),
+                    (bs, 1, 1),
+                    &args,
+                    shmem_bytes,
+                )
+                .unwrap();
+        }
+    }
+
+    // ---- Per-chip bivariate geq corrections ----
+    if poly.n_geq_chips > 0 {
+        const GEQ_BLOCK_SIZE: u32 = 256;
+        let geq_indices = poly.geq_chip_indices_dev.as_ref().unwrap();
+        let out_ptr = unsafe { node_partials_ptr.add(geq_slot) };
+        let shmem_bytes = (GEQ_BLOCK_SIZE as usize / 32) * std::mem::size_of::<Ext>();
+        unsafe {
+            let args = args!(
+                geq_indices.as_ptr(),
+                (poly.n_geq_chips as u32),
+                poly.chip_geq_state_dev.as_ptr(),
+                poly.chip_pad_adj_dev.as_ptr(),
+                poly.powers_of_lambda.as_ptr(),
+                chip_layouts_ptr,
+                partial_lagrange.as_ptr(),
+                rest_point_dim,
+                out_ptr
+            );
+            backend
+                .launch_kernel(
+                    zerocheck_geq_corrections_bivariate_kernel(),
+                    (poly.n_geq_chips as u32, 1, 1),
+                    (GEQ_BLOCK_SIZE, 1, 1),
+                    &args,
+                    shmem_bytes,
+                )
+                .unwrap();
+        }
+    }
+
+    // ---- GKR corner sweep ----
+    if !corner_dispatch.is_empty() {
+        let gkr_ptr =
+            refill_buffer(&mut poly.cached_gkr_dispatch, &corner_dispatch, backend).as_ptr();
+        let shmem_bytes = (GKR_BLOCK_SIZE as usize / 32) * std::mem::size_of::<Ext>();
+        unsafe {
+            let args = args!(
+                gkr_ptr,
+                chip_layouts_ptr,
+                poly.chip_gkr_info_dev.as_ptr(),
+                trace_ptr,
+                poly.gkr_powers.as_ptr(),
+                partial_lagrange.as_ptr(),
+                poly.powers_of_lambda.as_ptr(),
+                rest_point_dim,
+                corner_partials_ptr
+            );
+            backend
+                .launch_kernel(
+                    zerocheck_gkr_corner_sweep_kb_kernel(),
+                    (corner_dispatch.len() as u32, 1, 1),
+                    (GKR_BLOCK_SIZE, 1, 1),
+                    &args,
+                    shmem_bytes,
+                )
+                .unwrap();
+        }
+    }
+
+    // ---- Device-side aggregation into 16 totals ----
+    //
+    // `totals[0..12]` are the node totals (constraint + geq), `totals[12..16]`
+    // the corner GKR totals.
+    let mut totals_buf: Tensor<Ext, TaskScope> =
+        Tensor::with_sizes_in([NUM_NODES + NUM_CORNERS], backend.clone());
+    unsafe {
+        totals_buf.assume_init();
+    }
+    {
+        const AGG_BLOCK_SIZE: u32 = 256;
+        let shmem_bytes = (AGG_BLOCK_SIZE as usize / 32) * std::mem::size_of::<Ext>();
+        unsafe {
+            let args = args!(
+                node_partials_ptr as *const Ext,
+                (node_slots as u32),
+                (NUM_NODES as u32),
+                totals_buf.as_mut_ptr()
+            );
+            backend
+                .launch_kernel(
+                    zerocheck_aggregate_partials_strided_kernel(),
+                    (NUM_NODES as u32, 1, 1),
+                    (AGG_BLOCK_SIZE, 1, 1),
+                    &args,
+                    shmem_bytes,
+                )
+                .unwrap();
+            let args = args!(
+                corner_partials_ptr as *const Ext,
+                (corner_slots as u32),
+                (NUM_CORNERS as u32),
+                totals_buf.as_mut_ptr().add(NUM_NODES)
+            );
+            backend
+                .launch_kernel(
+                    zerocheck_aggregate_partials_strided_kernel(),
+                    (NUM_CORNERS as u32, 1, 1),
+                    (AGG_BLOCK_SIZE, 1, 1),
+                    &args,
+                    shmem_bytes,
+                )
+                .unwrap();
+        }
+    }
+
+    // ---- Single host sync + copy of the 16 totals ----
+    let totals: Vec<Ext> = unsafe { totals_buf.into_buffer().copy_into_host_vec() };
+    drop(node_partials);
+    drop(corner_partials);
+
+    // ---- Assemble the grid ----
+    //
+    // Corner order: `c = 2x + y`, matching both the corner-sweep kernel's
+    // row offset within the quadruple and the CPU prover's corner sums.
+    let corner = &totals[NUM_NODES..];
+    let (gkr_00, gkr_01, gkr_10, gkr_11) = (corner[0], corner[1], corner[2], corner[3]);
+    let gkr_x = gkr_10 - gkr_00;
+    let gkr_y = gkr_01 - gkr_00;
+    let gkr_xy = gkr_11 - gkr_10 - gkr_01 + gkr_00;
+
+    let mut grid = [[Ext::zero(); 4]; 4];
+    grid[0][0] = gkr_00;
+    grid[0][1] = gkr_01;
+    grid[1][0] = gkr_10;
+    grid[1][1] = gkr_11;
+    for (e, &(ix, iy)) in ZEROCHECK_CONSTRAINT_NODES.iter().enumerate() {
+        let x = Ext::from_canonical_u32(ZEROCHECK_NODE_XS[ix]);
+        let y = Ext::from_canonical_u32(ZEROCHECK_NODE_XS[iy]);
+        let gkr_eval = gkr_00 + gkr_x * x + gkr_y * y + gkr_xy * (x * y);
+        grid[ix][iy] = totals[e] + gkr_eval;
+    }
+    grid
+}
+
+// ============================================================================
 // Fix-last-variable: fold trace data, update eq_adjustment.
 // ============================================================================
 
@@ -2098,37 +2420,137 @@ where
         claim,
     );
 
+    // Whether the fused first-two-rounds path applies: it needs at least two
+    // variables and only Sequential chunks (ColumnTile has no bivariate
+    // kernel — shards containing one fall back to the round-by-round path).
+    // `SP1_GPU_ZEROCHECK_LEGACY_FIRST_ROUNDS` forces the round-by-round path
+    // for A/B comparison.
+    let has_column_tile = main_poly
+        .compiled
+        .iter()
+        .any(|chip| chip.chunks.iter().any(|c| matches!(c.kind, ChunkKind::ColumnTile)));
+    let use_fused_first_rounds = max_log_row_count >= 2
+        && !has_column_tile
+        && std::env::var("SP1_GPU_ZEROCHECK_LEGACY_FIRST_ROUNDS").is_err();
+    if debug_timing {
+        tracing::info!(
+            "zerocheck: fused first rounds {} (has_column_tile={})",
+            if use_fused_first_rounds { "ON" } else { "OFF" },
+            has_column_tile,
+        );
+    }
+
+    let round_timing = std::env::var("SP1_GPU_ZEROCHECK_ROUND_TIMING").is_ok();
     let mut univariate_polys = vec![];
     let mut jagged_point: Point<Ext> = Point::from(vec![]);
     let t_eval_total = std::time::Instant::now();
     let mut total_fold = std::time::Duration::ZERO;
     let mut total_eval = std::time::Duration::ZERO;
     let mut total_chal = std::time::Duration::ZERO;
-    let t = std::time::Instant::now();
-    let mut result = evaluate_zerocheck(&mut main_poly);
-    if debug_timing {
-        total_eval += t.elapsed();
-    }
-    let t = std::time::Instant::now();
-    let (mut point, mut next_claim) = challenger_update(&result, challenger);
-    if debug_timing {
-        total_chal += t.elapsed();
-    }
-    univariate_polys.push(result);
-    jagged_point.add_dimension(point);
-    let t = std::time::Instant::now();
-    let mut next_poly = zerocheck_fix_last_variable(main_poly, point, next_claim);
-    if debug_timing {
-        total_fold += t.elapsed();
-    }
-    for _ in 0..max_log_row_count - 1 {
+
+    let (mut next_poly, mut next_claim, remaining_rounds) = if use_fused_first_rounds {
+        // Fused first two rounds: one bivariate pass over the base-field
+        // trace yields both round messages; the second requires no kernel
+        // launch at all.
         let t = std::time::Instant::now();
-        result = evaluate_zerocheck(&mut next_poly);
+        let grid = evaluate_zerocheck_bivariate(&mut main_poly);
         if debug_timing {
             total_eval += t.elapsed();
         }
+        if round_timing {
+            tracing::info!("zerocheck rounds 0-1 (fused bivariate): eval={:?}", t.elapsed());
+        }
+        let (_, last_two) = main_poly.zeta.split_at(main_poly.zeta.dimension() - 2);
+        let z_a = *last_two[0];
+        let z_b = *last_two[1];
+
         let t = std::time::Instant::now();
-        (point, next_claim) = challenger_update(&result, challenger);
+        let first_msg = zerocheck_first_round_message_from_grid::<Felt, Ext>(
+            &grid,
+            z_a,
+            z_b,
+            main_poly.eq_adjustment,
+        );
+        debug_assert_eq!(
+            first_msg.eval_one_plus_eval_zero(),
+            main_poly.claim,
+            "fused first round message inconsistent with the claim"
+        );
+        let (alpha, claim_1) = challenger_update(&first_msg, challenger);
+        univariate_polys.push(first_msg);
+        jagged_point.add_dimension(alpha);
+
+        let second_msg = zerocheck_second_round_message_from_grid::<Felt, Ext>(
+            &grid,
+            z_a,
+            z_b,
+            main_poly.eq_adjustment,
+            alpha,
+        );
+        let (alpha_2, claim_2) = challenger_update(&second_msg, challenger);
+        univariate_polys.push(second_msg);
+        jagged_point.add_dimension(alpha_2);
+        if debug_timing {
+            total_chal += t.elapsed();
+        }
+
+        let t = std::time::Instant::now();
+        let mid_poly = zerocheck_fix_last_variable(main_poly, alpha, claim_1);
+        let next_poly = zerocheck_fix_last_variable(mid_poly, alpha_2, claim_2);
+        if debug_timing {
+            total_fold += t.elapsed();
+        }
+        if round_timing {
+            // Drain the two async folds so their cost is attributed here
+            // rather than to the next round's eval window.
+            next_poly.data.backend().synchronize_blocking().unwrap();
+            tracing::info!("zerocheck folds 0+1 (fused): drain={:?}", t.elapsed());
+        }
+        (next_poly, claim_2, max_log_row_count - 2)
+    } else {
+        let t = std::time::Instant::now();
+        let result = evaluate_zerocheck(&mut main_poly);
+        if debug_timing {
+            total_eval += t.elapsed();
+        }
+        if round_timing {
+            tracing::info!("zerocheck round 0: eval={:?}", t.elapsed());
+        }
+        let t = std::time::Instant::now();
+        let (point, next_claim) = challenger_update(&result, challenger);
+        if debug_timing {
+            total_chal += t.elapsed();
+        }
+        univariate_polys.push(result);
+        jagged_point.add_dimension(point);
+        let t = std::time::Instant::now();
+        let next_poly = zerocheck_fix_last_variable(main_poly, point, next_claim);
+        if debug_timing {
+            total_fold += t.elapsed();
+        }
+        if round_timing {
+            next_poly.data.backend().synchronize_blocking().unwrap();
+            tracing::info!("zerocheck fold 0: drain={:?}", t.elapsed());
+        }
+        (next_poly, next_claim, max_log_row_count - 1)
+    };
+
+    for round in 0..remaining_rounds {
+        let t = std::time::Instant::now();
+        let result = evaluate_zerocheck(&mut next_poly);
+        if debug_timing {
+            total_eval += t.elapsed();
+        }
+        if round_timing {
+            tracing::info!(
+                "zerocheck round {}: eval={:?}",
+                max_log_row_count - remaining_rounds + round,
+                t.elapsed()
+            );
+        }
+        let t = std::time::Instant::now();
+        let (point, claim) = challenger_update(&result, challenger);
+        next_claim = claim;
         if debug_timing {
             total_chal += t.elapsed();
         }
@@ -2138,6 +2560,14 @@ where
         next_poly = zerocheck_fix_last_variable(next_poly, point, next_claim);
         if debug_timing {
             total_fold += t.elapsed();
+        }
+        if round_timing {
+            next_poly.data.backend().synchronize_blocking().unwrap();
+            tracing::info!(
+                "zerocheck fold {}: drain={:?}",
+                max_log_row_count - remaining_rounds + round,
+                t.elapsed()
+            );
         }
     }
     if debug_timing {


### PR DESCRIPTION
This PR implements a one-round "zerocheck lookahead": instead of computing the univariate first message that the zerocheck prover currently performs, the prover instead computes a bivariate message (combining the first two rounds of sums into one), and deduces the individual round messages it needs from there.