### PR TITLE
fix(cuda): don't spawn from Drop when no Tokio runtime is in scope

### DIFF
--- a/crates/cuda/src/client.rs
+++ b/crates/cuda/src/client.rs
@@ -218,12 +218,26 @@ impl Drop for CudaClientInner {
     fn drop(&mut self) {
         let stream = self.stream.take().expect("stream already taken");
 
-        tokio::spawn(async move {
-            let mut stream = stream.lock().await;
+        // This may run with no Tokio runtime in scope -- notably when a caller of the
+        // blocking API drops the client after its runtime has already been torn down.
+        // `tokio::spawn` panics there, and a panic in a destructor aborts the process,
+        // so a program that has already finished its work exits with SIGABRT.
+        match tokio::runtime::Handle::try_current() {
+            Ok(handle) => {
+                handle.spawn(async move {
+                    let mut stream = stream.lock().await;
 
-            if let Err(e) = stream.shutdown().await {
-                tracing::error!("Failed to shutdown the stream: {}", e);
+                    if let Err(e) = stream.shutdown().await {
+                        tracing::error!("Failed to shutdown the stream: {}", e);
+                    }
+                });
             }
-        });
+            Err(_) => {
+                // Dropping the stream closes the file descriptor. The graceful shutdown
+                // is best-effort, so skipping it is preferable to aborting the process.
+                tracing::debug!("No Tokio runtime available; closing the CUDA stream directly");
+                drop(stream);
+            }
+        }
     }
 }

--- a/crates/cuda/src/pk.rs
+++ b/crates/cuda/src/pk.rs
@@ -60,10 +60,21 @@ impl Drop for SessionKey {
         let client = self.client.clone();
         let id = std::mem::take(&mut self.id);
 
-        tokio::spawn(async move {
-            if let Err(e) = client.destroy(id).await {
-                tracing::error!("Failed to destroy session key: {}", e);
+        // As in `CudaClientInner::drop`, this can run with no Tokio runtime in scope,
+        // where `tokio::spawn` panics and the panic aborts the process from a destructor.
+        match tokio::runtime::Handle::try_current() {
+            Ok(handle) => {
+                handle.spawn(async move {
+                    if let Err(e) = client.destroy(id).await {
+                        tracing::error!("Failed to destroy session key: {}", e);
+                    }
+                });
             }
-        });
+            Err(_) => {
+                // The server frees its keys when the connection closes, so skipping the
+                // explicit destroy is preferable to aborting the process.
+                tracing::debug!("No Tokio runtime available; skipping session key destroy");
+            }
+        }
     }
 }


### PR DESCRIPTION
### Problem

`CudaClientInner::drop` and `SessionKey::drop` both call `tokio::spawn` unconditionally. `Drop` can run with no Tokio runtime in scope — most easily reproduced by dropping a CUDA prover client from the blocking API, where the runtime that created the client has already been torn down. `tokio::spawn` panics in that situation, and a panic in a destructor aborts the process.

The result is that a program which has already completed all of its work successfully, and written all of its output, still dies:

```
thread 'main' panicked at .../tokio-1.x/src/runtime/context.rs:
there is no reactor running, must be called from the context of a Tokio 1.x runtime
...
Abort trap: 6      (exit code 134)
```

This is easy to mistake for a proving failure. Any script that gates on the exit code of an SP1 CUDA prove reads a successful run as a failed one, and the abort happens after the proof and its artifacts are already on disk. It reproduced on every CUDA prove we ran on v6.3.1 (Ubuntu 22.04, L40S, driver 580.167.08), and the same `tokio::spawn`-in-`Drop` is present on `main` today at `crates/cuda/src/client.rs:221` and `crates/cuda/src/pk.rs:63`.

### Fix

Use `Handle::try_current()` and only spawn when a runtime is actually available. Behaviour inside a runtime is unchanged; outside one, each destructor degrades instead of aborting:

- `CudaClientInner::drop` — drops the `UnixStream`, which closes the file descriptor. The graceful `shutdown()` is best-effort.
- `SessionKey::drop` — skips the explicit `destroy`, which the server already handles when the connection closes.

Both fallbacks log at `debug`.

### Alternative worth considering

If you would rather preserve the shutdown and destroy semantics exactly in the no-runtime case, the fallback arm could build a current-thread runtime and `block_on` the existing future. I did not propose that here because blocking inside `Drop` has its own failure modes, but it is a small change if you prefer it — happy to switch.

### Testing

The change is confined to the two `Drop` impls and is a no-op when a runtime is in scope, which is the case for all async callers. I have not been able to run the CUDA test suite locally (no local GPU); relying on CI here, and glad to iterate if anything comes back red.