### PR TITLE
perf(gpu): faster kb31 ext mul for W=3, fix frobeniusInverse constant

### DIFF
--- a/sp1-gpu/crates/sys/include/fields/kb31_extension_t.cuh
+++ b/sp1-gpu/crates/sys/include/fields/kb31_extension_t.cuh
@@ -3,7 +3,7 @@
 #include "fields/kb31_t.cuh"
 #include "fields/ptx.cuh"
 
-static constexpr size_t W_INT = 3; // The value of W in the kb31 field, used for multiplication
+static constexpr uint32_t W_INT = 3; // The value of W in the kb31 field, used for multiplication
 
 class kb31_extension_t {
   public:
@@ -11,7 +11,10 @@ class kb31_extension_t {
     static constexpr kb31_t W = kb31_t{3};
     static const uint32_t MOD = 0x7f000001u;
     static constexpr uint32_t M = 0x7effffffu;
-    static constexpr uint32_t MUL2_32 = 0x01fffffe; // 2^32 = 2^25 - 2
+    static constexpr uint32_t MUL2_32 = 0x01fffffe; // 2^32 mod MOD = 2^25 - 2
+    // W * (2^32 mod MOD): folds the high half of a wrap-around column in one wide mad.
+    // Fits in 27 bits, which keeps the fold accumulations in operator*= below 2^64.
+    static constexpr uint32_t W_X_MUL2_32 = W_INT * MUL2_32;
 
     kb31_t value[D];
 
@@ -132,7 +135,24 @@ class kb31_extension_t {
         mad_wide(a5, x2, y3, a5);
         mul_wide(a6, x3, y3);
 
-        // Reduction step to zero the top 4 bits in each accumulator
+        // Fold the X^4 = W wrap-around into columns 0..2: a_k += W * a_{k+4} (mod MOD).
+        // Split a_{k+4} = 2^32 * h + l; then W * a_{k+4} = W * l + W_X_MUL2_32 * h (mod MOD),
+        // two single-instruction wide mads per column. Worst case (all inputs < MOD) peaks
+        // at column 2 below 1.38e19 < 2^64, so the accumulators cannot overflow.
+
+        unpack(l4, h4, a4);
+        mad_wide(a0, l4, W_INT, a0);
+        mad_wide(a0, h4, W_X_MUL2_32, a0);
+        unpack(l5, h5, a5);
+        mad_wide(a1, l5, W_INT, a1);
+        mad_wide(a1, h5, W_X_MUL2_32, a1);
+        unpack(l6, h6, a6);
+        mad_wide(a2, l6, W_INT, a2);
+        mad_wide(a2, h6, W_X_MUL2_32, a2);
+
+        // One reduction pass: a_k = 2^32 * h + l -> h * MUL2_32 + l < 2^57, which keeps the
+        // Montgomery mad below clear of u64 overflow and bounds each Montgomery-reduced
+        // value by MOD + MUL2_32 (before the final subtractions).
 
         unpack(l0, h0, a0);
         l = l0;
@@ -150,41 +170,6 @@ class kb31_extension_t {
         l = l3;
         pack(w, l, h);
         mad_wide(a3, h3, MUL2_32, w);
-        unpack(l4, h4, a4);
-        l = l4;
-        pack(w, l, h);
-        mad_wide(a4, h4, MUL2_32, w);
-        unpack(l5, h5, a5);
-        l = l5;
-        pack(w, l, h);
-        mad_wide(a5, h5, MUL2_32, w);
-        unpack(l6, h6, a6);
-        l = l6;
-        pack(w, l, h);
-        mad_wide(a6, h6, MUL2_32, w);
-
-        unpack(l4, h4, a4);
-        unpack(l5, h5, a5);
-        unpack(l6, h6, a6);
-
-        mad_lo(a0, a4, W_INT, a0);
-        mad_lo(a1, a5, W_INT, a1);
-        mad_lo(a2, a6, W_INT, a2);
-
-        // Avoid overflow in Montgomery reduction
-
-        unpack(l0, h0, a0);
-        l = l0;
-        pack(w, l, h);
-        mad_wide(a0, h0, MUL2_32, w);
-        unpack(l1, h1, a1);
-        l = l1;
-        pack(w, l, h);
-        mad_wide(a1, h1, MUL2_32, w);
-        unpack(l2, h2, a2);
-        l = l2;
-        pack(w, l, h);
-        mad_wide(a2, h2, MUL2_32, w);
 
         unpack(l0, h0, a0);
         unpack(l1, h1, a1);
@@ -255,6 +240,9 @@ class kb31_extension_t {
     }
 
     __device__ __forceinline__ kb31_extension_t frobenius() {
+        // z0 = W^((MOD-1)/4). Limb i is scaled by z0^(i+1) rather than z0^i, so this
+        // returns z0 * a^MOD, not a^MOD. frobeniusInverse() applies it three times,
+        // picking up a total factor z0^3 that cancels in f * g^{-1}.
         kb31_t z0 = kb31_t(2113994754);
         kb31_t z = z0;
         kb31_extension_t result;
@@ -277,7 +265,8 @@ class kb31_extension_t {
         for (size_t i = 1; i < D; i++) {
             g += a.value[i] * b.value[4 - i];
         }
-        g *= kb31_t(11);
+        // Constant term of a * b in F_p[X]/(X^4 - W) is a_0*b_0 + W*(a_1*b_3 + a_2*b_2 + a_3*b_1).
+        g *= W;
         g += a.value[0] * b.value[0];
         return f * g.reciprocal();
     }
@@ -349,7 +338,24 @@ class kb31_extension_t {
         mad_wide(a5, x2, y3, a5);
         mul_wide(a6, x3, y3);
 
-        // Reduction step to zero the top 4 bits in each accumulator
+        // Fold the X^4 = W wrap-around into columns 0..2: a_k += W * a_{k+4} (mod MOD).
+        // Split a_{k+4} = 2^32 * h + l; then W * a_{k+4} = W * l + W_X_MUL2_32 * h (mod MOD),
+        // two single-instruction wide mads per column. Worst case (all inputs < MOD) peaks
+        // at column 2 below 1.38e19 < 2^64, so the accumulators cannot overflow.
+
+        unpack(l4, h4, a4);
+        mad_wide(a0, l4, W_INT, a0);
+        mad_wide(a0, h4, W_X_MUL2_32, a0);
+        unpack(l5, h5, a5);
+        mad_wide(a1, l5, W_INT, a1);
+        mad_wide(a1, h5, W_X_MUL2_32, a1);
+        unpack(l6, h6, a6);
+        mad_wide(a2, l6, W_INT, a2);
+        mad_wide(a2, h6, W_X_MUL2_32, a2);
+
+        // One reduction pass: a_k = 2^32 * h + l -> h * MUL2_32 + l < 2^57, which keeps the
+        // Montgomery mad below clear of u64 overflow and bounds each Montgomery-reduced
+        // value by MOD + MUL2_32 (before the final subtractions).
 
         unpack(l0, h0, a0);
         l = l0;
@@ -367,41 +373,6 @@ class kb31_extension_t {
         l = l3;
         pack(w, l, h);
         mad_wide(a3, h3, MUL2_32, w);
-        unpack(l4, h4, a4);
-        l = l4;
-        pack(w, l, h);
-        mad_wide(a4, h4, MUL2_32, w);
-        unpack(l5, h5, a5);
-        l = l5;
-        pack(w, l, h);
-        mad_wide(a5, h5, MUL2_32, w);
-        unpack(l6, h6, a6);
-        l = l6;
-        pack(w, l, h);
-        mad_wide(a6, h6, MUL2_32, w);
-
-        unpack(l4, h4, a4);
-        unpack(l5, h5, a5);
-        unpack(l6, h6, a6);
-
-        mad_lo(a0, a4, W_INT, a0);
-        mad_lo(a1, a5, W_INT, a1);
-        mad_lo(a2, a6, W_INT, a2);
-
-        // Avoid overflow in Montgomery reduction
-
-        unpack(l0, h0, a0);
-        l = l0;
-        pack(w, l, h);
-        mad_wide(a0, h0, MUL2_32, w);
-        unpack(l1, h1, a1);
-        l = l1;
-        pack(w, l, h);
-        mad_wide(a1, h1, MUL2_32, w);
-        unpack(l2, h2, a2);
-        l = l2;
-        pack(w, l, h);
-        mad_wide(a2, h2, MUL2_32, w);
 
         unpack(l0, h0, a0);
         unpack(l1, h1, a1);
@@ -425,7 +396,10 @@ class kb31_extension_t {
         unpack(l2, x2, a2);
         unpack(l3, x3, a3);
 
-        // Add the zero-value before final reductions
+        // Add the zero-value before the final reductions. Each x_k above is bounded by
+        // MOD + MUL2_32 and zero < MOD, so x_k + zero <= 2^32 - 1 exactly: this u32 add
+        // cannot wrap, but there is no slack. Loosening the reduction bounds above (e.g.
+        // dropping the reduction pass) overflows this add.
 
         add(x0, x0, zero.value[0].val);
         add(x1, x1, zero.value[1].val);
@@ -474,7 +448,8 @@ class kb31_extension_t {
         mul_wide(a2, x2, y0);
         mul_wide(a3, x3, y0);
 
-        // Reduction step to zero the top 4 bits in each accumulator
+        // One reduction pass: a_k = 2^32 * h + l -> h * MUL2_32 + l < 2^55, bounding each
+        // Montgomery-reduced value by MOD + MUL2_32 so the x0 + zero add below cannot wrap.
 
         unpack(l0, h0, a0);
         l = l0;


### PR DESCRIPTION
## Motivation

The CUDA degree-4 extension multiply in `kb31_extension_t.cuh` still carries the reduction structure it was written with for BabyBear (W = 11, 2^32 mod p = 2^28 − 2): reduce all seven partial-product columns, fold the X^4 = W wrap-around with emulated 64-bit `mad.lo.u64`s, then run a second "avoid overflow" reduction pass. With KoalaBear (W = 3, 2^32 mod p = 2^25 − 2) that structure is heavier than necessary — and `frobeniusInverse` still uses the BabyBear norm multiplier `kb31_t(11)`.

## Solution

- **`operator*=(ext)` / `interpolateLinear(ext, ext)`**: fold the wrap columns `a4..a6` directly into `a0..a2` by splitting each into 32-bit halves — `W*a = W*l + (W*(2^32 mod p))*h (mod p)`, where the new constant `W_X_MUL2_32 = 3*(2^32 mod p)` fits in 27 bits — then do a single reduction pass over `a0..a3`. This drops the wrap columns' reduction pass, the emulated 64-bit mads, and the entire second reduction pass: ~16 → ~10 SASS-level ops in the reduction phase, every remaining multiply a single-instruction `mad.wide.u32`.
- **`frobeniusInverse` fix**: the norm multiplier is the constant term of `a * b`, i.e. `a0*b0 + W*(a1*b3 + a2*b2 + a3*b1)`, so `g *= W` (= 3), not 11. With 11, extension `reciprocal()`/`operator/` return wrong results (currently unreachable — the only kernel `reciprocal()` call site is base-field).
- **Comments**: document the fold/reduction bound invariants; call out the exact-boundary u32 add in `interpolateLinear` (`x_k ≤ MOD + MUL2_32`, `zero < MOD` ⇒ `x_k + zero ≤ 2^32 − 1` with zero slack — the reason the remaining reduction pass must never be dropped there); replace the stale BabyBear "top 4 bits" comments; note that `frobenius()` returns `z0 * a^p` (the z0^3 factor cancels inside `frobeniusInverse`).

### Verification

- Bit-exact Python model of the u32/u64 device semantics, differentially tested against a reference implementation on ~190k inputs (all-corner limb patterns, uniform random, adversarial near-max), with exact worst-case interval bounds for every accumulator (peak: column-2 fold at ~1.38e19 < 2^64; post-reduction columns < 2^57; single final subtraction bound `MOD + 2^25 − 2`).
- `cargo test --release -p sp1-gpu-logup-gkr`: 5/5 pass, including `test_logup_gkr_e2e` (GPU prove on a real fibonacci trace verified by the CPU-side `LogUpGkrVerifier`).

### Benchmarks

RTX 4090 (`CUDA_ARCHS=89`), `cargo bench -p sp1-gpu-logup-gkr --bench gkr`, `random/core_2^25`, criterion:

| group | before | after | change |
|---|---|---|---|
| `prove` | 42.79 ms | 41.8–42.0 ms | ≈ −2% (p = 0.00) |
| `populate_circuit` | 5.70 ms | 5.47–5.49 ms | ≈ −3% (p = 0.00) |

A follow-up could also skip the reduction pass for limbs 1–3 of the ext×base `interpolateLinear` (only limb 0 feeds the tight zero-add); left out so this PR is exactly the change that was verified.

## PR Checklist

- [ ] Added Tests (arithmetic-only change; covered by existing sp1-gpu differential/e2e tests)
- [x] Added Documentation (bound invariants documented inline)
- [ ] Breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
