### PR TITLE
fix(sdk): use reserved schema for proof request details

### DIFF
--- a/crates/sdk/src/network/client.rs
+++ b/crates/sdk/src/network/client.rs
@@ -50,8 +50,11 @@ use crate::network::proto::{
         GetBalanceRequest as BaseGetBalanceRequest,
         GetFilteredProofRequestsRequest as BaseGetFilteredProofRequestsRequest,
         GetNonceRequest as BaseGetNonceRequest, GetProgramRequest as BaseGetProgramRequest,
+        GetProofRequestDetailsRequest as BaseGetProofRequestDetailsRequest,
+        GetProofRequestDetailsResponse as BaseGetProofRequestDetailsResponse,
         GetProofRequestStatusRequest as BaseGetProofRequestStatusRequest,
-        MessageFormat as BaseMessageFormat, RequestProofRequest as BaseRequestProofRequest,
+        MessageFormat as BaseMessageFormat, ProofRequest as BaseProofRequest,
+        RequestProofRequest as BaseRequestProofRequest,
         RequestProofRequestBody as BaseRequestProofRequestBody,
     },
     // Import standard types (auction by default for backwards compatibility).
@@ -584,23 +587,131 @@ impl NetworkClient {
         request_id: B256,
         timeout: Option<Duration>,
     ) -> Result<GetProofRequestDetailsResponse> {
-        let res = self
-            .with_retry_timeout(
-                || async {
-                    let mut rpc = self.prover_network_client().await?;
-                    Ok(rpc
-                        .get_proof_request_details(GetProofRequestDetailsRequest {
-                            request_id: request_id.to_vec(),
-                        })
-                        .await?
-                        .into_inner())
-                },
-                timeout.unwrap_or(DEFAULT_RETRY_TIMEOUT),
-                "getting proof request details",
-            )
-            .await?;
+        let res = match self.network_mode {
+            NetworkMode::Mainnet => {
+                self.with_retry_timeout(
+                    || async {
+                        let mut rpc = self.auction_prover_network_client().await?;
+                        Ok(rpc
+                            .get_proof_request_details(GetProofRequestDetailsRequest {
+                                request_id: request_id.to_vec(),
+                            })
+                            .await?
+                            .into_inner())
+                    },
+                    timeout.unwrap_or(DEFAULT_RETRY_TIMEOUT),
+                    "getting proof request details",
+                )
+                .await?
+            }
+            NetworkMode::Reserved => {
+                let response = self
+                    .with_retry_timeout(
+                        || async {
+                            let mut rpc = self.base_prover_network_client().await?;
+                            Ok(rpc
+                                .get_proof_request_details(BaseGetProofRequestDetailsRequest {
+                                    request_id: request_id.to_vec(),
+                                })
+                                .await?
+                                .into_inner())
+                        },
+                        timeout.unwrap_or(DEFAULT_RETRY_TIMEOUT),
+                        "getting proof request details",
+                    )
+                    .await?;
+                Self::convert_base_proof_request_details(response)
+            }
+        };
 
         Ok(res)
+    }
+
+    fn convert_base_proof_request_details(
+        response: BaseGetProofRequestDetailsResponse,
+    ) -> GetProofRequestDetailsResponse {
+        GetProofRequestDetailsResponse {
+            request: response.request.map(|request| {
+                let BaseProofRequest {
+                    request_id,
+                    vk_hash,
+                    version,
+                    mode,
+                    strategy,
+                    program_uri,
+                    stdin_uri,
+                    deadline,
+                    cycle_limit,
+                    gas_price,
+                    fulfillment_status,
+                    execution_status,
+                    requester,
+                    fulfiller,
+                    program_name,
+                    requester_name,
+                    fulfiller_name,
+                    created_at,
+                    updated_at,
+                    fulfilled_at,
+                    tx_hash,
+                    cycles,
+                    public_values_hash,
+                    deduction_amount,
+                    refund_amount,
+                    gas_limit,
+                    gas_used,
+                    execute_fail_cause,
+                    settlement_status,
+                    program_public_uri,
+                    stdin_public_uri,
+                    min_auction_period,
+                    whitelist,
+                    error,
+                    stdin_private,
+                } = request;
+
+                crate::network::proto::auction_types::ProofRequest {
+                    request_id,
+                    vk_hash,
+                    version,
+                    mode,
+                    strategy,
+                    program_uri,
+                    stdin_uri,
+                    deadline,
+                    cycle_limit,
+                    gas_price,
+                    fulfillment_status,
+                    execution_status,
+                    requester,
+                    fulfiller,
+                    program_name,
+                    requester_name,
+                    fulfiller_name,
+                    created_at,
+                    updated_at,
+                    fulfilled_at,
+                    tx_hash,
+                    cycles,
+                    public_values_hash,
+                    deduction_amount,
+                    refund_amount,
+                    gas_limit,
+                    gas_used,
+                    execute_fail_cause,
+                    settlement_status,
+                    program_public_uri,
+                    stdin_public_uri,
+                    min_auction_period,
+                    whitelist,
+                    base_fee: None,
+                    max_price_per_pgu: None,
+                    error,
+                    is_canceled: false,
+                    stdin_private,
+                }
+            }),
+        }
     }
 
     /// Creates a proof request with the given verifying key hash and stdin.
@@ -760,8 +871,7 @@ impl NetworkClient {
         }
     }
 
-    // NetworkMode-aware generic client for shared operations (create_program,
-    // get_proof_request_details).
+    // Auction client for operations whose schemas are wire-compatible across network modes.
     pub(crate) async fn prover_network_client(
         &self,
     ) -> Result<AuctionProverNetworkClient<Channel>> {
@@ -909,12 +1019,133 @@ impl NetworkClient {
 
 #[cfg(test)]
 mod test {
-    use crate::network::{signer::NetworkSigner, NetworkMode, RESERVED_RPC_URL};
+    use std::{
+        convert::Infallible,
+        task::{Context, Poll},
+        time::Duration,
+    };
+
+    use alloy_primitives::B256;
+    use tonic::{
+        codegen::{http, Body, BoxFuture, Service, StdError},
+        server::{Grpc, NamedService, UnaryService},
+        transport::Server,
+        Request, Response, Status,
+    };
+
+    use crate::network::{proto::base_types, signer::NetworkSigner, NetworkMode, RESERVED_RPC_URL};
+
+    #[derive(Clone)]
+    struct ReservedProofDetailsFixture(base_types::GetProofRequestDetailsResponse);
+
+    impl NamedService for ReservedProofDetailsFixture {
+        const NAME: &'static str = "network.ProverNetwork";
+    }
+
+    impl UnaryService<base_types::GetProofRequestDetailsRequest> for ReservedProofDetailsFixture {
+        type Response = base_types::GetProofRequestDetailsResponse;
+        type Future = BoxFuture<Response<Self::Response>, Status>;
+
+        fn call(
+            &mut self,
+            request: Request<base_types::GetProofRequestDetailsRequest>,
+        ) -> Self::Future {
+            assert_eq!(
+                request.into_inner().request_id,
+                self.0.request.as_ref().unwrap().request_id
+            );
+            let response = self.0.clone();
+            Box::pin(async move { Ok(Response::new(response)) })
+        }
+    }
+
+    impl<B> Service<http::Request<B>> for ReservedProofDetailsFixture
+    where
+        B: Body + Send + 'static,
+        B::Error: Into<StdError> + Send + 'static,
+    {
+        type Response = http::Response<tonic::body::BoxBody>;
+        type Error = Infallible;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, request: http::Request<B>) -> Self::Future {
+            assert_eq!(request.uri().path(), "/network.ProverNetwork/GetProofRequestDetails");
+
+            let method = self.clone();
+            Box::pin(async move {
+                Ok(Grpc::new(tonic::codec::ProstCodec::default()).unary(method, request).await)
+            })
+        }
+    }
 
     #[test]
     fn test_can_create_network_client_with_0x_bytes() {
         let private_key = hex::encode(alloy_signer_local::PrivateKeySigner::random().to_bytes());
         let signer = NetworkSigner::local(&private_key).unwrap();
         let _ = super::NetworkClient::new(signer, RESERVED_RPC_URL, NetworkMode::Reserved);
+    }
+
+    #[tokio::test]
+    async fn reserved_proof_request_details_uses_reserved_schema() {
+        let request_id = B256::repeat_byte(0x11);
+        let request = base_types::ProofRequest {
+            request_id: request_id.to_vec(),
+            vk_hash: vec![0x22; 32],
+            version: "sp1-v6.3.1".to_string(),
+            mode: base_types::ProofMode::Plonk.into(),
+            strategy: base_types::FulfillmentStrategy::Reserved.into(),
+            program_uri: "programs/test".to_string(),
+            stdin_uri: "stdins/test".to_string(),
+            deadline: 1_800_000_000,
+            cycle_limit: 1_000_000,
+            error: base_types::ProofRequestError::ExecutionFailure.into(),
+            stdin_private: true,
+            ..Default::default()
+        };
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let incoming = futures::stream::unfold(listener, |listener| async move {
+            let connection = listener.accept().await.map(|(stream, _)| stream);
+            Some((connection, listener))
+        });
+        let server = tokio::spawn(
+            Server::builder()
+                .add_service(ReservedProofDetailsFixture(
+                    base_types::GetProofRequestDetailsResponse { request: Some(request) },
+                ))
+                .serve_with_incoming(incoming),
+        );
+
+        let private_key = hex::encode(alloy_signer_local::PrivateKeySigner::random().to_bytes());
+        let signer = NetworkSigner::local(&private_key).unwrap();
+        let client =
+            super::NetworkClient::new(signer, format!("http://{address}"), NetworkMode::Reserved);
+
+        let response = client
+            .get_proof_request_details(request_id, Some(Duration::from_secs(1)))
+            .await
+            .unwrap();
+        server.abort();
+
+        let request = response.request.unwrap();
+        assert_eq!(request.request_id, request_id.as_slice());
+        assert_eq!(request.vk_hash, vec![0x22; 32]);
+        assert_eq!(request.version, "sp1-v6.3.1");
+        assert_eq!(request.mode, base_types::ProofMode::Plonk as i32);
+        assert_eq!(request.strategy, base_types::FulfillmentStrategy::Reserved as i32);
+        assert_eq!(request.program_uri, "programs/test");
+        assert_eq!(request.stdin_uri, "stdins/test");
+        assert_eq!(request.deadline, 1_800_000_000);
+        assert_eq!(request.cycle_limit, 1_000_000);
+        assert_eq!(request.error, base_types::ProofRequestError::ExecutionFailure as i32);
+        assert!(request.stdin_private);
+        assert_eq!(request.base_fee, None);
+        assert_eq!(request.max_price_per_pgu, None);
+        assert!(!request.is_canceled);
     }
 }


### PR DESCRIPTION
## What
- Route `NetworkClient::get_proof_request_details` through the auction schema for `NetworkMode::Mainnet` and the base/reserved schema for `NetworkMode::Reserved`.
- Convert reserved responses into the existing public response type while preserving every current shared v6 field.
- Add a local tonic regression test that exercises the public `NetworkClient` flow with a nonzero reserved `ProofRequest.error`.

## Why
Reserved `ProofRequest` field 34 is the `error` enum encoded as a varint, while auction `ProofRequest` field 34 is optional string `base_fee`. Decoding a reserved response with the auction client produces the production symptom:

`ProofRequest.base_fee: GetProofRequestDetailsResponse.request: invalid wire type: Varint (expected LengthDelimited)`

This is a regression, not new behavior: [#2515](https://github.com/succinctlabs/sp1/pull/2515) added mode-aware routing in v5.2.4, and the fix was lost when [#2580](https://github.com/succinctlabs/sp1/pull/2580) merged `multilinear_v6`.

## Validation
- `cargo test -p sp1-sdk --features network reserved_proof_request_details_uses_reserved_schema`
- `cargo test -p sp1-sdk --features network --lib network:: -- --test-threads=1` (25 passed)
- `cargo fmt --all -- --check`
- `cargo check -p sp1-sdk --features network --lib`
- `cargo clippy -p sp1-sdk --features network --lib --tests` (passed; existing `clippy.toml` reachability warnings remain)

## Notes
- Full workspace and all-feature suites were not run because this change is isolated to the SDK network client.
- No generated protobuf, release, dependency, deployment, or OP Succinct changes.
