### PR TITLE
feat: (powdr) add lean-optimizer feature (published 0.1.5, on #2781)

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -151,6 +151,18 @@ runs:
           echo "pkg-config and libssl-dev are already installed."
         fi
 
+    # Lean toolchain (elan) — `--all-features` enables the `lean-optimizer` feature, whose
+    # FFI build script (powdr-autoprecompiles-lean-ffi) runs `lake build` on the apc-optimizer
+    # at build time, so `lake` must be on PATH. elan defers the actual Lean toolchain download
+    # to first `lake build`, so this step is cheap for jobs that don't compile the feature.
+    - name: Install Lean toolchain (elan)
+      shell: bash
+      run: |
+        if ! command -v lake &> /dev/null; then
+          curl -sSfL https://elan.lean-lang.org/elan-init.sh | sh -s -- -y --default-toolchain none
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+        fi
+
     - name: Install GPU dependencies
       if: inputs.setup_gpu == 'true'
       shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5498,6 +5498,7 @@ dependencies = [
  "log",
  "metrics",
  "num-traits",
+ "powdr-autoprecompiles-lean-ffi",
  "powdr-constraint-solver",
  "powdr-expression",
  "powdr-number",
@@ -5510,6 +5511,12 @@ dependencies = [
  "tracing",
  "tracing-subscriber 0.3.23",
 ]
+
+[[package]]
+name = "powdr-autoprecompiles-lean-ffi"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "383e77d48d22d9c21b72a3c2161a634c6bb5689ffcf7b28f2d708cf809c7021b"
 
 [[package]]
 name = "powdr-constraint-solver"

--- a/crates/core/machine/Cargo.toml
+++ b/crates/core/machine/Cargo.toml
@@ -93,6 +93,9 @@ mprotect = [
   "sp1-hypercube/mprotect",
 ]
 apc = []
+# Opt-in: route APC optimization through the verified Lean apc-optimizer (powdr-side), still gated
+# at runtime by `POWDR_USE_LEAN_OPTIMIZER`. Mirrors powdr's `openvm` crate feature.
+lean-optimizer = ["powdr-autoprecompiles/lean-optimizer"]
 
 [lib]
 path = "src/lib.rs"

--- a/crates/perf/Cargo.toml
+++ b/crates/perf/Cargo.toml
@@ -54,6 +54,7 @@ path = "src/bin/prover.rs"
 [features]
 bigint-rug = ["sp1-core-executor/bigint-rug"]
 native-gnark = ["sp1-sdk/native-gnark"]
+lean-optimizer = ["sp1-sdk/lean-optimizer"]
 network = ["sp1-sdk/network"]
 mprotect = [
   "sp1-core-executor/mprotect",

--- a/crates/prover/Cargo.toml
+++ b/crates/prover/Cargo.toml
@@ -119,6 +119,7 @@ mprotect = [
   "sp1-recursion-executor/mprotect",
 ]
 apc = ["experimental", "sp1-core-machine/apc"]
+lean-optimizer = ["sp1-core-machine/lean-optimizer"]
 
 [lints]
 workspace = true

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -126,6 +126,7 @@ mprotect = [
   "sp1-recursion-executor/mprotect",
 ]
 apc = ["experimental", "sp1-prover/apc"]
+lean-optimizer = ["sp1-prover/lean-optimizer"]
 profiling = [
   "sp1-core-executor/profiling",
   "sp1-core-executor-runner/profiling",


### PR DESCRIPTION
This PR should be merged if we desire leanr features in sp1. It installs lean tool chain in CI, because CI's `--all-targets` features will turn on the leanr feature, which requires the lean tool chain.

Proves via leanr optimizer verifies e2e, but need to set `POWDR_USE_LEAN_OPTIMIZER=1` when running the corresponding test.

---AI notes---
Rebase of #2901's lean-optimizer feature onto #2781, using **published powdr 0.1.5**.

- `lean-optimizer` feature wired through published `powdr-autoprecompiles 0.1.5` → pulls published `powdr-autoprecompiles-lean-ffi 0.1.5` (no git rev; runtime-gated by `POWDR_USE_LEAN_OPTIMIZER`).
- #2901's chip.rs 'support derived columns' commit is **dropped** — already in #2781 (via #2912/#2913), in a more advanced form.
- CI: elan added to the shared setup action so `--all-features` (which enables lean-optimizer → FFI `lake build`) compiles.

Note: no test currently exercises leanr (no `POWDR_USE_LEAN_OPTIMIZER` in the suite) — this is compile-coverage only.