### PR TITLE
fix: require explicit TEE signer pinning instead of trusting server-reported list

### DIFF
--- a/crates/sdk/src/network/builder.rs
+++ b/crates/sdk/src/network/builder.rs
@@ -193,18 +193,25 @@ impl NetworkProverBuilder {
             Some(tee_signers) => tee_signers,
 
             #[cfg(feature = "tee-2fa")]
-            None => crate::network::retry::retry_operation(
-                || async { crate::network::tee::get_tee_signers().await.map_err(Into::into) },
-                Some(crate::network::retry::DEFAULT_RETRY_TIMEOUT),
-                "get tee signers",
-            )
-            .await
-            .expect("Failed to get TEE signers"),
+            None => panic!(
+                "tee-2fa is enabled but no TEE signers were pinned via .tee_signers(). Fetching signers from the TEE server at build time is not a trust root, a compromised or impersonated server can supply an attacker-controlled signer set. Pin signers explicitly from a trusted config or on-chain source, or call network::tee::get_tee_signers() yourself and verify the result out-of-band before passing it in."
+            ),
 
             #[cfg(not(feature = "tee-2fa"))]
             None => vec![],
         };
 
         NetworkProver::new(signer, &rpc_url, network_mode).await.with_tee_signers(tee_signers)
+    }
+
+    #[cfg(feature = "tee-2fa")]
+    #[tokio::test]
+    #[should_panic(expected = "tee-2fa is enabled but no TEE signers were pinned")]
+    async fn test_build_panics_without_pinned_tee_signers() {
+        // Well-known Anvil/Foundry default test private key (public, not a secret).
+        let _ = NetworkProverBuilder::new()
+            .private_key("ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80")
+            .build()
+            .await;
     }
 }

--- a/crates/sdk/src/network/tee/mod.rs
+++ b/crates/sdk/src/network/tee/mod.rs
@@ -32,6 +32,13 @@ pub const SP1_TEE_VERSION: u32 = 2;
 ///
 /// See <https://github.com/succinctlabs/sp1-tee/blob/main/host/bin/validate_signers.rs>
 ///
+/// # Security
+/// This is UNTRUSTED convenience data. A compromised or impersonated TEE server
+/// can return an attacker-controlled address here, which would then pass
+/// `verify_tee_proof`'s empty-check while still being the wrong signer.
+/// Callers MUST cross-check the returned signers against an out-of-band pinned
+/// source (config or on-chain) before relying on them for verification.
+///
 /// # Errors
 /// - [`client::ClientError::Http`] - If the request fails to send.
 pub async fn get_tee_signers() -> Result<Vec<alloy_primitives::Address>, client::ClientError> {


### PR DESCRIPTION
## Summary

Fixes #2695

When `tee-2fa` is enabled and no signers are explicitly pinned via
`.tee_signers()`, `NetworkProverBuilder::build()` silently fetched
signers from `network::tee::get_tee_signers()` and trusted them
directly, with no verification or pinning.

`get_tee_signers()`'s own doc comment already says it works by
"trusting the server to honestly report the list of signers." A
compromised or impersonated TEE server could return an
attacker-controlled address, which would then pass
`verify_tee_proof`'s empty-check while still being the wrong signer,
defeating the purpose of TEE 2FA.

## Changes

- `crates/sdk/src/network/builder.rs`: replaced the silent
  `get_tee_signers()` fallback with a hard panic when `tee-2fa` is
  enabled and no signers were explicitly pinned, directing callers to
  source signers from a trusted config or on-chain source instead.
- `crates/sdk/src/network/tee/mod.rs`: added a `# Security` note to
  `get_tee_signers()`'s doc comment clarifying it returns untrusted
  convenience data and should be cross-checked out-of-band before use.

## Testing

Added `test_build_panics_without_pinned_tee_signers`, which confirms
`.build()` panics with the expected message when `tee-2fa` is enabled
and no signers are pinned. Ran the full `sp1-sdk` unit test suite
(`--features network,tee-2fa`) - all `network::builder` tests pass,
including the pre-existing ones. 8 unrelated failures in
`mock`/`env`/`light` tests are pre-existing local environment issues
(shared-memory space limits), confirmed present on unmodified `dev`
with no changes applied.

`cargo +nightly fmt --all -- --check` passes with no diffs.

## Notes

Went with `panic!` rather than a `Result`-returning refactor to stay
consistent with this block's existing pattern (`.expect(...)` was
already used here). Happy to convert to a `Result` if maintainers
prefer that direction - could be a larger follow-up affecting the
builder's broader error-handling approach.