### PR TITLE
fix: Revert "fix: launch fewer blocks in scan kernel (#2900)"

### DIFF
--- a/sp1-gpu/crates/tracegen/src/riscv/global.rs
+++ b/sp1-gpu/crates/tracegen/src/riscv/global.rs
@@ -151,7 +151,7 @@ impl CudaTracegenAir<F> for GlobalChip {
                 };
             } else {
                 let block_dim = SCAN_KERNEL_LARGE_SECTION_SIZE / 2;
-                let num_blocks = n.div_ceil(SCAN_KERNEL_LARGE_SECTION_SIZE);
+                let num_blocks = n.div_ceil(block_dim);
                 // Create `scan_values` as an array consisting of a single zero cell followed by
                 // `num_blocks` uninitialized cells.
                 let mut scan_values =


### PR DESCRIPTION
Reverts #2900.

This rolls back the one-line change to `sp1-gpu/crates/tracegen/src/riscv/global.rs` that altered the scan-kernel launch parameters in global tracegen (`num_blocks` computed from `SCAN_KERNEL_LARGE_SECTION_SIZE` instead of `block_dim`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)