### PR TITLE
ci: bind release/suite workflow inputs via env before shell

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -27,9 +27,11 @@ runs:
   steps:
     - name: Set up git private repo access
       shell: bash
+      env:
+        PULL_TOKEN: ${{ inputs.pull_token }}
       run: |
-        git config --global url."https://${{ inputs.pull_token }}@github.com/".insteadOf ssh://git@github.com
-        git config --global url."https://${{ inputs.pull_token }}@github.com".insteadOf https://github.com
+        git config --global url."https://${PULL_TOKEN}@github.com/".insteadOf ssh://git@github.com
+        git config --global url."https://${PULL_TOKEN}@github.com".insteadOf https://github.com
 
     - name: Install Go 1.22
       uses: actions/setup-go@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,13 +41,16 @@ jobs:
 
       - name: Compute release name and tag
         id: release_info
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+          RUN_ID: ${{ github.run_id }}
         run: |
           # Parse the version from the `Cargo.toml` file.
           VERSION=$(cargo metadata --format-version=1 --no-deps | jq -r '.packages[] | select(.name == "sp1-primitives") | .version')
           TAG_NAME="v${VERSION}"
           # Append suffix for dry runs to avoid tag collisions with existing releases
-          if [ "${{ inputs.dry_run }}" == "true" ]; then
-            TAG_NAME="${TAG_NAME}-dry-run-${{ github.run_id }}"
+          if [ "$DRY_RUN" == "true" ]; then
+            TAG_NAME="${TAG_NAME}-dry-run-${RUN_ID}"
           fi
           echo "tag_name=${TAG_NAME}" >> $GITHUB_OUTPUT
           echo "release_name=${TAG_NAME}" >> $GITHUB_OUTPUT
@@ -56,11 +59,20 @@ jobs:
         id: create_release
         env:
           GH_TOKEN: ${{ secrets.SP1_RELEASE_TOKEN }}
+          TARGET_BRANCH: ${{ inputs.target_branch || github.ref_name }}
+          PRERELEASE: ${{ inputs.prerelease }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          TAG_NAME: ${{ steps.release_info.outputs.tag_name }}
         run: |
-          TARGET_BRANCH="${{ inputs.target_branch || github.ref_name }}"
-          PRERELEASE_FLAG=${{ inputs.prerelease && '"--prerelease"' || '""' }}
-          DRAFT_FLAG=${{ inputs.dry_run && '"--draft"' || '""' }}
-          GH_DEBUG=api gh release create ${{ steps.release_info.outputs.tag_name }} --target "$TARGET_BRANCH" --generate-notes --latest=false $PRERELEASE_FLAG $DRAFT_FLAG
+          PRERELEASE_FLAG=""
+          if [ "$PRERELEASE" == "true" ]; then
+            PRERELEASE_FLAG="--prerelease"
+          fi
+          DRAFT_FLAG=""
+          if [ "$DRY_RUN" == "true" ]; then
+            DRAFT_FLAG="--draft"
+          fi
+          GH_DEBUG=api gh release create "$TAG_NAME" --target "$TARGET_BRANCH" --generate-notes --latest=false $PRERELEASE_FLAG $DRAFT_FLAG
 
       - name: Categorize release notes by Conventional Commit prefix
         env:

--- a/.github/workflows/suite.yml
+++ b/.github/workflows/suite.yml
@@ -396,5 +396,6 @@ jobs:
           NETWORK_PRIVATE_KEY: ${{ secrets.NETWORK_PRIVATE_KEY }}
           NETWORK_RPC_URL: "https://rpc.production.succinct.xyz" 
           AUCTION_TIMEOUT_SECONDS: ${{ github.event.inputs.auction_timeout_seconds }}
+          NETWORK_CONCURRENT_REPEAT_COUNT: ${{ github.event.inputs.network_concurrent_repeat_count }}
         run: |
-          ~/.sp1/bin/sp1-perf --program workdir/program.bin --stdin workdir/stdin.bin --mode network --concurrent-repeat-count ${{ github.event.inputs.network_concurrent_repeat_count }}
+          ~/.sp1/bin/sp1-perf --program workdir/program.bin --stdin workdir/stdin.bin --mode network --concurrent-repeat-count "$NETWORK_CONCURRENT_REPEAT_COUNT"

--- a/.github/workflows/zkevm-sdk-build.yml
+++ b/.github/workflows/zkevm-sdk-build.yml
@@ -55,7 +55,9 @@ jobs:
         run: cargo run -p sp1-cli --no-default-features -- prove install-toolchain
 
       - name: Build SDK archive
-        run: make -C zkevm sdk-archive SDK_VERSION=${{ inputs.version }}
+        env:
+          SDK_VERSION: ${{ inputs.version }}
+        run: make -C zkevm sdk-archive SDK_VERSION="$SDK_VERSION"
 
       - name: Upload tarball as workflow artifact
         if: ${{ inputs.release_tag == '' }}
@@ -69,5 +71,7 @@ jobs:
         if: ${{ inputs.release_tag != '' && inputs.dry_run != true }}
         env:
           GH_TOKEN: ${{ secrets.SP1_RELEASE_TOKEN }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          SDK_VERSION: ${{ inputs.version }}
         run: |
-          gh release upload "${{ inputs.release_tag }}" "zkevm/zkevm-sdk-${{ inputs.version }}.tar.gz"
+          gh release upload "$RELEASE_TAG" "zkevm/zkevm-sdk-${SDK_VERSION}.tar.gz"


### PR DESCRIPTION
## Summary
- Bind `inputs.dry_run` / `target_branch` / `prerelease` (and release tag output) through `env:` before shell steps in `release.yml`.
- Bind `github.event.inputs.network_concurrent_repeat_count` through `env:` before the `sp1-perf` shell invocation in `suite.yml`.
- Same class as GitHub’s documented script-injection guidance for interpolating workflow inputs into `run:` scripts.

## Test plan
- [ ] Dry-run release still creates draft tags with run-id suffix
- [ ] `gh release create` flags for prerelease/draft unchanged for trusted inputs
- [ ] Network suite still forwards concurrent-repeat-count


Made with [Cursor](https://cursor.com)