### PR TITLE
fix(sdk): handle unknown fulfillment statuses safely

### DIFF
--- a/crates/sdk/src/network/client.rs
+++ b/crates/sdk/src/network/client.rs
@@ -83,6 +83,18 @@ pub struct MarketPrice {
     pub as_of: u64,
 }
 
+pub(super) fn parse_fulfillment_status(
+    raw_status: i32,
+    request_id: B256,
+) -> Result<FulfillmentStatus> {
+    FulfillmentStatus::try_from(raw_status).with_context(|| {
+        format!(
+            "unsupported fulfillment status {raw_status} while getting proof request status for request 0x{}",
+            hex::encode(request_id)
+        )
+    })
+}
+
 /// A client for interacting with the network.
 #[derive(Clone)]
 pub struct NetworkClient {
@@ -564,7 +576,7 @@ impl NetworkClient {
             }
         };
 
-        let status = FulfillmentStatus::try_from(res.fulfillment_status())?;
+        let status = parse_fulfillment_status(res.fulfillment_status(), request_id)?;
         let proof = match status {
             FulfillmentStatus::Fulfilled => {
                 let proof_uri =
@@ -909,12 +921,30 @@ impl NetworkClient {
 
 #[cfg(test)]
 mod test {
+    use alloy_primitives::B256;
+
     use crate::network::{signer::NetworkSigner, NetworkMode, RESERVED_RPC_URL};
+
+    use super::parse_fulfillment_status;
 
     #[test]
     fn test_can_create_network_client_with_0x_bytes() {
         let private_key = hex::encode(alloy_signer_local::PrivateKeySigner::random().to_bytes());
         let signer = NetworkSigner::local(&private_key).unwrap();
         let _ = super::NetworkClient::new(signer, RESERVED_RPC_URL, NetworkMode::Reserved);
+    }
+
+    #[test]
+    fn fulfillment_status_parser_handles_known_and_unknown_values() {
+        let request_id = B256::from([0xab; 32]);
+
+        for raw_status in 0..=6 {
+            let status = parse_fulfillment_status(raw_status, request_id).unwrap();
+            assert_eq!(status as i32, raw_status);
+        }
+
+        let error = parse_fulfillment_status(7, request_id).unwrap_err().to_string();
+        assert!(error.contains("unsupported fulfillment status 7"));
+        assert!(error.contains(&format!("0x{}", hex::encode(request_id))));
     }
 }

--- a/crates/sdk/src/network/prover.rs
+++ b/crates/sdk/src/network/prover.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, Instant};
 use super::prove::NetworkProveBuilder;
 use crate::{
     network::{
-        client::NetworkClient,
+        client::{parse_fulfillment_status, NetworkClient},
         proto::{
             types::{
                 ExecutionStatus, FulfillmentStatus, FulfillmentStrategy, ProofMode, ProofRequest,
@@ -414,7 +414,7 @@ impl NetworkProver {
         let maybe_proof: Option<SP1ProofWithPublicValues> = maybe_proof.map(Into::into);
 
         let execution_status = ExecutionStatus::try_from(status.execution_status()).unwrap();
-        let fulfillment_status = FulfillmentStatus::try_from(status.fulfillment_status()).unwrap();
+        let fulfillment_status = parse_fulfillment_status(status.fulfillment_status(), request_id)?;
 
         let current_time =
             std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();


### PR DESCRIPTION
## What

- Return a contextual error for unknown fulfillment status wire values.
- Remove the remaining panic-capable status parse.
- Preserve handling for all known statuses.

## Why

New server enum values must not crash or produce context-free errors in older SDK clients.

## Validation

- `cargo +nightly fmt --all -- --check`
- focused fulfillment-status regression test
- `cargo build --release -p sp1-sdk --features network`
- `cargo test --release -p sp1-sdk --features network --lib`
- `cargo clippy --release -p sp1-sdk --features network --lib --tests`
- `git diff --check`

## Notes

No public error variant, proto/generated change, or polling/retry semantic change.
