### PR TITLE
fix(prover): drop duplicate shard proofs from CoreExecute redelivery

### DIFF
--- a/crates/prover/src/worker/controller/compress.rs
+++ b/crates/prover/src/worker/controller/compress.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, VecDeque},
+    collections::{BTreeMap, HashSet, VecDeque},
     sync::{Arc, Mutex},
 };
 
@@ -354,7 +354,34 @@ impl CompressTree {
             let core_proof_map = core_proof_map.clone();
             async move {
                 let mut num_core_proofs = 0;
+                // A re-delivered CoreExecute streams a second full set of shard proofs.
+                // The compress tree assumes disjoint ranges, so a duplicate range would
+                // corrupt it and wedge the reduction; keep only the first proof per range.
+                // Precompile shards all share the degenerate `ShardRange::precompile()`
+                // range, so they pass through; that never corrupts the tree. Duplicates
+                // of them are prevented upstream by the recovery guard in
+                // `SP1Controller::execute` — a slip-through fails the final reduce
+                // loudly instead of wedging.
+                let mut seen_ranges = HashSet::<ShardRange>::new();
+                let mut seen_task_ids = HashSet::<TaskId>::new();
                 while let Some(proof_data) = core_proofs_rx.recv().await {
+                    if !seen_task_ids.insert(proof_data.task_id.clone()) {
+                        tracing::warn!(
+                            "skipping duplicate core proof message for task {}",
+                            proof_data.task_id
+                        );
+                        continue;
+                    }
+                    if proof_data.range != ShardRange::precompile()
+                        && !seen_ranges.insert(proof_data.range)
+                    {
+                        tracing::warn!(
+                            "skipping duplicate core proof for range {:?} (task {})",
+                            proof_data.range,
+                            proof_data.task_id
+                        );
+                        continue;
+                    }
                     core_proofs_subscriber
                         .subscribe(proof_data.task_id.clone())
                         .map_err(|e| TaskError::Fatal(e.into()))?;
@@ -460,6 +487,19 @@ impl CompressTree {
                         let proofs = RangeProofs::new(range, queue);
                         self.insert(proofs);
                     }
+                    // `full_range.is_some()` implies every core proof has completed and been
+                    // counted into `pending_tasks`; from then on `pending_tasks` tracks all
+                    // possible future `proof_rx` items (queued completions and in-flight
+                    // reduce tasks). If nothing is pending and completion hasn't been
+                    // reached, the tree can never progress — fail now rather than wait
+                    // silently until the proof deadline.
+                    if pending_tasks == 0 && full_range.is_some() {
+                        return Err(TaskError::Fatal(anyhow::anyhow!(
+                            "compress tree wedged with no pending work: full_range={:?}, tree ranges={:?}",
+                            full_range,
+                            self.map.values().map(|p| p.shard_range).collect::<Vec<_>>()
+                        )));
+                    }
                 }
                 Some((task_id, status)) = event_stream.recv() => {
                     if status != TaskStatus::Succeeded {
@@ -552,6 +592,24 @@ mod test_utils {
 
     use super::*;
 
+    /// Task-duration ranges for `mock_worker_client`, which requires an entry for
+    /// every task type it dispatches.
+    fn default_random_intervals() -> HashMap<TaskType, std::ops::Range<Duration>> {
+        HashMap::from([
+            (TaskType::Controller, Duration::from_millis(20)..Duration::from_millis(100)),
+            (TaskType::SetupVkey, Duration::from_millis(20)..Duration::from_millis(100)),
+            (TaskType::RecursionReduce, Duration::from_millis(100)..Duration::from_millis(200)),
+            (TaskType::ProveShard, Duration::from_millis(200)..Duration::from_millis(500)),
+            (TaskType::MarkerDeferredRecord, Duration::from_millis(20)..Duration::from_millis(100)),
+            (TaskType::RecursionDeferred, Duration::from_millis(20)..Duration::from_millis(100)),
+            (TaskType::ShrinkWrap, Duration::from_millis(20)..Duration::from_millis(100)),
+            (TaskType::PlonkWrap, Duration::from_millis(20)..Duration::from_millis(100)),
+            (TaskType::Groth16Wrap, Duration::from_millis(20)..Duration::from_millis(100)),
+            (TaskType::ExecuteOnly, Duration::from_millis(20)..Duration::from_millis(100)),
+            (TaskType::CoreExecute, Duration::from_millis(20)..Duration::from_millis(100)),
+        ])
+    }
+
     async fn create_dummy_prove_shard_task(
         range: ShardRange,
         elf_artifact: Artifact,
@@ -594,19 +652,7 @@ mod test_utils {
         let num_deferred_shards = 100;
         let deferred_start_delay = Duration::from_millis(1);
         let num_iterations = 1;
-        let random_intervals = HashMap::from([
-            (TaskType::Controller, Duration::from_millis(20)..Duration::from_millis(100)),
-            (TaskType::SetupVkey, Duration::from_millis(20)..Duration::from_millis(100)),
-            (TaskType::RecursionReduce, Duration::from_millis(100)..Duration::from_millis(200)),
-            (TaskType::ProveShard, Duration::from_millis(200)..Duration::from_millis(500)),
-            (TaskType::MarkerDeferredRecord, Duration::from_millis(20)..Duration::from_millis(100)),
-            (TaskType::RecursionDeferred, Duration::from_millis(20)..Duration::from_millis(100)),
-            (TaskType::ShrinkWrap, Duration::from_millis(20)..Duration::from_millis(100)),
-            (TaskType::PlonkWrap, Duration::from_millis(20)..Duration::from_millis(100)),
-            (TaskType::Groth16Wrap, Duration::from_millis(20)..Duration::from_millis(100)),
-            (TaskType::ExecuteOnly, Duration::from_millis(20)..Duration::from_millis(100)),
-            (TaskType::CoreExecute, Duration::from_millis(20)..Duration::from_millis(100)),
-        ]);
+        let random_intervals = default_random_intervals();
 
         for _ in 0..num_iterations {
             let worker_client = mock_worker_client(random_intervals.clone());
@@ -750,5 +796,201 @@ mod test_utils {
                 .await
                 .unwrap();
         }
+    }
+
+    /// A re-delivered CoreExecute runs the full execution again and streams a second,
+    /// identical set of shard proofs into the controller. The compress tree must ignore
+    /// the duplicates (except precompile shards, whose shared degenerate range merges
+    /// safely) and still reduce to completion instead of wedging.
+    #[tokio::test]
+    async fn test_compress_tree_ignores_redelivered_core_proofs() {
+        setup_logger();
+        let num_core_shards = 50;
+        let num_memory_shards = 10;
+        let num_precompile_shards = 5;
+        let num_deferred_shards = 10;
+        let random_intervals = default_random_intervals();
+
+        let worker_client = mock_worker_client(random_intervals);
+        let artifact_client = InMemoryArtifactClient::new();
+        let mut compress_tree = CompressTree::new(DEFAULT_ARITY);
+
+        let context = TaskContext {
+            proof_id: ProofId::new("test_compress_tree_redelivery"),
+            parent_id: None,
+            parent_context: None,
+            requester_id: RequesterId::new("test_compress_tree_redelivery"),
+        };
+
+        let (core_proofs_tx, core_proofs_rx_inner) = mpsc::unbounded_channel::<Vec<u8>>();
+        let core_proofs_rx = MessageReceiver::<ProofData>::new(core_proofs_rx_inner);
+
+        let elf_artifact = artifact_client.create_artifact().unwrap();
+        let common_input_artifact = artifact_client.create_artifact().unwrap();
+
+        // Two identical passes over every shard range — what a re-delivered
+        // CoreExecute produces.
+        for execution in 0..2u64 {
+            tokio::task::spawn({
+                let worker_client = worker_client.clone();
+                let artifact_client = artifact_client.clone();
+                let elf_artifact = elf_artifact.clone();
+                let common_input_artifact = common_input_artifact.clone();
+                let context = context.clone();
+                let core_proofs_tx = core_proofs_tx.clone();
+                async move {
+                    tokio::time::sleep(Duration::from_millis(10 + execution * 300)).await;
+                    for i in 0..num_deferred_shards {
+                        let range = ShardRange::deferred(i, i + 1);
+                        create_dummy_prove_shard_task(
+                            range,
+                            elf_artifact.clone(),
+                            common_input_artifact.clone(),
+                            context.clone(),
+                            &core_proofs_tx,
+                            &worker_client,
+                            &artifact_client,
+                        )
+                        .await;
+                    }
+                    for _ in 0..num_precompile_shards {
+                        let range = ShardRange::precompile();
+                        create_dummy_prove_shard_task(
+                            range,
+                            elf_artifact.clone(),
+                            common_input_artifact.clone(),
+                            context.clone(),
+                            &core_proofs_tx,
+                            &worker_client,
+                            &artifact_client,
+                        )
+                        .await;
+                    }
+                    for i in 1..=num_core_shards {
+                        let range = ShardRange {
+                            timestamp_range: (i, i + 1),
+                            initialized_address_range: (0, 0),
+                            finalized_address_range: (0, 0),
+                            initialized_page_index_range: (0, 0),
+                            finalized_page_index_range: (0, 0),
+                            deferred_proof_range: (num_deferred_shards, num_deferred_shards),
+                        };
+                        create_dummy_prove_shard_task(
+                            range,
+                            elf_artifact.clone(),
+                            common_input_artifact.clone(),
+                            context.clone(),
+                            &core_proofs_tx,
+                            &worker_client,
+                            &artifact_client,
+                        )
+                        .await;
+                    }
+                    for i in 0..num_memory_shards {
+                        let range = ShardRange {
+                            timestamp_range: (num_core_shards + 1, num_core_shards + 1),
+                            initialized_address_range: (i, i + 1),
+                            finalized_address_range: (i, i + 1),
+                            initialized_page_index_range: (0, 0),
+                            finalized_page_index_range: (0, 0),
+                            deferred_proof_range: (num_deferred_shards, num_deferred_shards),
+                        };
+                        create_dummy_prove_shard_task(
+                            range,
+                            elf_artifact.clone(),
+                            common_input_artifact.clone(),
+                            context.clone(),
+                            &core_proofs_tx,
+                            &worker_client,
+                            &artifact_client,
+                        )
+                        .await;
+                    }
+                }
+            });
+        }
+        drop(core_proofs_tx);
+
+        let output = artifact_client.create_artifact().unwrap();
+
+        tokio::time::timeout(
+            Duration::from_secs(120),
+            compress_tree.reduce_proofs(
+                context,
+                output,
+                core_proofs_rx,
+                &artifact_client,
+                &worker_client,
+            ),
+        )
+        .await
+        .expect("reduce_proofs did not terminate — compress tree wedged on duplicates")
+        .unwrap();
+    }
+
+    /// Overlapping-but-unequal ranges pass the range dedup (they are distinct keys) and
+    /// corrupt the tree: the fragments can never merge to the full range. The fail-fast
+    /// must turn that into an immediate `Fatal` instead of waiting forever.
+    #[tokio::test]
+    async fn test_compress_tree_fails_fast_on_overlapping_ranges() {
+        setup_logger();
+        let random_intervals = default_random_intervals();
+
+        let worker_client = mock_worker_client(random_intervals);
+        let artifact_client = InMemoryArtifactClient::new();
+        let mut compress_tree = CompressTree::new(DEFAULT_ARITY);
+
+        let context = TaskContext {
+            proof_id: ProofId::new("test_compress_tree_fail_fast"),
+            parent_id: None,
+            parent_context: None,
+            requester_id: RequesterId::new("test_compress_tree_fail_fast"),
+        };
+
+        let (core_proofs_tx, core_proofs_rx_inner) = mpsc::unbounded_channel::<Vec<u8>>();
+        let core_proofs_rx = MessageReceiver::<ProofData>::new(core_proofs_rx_inner);
+
+        let elf_artifact = artifact_client.create_artifact().unwrap();
+        let common_input_artifact = artifact_client.create_artifact().unwrap();
+
+        for timestamp_range in [(1, 3), (2, 4)] {
+            let range = ShardRange {
+                timestamp_range,
+                initialized_address_range: (0, 0),
+                finalized_address_range: (0, 0),
+                initialized_page_index_range: (0, 0),
+                finalized_page_index_range: (0, 0),
+                deferred_proof_range: (0, 0),
+            };
+            create_dummy_prove_shard_task(
+                range,
+                elf_artifact.clone(),
+                common_input_artifact.clone(),
+                context.clone(),
+                &core_proofs_tx,
+                &worker_client,
+                &artifact_client,
+            )
+            .await;
+        }
+        drop(core_proofs_tx);
+
+        let output = artifact_client.create_artifact().unwrap();
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(60),
+            compress_tree.reduce_proofs(
+                context,
+                output,
+                core_proofs_rx,
+                &artifact_client,
+                &worker_client,
+            ),
+        )
+        .await
+        .expect("reduce_proofs did not terminate — fail-fast did not fire");
+
+        let err = result.expect_err("overlapping ranges must fail, not complete");
+        assert!(err.to_string().contains("compress tree wedged"), "unexpected error: {err}");
     }
 }

--- a/crates/prover/src/worker/controller/compress.rs
+++ b/crates/prover/src/worker/controller/compress.rs
@@ -781,8 +781,11 @@ mod test_utils {
 
     /// A re-delivered CoreExecute runs the full execution again and streams a second,
     /// identical set of shard proofs into the controller. The compress tree must ignore
-    /// the duplicates (except precompile shards, whose shared degenerate range merges
-    /// safely) and still reduce to completion instead of wedging.
+    /// the duplicates and still reduce to completion instead of wedging.
+    ///
+    /// Scope: the mocks report completion without proving anything, so this covers the
+    /// tree's shape, not proof validity. Duplicate precompile shards merge without
+    /// wedging it, but verification downstream would still reject them.
     #[tokio::test]
     async fn test_compress_tree_ignores_redelivered_core_proofs() {
         setup_logger();

--- a/crates/prover/src/worker/controller/compress.rs
+++ b/crates/prover/src/worker/controller/compress.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, HashSet, VecDeque},
+    collections::{BTreeMap, VecDeque},
     sync::{Arc, Mutex},
 };
 
@@ -15,6 +15,7 @@ use sp1_recursion_circuit::machine::SP1ShapedWitnessValues;
 use tokio::{sync::mpsc, task::JoinSet};
 use tracing::Instrument;
 
+use super::DuplicateShardFilter;
 use crate::{
     worker::{
         MessageReceiver, ProofData, RecursionProverData, ReduceTaskRequest, TaskContext, TaskError,
@@ -354,32 +355,12 @@ impl CompressTree {
             let core_proof_map = core_proof_map.clone();
             async move {
                 let mut num_core_proofs = 0;
-                // A re-delivered CoreExecute streams a second full set of shard proofs.
-                // The compress tree assumes disjoint ranges, so a duplicate range would
-                // corrupt it and wedge the reduction; keep only the first proof per range.
-                // Precompile shards all share the degenerate `ShardRange::precompile()`
-                // range, so they pass through; that never corrupts the tree. Duplicates
-                // of them are prevented upstream by the recovery guard in
-                // `SP1Controller::execute` — a slip-through fails the final reduce
-                // loudly instead of wedging.
-                let mut seen_ranges = HashSet::<ShardRange>::new();
-                let mut seen_task_ids = HashSet::<TaskId>::new();
+                // The compress tree assumes disjoint ranges, so a duplicate range
+                // corrupts it and wedges the reduction. An exempt precompile shard
+                // that slips through fails the final reduce loudly instead.
+                let mut duplicates = DuplicateShardFilter::default();
                 while let Some(proof_data) = core_proofs_rx.recv().await {
-                    if !seen_task_ids.insert(proof_data.task_id.clone()) {
-                        tracing::warn!(
-                            "skipping duplicate core proof message for task {}",
-                            proof_data.task_id
-                        );
-                        continue;
-                    }
-                    if proof_data.range != ShardRange::precompile()
-                        && !seen_ranges.insert(proof_data.range)
-                    {
-                        tracing::warn!(
-                            "skipping duplicate core proof for range {:?} (task {})",
-                            proof_data.range,
-                            proof_data.task_id
-                        );
+                    if duplicates.seen(&proof_data) {
                         continue;
                     }
                     core_proofs_subscriber

--- a/crates/prover/src/worker/controller/mod.rs
+++ b/crates/prover/src/worker/controller/mod.rs
@@ -25,7 +25,7 @@ use sp1_core_executor::SP1CoreOpts;
 use sp1_core_executor_runner::MinimalExecutorRunner;
 use sp1_core_machine::{executor::ExecutionOutput, io::SP1Stdin};
 use sp1_hypercube::{
-    air::{PublicValues, PROOF_NONCE_NUM_WORDS},
+    air::{PublicValues, ShardRange, PROOF_NONCE_NUM_WORDS},
     SP1PcsProofInner, SP1VerifyingKey, ShardProof,
 };
 use sp1_primitives::{io::SP1PublicValues, SP1GlobalContext};
@@ -33,7 +33,7 @@ use sp1_prover_types::{
     network_base_types::ProofMode, Artifact, ArtifactClient, ArtifactType, TaskStatus, TaskType,
 };
 use sp1_verifier::{ProofFromNetwork, SP1Proof};
-use std::{borrow::Borrow, sync::Arc};
+use std::{borrow::Borrow, collections::HashSet, sync::Arc};
 use tokio::{
     sync::{oneshot, Mutex, MutexGuard},
     task::JoinSet,
@@ -141,8 +141,10 @@ where
     /// Run the core executor and deferred proof emitter for a `CoreExecute` task. Proof shards
     /// are streamed back to the consumer via the task's message channel.
     ///
-    /// Idempotent under redelivery: if the execution output artifact already exists, a prior
-    /// delivery completed this task and the recorded output is returned without re-executing.
+    /// Redelivery-safe on both sides: if the execution output artifact already exists, a prior
+    /// delivery finished this task and its recorded output is returned without re-executing. A
+    /// redelivery that overlaps the original still streams a second set of shard proofs, which
+    /// the consumers drop by range.
     pub async fn execute(
         &self,
         task_id: TaskId,
@@ -568,6 +570,43 @@ where
     }
 }
 
+/// Drops shard proofs that have already been streamed for this proof.
+///
+/// A re-delivered `CoreExecute` runs alongside the original and streams a second
+/// full set of shard proofs. Both consumers assume one proof per range, so the
+/// second set has to be dropped rather than accepted.
+///
+/// Precompile shards are exempt: they all share the degenerate
+/// `ShardRange::precompile()` range, so range is no longer an identity for them.
+/// Duplicates of those are prevented upstream by the recovery guard in
+/// [`SP1Controller::execute`].
+#[derive(Default)]
+struct DuplicateShardFilter {
+    task_ids: HashSet<TaskId>,
+    ranges: HashSet<ShardRange>,
+}
+
+impl DuplicateShardFilter {
+    /// True once this proof has been seen, by task or by range.
+    fn seen(&mut self, proof_data: &ProofData) -> bool {
+        // Guards against the transport itself: the message channel retries
+        // forever and the coordinator replays its buffer on reconnect.
+        if !self.task_ids.insert(proof_data.task_id.clone()) {
+            tracing::warn!("skipping duplicate proof message for task {}", proof_data.task_id);
+            return true;
+        }
+        if proof_data.range != ShardRange::precompile() && !self.ranges.insert(proof_data.range) {
+            tracing::warn!(
+                "skipping duplicate proof for range {:?} (task {})",
+                proof_data.range,
+                proof_data.task_id
+            );
+            return true;
+        }
+        false
+    }
+}
+
 async fn collect_core_proofs(
     worker_client: impl WorkerClient,
     artifact_client: impl ArtifactClient,
@@ -577,7 +616,12 @@ async fn collect_core_proofs(
 ) -> Result<(), TaskError> {
     let subscriber = worker_client.subscriber(context.proof_id.clone()).await?.per_task();
     let mut shard_proofs = Vec::new();
+    // Here a duplicate lands in the core proof itself, which the verifier rejects.
+    let mut duplicates = DuplicateShardFilter::default();
     while let Some(proof_data) = core_proof_rx.recv().await {
+        if duplicates.seen(&proof_data) {
+            continue;
+        }
         let ProofData { task_id, proof, .. } = proof_data;
         let status = subscriber.wait_task(task_id.clone()).await?;
         if status != TaskStatus::Succeeded {
@@ -669,5 +713,58 @@ impl ControllerInputMetadata {
         } else {
             ArtifactType::Stdin
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn proof_data(task_id: &str, range: ShardRange) -> ProofData {
+        ProofData {
+            task_id: TaskId::new(task_id),
+            range,
+            proof: Artifact::from(task_id.to_string()),
+        }
+    }
+
+    fn shard(timestamp: u64) -> ShardRange {
+        ShardRange { timestamp_range: (timestamp, timestamp + 1), ..Default::default() }
+    }
+
+    #[test]
+    fn distinct_shards_pass_through() {
+        let mut filter = DuplicateShardFilter::default();
+
+        assert!(!filter.seen(&proof_data("t1", shard(1))));
+        assert!(!filter.seen(&proof_data("t2", shard(2))));
+    }
+
+    #[test]
+    fn a_re_executed_shard_is_dropped() {
+        let mut filter = DuplicateShardFilter::default();
+        filter.seen(&proof_data("t1", shard(1)));
+
+        // Re-execution proves the same range under a new task, so the task id
+        // says nothing — the range is what identifies the shard.
+        assert!(filter.seen(&proof_data("t2", shard(1))));
+    }
+
+    #[test]
+    fn a_redelivered_message_is_dropped() {
+        let mut filter = DuplicateShardFilter::default();
+        filter.seen(&proof_data("t1", shard(1)));
+
+        assert!(filter.seen(&proof_data("t1", shard(1))));
+    }
+
+    #[test]
+    fn precompile_shards_are_exempt() {
+        let mut filter = DuplicateShardFilter::default();
+
+        // They all carry the same degenerate range, so dropping by range would
+        // discard every precompile shard after the first.
+        assert!(!filter.seen(&proof_data("t1", ShardRange::precompile())));
+        assert!(!filter.seen(&proof_data("t2", ShardRange::precompile())));
     }
 }

--- a/crates/prover/src/worker/controller/mod.rs
+++ b/crates/prover/src/worker/controller/mod.rs
@@ -140,11 +140,46 @@ where
     /// Execute Risc-V program, and trigger shard proofs for each trace chunk.
     /// Run the core executor and deferred proof emitter for a `CoreExecute` task. Proof shards
     /// are streamed back to the consumer via the task's message channel.
+    ///
+    /// Idempotent under redelivery: if the execution output artifact already exists, a prior
+    /// delivery completed this task and the recorded output is returned without re-executing.
     pub async fn execute(
         &self,
         task_id: TaskId,
         request: CoreExecuteTaskRequest,
     ) -> Result<ExecutionOutput, TaskError> {
+        // The cluster delivers tasks at-least-once. `execution_output` is uploaded as
+        // the final step of a successful run, strictly after every shard proof has
+        // been spawned and streamed to the consumer — so if it exists, a prior
+        // delivery already completed this task, and re-executing would stream a
+        // duplicate set of shard proofs into the controller's compress tree.
+        let prior_output_exists = match self
+            .artifact_client
+            .exists(&request.execution_output, ArtifactType::UnspecifiedArtifactType)
+            .await
+        {
+            Ok(exists) => exists,
+            Err(e) => {
+                tracing::warn!(
+                    "failed to check for a prior execution output of task {}: {:?}; \
+                     falling back to re-execution",
+                    task_id,
+                    e
+                );
+                false
+            }
+        };
+        if prior_output_exists {
+            tracing::info!(
+                "CoreExecute task {} already completed by a prior delivery; \
+                 returning recorded output without re-executing",
+                task_id
+            );
+            let output =
+                self.artifact_client.download::<ExecutionOutput>(&request.execution_output).await?;
+            return Ok(output);
+        }
+
         let stdin_artifact_type =
             if request.stdin_private { ArtifactType::PrivateStdin } else { ArtifactType::Stdin };
         let stdin = self

--- a/crates/prover/src/worker/controller/mod.rs
+++ b/crates/prover/src/worker/controller/mod.rs
@@ -150,35 +150,10 @@ where
         task_id: TaskId,
         request: CoreExecuteTaskRequest,
     ) -> Result<ExecutionOutput, TaskError> {
-        // The cluster delivers tasks at-least-once. `execution_output` is uploaded as
-        // the final step of a successful run, strictly after every shard proof has
-        // been spawned and streamed to the consumer — so if it exists, a prior
-        // delivery already completed this task, and re-executing would stream a
-        // duplicate set of shard proofs into the controller's compress tree.
-        let prior_output_exists = match self
-            .artifact_client
-            .exists(&request.execution_output, ArtifactType::UnspecifiedArtifactType)
-            .await
+        if let Some(output) =
+            recorded_execution_output(&self.artifact_client, &task_id, &request.execution_output)
+                .await?
         {
-            Ok(exists) => exists,
-            Err(e) => {
-                tracing::warn!(
-                    "failed to check for a prior execution output of task {}: {:?}; \
-                     falling back to re-execution",
-                    task_id,
-                    e
-                );
-                false
-            }
-        };
-        if prior_output_exists {
-            tracing::info!(
-                "CoreExecute task {} already completed by a prior delivery; \
-                 returning recorded output without re-executing",
-                task_id
-            );
-            let output =
-                self.artifact_client.download::<ExecutionOutput>(&request.execution_output).await?;
             return Ok(output);
         }
 
@@ -570,6 +545,39 @@ where
     }
 }
 
+/// The output of a prior delivery of this task, if one already finished it.
+///
+/// The cluster delivers tasks at-least-once, and this artifact is uploaded last,
+/// after every shard proof has been streamed — so its presence means re-executing
+/// would stream a second set. A failed lookup re-executes rather than failing the
+/// task: duplicates are recoverable, a lost proof is not.
+async fn recorded_execution_output<A: ArtifactClient>(
+    artifact_client: &A,
+    task_id: &TaskId,
+    execution_output: &Artifact,
+) -> Result<Option<ExecutionOutput>, TaskError> {
+    match artifact_client.exists(execution_output, ArtifactType::UnspecifiedArtifactType).await {
+        Ok(true) => {
+            tracing::info!(
+                "CoreExecute task {} already completed by a prior delivery; \
+                 returning recorded output without re-executing",
+                task_id
+            );
+            Ok(Some(artifact_client.download::<ExecutionOutput>(execution_output).await?))
+        }
+        Ok(false) => Ok(None),
+        Err(e) => {
+            tracing::warn!(
+                "failed to check for a prior execution output of task {}: {:?}; \
+                 falling back to re-execution",
+                task_id,
+                e
+            );
+            Ok(None)
+        }
+    }
+}
+
 /// Drops shard proofs that have already been streamed for this proof.
 ///
 /// A re-delivered `CoreExecute` runs alongside the original and streams a second
@@ -719,6 +727,39 @@ impl ControllerInputMetadata {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sp1_prover_types::InMemoryArtifactClient;
+
+    #[tokio::test]
+    async fn a_first_delivery_executes() {
+        let artifact_client = InMemoryArtifactClient::new();
+        let execution_output = artifact_client.create_artifact().unwrap();
+
+        let recorded =
+            recorded_execution_output(&artifact_client, &TaskId::new("t1"), &execution_output)
+                .await
+                .unwrap();
+
+        assert!(recorded.is_none());
+    }
+
+    #[tokio::test]
+    async fn a_redelivery_returns_the_recorded_output() {
+        let artifact_client = InMemoryArtifactClient::new();
+        let execution_output = artifact_client.create_artifact().unwrap();
+        // Uploaded last by the run that finished, after every shard proof was streamed.
+        artifact_client
+            .upload(&execution_output, ExecutionOutput { public_value_stream: vec![7], cycles: 42 })
+            .await
+            .unwrap();
+
+        let recorded =
+            recorded_execution_output(&artifact_client, &TaskId::new("t1"), &execution_output)
+                .await
+                .unwrap()
+                .expect("a finished delivery's output was not reused");
+
+        assert_eq!(recorded.cycles, 42);
+    }
 
     fn proof_data(task_id: &str, range: ShardRange) -> ProofData {
         ProofData {
@@ -762,8 +803,9 @@ mod tests {
     fn precompile_shards_are_exempt() {
         let mut filter = DuplicateShardFilter::default();
 
-        // They all carry the same degenerate range, so dropping by range would
-        // discard every precompile shard after the first.
+        // They share one degenerate range, so dropping by range would discard every
+        // precompile shard after the first. The cost: a redelivery's precompile
+        // duplicates get through, until they carry an identity of their own.
         assert!(!filter.seen(&proof_data("t1", ShardRange::precompile())));
         assert!(!filter.seen(&proof_data("t2", ShardRange::precompile())));
     }


### PR DESCRIPTION
## Summary

The cluster delivers tasks at-least-once, but a re-delivered `CoreExecute` re-runs the full execution and streams a second, identical set of per-shard `ProofData` into the controller. The `CompressTree` assumes disjoint shard ranges, so the duplicates corrupt it and proving wedges silently — no failure, no status write — until the request deadline evicts the proof hours later.

## Incidents
- 2026-07-15, [mainnet request](https://explorer.succinct.xyz/request/0x38a5edaff6dcf00aff3c5a1492bd05b5e71282a4b25a0336ee5a00841546c399) — 45M-cycle proof, executed in 1.5s. A CPU worker's heartbeat arrived 35s late under a 5× traffic spike; the coordinator declared it dead and re-delivered its in-flight `CoreExecute` while the original run was still going. Both runs streamed a full shard set (30 ProveShards for a ~15-shard proof). All shards and reduces completed, then the controller went silent at the reduce→wrap boundary for 3h54m.
- Same day, 1aee2eb0… — identical wedge signature; here the worker genuinely died mid-run (gnark panic), so the redelivery was legitimate. Both flavors — false-positive and real death — poison the tree the same way.
- 2026-07-27 recurrence — same signature on another request from the same customer, ~2h01m customer latency; independently root-caused to the same retry bug.

**Connected PR in sp1-cluster:** https://github.com/succinctlabs/sp1-cluster/pull/163