### PR TITLE
feat(prover): Report GPU name and shrink-wrap GPU time

### DIFF
--- a/crates/prover-types/proto/cluster.proto
+++ b/crates/prover-types/proto/cluster.proto
@@ -32,6 +32,9 @@ service ClusterService {
 // previous manifest (full snapshot).
 message SetClusterComponentInfoRequest {
   repeated worker.ClusterComponentInfo components = 1;
+  // GPU capacity snapshot built alongside the component manifest. Absent when the
+  // coordinator has no capacity data to report.
+  optional worker.ClusterCapacitySnapshot capacity = 2;
 }
 
 // The latest manifest as held by the API, with the server-owned time it was last
@@ -42,6 +45,8 @@ message ClusterComponentManifest {
   repeated worker.ClusterComponentInfo components = 1;
   // Unix seconds when the API last stored a manifest (server-owned).
   uint64 updated_at = 2;
+  // GPU capacity snapshot from the same manifest write.
+  optional worker.ClusterCapacitySnapshot capacity = 3;
 }
 
 message ProofRequestCreateRequest {

--- a/crates/prover-types/proto/worker.proto
+++ b/crates/prover-types/proto/worker.proto
@@ -122,6 +122,8 @@ message OpenRequest {
     string version = 4;
     string git_sha = 5;
     string image_tag = 6;
+    string gpu_name = 7;
+    uint64 gpu_memory_total_bytes = 8;
 }
 
 message ServerMessage {
@@ -299,6 +301,35 @@ message ClusterComponentInfo {
     string version = 2;
     string git_sha = 3;
     string image_tag = 4;
+}
+
+// Point-in-time GPU capacity and utilization for a cluster, built by the coordinator from
+// its in-memory worker registry. Cluster-internal; the fulfiller maps it onto the SPN
+// ClusterCapacitySnapshot wire type. All GPU time is in GPU-milliseconds.
+message ClusterCapacitySnapshot {
+    // Unix seconds on the coordinator's clock when this snapshot was built.
+    uint64 observed_at = 1;
+    // Unix seconds when this coordinator process started, i.e. when the monotonic counters
+    // below were last reset.
+    uint64 counters_since = 2;
+    // GPU worker nodes connected at `observed_at`; one GPU per node, so a device count.
+    uint32 gpu_nodes = 3;
+    // Monotonic integral of `gpu_nodes` over wall-clock time, in GPU-milliseconds.
+    uint64 gpu_available_ms_total = 4;
+    // Monotonic sum of per-task GPU permit-hold time, in GPU-milliseconds.
+    uint64 gpu_busy_ms_total = 5;
+    // One entry per distinct GPU model; `node_count` values sum to `gpu_nodes`.
+    repeated GpuClassCount gpus = 6;
+}
+
+// The number of connected GPU nodes sharing one GPU model.
+message GpuClassCount {
+    // Device name as reported by CUDA, e.g. "NVIDIA L4". Empty when unknown.
+    string name = 1;
+    // Total VRAM of that device in bytes. Zero when unknown.
+    uint64 memory_total_bytes = 2;
+    // Connected GPU nodes bound to a device with this (name, memory_total_bytes).
+    uint32 node_count = 3;
 }
 
 

--- a/crates/prover/src/worker/node/full/init.rs
+++ b/crates/prover/src/worker/node/full/init.rs
@@ -479,8 +479,7 @@ impl<C: SP1ProverComponents> SP1LocalNodeBuilder<C> {
                                 .prover_engine()
                                 .run_shrink_wrap(request.clone())
                                 .instrument(span)
-                                .await
-                                .map(|_| TaskMetadata::default());
+                                .await;
                             TaskOutput::handle_worker_result(Ok(result), &task_tx, proof_id, id, request, TaskType::ShrinkWrap);
                         }
                         Some(output) = task_rx.recv() => {

--- a/crates/prover/src/worker/prover/engine.rs
+++ b/crates/prover/src/worker/prover/engine.rs
@@ -12,7 +12,7 @@ use crate::{
         CoreProveSubmitHandle, RawTaskRequest, RecursionVkWorker, ReduceSubmitHandle,
         SP1CoreProver, SP1CoreProverConfig, SP1DeferredProver, SP1DeferredProverConfig,
         SP1DeferredSubmitHandle, SP1RecursionProver, SP1RecursionProverConfig, SetupSubmitHandle,
-        SetupTask, TaskError, TaskId, WorkerClient,
+        SetupTask, TaskError, TaskId, TaskMetadata, WorkerClient,
     },
     SP1ProverComponents, WrapProverBuilder,
 };
@@ -129,7 +129,10 @@ impl<A: ArtifactClient, W: WorkerClient, C: SP1ProverComponents> SP1ProverEngine
         self.deferred_prover.submit(request).await
     }
 
-    pub async fn run_shrink_wrap(&self, request: RawTaskRequest) -> Result<(), TaskError> {
+    pub async fn run_shrink_wrap(
+        &self,
+        request: RawTaskRequest,
+    ) -> Result<TaskMetadata, TaskError> {
         self.recursion_prover.run_shrink_wrap(request).await
     }
 

--- a/crates/prover/src/worker/prover/recursion.rs
+++ b/crates/prover/src/worker/prover/recursion.rs
@@ -688,10 +688,15 @@ impl<A: ArtifactClient, C: SP1ProverComponents> SP1RecursionProver<A, C> {
         Ok(wrap_prover.clone())
     }
 
-    pub async fn run_shrink_wrap(&self, request: RawTaskRequest) -> Result<(), TaskError> {
+    pub async fn run_shrink_wrap(
+        &self,
+        request: RawTaskRequest,
+    ) -> Result<TaskMetadata, TaskError> {
         let RawTaskRequest { inputs, outputs, .. } = request;
         let [compress_proof_artifact] = inputs.try_into().unwrap();
         let [wrap_proof_artifact] = outputs.try_into().unwrap();
+
+        let metrics = ProverMetrics::new();
 
         let compress_proof = self
             .artifact_client
@@ -701,7 +706,7 @@ impl<A: ArtifactClient, C: SP1ProverComponents> SP1RecursionProver<A, C> {
 
         let shrink_proof = self
             .shrink_prover
-            .prove(compress_proof)
+            .prove(compress_proof, &metrics)
             .instrument(tracing::info_span!("prove shrink"))
             .await?;
 
@@ -709,8 +714,10 @@ impl<A: ArtifactClient, C: SP1ProverComponents> SP1RecursionProver<A, C> {
             .in_scope(|| self.shrink_prover.verify(&shrink_proof))?;
 
         let wrap_prover = self.wrap_prover().await?;
-        let wrap_proof =
-            wrap_prover.prove(shrink_proof).instrument(tracing::info_span!("prove wrap")).await?;
+        let wrap_proof = wrap_prover
+            .prove(shrink_proof, &metrics)
+            .instrument(tracing::info_span!("prove wrap"))
+            .await?;
 
         tracing::debug_span!("verify wrap proof").in_scope(|| wrap_prover.verify(&wrap_proof))?;
 
@@ -719,7 +726,7 @@ impl<A: ArtifactClient, C: SP1ProverComponents> SP1RecursionProver<A, C> {
             .instrument(tracing::debug_span!("upload wrap proof"))
             .await?;
 
-        Ok(())
+        Ok(metrics.to_metadata())
     }
 
     pub async fn run_groth16(&self, request: RawTaskRequest) -> Result<(), TaskError> {
@@ -1081,6 +1088,7 @@ impl<C: SP1ProverComponents> ShrinkProver<C> {
     async fn prove(
         &self,
         compressed_proof: SP1RecursionProof<SP1GlobalContext, SP1PcsProofInner>,
+        metrics: &ProverMetrics,
     ) -> Result<SP1RecursionProof<SP1GlobalContext, SP1PcsProofInner>, TaskError> {
         let execution_record = {
             let mut runtime =
@@ -1109,7 +1117,7 @@ impl<C: SP1ProverComponents> ShrinkProver<C> {
             runtime.record
         };
 
-        let (vk, proof, _permit) = self
+        let (vk, proof, permit) = self
             .prover
             .setup_and_prove_shard(
                 self.program.clone(),
@@ -1118,6 +1126,9 @@ impl<C: SP1ProverComponents> ShrinkProver<C> {
                 self.permits.clone(),
             )
             .await;
+        let duration = permit.release();
+        metrics.increment_permit_time(duration);
+
         let vk_merkle_proof = self.prover_data.recursion_vks.open(&vk)?.1;
         Ok(SP1RecursionProof { vk: self.verifying_key.clone(), proof, vk_merkle_proof })
     }
@@ -1185,6 +1196,7 @@ impl<C: SP1ProverComponents> WrapProver<C> {
     pub async fn prove(
         &self,
         shrunk_proof: SP1RecursionProof<SP1GlobalContext, SP1PcsProofInner>,
+        metrics: &ProverMetrics,
     ) -> Result<SP1WrapProof<SP1OuterGlobalContext, SP1PcsProofOuter>, TaskError> {
         let execution_record = {
             let mut runtime =
@@ -1202,7 +1214,7 @@ impl<C: SP1ProverComponents> WrapProver<C> {
             runtime.record
         };
 
-        let (_, proof, _permit) = self
+        let (_, proof, permit) = self
             .prover
             .setup_and_prove_shard(
                 self.program.clone(),
@@ -1211,6 +1223,8 @@ impl<C: SP1ProverComponents> WrapProver<C> {
                 self.permits.clone(),
             )
             .await;
+        let duration = permit.release();
+        metrics.increment_permit_time(duration);
 
         Ok(SP1WrapProof { vk: self.verifying_key.clone(), proof })
     }

--- a/sp1-gpu/crates/cuda/src/device.rs
+++ b/sp1-gpu/crates/cuda/src/device.rs
@@ -1,6 +1,11 @@
+use std::{
+    ffi::{c_char, CStr},
+    sync::OnceLock,
+};
+
 use crate::{CudaError, TaskScope};
 use slop_alloc::{mem::CopyError, CopyIntoBackend, CopyToBackend, CpuBackend};
-use sp1_gpu_sys::runtime::cuda_mem_get_info;
+use sp1_gpu_sys::runtime::{cuda_get_device_name, cuda_mem_get_info};
 
 pub trait DeviceCopy: Copy + 'static + Sized {}
 
@@ -12,6 +17,30 @@ pub fn cuda_memory_info() -> Result<(usize, usize), CudaError> {
     let mut total: usize = 0;
     CudaError::result_from_ffi(unsafe { cuda_mem_get_info(&mut free, &mut total) })?;
     Ok((free, total))
+}
+
+/// Returns the name of the CUDA device the calling thread is bound to, e.g. `"NVIDIA L4"`.
+///
+/// The name is queried once and cached for the lifetime of the process, because the underlying
+/// `cudaGetDeviceProperties` call materializes the whole device property struct and costs tens of
+/// milliseconds on the first call. Errors are never cached, so a failed query may be retried.
+pub fn cuda_device_name() -> Result<&'static str, CudaError> {
+    static DEVICE_NAME: OnceLock<String> = OnceLock::new();
+    if let Some(name) = DEVICE_NAME.get() {
+        return Ok(name);
+    }
+
+    // `cudaDeviceProp::name` is a 256 byte NUL terminated buffer, and the shim NUL terminates
+    // whatever it writes, so a NUL is always present within the buffer.
+    let mut name = [0u8; 256];
+    CudaError::result_from_ffi(unsafe {
+        cuda_get_device_name(name.as_mut_ptr().cast::<c_char>(), name.len())
+    })?;
+    let name = CStr::from_bytes_until_nul(&name)
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_default();
+
+    Ok(DEVICE_NAME.get_or_init(|| name))
 }
 
 pub trait IntoDevice: CopyIntoBackend<TaskScope, CpuBackend> + Sized {

--- a/sp1-gpu/crates/sys/include/runtime/memory.cuh
+++ b/sp1-gpu/crates/sys/include/runtime/memory.cuh
@@ -16,6 +16,8 @@ extern "C" rustCudaError_t cuda_host_unregister(void* hostPtr);
 
 extern "C" rustCudaError_t cuda_mem_get_info(size_t* free, size_t* total);
 
+extern "C" rustCudaError_t cuda_get_device_name(char* name, size_t len);
+
 extern "C" rustCudaError_t cuda_mem_copy_host_to_device(void* dst, const void* src, size_t count);
 
 extern "C" rustCudaError_t cuda_mem_copy_device_to_host(void* dst, const void* src, size_t count);

--- a/sp1-gpu/crates/sys/lib/runtime/memory.cu
+++ b/sp1-gpu/crates/sys/lib/runtime/memory.cu
@@ -2,6 +2,7 @@
 
 #include "runtime/exception.cuh"
 #include <cstdint>
+#include <cstdio>
 
 extern "C" rustCudaError_t cuda_malloc(void** devPtr, size_t size) {
     CUDA_OK(cudaMalloc(devPtr, size));
@@ -35,6 +36,15 @@ extern "C" rustCudaError_t cuda_host_unregister(void* hostPtr) {
 
 extern "C" rustCudaError_t cuda_mem_get_info(size_t* free, size_t* total) {
     CUDA_OK(cudaMemGetInfo(free, total));
+    return CUDA_SUCCESS_CSL;
+}
+
+extern "C" rustCudaError_t cuda_get_device_name(char* name, size_t len) {
+    int device = 0;
+    CUDA_OK(cudaGetDevice(&device));
+    cudaDeviceProp prop;
+    CUDA_OK(cudaGetDeviceProperties(&prop, device));
+    std::snprintf(name, len, "%s", prop.name);
     return CUDA_SUCCESS_CSL;
 }
 

--- a/sp1-gpu/crates/sys/src/runtime.rs
+++ b/sp1-gpu/crates/sys/src/runtime.rs
@@ -19,6 +19,8 @@ extern "C" {
 
     pub fn cuda_mem_get_info(free: *mut usize, total: *mut usize) -> CudaRustError;
 
+    pub fn cuda_get_device_name(name: *mut c_char, len: usize) -> CudaRustError;
+
     pub fn cuda_malloc_host(ptr: *mut *mut c_void, count: usize) -> CudaRustError;
     pub fn cuda_host_register(ptr: *const c_void, count: usize) -> CudaRustError;
     pub fn cuda_free_host(ptr: *const c_void) -> CudaRustError;


### PR DESCRIPTION
## Motivation

We want to get an overview of the types of Nvidia GPUs being used in the Succinct prover network, as well as their capacity/usage over time.

## Solution

Adds the ability to query GPU name, and track how much gpu time shrink-wrap is using.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes