### PR TITLE
fix: Right-align RIPEMD-160 precompile digest per zkVM accelerator standard

### DIFF
--- a/zkevm/examples/ripemd-c/program/main.c
+++ b/zkevm/examples/ripemd-c/program/main.c
@@ -2,8 +2,8 @@
  * ripemd-c — RIPEMD-160 precompile demo, C edition.
  *
  * Reads bytes via read_input, computes RIPEMD-160 via libzkevm's
- * `zkvm_ripemd160`, writes the 32-byte output (20-byte digest +
- * 12-byte zero pad, per `zkvm_accelerators.h`) via write_output.
+ * `zkvm_ripemd160`, writes the 32-byte output (12-byte zero pad +
+ * 20-byte digest, per `zkvm_accelerators.h`) via write_output.
  */
 
 #include <stddef.h>

--- a/zkevm/examples/ripemd-c/script/src/execute.rs
+++ b/zkevm/examples/ripemd-c/script/src/execute.rs
@@ -12,7 +12,7 @@ fn ripemd160_host_padded(data: &[u8]) -> [u8; 32] {
     hasher.update(data);
     let digest = hasher.finalize();
     let mut out = [0u8; 32];
-    out[..20].copy_from_slice(&digest);
+    out[12..].copy_from_slice(&digest);
     out
 }
 

--- a/zkevm/include/zkvm_accelerators.h
+++ b/zkevm/include/zkvm_accelerators.h
@@ -97,7 +97,7 @@ typedef struct {
 typedef zkvm_bytes_32 zkvm_keccak256_hash;
 typedef zkvm_bytes_32 zkvm_sha256_hash;
 typedef zkvm_bytes_32
-    zkvm_ripemd160_hash; /* 20-byte hash padded to 32 bytes, last 12 bytes are zero */
+    zkvm_ripemd160_hash; /* 20-byte hash padded to 32 bytes, first 12 bytes are zero */
 
 /* secp256k1 types */
 typedef zkvm_bytes_32 zkvm_secp256k1_hash;
@@ -231,7 +231,7 @@ zkvm_status zkvm_sha256(const uint8_t* data, size_t len,
  *
  * @param data Pointer to input data
  * @param len Length of input data in bytes
- * @param[out] output Pointer to output hash (20 bytes of hash, last 12 bytes zero-padded)
+ * @param[out] output Pointer to output hash (20 bytes of hash, first 12 bytes zero-padded)
  * @return ZKVM_EOK on success, ZKVM_EFAIL on failure
  */
 zkvm_status zkvm_ripemd160(const uint8_t* data, size_t len,

--- a/zkevm/libzkevm/src/precompile/hash.rs
+++ b/zkevm/libzkevm/src/precompile/hash.rs
@@ -65,8 +65,9 @@ pub unsafe extern "C" fn zkvm_sha256(data: *const u8, len: usize, output: *mut S
 /// `zkvm_status zkvm_ripemd160(const uint8_t* data, size_t len, zkvm_ripemd160_hash* output)`.
 ///
 /// SP1 path: no precompile; software impl via the stock RustCrypto `ripemd`
-/// crate. Output layout per the header is 20 hash bytes followed by 12 zero
-/// bytes — the 12-byte tail is zeroed before writing the digest.
+/// crate. Output layout per the header is 12 zero bytes followed by the
+/// 20-byte digest (EVM right-aligned): the word is zeroed, then the digest
+/// is written into the trailing 20 bytes.
 #[no_mangle]
 pub unsafe extern "C" fn zkvm_ripemd160(
     data: *const u8,
@@ -85,6 +86,6 @@ pub unsafe extern "C" fn zkvm_ripemd160(
     let digest = hasher.finalize();
     let out = &mut (*output).data;
     *out = [0u8; 32];
-    out[..20].copy_from_slice(&digest);
+    out[12..].copy_from_slice(&digest);
     ZKVM_EOK
 }

--- a/zkevm/libzkevm/src/precompile/types.rs
+++ b/zkevm/libzkevm/src/precompile/types.rs
@@ -42,7 +42,7 @@ pub struct ZkvmBytes192 {
 // Aliases (size-equivalent, just for header parity).
 pub type Keccak256Hash = ZkvmBytes32;
 pub type Sha256Hash = ZkvmBytes32;
-pub type Ripemd160Hash = ZkvmBytes32; // 20 bytes + 12 zero pad
+pub type Ripemd160Hash = ZkvmBytes32; // 12 zero pad + 20 bytes
 
 pub type Secp256k1Hash = ZkvmBytes32;
 pub type Secp256k1Signature = ZkvmBytes64;

--- a/zkevm/libzkevm/tests/conformance/evm.rs
+++ b/zkevm/libzkevm/tests/conformance/evm.rs
@@ -1,13 +1,19 @@
 //! Conformance for the remaining EVM precompiles against the full
 //! go-ethereum vector suites: BN254 (0x06–0x08), ecrecover (0x01),
-//! modexp (0x05), blake2f (0x09), KZG point evaluation (0x0a), and
-//! p256verify (0x100).
+//! ripemd160 (0x03), modexp (0x05), blake2f (0x09), KZG point evaluation
+//! (0x0a), and p256verify (0x100).
+//!
+//! NOTE: go-ethereum ships no golden vector file for ripemd160, so unlike
+//! the other precompiles here its vectors are inlined rather than loaded
+//! from `tests/data/geth/`. They come from the RIPEMD-160 designers'
+//! official "test values" page (A. Bosselaers, KU Leuven COSIC:
+//! https://homes.esat.kuleuven.be/~bosselae/ripemd160.html)
 
 use crate::support::*;
-use crate::EOK;
+use crate::{EFAIL, EOK};
 use zkevm::precompile::blake2f::zkvm_blake2f;
 use zkevm::precompile::bn254::*;
-use zkevm::precompile::hash::{zkvm_keccak256, zkvm_sha256};
+use zkevm::precompile::hash::{zkvm_keccak256, zkvm_ripemd160, zkvm_sha256};
 use zkevm::precompile::kzg::zkvm_kzg_point_eval;
 use zkevm::precompile::modexp::zkvm_modexp;
 use zkevm::precompile::secp256k1::zkvm_secp256k1_ecrecover;
@@ -26,6 +32,85 @@ fn sha256(data: &[u8]) -> [u8; 32] {
     let status = unsafe { zkvm_sha256(data.as_ptr(), data.len(), &mut out) };
     assert_eq!(status, EOK);
     out.data
+}
+
+fn run_ripemd160(data: &[u8]) -> [u8; 32] {
+    let mut out = ZkvmBytes32 { data: [0u8; 32] };
+    let status = unsafe { zkvm_ripemd160(data.as_ptr(), data.len(), &mut out) };
+    assert_eq!(status, EOK);
+    out.data
+}
+
+/// Assert `ripemd160(data)` is `digest_hex` right-aligned in the 32-byte
+/// output word: 12 zero bytes followed by the 20-byte digest.
+fn assert_ripemd160(data: &[u8], digest_hex: &str) {
+    let digest = unhex(digest_hex);
+    assert_eq!(digest.len(), 20, "RIPEMD-160 digest is 20 bytes");
+    let out = run_ripemd160(data);
+    assert_eq!(&out[..12], &[0u8; 12][..], "leading 12 bytes must be zero");
+    assert_eq!(&out[12..], digest.as_slice(), "digest mismatch for {digest_hex}");
+}
+
+#[test]
+fn ripemd160() {
+    // Reference vectors from the RIPEMD-160 designers' "test values" page
+    // (A. Bosselaers, KU Leuven COSIC:
+    // https://homes.esat.kuleuven.be/~bosselae/ripemd160.html), the same
+    // set evmone checks in test/unittests/precompiles_ripemd160_test.cpp.
+    let string_cases: &[(&[u8], &str)] = &[
+        (b"", "9c1185a5c5e9fc54612808977ee8f548b2258d31"),
+        (b"abc", "8eb208f7e05d987a9b044a8e98c6b087f15a0bfc"),
+        (b"message digest", "5d0689ef49d2fae572b881b123a85ffa21595f36"),
+        (b"abcdefghijklmnopqrstuvwxyz", "f71c27109c692c1b56bbdceb5b9d2865b3708dbc"),
+        (
+            b"abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq",
+            "12a053384a9c0c88e405a06c27dcf49ada62eb2b",
+        ),
+        (
+            b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789",
+            "b0e20b6e3116640286ed3a87a5713079b21f5189",
+        ),
+        (
+            b"12345678901234567890123456789012345678901234567890123456789012345678901234567890",
+            "9b752e45573d4b39f4dbd3323cab82bf63326bfb",
+        ),
+        (
+            b"The quick brown fox jumps over the lazy dog",
+            "37f332f68db77bd9d7edd4969571ad671cf9dd3b",
+        ),
+    ];
+    for (input, digest_hex) in string_cases {
+        assert_ripemd160(input, digest_hex);
+    }
+
+    // `len` repetitions of 'a'
+    let length_cases: &[(usize, &str)] = &[
+        (0, "9c1185a5c5e9fc54612808977ee8f548b2258d31"),
+        (1, "0bdc9d2d256b3ee9daae347be6f4dc835a467ffe"),
+        (54, "a57fa1577740fd73b6859dd20e090cdac4d2af36"),
+        (55, "0d8a8c9063a48576a7c97e9f95253a6e53ff6765"),
+        (56, "e72334b46c83cc70bef979e15453706c95b888be"),
+        (57, "eed82d19d597ab275b550ff3d6e0bc2a75350388"),
+        (63, "e640041293fe663b9bf3f8c21ffecac03819e6b2"),
+        (64, "9dfb7d374ad924f3f88de96291c33e9abed53e32"),
+        (65, "99724bb11811e7166af38f671b6a082d8ab4960b"),
+        (119, "23e398ff2bac815aa1bbb57ca2a669c841872919"),
+        (120, "c476770a6dae31fcee8d25efe6559a05c8024595"),
+        (121, "725c88a6f41605e99477a1478607d3fe25ced606"),
+        (127, "64f2d68b85f394e2e4f49009c4bd50224c2698ed"),
+        (128, "8dfdfb32b2ed5cb41a73478b4fd60cc5b4648b15"),
+        (129, "62bb9091f499f294f15aa5b951df4d9744d50cf2"),
+        (1_000_000, "52783243c1697bdbe16d37f97f68f08325dc1528"),
+    ];
+    for (len, digest_hex) in length_cases {
+        assert_ripemd160(&vec![b'a'; *len], digest_hex);
+    }
+
+    // null data with a non-zero len, and a null output, are both errors.
+    let mut out = ZkvmBytes32 { data: [0u8; 32] };
+    assert_eq!(unsafe { zkvm_ripemd160(std::ptr::null(), 4, &mut out) }, EFAIL);
+    let data = [1u8, 2, 3];
+    assert_eq!(unsafe { zkvm_ripemd160(data.as_ptr(), data.len(), std::ptr::null_mut()) }, EFAIL);
 }
 
 // --- BN254 (EIP-196/197). Inputs use EVM `getData` padding; the wire


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Fixes #2880

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [x] Breaking changes