### PR TITLE
chore(release): bump SP1 to v6.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4057,7 +4057,7 @@ dependencies = [
 
 [[package]]
 name = "libzkevm"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "bls12_381",
  "hex",
@@ -6460,7 +6460,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slop-air"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "p3-air",
 ]
@@ -6478,7 +6478,7 @@ dependencies = [
 
 [[package]]
 name = "slop-algebra"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -6488,42 +6488,42 @@ dependencies = [
 
 [[package]]
 name = "slop-alloc"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "serde",
- "slop-algebra 6.3.1",
+ "slop-algebra 6.4.0",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "slop-baby-bear"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "lazy_static",
  "p3-baby-bear",
  "serde",
- "slop-algebra 6.3.1",
- "slop-challenger 6.3.1",
- "slop-poseidon2 6.3.1",
- "slop-symmetric 6.3.1",
+ "slop-algebra 6.4.0",
+ "slop-challenger 6.4.0",
+ "slop-poseidon2 6.4.0",
+ "slop-symmetric 6.4.0",
 ]
 
 [[package]]
 name = "slop-basefold"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
  "serde",
- "slop-algebra 6.3.1",
+ "slop-algebra 6.4.0",
  "slop-alloc",
  "slop-baby-bear",
- "slop-bn254 6.3.1",
- "slop-challenger 6.3.1",
- "slop-koala-bear 6.3.1",
+ "slop-bn254 6.4.0",
+ "slop-challenger 6.4.0",
+ "slop-koala-bear 6.4.0",
  "slop-merkle-tree",
  "slop-multilinear",
- "slop-primitives 6.3.1",
+ "slop-primitives 6.4.0",
  "slop-tensor",
  "slop-utils",
  "thiserror 1.0.69",
@@ -6531,24 +6531,24 @@ dependencies = [
 
 [[package]]
 name = "slop-basefold-prover"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "derive-where",
  "futures",
  "itertools 0.14.0",
  "rand 0.8.6",
  "serde",
- "slop-algebra 6.3.1",
+ "slop-algebra 6.4.0",
  "slop-alloc",
  "slop-baby-bear",
  "slop-basefold",
- "slop-bn254 6.3.1",
- "slop-challenger 6.3.1",
+ "slop-bn254 6.4.0",
+ "slop-challenger 6.4.0",
  "slop-commit",
  "slop-dft",
  "slop-fri",
  "slop-futures",
- "slop-koala-bear 6.3.1",
+ "slop-koala-bear 6.4.0",
  "slop-merkle-tree",
  "slop-multilinear",
  "slop-tensor",
@@ -6572,15 +6572,15 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "ff",
  "p3-bn254-fr",
  "serde",
- "slop-algebra 6.3.1",
- "slop-challenger 6.3.1",
- "slop-poseidon2 6.3.1",
- "slop-symmetric 6.3.1",
+ "slop-algebra 6.4.0",
+ "slop-challenger 6.4.0",
+ "slop-poseidon2 6.4.0",
+ "slop-symmetric 6.4.0",
 ]
 
 [[package]]
@@ -6598,18 +6598,18 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "futures",
  "p3-challenger",
  "serde",
- "slop-algebra 6.3.1",
- "slop-symmetric 6.3.1",
+ "slop-algebra 6.4.0",
+ "slop-symmetric 6.4.0",
 ]
 
 [[package]]
 name = "slop-commit"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "p3-commit",
  "serde",
@@ -6618,11 +6618,11 @@ dependencies = [
 
 [[package]]
 name = "slop-dft"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "p3-dft",
  "serde",
- "slop-algebra 6.3.1",
+ "slop-algebra 6.4.0",
  "slop-alloc",
  "slop-matrix",
  "slop-tensor",
@@ -6630,14 +6630,14 @@ dependencies = [
 
 [[package]]
 name = "slop-fri"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "p3-fri",
 ]
 
 [[package]]
 name = "slop-futures"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "crossbeam",
  "futures",
@@ -6651,7 +6651,7 @@ dependencies = [
 
 [[package]]
 name = "slop-jagged"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "derive-where",
  "futures",
@@ -6660,21 +6660,21 @@ dependencies = [
  "rand 0.8.6",
  "rayon",
  "serde",
- "slop-algebra 6.3.1",
+ "slop-algebra 6.4.0",
  "slop-alloc",
  "slop-baby-bear",
  "slop-basefold",
  "slop-basefold-prover",
- "slop-bn254 6.3.1",
- "slop-challenger 6.3.1",
+ "slop-bn254 6.4.0",
+ "slop-challenger 6.4.0",
  "slop-commit",
  "slop-futures",
- "slop-koala-bear 6.3.1",
+ "slop-koala-bear 6.4.0",
  "slop-merkle-tree",
  "slop-multilinear",
  "slop-stacked",
  "slop-sumcheck",
- "slop-symmetric 6.3.1",
+ "slop-symmetric 6.4.0",
  "slop-tensor",
  "slop-utils",
  "thiserror 1.0.69",
@@ -6683,7 +6683,7 @@ dependencies = [
 
 [[package]]
 name = "slop-keccak-air"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "p3-keccak-air",
 ]
@@ -6705,51 +6705,51 @@ dependencies = [
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
  "serde",
- "slop-algebra 6.3.1",
- "slop-challenger 6.3.1",
- "slop-poseidon2 6.3.1",
- "slop-symmetric 6.3.1",
+ "slop-algebra 6.4.0",
+ "slop-challenger 6.4.0",
+ "slop-poseidon2 6.4.0",
+ "slop-symmetric 6.4.0",
 ]
 
 [[package]]
 name = "slop-matrix"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "p3-matrix",
 ]
 
 [[package]]
 name = "slop-maybe-rayon"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "p3-maybe-rayon",
 ]
 
 [[package]]
 name = "slop-merkle-tree"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
  "p3-merkle-tree",
  "rand 0.8.6",
  "serde",
- "slop-algebra 6.3.1",
+ "slop-algebra 6.4.0",
  "slop-alloc",
  "slop-baby-bear",
- "slop-bn254 6.3.1",
- "slop-challenger 6.3.1",
+ "slop-bn254 6.4.0",
+ "slop-challenger 6.4.0",
  "slop-commit",
  "slop-futures",
- "slop-koala-bear 6.3.1",
+ "slop-koala-bear 6.4.0",
  "slop-matrix",
- "slop-poseidon2 6.3.1",
- "slop-symmetric 6.3.1",
+ "slop-poseidon2 6.4.0",
+ "slop-symmetric 6.4.0",
  "slop-tensor",
  "slop-utils",
  "thiserror 1.0.69",
@@ -6757,7 +6757,7 @@ dependencies = [
 
 [[package]]
 name = "slop-multilinear"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "derive-where",
  "futures",
@@ -6766,10 +6766,10 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
- "slop-algebra 6.3.1",
+ "slop-algebra 6.4.0",
  "slop-alloc",
  "slop-baby-bear",
- "slop-challenger 6.3.1",
+ "slop-challenger 6.4.0",
  "slop-commit",
  "slop-futures",
  "slop-matrix",
@@ -6778,16 +6778,16 @@ dependencies = [
 
 [[package]]
 name = "slop-pgspcs"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "futures",
  "rand 0.8.6",
- "slop-algebra 6.3.1",
+ "slop-algebra 6.4.0",
  "slop-alloc",
  "slop-baby-bear",
  "slop-basefold",
  "slop-basefold-prover",
- "slop-challenger 6.3.1",
+ "slop-challenger 6.4.0",
  "slop-commit",
  "slop-merkle-tree",
  "slop-multilinear",
@@ -6805,7 +6805,7 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "p3-poseidon2",
 ]
@@ -6821,22 +6821,22 @@ dependencies = [
 
 [[package]]
 name = "slop-primitives"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
- "slop-algebra 6.3.1",
+ "slop-algebra 6.4.0",
 ]
 
 [[package]]
 name = "slop-spartan"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "futures",
  "itertools 0.14.0",
  "rand 0.8.6",
- "slop-algebra 6.3.1",
+ "slop-algebra 6.4.0",
  "slop-alloc",
  "slop-baby-bear",
- "slop-challenger 6.3.1",
+ "slop-challenger 6.4.0",
  "slop-merkle-tree",
  "slop-multilinear",
  "slop-pgspcs",
@@ -6846,19 +6846,19 @@ dependencies = [
 
 [[package]]
 name = "slop-stacked"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "derive-where",
  "futures",
  "itertools 0.14.0",
  "rand 0.8.6",
  "serde",
- "slop-algebra 6.3.1",
+ "slop-algebra 6.4.0",
  "slop-alloc",
  "slop-baby-bear",
  "slop-basefold",
  "slop-basefold-prover",
- "slop-challenger 6.3.1",
+ "slop-challenger 6.4.0",
  "slop-commit",
  "slop-futures",
  "slop-merkle-tree",
@@ -6869,17 +6869,17 @@ dependencies = [
 
 [[package]]
 name = "slop-sumcheck"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "futures",
  "itertools 0.14.0",
  "rand 0.8.6",
  "rayon",
  "serde",
- "slop-algebra 6.3.1",
+ "slop-algebra 6.4.0",
  "slop-alloc",
  "slop-baby-bear",
- "slop-challenger 6.3.1",
+ "slop-challenger 6.4.0",
  "slop-multilinear",
  "thiserror 1.0.69",
 ]
@@ -6895,14 +6895,14 @@ dependencies = [
 
 [[package]]
 name = "slop-symmetric"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "p3-symmetric",
 ]
 
 [[package]]
 name = "slop-tensor"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "arrayvec",
  "derive-where",
@@ -6911,7 +6911,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
- "slop-algebra 6.3.1",
+ "slop-algebra 6.4.0",
  "slop-alloc",
  "slop-baby-bear",
  "slop-futures",
@@ -6922,14 +6922,14 @@ dependencies = [
 
 [[package]]
 name = "slop-uni-stark"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "p3-uni-stark",
 ]
 
 [[package]]
 name = "slop-utils"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "p3-util",
  "tracing-forest",
@@ -6938,7 +6938,7 @@ dependencies = [
 
 [[package]]
 name = "slop-veil"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "bincode",
  "derive-where",
@@ -6948,23 +6948,23 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rayon",
  "serde",
- "slop-algebra 6.3.1",
+ "slop-algebra 6.4.0",
  "slop-alloc",
  "slop-basefold",
  "slop-basefold-prover",
- "slop-challenger 6.3.1",
+ "slop-challenger 6.4.0",
  "slop-commit",
  "slop-dft",
  "slop-futures",
  "slop-jagged",
- "slop-koala-bear 6.3.1",
+ "slop-koala-bear 6.4.0",
  "slop-matrix",
  "slop-merkle-tree",
  "slop-multilinear",
- "slop-poseidon2 6.3.1",
+ "slop-poseidon2 6.4.0",
  "slop-stacked",
  "slop-sumcheck",
- "slop-symmetric 6.3.1",
+ "slop-symmetric 6.4.0",
  "slop-tensor",
  "slop-utils",
  "thiserror 1.0.69",
@@ -6973,7 +6973,7 @@ dependencies = [
 
 [[package]]
 name = "slop-whir"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "bincode",
  "derive-where",
@@ -6982,15 +6982,15 @@ dependencies = [
  "rand 0.8.6",
  "rayon",
  "serde",
- "slop-algebra 6.3.1",
+ "slop-algebra 6.4.0",
  "slop-alloc",
  "slop-baby-bear",
  "slop-basefold",
- "slop-challenger 6.3.1",
+ "slop-challenger 6.4.0",
  "slop-commit",
  "slop-dft",
  "slop-jagged",
- "slop-koala-bear 6.3.1",
+ "slop-koala-bear 6.4.0",
  "slop-matrix",
  "slop-merkle-tree",
  "slop-multilinear",
@@ -7042,19 +7042,19 @@ dependencies = [
 
 [[package]]
 name = "sp1-build"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
  "chrono",
  "clap",
  "dirs",
- "sp1-primitives 6.3.1",
+ "sp1-primitives 6.4.0",
 ]
 
 [[package]]
 name = "sp1-cli"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -7075,19 +7075,19 @@ dependencies = [
 
 [[package]]
 name = "sp1-constraint-compiler"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "clap",
  "serde_json",
  "slop-air",
  "sp1-core-machine",
  "sp1-hypercube",
- "sp1-primitives 6.3.1",
+ "sp1-primitives 6.4.0",
 ]
 
 [[package]]
 name = "sp1-core-executor"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -7111,13 +7111,13 @@ dependencies = [
  "serde_arrays",
  "serde_json",
  "slop-air",
- "slop-algebra 6.3.1",
+ "slop-algebra 6.4.0",
  "slop-maybe-rayon",
- "slop-symmetric 6.3.1",
+ "slop-symmetric 6.4.0",
  "sp1-curves",
  "sp1-hypercube",
  "sp1-jit",
- "sp1-primitives 6.3.1",
+ "sp1-primitives 6.4.0",
  "sp1-zkvm",
  "strum",
  "subenum",
@@ -7131,7 +7131,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor-runner"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -7144,7 +7144,7 @@ dependencies = [
  "sp1-core-executor-runner-binary",
  "sp1-core-machine",
  "sp1-jit",
- "sp1-primitives 6.3.1",
+ "sp1-primitives 6.4.0",
  "sysinfo 0.30.13",
  "test-artifacts",
  "tracing",
@@ -7153,7 +7153,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor-runner-binary"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "bincode",
  "crash-handler",
@@ -7166,7 +7166,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-machine"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "bincode",
  "cfg-if",
@@ -7184,10 +7184,10 @@ dependencies = [
  "serde",
  "serde_json",
  "slop-air",
- "slop-algebra 6.3.1",
+ "slop-algebra 6.4.0",
  "slop-alloc",
  "slop-basefold",
- "slop-challenger 6.3.1",
+ "slop-challenger 6.4.0",
  "slop-futures",
  "slop-keccak-air",
  "slop-matrix",
@@ -7202,7 +7202,7 @@ dependencies = [
  "sp1-derive",
  "sp1-hypercube",
  "sp1-jit",
- "sp1-primitives 6.3.1",
+ "sp1-primitives 6.4.0",
  "static_assertions",
  "struct-reflection",
  "strum",
@@ -7220,7 +7220,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cuda"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "bincode",
  "bytes",
@@ -7230,7 +7230,7 @@ dependencies = [
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-hypercube",
- "sp1-primitives 6.3.1",
+ "sp1-primitives 6.4.0",
  "sp1-prover",
  "sp1-prover-types",
  "thiserror 1.0.69",
@@ -7240,7 +7240,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -7253,15 +7253,15 @@ dependencies = [
  "rand 0.8.6",
  "rug",
  "serde",
- "slop-algebra 6.3.1",
+ "slop-algebra 6.4.0",
  "snowbridge-amcl",
- "sp1-primitives 6.3.1",
+ "sp1-primitives 6.4.0",
  "typenum",
 ]
 
 [[package]]
 name = "sp1-derive"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7270,42 +7270,42 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-air"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "lazy_static",
  "slop-air",
- "slop-algebra 6.3.1",
+ "slop-algebra 6.4.0",
  "slop-matrix",
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-hypercube",
- "sp1-primitives 6.3.1",
+ "sp1-primitives 6.4.0",
 ]
 
 [[package]]
 name = "sp1-gpu-basefold"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "futures",
  "itertools 0.14.0",
  "rand 0.8.6",
  "serde",
  "serial_test",
- "slop-algebra 6.3.1",
+ "slop-algebra 6.4.0",
  "slop-alloc",
  "slop-basefold",
  "slop-basefold-prover",
- "slop-bn254 6.3.1",
- "slop-challenger 6.3.1",
+ "slop-bn254 6.4.0",
+ "slop-challenger 6.4.0",
  "slop-commit",
  "slop-dft",
  "slop-futures",
- "slop-koala-bear 6.3.1",
+ "slop-koala-bear 6.4.0",
  "slop-merkle-tree",
  "slop-multilinear",
- "slop-poseidon2 6.3.1",
+ "slop-poseidon2 6.4.0",
  "slop-stacked",
- "slop-symmetric 6.3.1",
+ "slop-symmetric 6.4.0",
  "slop-tensor",
  "sp1-core-machine",
  "sp1-gpu-challenger",
@@ -7317,7 +7317,7 @@ dependencies = [
  "sp1-gpu-tracegen",
  "sp1-gpu-utils",
  "sp1-hypercube",
- "sp1-primitives 6.3.1",
+ "sp1-primitives 6.4.0",
  "sp1-recursion-circuit",
  "sp1-recursion-compiler",
  "sp1-sdk",
@@ -7329,38 +7329,38 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-challenger"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
- "slop-algebra 6.3.1",
+ "slop-algebra 6.4.0",
  "slop-alloc",
- "slop-challenger 6.3.1",
- "slop-koala-bear 6.3.1",
- "slop-poseidon2 6.3.1",
- "slop-symmetric 6.3.1",
+ "slop-challenger 6.4.0",
+ "slop-koala-bear 6.4.0",
+ "slop-poseidon2 6.4.0",
+ "slop-symmetric 6.4.0",
  "sp1-gpu-cudart",
  "sp1-hypercube",
- "sp1-primitives 6.3.1",
+ "sp1-primitives 6.4.0",
  "tokio",
 ]
 
 [[package]]
 name = "sp1-gpu-commit"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "criterion",
  "itertools 0.14.0",
  "rand 0.8.6",
  "serial_test",
- "slop-algebra 6.3.1",
+ "slop-algebra 6.4.0",
  "slop-alloc",
- "slop-challenger 6.3.1",
+ "slop-challenger 6.4.0",
  "slop-dft",
  "slop-futures",
  "slop-jagged",
- "slop-koala-bear 6.3.1",
+ "slop-koala-bear 6.4.0",
  "slop-merkle-tree",
  "slop-stacked",
- "slop-symmetric 6.3.1",
+ "slop-symmetric 6.4.0",
  "slop-tensor",
  "sp1-core-machine",
  "sp1-gpu-basefold",
@@ -7372,7 +7372,7 @@ dependencies = [
  "sp1-gpu-tracegen",
  "sp1-gpu-utils",
  "sp1-hypercube",
- "sp1-primitives 6.3.1",
+ "sp1-primitives 6.4.0",
  "sp1-recursion-circuit",
  "sp1-recursion-compiler",
  "sp1-sdk",
@@ -7384,28 +7384,28 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-cudart"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "crossbeam",
  "futures",
  "itertools 0.14.0",
  "pin-project",
  "rand 0.8.6",
- "slop-algebra 6.3.1",
+ "slop-algebra 6.4.0",
  "slop-alloc",
  "slop-basefold",
- "slop-challenger 6.3.1",
+ "slop-challenger 6.4.0",
  "slop-commit",
  "slop-futures",
  "slop-jagged",
- "slop-koala-bear 6.3.1",
+ "slop-koala-bear 6.4.0",
  "slop-multilinear",
  "slop-stacked",
  "slop-sumcheck",
  "slop-tensor",
  "sp1-gpu-sys",
  "sp1-hypercube",
- "sp1-primitives 6.3.1",
+ "sp1-primitives 6.4.0",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -7413,28 +7413,28 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-jagged-assist"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "futures",
  "itertools 0.14.0",
  "rand 0.8.6",
  "serde",
  "serial_test",
- "slop-algebra 6.3.1",
+ "slop-algebra 6.4.0",
  "slop-alloc",
  "slop-basefold",
- "slop-bn254 6.3.1",
- "slop-challenger 6.3.1",
+ "slop-bn254 6.4.0",
+ "slop-challenger 6.4.0",
  "slop-commit",
  "slop-jagged",
- "slop-koala-bear 6.3.1",
+ "slop-koala-bear 6.4.0",
  "slop-multilinear",
  "slop-sumcheck",
  "slop-tensor",
  "sp1-gpu-challenger",
  "sp1-gpu-cudart",
  "sp1-gpu-tracing",
- "sp1-primitives 6.3.1",
+ "sp1-primitives 6.4.0",
  "sp1-prover",
  "tokio",
  "tracing",
@@ -7442,7 +7442,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-jagged-sumcheck"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "criterion",
  "futures",
@@ -7451,9 +7451,9 @@ dependencies = [
  "rand 0.8.6",
  "rayon",
  "serial_test",
- "slop-algebra 6.3.1",
+ "slop-algebra 6.4.0",
  "slop-alloc",
- "slop-challenger 6.3.1",
+ "slop-challenger 6.4.0",
  "slop-futures",
  "slop-jagged",
  "slop-multilinear",
@@ -7476,7 +7476,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-jagged-tracegen"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "criterion",
  "futures",
@@ -7487,9 +7487,9 @@ dependencies = [
  "serde_json",
  "serial_test",
  "slop-air",
- "slop-algebra 6.3.1",
+ "slop-algebra 6.4.0",
  "slop-alloc",
- "slop-challenger 6.3.1",
+ "slop-challenger 6.4.0",
  "slop-futures",
  "slop-jagged",
  "slop-multilinear",
@@ -7516,7 +7516,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-logup-gkr"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "criterion",
  "futures",
@@ -7527,19 +7527,19 @@ dependencies = [
  "serde_json",
  "serial_test",
  "slop-air",
- "slop-algebra 6.3.1",
+ "slop-algebra 6.4.0",
  "slop-alloc",
  "slop-basefold-prover",
- "slop-bn254 6.3.1",
- "slop-challenger 6.3.1",
+ "slop-bn254 6.4.0",
+ "slop-challenger 6.4.0",
  "slop-commit",
  "slop-dft",
  "slop-futures",
- "slop-koala-bear 6.3.1",
+ "slop-koala-bear 6.4.0",
  "slop-merkle-tree",
  "slop-multilinear",
  "slop-sumcheck",
- "slop-symmetric 6.3.1",
+ "slop-symmetric 6.4.0",
  "slop-tensor",
  "sp1-core-executor",
  "sp1-core-machine",
@@ -7549,7 +7549,7 @@ dependencies = [
  "sp1-gpu-utils",
  "sp1-gpu-zerocheck",
  "sp1-hypercube",
- "sp1-primitives 6.3.1",
+ "sp1-primitives 6.4.0",
  "sp1-recursion-circuit",
  "sp1-sdk",
  "test-artifacts",
@@ -7562,20 +7562,20 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-merkle-tree"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "serial_test",
- "slop-algebra 6.3.1",
+ "slop-algebra 6.4.0",
  "slop-alloc",
- "slop-bn254 6.3.1",
- "slop-challenger 6.3.1",
+ "slop-bn254 6.4.0",
+ "slop-challenger 6.4.0",
  "slop-commit",
  "slop-futures",
- "slop-koala-bear 6.3.1",
+ "slop-koala-bear 6.4.0",
  "slop-merkle-tree",
  "slop-multilinear",
  "slop-stacked",
- "slop-symmetric 6.3.1",
+ "slop-symmetric 6.4.0",
  "slop-tensor",
  "sp1-core-machine",
  "sp1-gpu-cudart",
@@ -7584,7 +7584,7 @@ dependencies = [
  "sp1-gpu-tracegen",
  "sp1-gpu-utils",
  "sp1-hypercube",
- "sp1-primitives 6.3.1",
+ "sp1-primitives 6.4.0",
  "sp1-recursion-circuit",
  "sp1-recursion-compiler",
  "test-artifacts",
@@ -7595,7 +7595,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-perf"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "bincode",
  "clap",
@@ -7609,7 +7609,7 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "serde_json",
- "slop-algebra 6.3.1",
+ "slop-algebra 6.4.0",
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-gpu-cudart",
@@ -7617,7 +7617,7 @@ dependencies = [
  "sp1-gpu-shard-prover",
  "sp1-gpu-tracing",
  "sp1-hypercube",
- "sp1-primitives 6.3.1",
+ "sp1-primitives 6.4.0",
  "sp1-prover",
  "sp1-prover-types",
  "sp1-recursion-circuit",
@@ -7635,18 +7635,18 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-prover"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "clap",
  "serde",
  "slop-air",
- "slop-algebra 6.3.1",
+ "slop-algebra 6.4.0",
  "slop-basefold",
- "slop-bn254 6.3.1",
- "slop-challenger 6.3.1",
+ "slop-bn254 6.4.0",
+ "slop-challenger 6.4.0",
  "slop-futures",
  "slop-jagged",
- "slop-koala-bear 6.3.1",
+ "slop-koala-bear 6.4.0",
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-gpu-air",
@@ -7660,7 +7660,7 @@ dependencies = [
  "sp1-gpu-shard-prover",
  "sp1-gpu-tracegen",
  "sp1-hypercube",
- "sp1-primitives 6.3.1",
+ "sp1-primitives 6.4.0",
  "sp1-prover",
  "sp1-prover-types",
  "sysinfo 0.31.4",
@@ -7669,7 +7669,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-server"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "bincode",
  "clap",
@@ -7679,7 +7679,7 @@ dependencies = [
  "sp1-cuda",
  "sp1-gpu-cudart",
  "sp1-gpu-prover",
- "sp1-primitives 6.3.1",
+ "sp1-primitives 6.4.0",
  "sp1-prover",
  "sp1-prover-types",
  "sp1-recursion-gnark-ffi",
@@ -7691,17 +7691,17 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-shard-prover"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "criterion",
  "rand 0.8.6",
  "serde_json",
  "serial_test",
  "slop-air",
- "slop-algebra 6.3.1",
+ "slop-algebra 6.4.0",
  "slop-alloc",
  "slop-basefold",
- "slop-challenger 6.3.1",
+ "slop-challenger 6.4.0",
  "slop-commit",
  "slop-futures",
  "slop-jagged",
@@ -7724,7 +7724,7 @@ dependencies = [
  "sp1-gpu-utils",
  "sp1-gpu-zerocheck",
  "sp1-hypercube",
- "sp1-primitives 6.3.1",
+ "sp1-primitives 6.4.0",
  "sp1-recursion-circuit",
  "sp1-recursion-compiler",
  "test-artifacts",
@@ -7736,39 +7736,39 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-sys"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "cbindgen",
  "cmake",
  "pathdiff",
- "slop-koala-bear 6.3.1",
+ "slop-koala-bear 6.4.0",
  "sp1-core-executor",
  "sp1-core-machine",
- "sp1-primitives 6.3.1",
+ "sp1-primitives 6.4.0",
  "sp1-recursion-executor",
  "sp1-recursion-machine",
 ]
 
 [[package]]
 name = "sp1-gpu-tracegen"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "futures",
  "rand 0.8.6",
  "rayon",
  "slop-air",
- "slop-algebra 6.3.1",
+ "slop-algebra 6.4.0",
  "slop-alloc",
  "slop-futures",
- "slop-koala-bear 6.3.1",
+ "slop-koala-bear 6.4.0",
  "slop-multilinear",
- "slop-symmetric 6.3.1",
+ "slop-symmetric 6.4.0",
  "slop-tensor",
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-gpu-cudart",
  "sp1-hypercube",
- "sp1-primitives 6.3.1",
+ "sp1-primitives 6.4.0",
  "sp1-recursion-executor",
  "sp1-recursion-machine",
  "tokio",
@@ -7777,7 +7777,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-tracing"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "sp1-gpu-cudart",
  "tracing",
@@ -7786,18 +7786,18 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-utils"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "rand 0.8.6",
  "serial_test",
- "slop-algebra 6.3.1",
+ "slop-algebra 6.4.0",
  "slop-alloc",
- "slop-koala-bear 6.3.1",
+ "slop-koala-bear 6.4.0",
  "slop-stacked",
  "slop-tensor",
  "sp1-gpu-cudart",
  "sp1-gpu-prover",
- "sp1-primitives 6.3.1",
+ "sp1-primitives 6.4.0",
  "sp1-recursion-circuit",
  "sp1-recursion-compiler",
  "sp1-sdk",
@@ -7806,19 +7806,19 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-zerocheck"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "criterion",
  "itertools 0.14.0",
  "rand 0.8.6",
  "serial_test",
  "slop-air",
- "slop-algebra 6.3.1",
+ "slop-algebra 6.4.0",
  "slop-alloc",
- "slop-challenger 6.3.1",
+ "slop-challenger 6.4.0",
  "slop-commit",
  "slop-futures",
- "slop-koala-bear 6.3.1",
+ "slop-koala-bear 6.4.0",
  "slop-matrix",
  "slop-multilinear",
  "slop-stacked",
@@ -7834,7 +7834,7 @@ dependencies = [
  "sp1-gpu-tracegen",
  "sp1-gpu-utils",
  "sp1-hypercube",
- "sp1-primitives 6.3.1",
+ "sp1-primitives 6.4.0",
  "sp1-recursion-circuit",
  "sp1-recursion-compiler",
  "sp1-sdk",
@@ -7847,14 +7847,14 @@ dependencies = [
 
 [[package]]
 name = "sp1-helper"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "sp1-build",
 ]
 
 [[package]]
 name = "sp1-hypercube"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "arrayref",
  "deepsize2",
@@ -7870,28 +7870,28 @@ dependencies = [
  "rayon-scan",
  "serde",
  "slop-air",
- "slop-algebra 6.3.1",
+ "slop-algebra 6.4.0",
  "slop-alloc",
  "slop-basefold",
  "slop-basefold-prover",
- "slop-bn254 6.3.1",
- "slop-challenger 6.3.1",
+ "slop-bn254 6.4.0",
+ "slop-challenger 6.4.0",
  "slop-commit",
  "slop-futures",
  "slop-jagged",
- "slop-koala-bear 6.3.1",
+ "slop-koala-bear 6.4.0",
  "slop-matrix",
  "slop-merkle-tree",
  "slop-multilinear",
- "slop-poseidon2 6.3.1",
+ "slop-poseidon2 6.4.0",
  "slop-stacked",
  "slop-sumcheck",
- "slop-symmetric 6.3.1",
+ "slop-symmetric 6.4.0",
  "slop-tensor",
  "slop-uni-stark",
  "slop-whir",
  "sp1-derive",
- "sp1-primitives 6.3.1",
+ "sp1-primitives 6.4.0",
  "sp1-zkvm",
  "struct-reflection",
  "strum",
@@ -7903,7 +7903,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-jit"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "bincode",
  "dynasmrt",
@@ -7912,7 +7912,7 @@ dependencies = [
  "memfd",
  "memmap2",
  "serde",
- "sp1-primitives 6.3.1",
+ "sp1-primitives 6.4.0",
  "tracing",
  "uuid",
 ]
@@ -7931,17 +7931,17 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "bincode",
  "elliptic-curve",
  "serde",
- "sp1-primitives 6.3.1",
+ "sp1-primitives 6.4.0",
 ]
 
 [[package]]
 name = "sp1-perf"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -7951,12 +7951,12 @@ dependencies = [
  "dotenv",
  "rand 0.8.6",
  "rustyline",
- "slop-algebra 6.3.1",
+ "slop-algebra 6.4.0",
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-cuda",
  "sp1-hypercube",
- "sp1-primitives 6.3.1",
+ "sp1-primitives 6.4.0",
  "sp1-prover",
  "sp1-prover-types",
  "sp1-sdk",
@@ -7992,7 +7992,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -8003,18 +8003,18 @@ dependencies = [
  "num-bigint 0.4.6",
  "serde",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-algebra 6.3.1",
- "slop-bn254 6.3.1",
- "slop-challenger 6.3.1",
- "slop-koala-bear 6.3.1",
- "slop-poseidon2 6.3.1",
- "slop-primitives 6.3.1",
- "slop-symmetric 6.3.1",
+ "slop-algebra 6.4.0",
+ "slop-bn254 6.4.0",
+ "slop-challenger 6.4.0",
+ "slop-koala-bear 6.4.0",
+ "slop-poseidon2 6.4.0",
+ "slop-primitives 6.4.0",
+ "slop-symmetric 6.4.0",
 ]
 
 [[package]]
 name = "sp1-prover"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8041,22 +8041,22 @@ dependencies = [
  "serial_test",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "slop-air",
- "slop-algebra 6.3.1",
+ "slop-algebra 6.4.0",
  "slop-basefold",
- "slop-bn254 6.3.1",
- "slop-challenger 6.3.1",
+ "slop-bn254 6.4.0",
+ "slop-challenger 6.4.0",
  "slop-futures",
  "slop-jagged",
  "slop-multilinear",
  "slop-stacked",
- "slop-symmetric 6.3.1",
+ "slop-symmetric 6.4.0",
  "sp1-core-executor",
  "sp1-core-executor-runner",
  "sp1-core-machine",
  "sp1-derive",
  "sp1-hypercube",
  "sp1-jit",
- "sp1-primitives 6.3.1",
+ "sp1-primitives 6.4.0",
  "sp1-prover-types",
  "sp1-recursion-circuit",
  "sp1-recursion-compiler",
@@ -8078,7 +8078,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover-types"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -8091,7 +8091,7 @@ dependencies = [
  "serde",
  "sp1-core-machine",
  "sp1-hypercube",
- "sp1-primitives 6.3.1",
+ "sp1-primitives 6.4.0",
  "tokio",
  "tonic 0.12.3",
  "tonic-build",
@@ -8100,7 +8100,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-circuit"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "bincode",
  "futures",
@@ -8109,29 +8109,29 @@ dependencies = [
  "rayon",
  "serde",
  "slop-air",
- "slop-algebra 6.3.1",
+ "slop-algebra 6.4.0",
  "slop-alloc",
  "slop-basefold",
  "slop-basefold-prover",
- "slop-bn254 6.3.1",
- "slop-challenger 6.3.1",
+ "slop-bn254 6.4.0",
+ "slop-challenger 6.4.0",
  "slop-commit",
  "slop-dft",
  "slop-jagged",
- "slop-koala-bear 6.3.1",
+ "slop-koala-bear 6.4.0",
  "slop-matrix",
  "slop-merkle-tree",
  "slop-multilinear",
  "slop-stacked",
  "slop-sumcheck",
- "slop-symmetric 6.3.1",
+ "slop-symmetric 6.4.0",
  "slop-tensor",
  "slop-whir",
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-derive",
  "sp1-hypercube",
- "sp1-primitives 6.3.1",
+ "sp1-primitives 6.4.0",
  "sp1-recursion-compiler",
  "sp1-recursion-executor",
  "sp1-recursion-gnark-ffi",
@@ -8143,19 +8143,19 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-compiler"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "backtrace",
  "cfg-if",
  "itertools 0.14.0",
  "rand 0.8.6",
  "serde",
- "slop-algebra 6.3.1",
- "slop-bn254 6.3.1",
- "slop-symmetric 6.3.1",
+ "slop-algebra 6.4.0",
+ "slop-bn254 6.4.0",
+ "slop-symmetric 6.4.0",
  "sp1-core-machine",
  "sp1-hypercube",
- "sp1-primitives 6.3.1",
+ "sp1-primitives 6.4.0",
  "sp1-recursion-executor",
  "tracing",
  "vec_map",
@@ -8163,7 +8163,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-executor"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -8171,10 +8171,10 @@ dependencies = [
  "itertools 0.14.0",
  "range-set-blaze",
  "serde",
- "slop-algebra 6.3.1",
+ "slop-algebra 6.4.0",
  "slop-maybe-rayon",
- "slop-poseidon2 6.3.1",
- "slop-symmetric 6.3.1",
+ "slop-poseidon2 6.4.0",
+ "slop-symmetric 6.4.0",
  "smallvec",
  "sp1-derive",
  "sp1-hypercube",
@@ -8185,7 +8185,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-cli"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "bincode",
  "clap",
@@ -8194,7 +8194,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-ffi"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8205,10 +8205,10 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-algebra 6.3.1",
- "slop-symmetric 6.3.1",
+ "slop-algebra 6.4.0",
+ "slop-symmetric 6.4.0",
  "sp1-hypercube",
- "sp1-primitives 6.3.1",
+ "sp1-primitives 6.4.0",
  "sp1-recursion-compiler",
  "sp1-verifier",
  "tempfile",
@@ -8217,21 +8217,21 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-machine"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.6",
  "slop-air",
- "slop-algebra 6.3.1",
+ "slop-algebra 6.4.0",
  "slop-basefold",
- "slop-challenger 6.3.1",
+ "slop-challenger 6.4.0",
  "slop-matrix",
  "slop-maybe-rayon",
- "slop-symmetric 6.3.1",
+ "slop-symmetric 6.4.0",
  "sp1-core-machine",
  "sp1-derive",
  "sp1-hypercube",
- "sp1-primitives 6.3.1",
+ "sp1-primitives 6.4.0",
  "sp1-recursion-executor",
  "strum",
  "tokio",
@@ -8240,7 +8240,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-sdk"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -8274,7 +8274,7 @@ dependencies = [
  "sp1-core-machine",
  "sp1-cuda",
  "sp1-hypercube",
- "sp1-primitives 6.3.1",
+ "sp1-primitives 6.4.0",
  "sp1-prover",
  "sp1-prover-types",
  "sp1-recursion-executor",
@@ -8294,7 +8294,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-verifier"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -8311,12 +8311,12 @@ dependencies = [
  "serde",
  "serial_test",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-algebra 6.3.1",
- "slop-challenger 6.3.1",
- "slop-primitives 6.3.1",
- "slop-symmetric 6.3.1",
+ "slop-algebra 6.4.0",
+ "slop-challenger 6.4.0",
+ "slop-primitives 6.4.0",
+ "slop-symmetric 6.4.0",
  "sp1-hypercube",
- "sp1-primitives 6.3.1",
+ "sp1-primitives 6.4.0",
  "sp1-recursion-executor",
  "sp1-recursion-machine",
  "sp1-sdk",
@@ -8329,7 +8329,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "blake3",
  "cfg-if",
@@ -8341,9 +8341,9 @@ dependencies = [
  "libm",
  "rand 0.8.6",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-algebra 6.3.1",
- "sp1-lib 6.3.1",
- "sp1-primitives 6.3.1",
+ "slop-algebra 6.4.0",
+ "sp1-lib 6.4.0",
+ "sp1-primitives 6.4.0",
 ]
 
 [[package]]
@@ -8623,7 +8623,7 @@ dependencies = [
 
 [[package]]
 name = "test-artifacts"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "sp1-build",
 ]
@@ -10299,7 +10299,7 @@ dependencies = [
 
 [[package]]
 name = "zkevm-build-sdk"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "sp1-build",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "6.3.1"
+version = "6.4.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/succinctlabs/sp1"
@@ -118,53 +118,53 @@ debug = true
 debug-assertions = true
 
 [workspace.dependencies]
-sp1-build = { version = "6.3.1", path = "crates/build" }
-sp1-cli = { version = "6.3.1", path = "crates/cli", default-features = false }
-sp1-core-executor = { version = "6.3.1", path = "crates/core/executor" }
-sp1-core-executor-runner = { version = "6.3.1", path = "crates/core/runner" }
-sp1-core-executor-runner-binary = { version = "6.3.1", path = "crates/core/runner-binary" }
-sp1-core-machine = { version = "6.3.1", path = "crates/core/machine" }
-sp1-cuda = { version = "6.3.1", path = "crates/cuda" }
-sp1-curves = { version = "6.3.1", path = "crates/curves" }
-sp1-derive = { version = "6.3.1", path = "crates/derive" }
-# sp1-eval = { version = "6.3.1", path = "crates/eval" }
-sp1-helper = { version = "6.3.1", path = "crates/helper", default-features = false }
-sp1-hypercube = { version = "6.3.1", path = "crates/hypercube" }
-sp1-jit = { version = "6.3.1", path = "crates/core/jit" }
-sp1-lib = { version = "6.3.1", path = "crates/zkvm/lib", default-features = false }
-sp1-primitives = { version = "6.3.1", path = "crates/primitives" }
-sp1-prover = { version = "6.3.1", path = "crates/prover" }
-sp1-prover-types = { version = "6.3.1", path = "crates/prover-types" }
-sp1-recursion-circuit = { version = "6.3.1", path = "crates/recursion/circuit", default-features = false }
-sp1-recursion-compiler = { version = "6.3.1", path = "crates/recursion/compiler" }
-sp1-recursion-executor = { version = "6.3.1", path = "crates/recursion/executor", default-features = false }
-sp1-recursion-gnark-ffi = { version = "6.3.1", path = "crates/recursion/gnark-ffi", default-features = false }
-sp1-recursion-machine = { version = "6.3.1", path = "crates/recursion/machine", default-features = false }
-sp1-sdk = { version = "6.3.1", path = "crates/sdk", default-features = false }
-sp1-verifier = { version = "6.3.1", path = "crates/verifier", default-features = false, features = ["full"] }
-sp1-zkvm = { version = "6.3.1", path = "crates/zkvm/entrypoint", default-features = false }
+sp1-build = { version = "6.4.0", path = "crates/build" }
+sp1-cli = { version = "6.4.0", path = "crates/cli", default-features = false }
+sp1-core-executor = { version = "6.4.0", path = "crates/core/executor" }
+sp1-core-executor-runner = { version = "6.4.0", path = "crates/core/runner" }
+sp1-core-executor-runner-binary = { version = "6.4.0", path = "crates/core/runner-binary" }
+sp1-core-machine = { version = "6.4.0", path = "crates/core/machine" }
+sp1-cuda = { version = "6.4.0", path = "crates/cuda" }
+sp1-curves = { version = "6.4.0", path = "crates/curves" }
+sp1-derive = { version = "6.4.0", path = "crates/derive" }
+# sp1-eval = { version = "6.4.0", path = "crates/eval" }
+sp1-helper = { version = "6.4.0", path = "crates/helper", default-features = false }
+sp1-hypercube = { version = "6.4.0", path = "crates/hypercube" }
+sp1-jit = { version = "6.4.0", path = "crates/core/jit" }
+sp1-lib = { version = "6.4.0", path = "crates/zkvm/lib", default-features = false }
+sp1-primitives = { version = "6.4.0", path = "crates/primitives" }
+sp1-prover = { version = "6.4.0", path = "crates/prover" }
+sp1-prover-types = { version = "6.4.0", path = "crates/prover-types" }
+sp1-recursion-circuit = { version = "6.4.0", path = "crates/recursion/circuit", default-features = false }
+sp1-recursion-compiler = { version = "6.4.0", path = "crates/recursion/compiler" }
+sp1-recursion-executor = { version = "6.4.0", path = "crates/recursion/executor", default-features = false }
+sp1-recursion-gnark-ffi = { version = "6.4.0", path = "crates/recursion/gnark-ffi", default-features = false }
+sp1-recursion-machine = { version = "6.4.0", path = "crates/recursion/machine", default-features = false }
+sp1-sdk = { version = "6.4.0", path = "crates/sdk", default-features = false }
+sp1-verifier = { version = "6.4.0", path = "crates/verifier", default-features = false, features = ["full"] }
+sp1-zkvm = { version = "6.4.0", path = "crates/zkvm/entrypoint", default-features = false }
 test-artifacts = { path = "crates/test-artifacts" }
 
 # sp1-gpu crates
-sp1-gpu-air = { version = "6.3.1", path = "sp1-gpu/crates/air" }
-sp1-gpu-basefold = { version = "6.3.1", path = "sp1-gpu/crates/basefold" }
-sp1-gpu-challenger = { version = "6.3.1", path = "sp1-gpu/crates/challenger" }
-sp1-gpu-commit = { version = "6.3.1", path = "sp1-gpu/crates/commit" }
-sp1-gpu-cudart = { version = "6.3.1", path = "sp1-gpu/crates/cuda" }
-sp1-gpu-jagged-assist = { version = "6.3.1", path = "sp1-gpu/crates/jagged_assist" }
-sp1-gpu-jagged-sumcheck = { version = "6.3.1", path = "sp1-gpu/crates/jagged_sumcheck" }
-sp1-gpu-jagged-tracegen = { version = "6.3.1", path = "sp1-gpu/crates/jagged_tracegen" }
-sp1-gpu-logup-gkr = { version = "6.3.1", path = "sp1-gpu/crates/logup_gkr" }
-sp1-gpu-merkle-tree = { version = "6.3.1", path = "sp1-gpu/crates/merkle_tree" }
-sp1-gpu-perf = { version = "6.3.1", path = "sp1-gpu/crates/perf" }
-sp1-gpu-prover = { version = "6.3.1", path = "sp1-gpu/crates/prover_components" }
-sp1-gpu-server = { version = "6.3.1", path = "sp1-gpu/crates/server" }
-sp1-gpu-shard-prover = { version = "6.3.1", path = "sp1-gpu/crates/shard_prover" }
-sp1-gpu-sys = { version = "6.3.1", path = "sp1-gpu/crates/sys" }
-sp1-gpu-tracegen = { version = "6.3.1", path = "sp1-gpu/crates/tracegen" }
-sp1-gpu-tracing = { version = "6.3.1", path = "sp1-gpu/crates/tracing" }
-sp1-gpu-utils = { version = "6.3.1", path = "sp1-gpu/crates/utils" }
-sp1-gpu-zerocheck = { version = "6.3.1", path = "sp1-gpu/crates/zerocheck" }
+sp1-gpu-air = { version = "6.4.0", path = "sp1-gpu/crates/air" }
+sp1-gpu-basefold = { version = "6.4.0", path = "sp1-gpu/crates/basefold" }
+sp1-gpu-challenger = { version = "6.4.0", path = "sp1-gpu/crates/challenger" }
+sp1-gpu-commit = { version = "6.4.0", path = "sp1-gpu/crates/commit" }
+sp1-gpu-cudart = { version = "6.4.0", path = "sp1-gpu/crates/cuda" }
+sp1-gpu-jagged-assist = { version = "6.4.0", path = "sp1-gpu/crates/jagged_assist" }
+sp1-gpu-jagged-sumcheck = { version = "6.4.0", path = "sp1-gpu/crates/jagged_sumcheck" }
+sp1-gpu-jagged-tracegen = { version = "6.4.0", path = "sp1-gpu/crates/jagged_tracegen" }
+sp1-gpu-logup-gkr = { version = "6.4.0", path = "sp1-gpu/crates/logup_gkr" }
+sp1-gpu-merkle-tree = { version = "6.4.0", path = "sp1-gpu/crates/merkle_tree" }
+sp1-gpu-perf = { version = "6.4.0", path = "sp1-gpu/crates/perf" }
+sp1-gpu-prover = { version = "6.4.0", path = "sp1-gpu/crates/prover_components" }
+sp1-gpu-server = { version = "6.4.0", path = "sp1-gpu/crates/server" }
+sp1-gpu-shard-prover = { version = "6.4.0", path = "sp1-gpu/crates/shard_prover" }
+sp1-gpu-sys = { version = "6.4.0", path = "sp1-gpu/crates/sys" }
+sp1-gpu-tracegen = { version = "6.4.0", path = "sp1-gpu/crates/tracegen" }
+sp1-gpu-tracing = { version = "6.4.0", path = "sp1-gpu/crates/tracing" }
+sp1-gpu-utils = { version = "6.4.0", path = "sp1-gpu/crates/utils" }
+sp1-gpu-zerocheck = { version = "6.4.0", path = "sp1-gpu/crates/zerocheck" }
 
 p3-air = "=0.4.3-succinct"
 p3-baby-bear = "=0.4.3-succinct"
@@ -184,37 +184,37 @@ p3-symmetric = "=0.4.3-succinct"
 p3-uni-stark = "=0.4.3-succinct"
 p3-util = "=0.4.3-succinct"
 
-slop-air = { version = "6.3.1", path = "./slop/crates/air" }
-slop-algebra = { version = "6.3.1", path = "./slop/crates/algebra" }
-slop-alloc = { version = "6.3.1", path = "./slop/crates/alloc" }
-slop-baby-bear = { version = "6.3.1", path = "./slop/crates/baby-bear" }
-slop-basefold = { version = "6.3.1", path = "./slop/crates/basefold" }
-slop-basefold-prover = { version = "6.3.1", path = "./slop/crates/basefold-prover" }
-slop-bn254 = { version = "6.3.1", path = "./slop/crates/bn254" }
-slop-challenger = { version = "6.3.1", path = "./slop/crates/challenger" }
-slop-commit = { version = "6.3.1", path = "./slop/crates/commit" }
-slop-dft = { version = "6.3.1", path = "./slop/crates/dft" }
-slop-fri = { version = "6.3.1", path = "./slop/crates/fri" }
-slop-futures = { version = "6.3.1", path = "./slop/crates/futures" }
-slop-jagged = { version = "6.3.1", path = "./slop/crates/jagged" }
-slop-keccak-air = { version = "6.3.1", path = "./slop/crates/keccak-air" }
-slop-koala-bear = { version = "6.3.1", path = "./slop/crates/koala-bear" }
-slop-matrix = { version = "6.3.1", path = "./slop/crates/matrix" }
-slop-maybe-rayon = { version = "6.3.1", path = "./slop/crates/maybe-rayon" }
-slop-merkle-tree = { version = "6.3.1", path = "./slop/crates/merkle-tree" }
-slop-multilinear = { version = "6.3.1", path = "./slop/crates/multilinear" }
-slop-pgspcs = { version = "6.3.1", path = "./slop/crates/pgspcs" }
-slop-primitives = { version = "6.3.1", path = "./slop/crates/primitives" }
-slop-poseidon2 = { version = "6.3.1", path = "./slop/crates/poseidon2" }
-slop-spartan = { version = "6.3.1", path = "./slop/crates/spartan" }
-slop-stacked = { version = "6.3.1", path = "./slop/crates/stacked" }
-slop-sumcheck = { version = "6.3.1", path = "./slop/crates/sumcheck" }
-slop-symmetric = { version = "6.3.1", path = "./slop/crates/symmetric" }
-slop-tensor = { version = "6.3.1", path = "./slop/crates/tensor" }
-slop-uni-stark = { version = "6.3.1", path = "./slop/crates/uni-stark" }
-slop-utils = { version = "6.3.1", path = "./slop/crates/utils" }
-slop-veil = { version = "6.3.1", path = "./slop/crates/veil" }
-slop-whir = { version = "6.3.1", path = "./slop/crates/whir" }
+slop-air = { version = "6.4.0", path = "./slop/crates/air" }
+slop-algebra = { version = "6.4.0", path = "./slop/crates/algebra" }
+slop-alloc = { version = "6.4.0", path = "./slop/crates/alloc" }
+slop-baby-bear = { version = "6.4.0", path = "./slop/crates/baby-bear" }
+slop-basefold = { version = "6.4.0", path = "./slop/crates/basefold" }
+slop-basefold-prover = { version = "6.4.0", path = "./slop/crates/basefold-prover" }
+slop-bn254 = { version = "6.4.0", path = "./slop/crates/bn254" }
+slop-challenger = { version = "6.4.0", path = "./slop/crates/challenger" }
+slop-commit = { version = "6.4.0", path = "./slop/crates/commit" }
+slop-dft = { version = "6.4.0", path = "./slop/crates/dft" }
+slop-fri = { version = "6.4.0", path = "./slop/crates/fri" }
+slop-futures = { version = "6.4.0", path = "./slop/crates/futures" }
+slop-jagged = { version = "6.4.0", path = "./slop/crates/jagged" }
+slop-keccak-air = { version = "6.4.0", path = "./slop/crates/keccak-air" }
+slop-koala-bear = { version = "6.4.0", path = "./slop/crates/koala-bear" }
+slop-matrix = { version = "6.4.0", path = "./slop/crates/matrix" }
+slop-maybe-rayon = { version = "6.4.0", path = "./slop/crates/maybe-rayon" }
+slop-merkle-tree = { version = "6.4.0", path = "./slop/crates/merkle-tree" }
+slop-multilinear = { version = "6.4.0", path = "./slop/crates/multilinear" }
+slop-pgspcs = { version = "6.4.0", path = "./slop/crates/pgspcs" }
+slop-primitives = { version = "6.4.0", path = "./slop/crates/primitives" }
+slop-poseidon2 = { version = "6.4.0", path = "./slop/crates/poseidon2" }
+slop-spartan = { version = "6.4.0", path = "./slop/crates/spartan" }
+slop-stacked = { version = "6.4.0", path = "./slop/crates/stacked" }
+slop-sumcheck = { version = "6.4.0", path = "./slop/crates/sumcheck" }
+slop-symmetric = { version = "6.4.0", path = "./slop/crates/symmetric" }
+slop-tensor = { version = "6.4.0", path = "./slop/crates/tensor" }
+slop-uni-stark = { version = "6.4.0", path = "./slop/crates/uni-stark" }
+slop-utils = { version = "6.4.0", path = "./slop/crates/utils" }
+slop-veil = { version = "6.4.0", path = "./slop/crates/veil" }
+slop-whir = { version = "6.4.0", path = "./slop/crates/whir" }
 
 # For testing.
 tokio-test = "0.4.4"

--- a/crates/test-artifacts/programs/Cargo.lock
+++ b/crates/test-artifacts/programs/Cargo.lock
@@ -406,7 +406,7 @@ version = "1.1.0"
 dependencies = [
  "common-test-utils",
  "sp1-curves",
- "sp1-lib 6.3.1",
+ "sp1-lib 6.4.0",
  "sp1-zkvm",
 ]
 
@@ -449,7 +449,7 @@ name = "bls12381-mul-test"
 version = "1.1.0"
 dependencies = [
  "sp1-derive",
- "sp1-lib 6.3.1",
+ "sp1-lib 6.4.0",
  "sp1-zkvm",
 ]
 
@@ -459,7 +459,7 @@ version = "1.1.0"
 dependencies = [
  "common-test-utils",
  "sp1-curves",
- "sp1-lib 6.3.1",
+ "sp1-lib 6.4.0",
  "sp1-zkvm",
 ]
 
@@ -502,7 +502,7 @@ name = "bn254-mul-test"
 version = "1.1.0"
 dependencies = [
  "sp1-derive",
- "sp1-lib 6.3.1",
+ "sp1-lib 6.4.0",
  "sp1-zkvm",
 ]
 
@@ -572,7 +572,7 @@ name = "common-test-utils"
 version = "1.1.0"
 dependencies = [
  "num-bigint 0.4.6",
- "sp1-lib 6.3.1",
+ "sp1-lib 6.4.0",
 ]
 
 [[package]]
@@ -694,7 +694,7 @@ dependencies = [
  "digest 0.10.7",
  "fiat-crypto",
  "rustc_version 0.4.1",
- "sp1-lib 6.3.1",
+ "sp1-lib 6.4.0",
  "subtle",
  "zeroize",
 ]
@@ -2474,7 +2474,7 @@ version = "1.1.0"
 dependencies = [
  "common-test-utils",
  "sp1-curves",
- "sp1-lib 6.3.1",
+ "sp1-lib 6.4.0",
  "sp1-zkvm",
 ]
 
@@ -2510,7 +2510,7 @@ dependencies = [
  "num",
  "p256",
  "sp1-curves",
- "sp1-lib 6.3.1",
+ "sp1-lib 6.4.0",
  "sp1-zkvm",
 ]
 
@@ -2531,7 +2531,7 @@ dependencies = [
  "num",
  "p256",
  "sp1-curves",
- "sp1-lib 6.3.1",
+ "sp1-lib 6.4.0",
  "sp1-zkvm",
 ]
 
@@ -2755,7 +2755,7 @@ checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "slop-algebra"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -2764,7 +2764,7 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "ff",
  "p3-bn254-fr",
@@ -2777,7 +2777,7 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "futures",
  "p3-challenger",
@@ -2788,7 +2788,7 @@ dependencies = [
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -2801,21 +2801,21 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "p3-poseidon2",
 ]
 
 [[package]]
 name = "slop-primitives"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "slop-algebra",
 ]
 
 [[package]]
 name = "slop-symmetric"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "p3-symmetric",
 ]
@@ -2832,7 +2832,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -2851,7 +2851,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-derive"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2870,7 +2870,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "bincode",
  "elliptic-curve",
@@ -2880,7 +2880,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -2902,7 +2902,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -2914,7 +2914,7 @@ dependencies = [
  "rand 0.8.5",
  "sha2 0.10.9",
  "slop-algebra",
- "sp1-lib 6.3.1",
+ "sp1-lib 6.4.0",
  "sp1-primitives",
 ]
 
@@ -3163,7 +3163,7 @@ source = "git+https://github.com/sp1-patches/tiny-keccak?tag=patch-2.0.2-sp1-6.2
 dependencies = [
  "cfg-if",
  "crunchy",
- "sp1-lib 6.3.1",
+ "sp1-lib 6.4.0",
 ]
 
 [[package]]

--- a/crates/test-artifacts/programs/fibonacci-blake3/Cargo.lock
+++ b/crates/test-artifacts/programs/fibonacci-blake3/Cargo.lock
@@ -754,7 +754,7 @@ checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "slop-algebra"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -763,7 +763,7 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "ff",
  "p3-bn254-fr",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "futures",
  "p3-challenger",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -800,28 +800,28 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "p3-poseidon2",
 ]
 
 [[package]]
 name = "slop-primitives"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "slop-algebra",
 ]
 
 [[package]]
 name = "slop-symmetric"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "p3-symmetric",
 ]
 
 [[package]]
 name = "sp1-lib"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "bincode",
  "serde",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -852,7 +852,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "blake3",
  "cfg-if",

--- a/crates/test-artifacts/programs/trap-exec/Cargo.lock
+++ b/crates/test-artifacts/programs/trap-exec/Cargo.lock
@@ -756,7 +756,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slop-algebra"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "ff",
  "p3-bn254-fr",
@@ -778,7 +778,7 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "futures",
  "p3-challenger",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -802,28 +802,28 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "p3-poseidon2",
 ]
 
 [[package]]
 name = "slop-primitives"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "slop-algebra",
 ]
 
 [[package]]
 name = "slop-symmetric"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "p3-symmetric",
 ]
 
 [[package]]
 name = "sp1-derive"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "bincode",
  "serde",
@@ -841,7 +841,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "cfg-if",
  "critical-section",

--- a/crates/test-artifacts/programs/trap-load-store/Cargo.lock
+++ b/crates/test-artifacts/programs/trap-load-store/Cargo.lock
@@ -756,7 +756,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slop-algebra"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "ff",
  "p3-bn254-fr",
@@ -778,7 +778,7 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "futures",
  "p3-challenger",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -802,28 +802,28 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "p3-poseidon2",
 ]
 
 [[package]]
 name = "slop-primitives"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "slop-algebra",
 ]
 
 [[package]]
 name = "slop-symmetric"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "p3-symmetric",
 ]
 
 [[package]]
 name = "sp1-derive"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "bincode",
  "serde",
@@ -841,7 +841,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "cfg-if",
  "critical-section",

--- a/crates/verifier/guest-verify-programs/Cargo.lock
+++ b/crates/verifier/guest-verify-programs/Cargo.lock
@@ -943,7 +943,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slop-algebra"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "ff",
  "p3-bn254-fr",
@@ -965,7 +965,7 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "futures",
  "p3-challenger",
@@ -976,7 +976,7 @@ dependencies = [
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -989,28 +989,28 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "p3-poseidon2",
 ]
 
 [[package]]
 name = "slop-primitives"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "slop-algebra",
 ]
 
 [[package]]
 name = "slop-symmetric"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "p3-symmetric",
 ]
 
 [[package]]
 name = "sp1-lib"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "bincode",
  "elliptic-curve",
@@ -1020,7 +1020,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -1042,7 +1042,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-verifier"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "blake3",
  "cfg-if",
@@ -1056,7 +1056,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "blake3",
  "cfg-if",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -2122,6 +2122,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fd-lock"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
+dependencies = [
+ "cfg-if",
+ "rustix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4355,7 +4366,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -4375,7 +4386,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -4388,7 +4399,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -6179,14 +6190,14 @@ checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "slop-air"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "p3-air",
 ]
 
 [[package]]
 name = "slop-algebra"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -6195,7 +6206,7 @@ dependencies = [
 
 [[package]]
 name = "slop-alloc"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "serde",
  "slop-algebra",
@@ -6204,7 +6215,7 @@ dependencies = [
 
 [[package]]
 name = "slop-baby-bear"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "lazy_static",
  "p3-baby-bear",
@@ -6217,7 +6228,7 @@ dependencies = [
 
 [[package]]
 name = "slop-basefold"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -6238,7 +6249,7 @@ dependencies = [
 
 [[package]]
 name = "slop-basefold-prover"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -6263,7 +6274,7 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "ff",
  "p3-bn254-fr",
@@ -6276,7 +6287,7 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "futures",
  "p3-challenger",
@@ -6287,7 +6298,7 @@ dependencies = [
 
 [[package]]
 name = "slop-commit"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "p3-commit",
  "serde",
@@ -6296,7 +6307,7 @@ dependencies = [
 
 [[package]]
 name = "slop-dft"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "p3-dft",
  "serde",
@@ -6308,14 +6319,14 @@ dependencies = [
 
 [[package]]
 name = "slop-fri"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "p3-fri",
 ]
 
 [[package]]
 name = "slop-futures"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "crossbeam",
  "futures",
@@ -6328,7 +6339,7 @@ dependencies = [
 
 [[package]]
 name = "slop-jagged"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "derive-where",
  "futures",
@@ -6360,14 +6371,14 @@ dependencies = [
 
 [[package]]
 name = "slop-keccak-air"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "p3-keccak-air",
 ]
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -6380,21 +6391,21 @@ dependencies = [
 
 [[package]]
 name = "slop-matrix"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "p3-matrix",
 ]
 
 [[package]]
 name = "slop-maybe-rayon"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "p3-maybe-rayon",
 ]
 
 [[package]]
 name = "slop-merkle-tree"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -6418,7 +6429,7 @@ dependencies = [
 
 [[package]]
 name = "slop-multilinear"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "derive-where",
  "futures",
@@ -6437,21 +6448,21 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "p3-poseidon2",
 ]
 
 [[package]]
 name = "slop-primitives"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "slop-algebra",
 ]
 
 [[package]]
 name = "slop-stacked"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "derive-where",
  "futures",
@@ -6472,7 +6483,7 @@ dependencies = [
 
 [[package]]
 name = "slop-sumcheck"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -6488,14 +6499,14 @@ dependencies = [
 
 [[package]]
 name = "slop-symmetric"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "p3-symmetric",
 ]
 
 [[package]]
 name = "slop-tensor"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "arrayvec 0.7.6",
  "derive-where",
@@ -6513,14 +6524,14 @@ dependencies = [
 
 [[package]]
 name = "slop-uni-stark"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "p3-uni-stark",
 ]
 
 [[package]]
 name = "slop-utils"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "p3-util",
  "tracing-forest",
@@ -6529,7 +6540,7 @@ dependencies = [
 
 [[package]]
 name = "slop-whir"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "derive-where",
  "futures",
@@ -6596,7 +6607,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-build"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -6608,7 +6619,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -6647,7 +6658,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor-runner"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -6667,7 +6678,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor-runner-binary"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "bincode",
  "crash-handler",
@@ -6680,7 +6691,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-machine"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "bincode",
  "cfg-if",
@@ -6727,7 +6738,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cuda"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "bincode",
  "bytes",
@@ -6747,7 +6758,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -6766,7 +6777,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-derive"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6775,7 +6786,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-hypercube"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "arrayref",
  "deepsize2",
@@ -6822,7 +6833,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-jit"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "dynasmrt",
  "hashbrown 0.14.5",
@@ -6837,7 +6848,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "bincode",
  "elliptic-curve",
@@ -6847,7 +6858,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -6869,7 +6880,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6878,6 +6889,7 @@ dependencies = [
  "either",
  "enum-map",
  "eyre",
+ "fd-lock",
  "futures",
  "hashbrown 0.14.5",
  "hex",
@@ -6931,7 +6943,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover-types"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -6953,7 +6965,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-circuit"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "bincode",
  "itertools 0.14.0",
@@ -6991,7 +7003,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-compiler"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -7010,7 +7022,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-executor"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -7032,7 +7044,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-ffi"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -7054,7 +7066,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-machine"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.5",
@@ -7074,7 +7086,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-sdk"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7110,7 +7122,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-verifier"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -7135,7 +7147,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "cfg-if",
  "critical-section",

--- a/patch-testing/secp256k1/program-v0.29.1/Cargo.lock
+++ b/patch-testing/secp256k1/program-v0.29.1/Cargo.lock
@@ -100,9 +100,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.2.35"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "590f9024a68a8c40351881787f1934dc11afd69090f5edb6831464694d836ea3"
+checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -278,9 +278,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.0"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e178e4fba8a2726903f6ba98a6d221e76f9c12c650d5dc0e6afdc50677b49650"
+checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
 
 [[package]]
 name = "funty"
@@ -493,9 +493,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libm"
@@ -905,9 +905,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signature"
@@ -927,7 +927,7 @@ checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "slop-algebra"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "ff",
  "p3-bn254-fr",
@@ -949,7 +949,7 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "futures",
  "p3-challenger",
@@ -960,7 +960,7 @@ dependencies = [
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -973,28 +973,28 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "p3-poseidon2",
 ]
 
 [[package]]
 name = "slop-primitives"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "slop-algebra",
 ]
 
 [[package]]
 name = "slop-symmetric"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "p3-symmetric",
 ]
 
 [[package]]
 name = "sp1-lib"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "bincode",
  "elliptic-curve",
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -1185,18 +1185,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.26"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.26"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/zkevm/examples/Cargo.lock
+++ b/zkevm/examples/Cargo.lock
@@ -1410,26 +1410,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "blake2"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
-dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
-name = "blake2b_simd"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b79834656f71332577234b50bfc009996f7449e0c056884e6a02492ded0ca2f3"
-dependencies = [
- "arrayref",
- "arrayvec",
- "constant_time_eq",
-]
-
-[[package]]
 name = "blake2f-c-script"
 version = "0.0.1"
 dependencies = [
@@ -1476,9 +1456,9 @@ dependencies = [
 name = "bls12-c-script"
 version = "0.0.1"
 dependencies = [
- "bls12_381 0.8.0",
- "ff 0.13.1",
- "group 0.13.0",
+ "bls12_381",
+ "ff",
+ "group",
  "rand 0.8.6",
  "sp1-sdk",
  "tokio",
@@ -1489,28 +1469,15 @@ dependencies = [
 
 [[package]]
 name = "bls12_381"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3c196a77437e7cc2fb515ce413a6401291578b5afc8ecb29a3c7ab957f05941"
-dependencies = [
- "ff 0.12.1",
- "group 0.12.1",
- "pairing 0.22.0",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "bls12_381"
 version = "0.8.0"
 source = "git+https://github.com/sp1-patches/bls12_381?tag=patch-0.8.0-sp1-6.2.0#9e4e2ae4780d3d69cecbec000f5e814df2392468"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
- "ff 0.13.1",
- "group 0.13.0",
+ "ff",
+ "group",
  "hex",
- "pairing 0.23.0",
+ "pairing",
  "rand_core 0.6.4",
  "sp1-lib",
  "subtle",
@@ -2464,9 +2431,9 @@ dependencies = [
  "base16ct",
  "crypto-bigint",
  "digest 0.10.7",
- "ff 0.13.1",
+ "ff",
  "generic-array 0.14.9",
- "group 0.13.0",
+ "group",
  "hkdf",
  "pem-rfc7468",
  "pkcs8",
@@ -2612,14 +2579,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "ff"
-version = "0.12.1"
+name = "fd-lock"
+version = "4.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
- "bitvec",
- "rand_core 0.6.4",
- "subtle",
+ "cfg-if",
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2931,23 +2898,11 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "group"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
-dependencies = [
- "ff 0.12.1",
- "memuse",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff 0.13.1",
+ "ff",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -2969,29 +2924,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
-]
-
-[[package]]
-name = "halo2"
-version = "0.1.0-beta.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a23c779b38253fe1538102da44ad5bd5378495a61d2c4ee18d64eaa61ae5995"
-dependencies = [
- "halo2_proofs",
-]
-
-[[package]]
-name = "halo2_proofs"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e925780549adee8364c7f2b685c753f6f3df23bde520c67416e93bf615933760"
-dependencies = [
- "blake2b_simd",
- "ff 0.12.1",
- "group 0.12.1",
- "pasta_curves 0.4.1",
- "rand_core 0.6.4",
- "rayon",
 ]
 
 [[package]]
@@ -3579,20 +3511,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jubjub"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a575df5f985fe1cd5b2b05664ff6accfc46559032b954529fd225a2168d27b0f"
-dependencies = [
- "bitvec",
- "bls12_381 0.7.1",
- "ff 0.12.1",
- "group 0.12.1",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
 name = "k256"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3700,8 +3618,8 @@ name = "kzg-rs"
 version = "0.2.8"
 source = "git+https://github.com/succinctlabs/kzg-rs?tag=v0.2.8-sp1-6.2.0#2d48f8b948746d5cfa62ce7421369278a1c2e405"
 dependencies = [
- "bls12_381 0.8.0",
- "ff 0.13.1",
+ "bls12_381",
+ "ff",
  "hex",
  "serde_arrays",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3746,9 +3664,9 @@ dependencies = [
 
 [[package]]
 name = "libzkevm"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
- "bls12_381 0.8.0",
+ "bls12_381",
  "k256 0.13.4 (git+https://github.com/sp1-patches/elliptic-curves?tag=patch-k256-13.4-sp1-6.2.0)",
  "kzg-rs",
  "num-bigint-dig",
@@ -3876,12 +3794,6 @@ checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "memuse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d97bbf43eb4f088f8ca469930cde17fa036207c9a5e02ccc5107c4e8b17c964"
 
 [[package]]
 name = "mime"
@@ -4233,8 +4145,8 @@ version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3a5de20a2301bf2530de1ceb13768ec3a80f729fbf8b72f813e30bc54c5bce2"
 dependencies = [
- "p3-field 0.4.3-succinct",
- "p3-matrix 0.4.3-succinct",
+ "p3-field",
+ "p3-matrix",
  "serde",
 ]
 
@@ -4246,27 +4158,12 @@ checksum = "d69e6e9af4eaaaa60f7bb9f0e0f73ebcbaefe7e00974d97ad0fa542d6a4f0890"
 dependencies = [
  "cfg-if",
  "num-bigint 0.4.6",
- "p3-field 0.4.3-succinct",
- "p3-mds 0.4.3-succinct",
- "p3-poseidon2 0.4.3-succinct",
- "p3-symmetric 0.4.3-succinct",
+ "p3-field",
+ "p3-mds",
+ "p3-poseidon2",
+ "p3-symmetric",
  "rand 0.8.6",
  "rustc_version 0.4.1",
- "serde",
-]
-
-[[package]]
-name = "p3-bn254-fr"
-version = "0.3.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "577200e3fa7e49e2b21e940a6dc7399dc63acb8581da088558cdf7c455adafc0"
-dependencies = [
- "ff 0.13.1",
- "num-bigint 0.4.6",
- "p3-field 0.3.3-succinct",
- "p3-poseidon2 0.3.3-succinct",
- "p3-symmetric 0.3.3-succinct",
- "rand 0.8.6",
  "serde",
 ]
 
@@ -4276,27 +4173,13 @@ version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2077757c7cb514202ccb5368f521f23f5709c720599e6545c683c66e0a52d2d8"
 dependencies = [
- "ff 0.13.1",
+ "ff",
  "num-bigint 0.4.6",
- "p3-field 0.4.3-succinct",
- "p3-poseidon2 0.4.3-succinct",
- "p3-symmetric 0.4.3-succinct",
+ "p3-field",
+ "p3-poseidon2",
+ "p3-symmetric",
  "rand 0.8.6",
  "serde",
-]
-
-[[package]]
-name = "p3-challenger"
-version = "0.3.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75358edd6e2562752c01f5064a66d88144a3e75ace0407166dbdf8a727597f52"
-dependencies = [
- "p3-field 0.3.3-succinct",
- "p3-maybe-rayon 0.3.3-succinct",
- "p3-symmetric 0.3.3-succinct",
- "p3-util 0.3.3-succinct",
- "serde",
- "tracing",
 ]
 
 [[package]]
@@ -4305,10 +4188,10 @@ version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6a908924d43e4cfb93fb41c8346cac211b70314385a9037e9241f5b7f3eaf77"
 dependencies = [
- "p3-field 0.4.3-succinct",
- "p3-maybe-rayon 0.4.3-succinct",
- "p3-symmetric 0.4.3-succinct",
- "p3-util 0.4.3-succinct",
+ "p3-field",
+ "p3-maybe-rayon",
+ "p3-symmetric",
+ "p3-util",
  "serde",
  "tracing",
 ]
@@ -4320,24 +4203,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50acacc7219fce6c01db938f82c1b21b5e7133990b7fff861f91534aeb569419"
 dependencies = [
  "itertools 0.12.1",
- "p3-challenger 0.4.3-succinct",
- "p3-field 0.4.3-succinct",
- "p3-matrix 0.4.3-succinct",
- "p3-util 0.4.3-succinct",
+ "p3-challenger",
+ "p3-field",
+ "p3-matrix",
+ "p3-util",
  "serde",
-]
-
-[[package]]
-name = "p3-dft"
-version = "0.3.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "761f1e1b014f2b1b69bd0309124e233d64aa3590e6a41ee786000dd849506d51"
-dependencies = [
- "p3-field 0.3.3-succinct",
- "p3-matrix 0.3.3-succinct",
- "p3-maybe-rayon 0.3.3-succinct",
- "p3-util 0.3.3-succinct",
- "tracing",
 ]
 
 [[package]]
@@ -4346,25 +4216,11 @@ version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be6408b10a2c27eb13a7d5580c546c2179a8dc7dbc10a990657311891f9b41c0"
 dependencies = [
- "p3-field 0.4.3-succinct",
- "p3-matrix 0.4.3-succinct",
- "p3-maybe-rayon 0.4.3-succinct",
- "p3-util 0.4.3-succinct",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-util",
  "tracing",
-]
-
-[[package]]
-name = "p3-field"
-version = "0.3.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2df7cebaa4079b24e0dd7e3aad59eebcbb99a67c1271f79ad884a7c032f5f183"
-dependencies = [
- "itertools 0.12.1",
- "num-bigint 0.4.6",
- "num-traits",
- "p3-util 0.3.3-succinct",
- "rand 0.8.6",
- "serde",
 ]
 
 [[package]]
@@ -4376,7 +4232,7 @@ dependencies = [
  "itertools 0.12.1",
  "num-bigint 0.4.6",
  "num-traits",
- "p3-util 0.4.3-succinct",
+ "p3-util",
  "rand 0.8.6",
  "serde",
 ]
@@ -4388,14 +4244,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cbc4965ee488f3247867b7ec4bb005b8afa72cb0d461a4dcb1387ecab6426d5"
 dependencies = [
  "itertools 0.12.1",
- "p3-challenger 0.4.3-succinct",
+ "p3-challenger",
  "p3-commit",
- "p3-dft 0.4.3-succinct",
- "p3-field 0.4.3-succinct",
+ "p3-dft",
+ "p3-field",
  "p3-interpolation",
- "p3-matrix 0.4.3-succinct",
- "p3-maybe-rayon 0.4.3-succinct",
- "p3-util 0.4.3-succinct",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-util",
  "serde",
  "tracing",
 ]
@@ -4406,9 +4262,9 @@ version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08ad7e9f08c336d7ea39d12e11951188473542565323bac2a6535e536b58487d"
 dependencies = [
- "p3-field 0.4.3-succinct",
- "p3-matrix 0.4.3-succinct",
- "p3-util 0.4.3-succinct",
+ "p3-field",
+ "p3-matrix",
+ "p3-util",
 ]
 
 [[package]]
@@ -4418,28 +4274,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f5bf177d56740078b5a5a842fa2393427796283dc8174b4a1a325c2d0b042de"
 dependencies = [
  "p3-air",
- "p3-field 0.4.3-succinct",
- "p3-matrix 0.4.3-succinct",
- "p3-maybe-rayon 0.4.3-succinct",
- "p3-util 0.4.3-succinct",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-util",
  "tracing",
-]
-
-[[package]]
-name = "p3-koala-bear"
-version = "0.3.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cea0ba3389b034b6088d566aea8b57aa29dd2e180966e0c8056f61331c92b4e"
-dependencies = [
- "cfg-if",
- "num-bigint 0.4.6",
- "p3-field 0.3.3-succinct",
- "p3-mds 0.3.3-succinct",
- "p3-poseidon2 0.3.3-succinct",
- "p3-symmetric 0.3.3-succinct",
- "rand 0.8.6",
- "rustc_version 0.4.1",
- "serde",
 ]
 
 [[package]]
@@ -4450,28 +4289,13 @@ checksum = "3a9683cd0ef68100df7c62490533047bcf19c04c4a0fa1efc9d7c1e03e31f6b3"
 dependencies = [
  "cfg-if",
  "num-bigint 0.4.6",
- "p3-field 0.4.3-succinct",
- "p3-mds 0.4.3-succinct",
- "p3-poseidon2 0.4.3-succinct",
- "p3-symmetric 0.4.3-succinct",
+ "p3-field",
+ "p3-mds",
+ "p3-poseidon2",
+ "p3-symmetric",
  "rand 0.8.6",
  "rustc_version 0.4.1",
  "serde",
-]
-
-[[package]]
-name = "p3-matrix"
-version = "0.3.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fae5cc6ce726cc265cc687c1214e3f1ac1f5c6e973442286ba00d1e75da1c3cb"
-dependencies = [
- "itertools 0.12.1",
- "p3-field 0.3.3-succinct",
- "p3-maybe-rayon 0.3.3-succinct",
- "p3-util 0.3.3-succinct",
- "rand 0.8.6",
- "serde",
- "tracing",
 ]
 
 [[package]]
@@ -4481,19 +4305,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75c3f150ceb90e09539413bf481e618d05ee19210b4e467d2902eb82d2e15281"
 dependencies = [
  "itertools 0.12.1",
- "p3-field 0.4.3-succinct",
- "p3-maybe-rayon 0.4.3-succinct",
- "p3-util 0.4.3-succinct",
+ "p3-field",
+ "p3-maybe-rayon",
+ "p3-util",
  "rand 0.8.6",
  "serde",
  "tracing",
 ]
-
-[[package]]
-name = "p3-maybe-rayon"
-version = "0.3.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55ac1d2f102cf8c71dba1b449575c99697781fcc028831e83d2245787bd7a650"
 
 [[package]]
 name = "p3-maybe-rayon"
@@ -4506,31 +4324,16 @@ dependencies = [
 
 [[package]]
 name = "p3-mds"
-version = "0.3.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f072643e385d65fb9eb089ee6824b320417f78671a0db748566e057e28b250e"
-dependencies = [
- "itertools 0.12.1",
- "p3-dft 0.3.3-succinct",
- "p3-field 0.3.3-succinct",
- "p3-matrix 0.3.3-succinct",
- "p3-symmetric 0.3.3-succinct",
- "p3-util 0.3.3-succinct",
- "rand 0.8.6",
-]
-
-[[package]]
-name = "p3-mds"
 version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4a5f250e174dcfca5cbeac6ad75713924e7e7320e0a335e3c50b8b1f4fe8ec"
 dependencies = [
  "itertools 0.12.1",
- "p3-dft 0.4.3-succinct",
- "p3-field 0.4.3-succinct",
- "p3-matrix 0.4.3-succinct",
- "p3-symmetric 0.4.3-succinct",
- "p3-util 0.4.3-succinct",
+ "p3-dft",
+ "p3-field",
+ "p3-matrix",
+ "p3-symmetric",
+ "p3-util",
  "rand 0.8.6",
 ]
 
@@ -4542,27 +4345,13 @@ checksum = "d5703d9229d52a8c09970e4d722c3a8b4d37e688c306c3a1c03b872efcd204e6"
 dependencies = [
  "itertools 0.12.1",
  "p3-commit",
- "p3-field 0.4.3-succinct",
- "p3-matrix 0.4.3-succinct",
- "p3-maybe-rayon 0.4.3-succinct",
- "p3-symmetric 0.4.3-succinct",
- "p3-util 0.4.3-succinct",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-symmetric",
+ "p3-util",
  "serde",
  "tracing",
-]
-
-[[package]]
-name = "p3-poseidon2"
-version = "0.3.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00cc4b6e8a439f79541b0910a016da9e6e12a05a24309bbb713e1db0db396952"
-dependencies = [
- "gcd",
- "p3-field 0.3.3-succinct",
- "p3-mds 0.3.3-succinct",
- "p3-symmetric 0.3.3-succinct",
- "rand 0.8.6",
- "serde",
 ]
 
 [[package]]
@@ -4572,21 +4361,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "522986377b2164c5f94f2dae88e0e0a3d169cc6239202ef4aeb4322d60feffd0"
 dependencies = [
  "gcd",
- "p3-field 0.4.3-succinct",
- "p3-mds 0.4.3-succinct",
- "p3-symmetric 0.4.3-succinct",
+ "p3-field",
+ "p3-mds",
+ "p3-symmetric",
  "rand 0.8.6",
- "serde",
-]
-
-[[package]]
-name = "p3-symmetric"
-version = "0.3.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eebff7fea7deb08a57ccf731a0ed39df25cc66a0e0c2d92c4472c4dee02ee21"
-dependencies = [
- "itertools 0.12.1",
- "p3-field 0.3.3-succinct",
  "serde",
 ]
 
@@ -4597,7 +4375,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9047ce85c086a9b3f118e10078f10636f7bfeed5da871a04da0b61400af8793a"
 dependencies = [
  "itertools 0.12.1",
- "p3-field 0.4.3-succinct",
+ "p3-field",
  "serde",
 ]
 
@@ -4609,24 +4387,15 @@ checksum = "fc3dfdeba14d8db621c4e52dd63973384ff35f353fd750154ff88397f4ea5adf"
 dependencies = [
  "itertools 0.12.1",
  "p3-air",
- "p3-challenger 0.4.3-succinct",
+ "p3-challenger",
  "p3-commit",
- "p3-dft 0.4.3-succinct",
- "p3-field 0.4.3-succinct",
- "p3-matrix 0.4.3-succinct",
- "p3-maybe-rayon 0.4.3-succinct",
- "p3-util 0.4.3-succinct",
+ "p3-dft",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-util",
  "serde",
  "tracing",
-]
-
-[[package]]
-name = "p3-util"
-version = "0.3.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8164df89bbc92e29938f916cc5f1ccbfe6a36fb5040f21ba93c1f21985b9868"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -4640,20 +4409,11 @@ dependencies = [
 
 [[package]]
 name = "pairing"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135590d8bdba2b31346f9cd1fb2a912329f5135e832a4f422942eb6ead8b6b3b"
-dependencies = [
- "group 0.12.1",
-]
-
-[[package]]
-name = "pairing"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
 dependencies = [
- "group 0.13.0",
+ "group",
 ]
 
 [[package]]
@@ -4732,36 +4492,6 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
-]
-
-[[package]]
-name = "pasta_curves"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc65faf8e7313b4b1fbaa9f7ca917a0eed499a9663be71477f87993604341d8"
-dependencies = [
- "blake2b_simd",
- "ff 0.12.1",
- "group 0.12.1",
- "lazy_static",
- "rand 0.8.6",
- "static_assertions",
- "subtle",
-]
-
-[[package]]
-name = "pasta_curves"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e57598f73cc7e1b2ac63c79c517b31a0877cd7c402cdcaa311b5208de7a095"
-dependencies = [
- "blake2b_simd",
- "ff 0.13.1",
- "group 0.13.0",
- "lazy_static",
- "rand 0.8.6",
- "static_assertions",
- "subtle",
 ]
 
 [[package]]
@@ -6138,69 +5868,69 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slop-air"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
  "p3-air",
 ]
 
 [[package]]
 name = "slop-algebra"
-version = "6.2.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2987d60942c83511c5819afdd9ca83a9723fed072c43d5e1144393beebbce49c"
+checksum = "8c112cafd4c5c374d267a48c8976d12fca3b0f2cc2e44e6fb1343808310b4fc6"
 dependencies = [
  "itertools 0.14.0",
- "p3-field 0.3.3-succinct",
+ "p3-field",
  "serde",
 ]
 
 [[package]]
 name = "slop-algebra"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
  "itertools 0.14.0",
- "p3-field 0.4.3-succinct",
+ "p3-field",
  "serde",
 ]
 
 [[package]]
 name = "slop-alloc"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
  "serde",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.4.0",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "slop-baby-bear"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
  "lazy_static",
  "p3-baby-bear",
  "serde",
- "slop-algebra 6.2.4",
- "slop-challenger 6.2.4",
- "slop-poseidon2 6.2.4",
- "slop-symmetric 6.2.4",
+ "slop-algebra 6.4.0",
+ "slop-challenger 6.4.0",
+ "slop-poseidon2 6.4.0",
+ "slop-symmetric 6.4.0",
 ]
 
 [[package]]
 name = "slop-basefold"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
  "serde",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.4.0",
  "slop-alloc",
  "slop-baby-bear",
- "slop-bn254 6.2.4",
- "slop-challenger 6.2.4",
- "slop-koala-bear 6.2.4",
+ "slop-bn254 6.4.0",
+ "slop-challenger 6.4.0",
+ "slop-koala-bear 6.4.0",
  "slop-merkle-tree",
  "slop-multilinear",
- "slop-primitives 6.2.4",
+ "slop-primitives 6.4.0",
  "slop-tensor",
  "slop-utils",
  "thiserror 1.0.69",
@@ -6208,23 +5938,23 @@ dependencies = [
 
 [[package]]
 name = "slop-basefold-prover"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
  "rand 0.8.6",
  "serde",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.4.0",
  "slop-alloc",
  "slop-baby-bear",
  "slop-basefold",
- "slop-bn254 6.2.4",
- "slop-challenger 6.2.4",
+ "slop-bn254 6.4.0",
+ "slop-challenger 6.4.0",
  "slop-commit",
  "slop-dft",
  "slop-fri",
  "slop-futures",
- "slop-koala-bear 6.2.4",
+ "slop-koala-bear 6.4.0",
  "slop-merkle-tree",
  "slop-multilinear",
  "slop-tensor",
@@ -6233,60 +5963,59 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.2.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b3ca8edc31419a3e33a9f4b9e11f072caf5fd6e2b32f2b9fcaa5b0863f3da66"
+checksum = "ea991a652ea2e55f0523649f5c9efbfb32cf9fdcc2bf3b3580b4343a94379503"
 dependencies = [
- "ff 0.13.1",
- "p3-bn254-fr 0.3.3-succinct",
+ "ff",
+ "p3-bn254-fr",
  "serde",
- "slop-algebra 6.2.0",
- "slop-challenger 6.2.0",
- "slop-poseidon2 6.2.0",
- "slop-symmetric 6.2.0",
- "zkhash",
+ "slop-algebra 6.3.1",
+ "slop-challenger 6.3.1",
+ "slop-poseidon2 6.3.1",
+ "slop-symmetric 6.3.1",
 ]
 
 [[package]]
 name = "slop-bn254"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
- "ff 0.13.1",
- "p3-bn254-fr 0.4.3-succinct",
+ "ff",
+ "p3-bn254-fr",
  "serde",
- "slop-algebra 6.2.4",
- "slop-challenger 6.2.4",
- "slop-poseidon2 6.2.4",
- "slop-symmetric 6.2.4",
+ "slop-algebra 6.4.0",
+ "slop-challenger 6.4.0",
+ "slop-poseidon2 6.4.0",
+ "slop-symmetric 6.4.0",
 ]
 
 [[package]]
 name = "slop-challenger"
-version = "6.2.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144e5c2ed52b6499792c98262b8bbeb435c361d005caa6f2a6c9ecb8529915b4"
+checksum = "33b33f1eaadcd4159157758b0edcf1c14f470915f85c648e660e4740ff83e921"
 dependencies = [
  "futures",
- "p3-challenger 0.3.3-succinct",
+ "p3-challenger",
  "serde",
- "slop-algebra 6.2.0",
- "slop-symmetric 6.2.0",
+ "slop-algebra 6.3.1",
+ "slop-symmetric 6.3.1",
 ]
 
 [[package]]
 name = "slop-challenger"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
  "futures",
- "p3-challenger 0.4.3-succinct",
+ "p3-challenger",
  "serde",
- "slop-algebra 6.2.4",
- "slop-symmetric 6.2.4",
+ "slop-algebra 6.4.0",
+ "slop-symmetric 6.4.0",
 ]
 
 [[package]]
 name = "slop-commit"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
  "p3-commit",
  "serde",
@@ -6295,11 +6024,11 @@ dependencies = [
 
 [[package]]
 name = "slop-dft"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
- "p3-dft 0.4.3-succinct",
+ "p3-dft",
  "serde",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.4.0",
  "slop-alloc",
  "slop-matrix",
  "slop-tensor",
@@ -6307,14 +6036,14 @@ dependencies = [
 
 [[package]]
 name = "slop-fri"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
  "p3-fri",
 ]
 
 [[package]]
 name = "slop-futures"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
  "crossbeam",
  "futures",
@@ -6327,7 +6056,7 @@ dependencies = [
 
 [[package]]
 name = "slop-jagged"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
  "derive-where",
  "futures",
@@ -6336,21 +6065,21 @@ dependencies = [
  "rand 0.8.6",
  "rayon",
  "serde",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.4.0",
  "slop-alloc",
  "slop-baby-bear",
  "slop-basefold",
  "slop-basefold-prover",
- "slop-bn254 6.2.4",
- "slop-challenger 6.2.4",
+ "slop-bn254 6.4.0",
+ "slop-challenger 6.4.0",
  "slop-commit",
  "slop-futures",
- "slop-koala-bear 6.2.4",
+ "slop-koala-bear 6.4.0",
  "slop-merkle-tree",
  "slop-multilinear",
  "slop-stacked",
  "slop-sumcheck",
- "slop-symmetric 6.2.4",
+ "slop-symmetric 6.4.0",
  "slop-tensor",
  "slop-utils",
  "thiserror 1.0.69",
@@ -6359,72 +6088,72 @@ dependencies = [
 
 [[package]]
 name = "slop-keccak-air"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
  "p3-keccak-air",
 ]
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.2.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ca44a6d3457836c6a1685dcb27b3f64c0b6f555ade06dd2a8fda5003e7594e"
+checksum = "8795ee9a92ecf0a604c0e3ed20e80bbc38772310c0622f94a2e1b66ca2455cb8"
 dependencies = [
  "lazy_static",
- "p3-koala-bear 0.3.3-succinct",
+ "p3-koala-bear",
  "serde",
- "slop-algebra 6.2.0",
- "slop-challenger 6.2.0",
- "slop-poseidon2 6.2.0",
- "slop-symmetric 6.2.0",
+ "slop-algebra 6.3.1",
+ "slop-challenger 6.3.1",
+ "slop-poseidon2 6.3.1",
+ "slop-symmetric 6.3.1",
 ]
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
  "lazy_static",
- "p3-koala-bear 0.4.3-succinct",
+ "p3-koala-bear",
  "serde",
- "slop-algebra 6.2.4",
- "slop-challenger 6.2.4",
- "slop-poseidon2 6.2.4",
- "slop-symmetric 6.2.4",
+ "slop-algebra 6.4.0",
+ "slop-challenger 6.4.0",
+ "slop-poseidon2 6.4.0",
+ "slop-symmetric 6.4.0",
 ]
 
 [[package]]
 name = "slop-matrix"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
- "p3-matrix 0.4.3-succinct",
+ "p3-matrix",
 ]
 
 [[package]]
 name = "slop-maybe-rayon"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
- "p3-maybe-rayon 0.4.3-succinct",
+ "p3-maybe-rayon",
 ]
 
 [[package]]
 name = "slop-merkle-tree"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
  "p3-merkle-tree",
  "serde",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.4.0",
  "slop-alloc",
  "slop-baby-bear",
- "slop-bn254 6.2.4",
- "slop-challenger 6.2.4",
+ "slop-bn254 6.4.0",
+ "slop-challenger 6.4.0",
  "slop-commit",
  "slop-futures",
- "slop-koala-bear 6.2.4",
+ "slop-koala-bear 6.4.0",
  "slop-matrix",
- "slop-poseidon2 6.2.4",
- "slop-symmetric 6.2.4",
+ "slop-poseidon2 6.4.0",
+ "slop-symmetric 6.4.0",
  "slop-tensor",
  "slop-utils",
  "thiserror 1.0.69",
@@ -6432,7 +6161,7 @@ dependencies = [
 
 [[package]]
 name = "slop-multilinear"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
  "derive-where",
  "futures",
@@ -6440,9 +6169,9 @@ dependencies = [
  "rand 0.8.6",
  "rayon",
  "serde",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.4.0",
  "slop-alloc",
- "slop-challenger 6.2.4",
+ "slop-challenger 6.4.0",
  "slop-commit",
  "slop-futures",
  "slop-matrix",
@@ -6451,49 +6180,49 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.2.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3386c5935d822f8621a19f305dffdcae3d9a1956a7b657a7f8893438abf22526"
+checksum = "25561d9ecf4bcf1aa2e800560ac557bff6dad943b9dc5cd0e8427fceca1e8c65"
 dependencies = [
- "p3-poseidon2 0.3.3-succinct",
+ "p3-poseidon2",
 ]
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
- "p3-poseidon2 0.4.3-succinct",
+ "p3-poseidon2",
 ]
 
 [[package]]
 name = "slop-primitives"
-version = "6.2.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d20475296d399080467eb486e6063967e85d3d13200301275e56541c356f96bd"
+checksum = "f6b24ad70b49f40d6acfe7b1ccf042db25820abe305a4c2232f15204f63f0227"
 dependencies = [
- "slop-algebra 6.2.0",
+ "slop-algebra 6.3.1",
 ]
 
 [[package]]
 name = "slop-primitives"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
- "slop-algebra 6.2.4",
+ "slop-algebra 6.4.0",
 ]
 
 [[package]]
 name = "slop-stacked"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
  "derive-where",
  "futures",
  "itertools 0.14.0",
  "serde",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.4.0",
  "slop-alloc",
  "slop-basefold",
  "slop-basefold-prover",
- "slop-challenger 6.2.4",
+ "slop-challenger 6.4.0",
  "slop-commit",
  "slop-futures",
  "slop-merkle-tree",
@@ -6504,39 +6233,39 @@ dependencies = [
 
 [[package]]
 name = "slop-sumcheck"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
  "futures",
  "itertools 0.14.0",
  "rayon",
  "serde",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.4.0",
  "slop-alloc",
  "slop-baby-bear",
- "slop-challenger 6.2.4",
+ "slop-challenger 6.4.0",
  "slop-multilinear",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "slop-symmetric"
-version = "6.2.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "580a4f683c60b000b7ac8ca3fcd200a2a70f4caf2e43268f9089323534d15ecc"
+checksum = "94e580d03bb5383aca1c12579a8a24b838afb12eb356439e740cba34904b6864"
 dependencies = [
- "p3-symmetric 0.3.3-succinct",
+ "p3-symmetric",
 ]
 
 [[package]]
 name = "slop-symmetric"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
- "p3-symmetric 0.4.3-succinct",
+ "p3-symmetric",
 ]
 
 [[package]]
 name = "slop-tensor"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
  "arrayvec",
  "derive-where",
@@ -6544,7 +6273,7 @@ dependencies = [
  "rand 0.8.6",
  "rayon",
  "serde",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.4.0",
  "slop-alloc",
  "slop-futures",
  "slop-matrix",
@@ -6554,23 +6283,23 @@ dependencies = [
 
 [[package]]
 name = "slop-uni-stark"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
  "p3-uni-stark",
 ]
 
 [[package]]
 name = "slop-utils"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
- "p3-util 0.4.3-succinct",
+ "p3-util",
  "tracing-forest",
  "tracing-subscriber",
 ]
 
 [[package]]
 name = "slop-whir"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
  "derive-where",
  "futures",
@@ -6578,15 +6307,15 @@ dependencies = [
  "rand 0.8.6",
  "rayon",
  "serde",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.4.0",
  "slop-alloc",
  "slop-baby-bear",
  "slop-basefold",
- "slop-challenger 6.2.4",
+ "slop-challenger 6.4.0",
  "slop-commit",
  "slop-dft",
  "slop-jagged",
- "slop-koala-bear 6.2.4",
+ "slop-koala-bear 6.4.0",
  "slop-matrix",
  "slop-merkle-tree",
  "slop-multilinear",
@@ -6637,19 +6366,19 @@ dependencies = [
 
 [[package]]
 name = "sp1-build"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
  "chrono",
  "clap",
  "dirs",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.4.0",
 ]
 
 [[package]]
 name = "sp1-core-executor"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -6670,13 +6399,13 @@ dependencies = [
  "serde_arrays",
  "serde_json",
  "slop-air",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.4.0",
  "slop-maybe-rayon",
- "slop-symmetric 6.2.4",
+ "slop-symmetric 6.4.0",
  "sp1-curves",
  "sp1-hypercube",
  "sp1-jit",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.4.0",
  "strum",
  "subenum",
  "thiserror 1.0.69",
@@ -6688,7 +6417,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor-runner"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -6700,7 +6429,7 @@ dependencies = [
  "sp1-core-executor",
  "sp1-core-executor-runner-binary",
  "sp1-jit",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.4.0",
  "sysinfo",
  "tracing",
  "uuid",
@@ -6708,7 +6437,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor-runner-binary"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
  "bincode",
  "crash-handler",
@@ -6721,7 +6450,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-machine"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
  "bincode",
  "cfg-if",
@@ -6738,8 +6467,8 @@ dependencies = [
  "serde",
  "serde_json",
  "slop-air",
- "slop-algebra 6.2.4",
- "slop-challenger 6.2.4",
+ "slop-algebra 6.4.0",
+ "slop-challenger 6.4.0",
  "slop-futures",
  "slop-keccak-air",
  "slop-matrix",
@@ -6752,7 +6481,7 @@ dependencies = [
  "sp1-derive",
  "sp1-hypercube",
  "sp1-jit",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.4.0",
  "static_assertions",
  "struct-reflection",
  "strum",
@@ -6768,7 +6497,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cuda"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
  "bincode",
  "bytes",
@@ -6778,7 +6507,7 @@ dependencies = [
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-hypercube",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.4.0",
  "sp1-prover",
  "sp1-prover-types",
  "thiserror 1.0.69",
@@ -6788,7 +6517,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -6799,15 +6528,15 @@ dependencies = [
  "num",
  "p256 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.4.0",
  "snowbridge-amcl",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.4.0",
  "typenum",
 ]
 
 [[package]]
 name = "sp1-derive"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6816,7 +6545,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-hypercube"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
  "arrayref",
  "deepsize2",
@@ -6831,28 +6560,28 @@ dependencies = [
  "rayon-scan",
  "serde",
  "slop-air",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.4.0",
  "slop-alloc",
  "slop-basefold",
  "slop-basefold-prover",
- "slop-bn254 6.2.4",
- "slop-challenger 6.2.4",
+ "slop-bn254 6.4.0",
+ "slop-challenger 6.4.0",
  "slop-commit",
  "slop-futures",
  "slop-jagged",
- "slop-koala-bear 6.2.4",
+ "slop-koala-bear 6.4.0",
  "slop-matrix",
  "slop-merkle-tree",
  "slop-multilinear",
- "slop-poseidon2 6.2.4",
+ "slop-poseidon2 6.4.0",
  "slop-stacked",
  "slop-sumcheck",
- "slop-symmetric 6.2.4",
+ "slop-symmetric 6.4.0",
  "slop-tensor",
  "slop-uni-stark",
  "slop-whir",
  "sp1-derive",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.4.0",
  "struct-reflection",
  "strum",
  "thiserror 1.0.69",
@@ -6863,7 +6592,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-jit"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
  "dynasmrt",
  "hashbrown 0.14.5",
@@ -6871,28 +6600,28 @@ dependencies = [
  "memfd",
  "memmap2",
  "serde",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.4.0",
  "tracing",
  "uuid",
 ]
 
 [[package]]
 name = "sp1-lib"
-version = "6.2.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1ce7f8d6098c930fb0c03c60f1c8b0ef61b6625811b210b2c694801ceb62f78"
+checksum = "629b673d6aa3c666b41e14d699323413fa90195c906365ba8c49d1b8e4531151"
 dependencies = [
  "bincode",
  "elliptic-curve",
  "serde",
- "sp1-primitives 6.2.0",
+ "sp1-primitives 6.3.1",
 ]
 
 [[package]]
 name = "sp1-primitives"
-version = "6.2.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03476134330b0677d5eee5dec288cf2b0f883511c7496e55dcc9c15cf8debb47"
+checksum = "421b4590a89bf7c263f8a64844a4034ee8cb73c351498911ce0acd18da6b5ed2"
 dependencies = [
  "bincode",
  "blake3",
@@ -6903,18 +6632,18 @@ dependencies = [
  "num-bigint 0.4.6",
  "serde",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-algebra 6.2.0",
- "slop-bn254 6.2.0",
- "slop-challenger 6.2.0",
- "slop-koala-bear 6.2.0",
- "slop-poseidon2 6.2.0",
- "slop-primitives 6.2.0",
- "slop-symmetric 6.2.0",
+ "slop-algebra 6.3.1",
+ "slop-bn254 6.3.1",
+ "slop-challenger 6.3.1",
+ "slop-koala-bear 6.3.1",
+ "slop-poseidon2 6.3.1",
+ "slop-primitives 6.3.1",
+ "slop-symmetric 6.3.1",
 ]
 
 [[package]]
 name = "sp1-primitives"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -6925,18 +6654,18 @@ dependencies = [
  "num-bigint 0.4.6",
  "serde",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-algebra 6.2.4",
- "slop-bn254 6.2.4",
- "slop-challenger 6.2.4",
- "slop-koala-bear 6.2.4",
- "slop-poseidon2 6.2.4",
- "slop-primitives 6.2.4",
- "slop-symmetric 6.2.4",
+ "slop-algebra 6.4.0",
+ "slop-bn254 6.4.0",
+ "slop-challenger 6.4.0",
+ "slop-koala-bear 6.4.0",
+ "slop-poseidon2 6.4.0",
+ "slop-primitives 6.4.0",
+ "slop-symmetric 6.4.0",
 ]
 
 [[package]]
 name = "sp1-prover"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6945,6 +6674,7 @@ dependencies = [
  "either",
  "enum-map",
  "eyre",
+ "fd-lock",
  "futures",
  "hashbrown 0.14.5",
  "hex",
@@ -6962,22 +6692,22 @@ dependencies = [
  "serial_test",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "slop-air",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.4.0",
  "slop-basefold",
- "slop-bn254 6.2.4",
- "slop-challenger 6.2.4",
+ "slop-bn254 6.4.0",
+ "slop-challenger 6.4.0",
  "slop-futures",
  "slop-jagged",
  "slop-multilinear",
  "slop-stacked",
- "slop-symmetric 6.2.4",
+ "slop-symmetric 6.4.0",
  "sp1-core-executor",
  "sp1-core-executor-runner",
  "sp1-core-machine",
  "sp1-derive",
  "sp1-hypercube",
  "sp1-jit",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.4.0",
  "sp1-prover-types",
  "sp1-recursion-circuit",
  "sp1-recursion-compiler",
@@ -6998,7 +6728,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover-types"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -7011,7 +6741,7 @@ dependencies = [
  "serde",
  "sp1-core-machine",
  "sp1-hypercube",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.4.0",
  "tokio",
  "tonic",
  "tonic-build",
@@ -7020,7 +6750,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-circuit"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
  "bincode",
  "itertools 0.14.0",
@@ -7028,28 +6758,28 @@ dependencies = [
  "rayon",
  "serde",
  "slop-air",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.4.0",
  "slop-alloc",
  "slop-basefold",
  "slop-basefold-prover",
- "slop-bn254 6.2.4",
- "slop-challenger 6.2.4",
+ "slop-bn254 6.4.0",
+ "slop-challenger 6.4.0",
  "slop-commit",
  "slop-jagged",
- "slop-koala-bear 6.2.4",
+ "slop-koala-bear 6.4.0",
  "slop-matrix",
  "slop-merkle-tree",
  "slop-multilinear",
  "slop-stacked",
  "slop-sumcheck",
- "slop-symmetric 6.2.4",
+ "slop-symmetric 6.4.0",
  "slop-tensor",
  "slop-whir",
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-derive",
  "sp1-hypercube",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.4.0",
  "sp1-recursion-compiler",
  "sp1-recursion-executor",
  "sp1-recursion-machine",
@@ -7058,18 +6788,18 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-compiler"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
  "backtrace",
  "cfg-if",
  "itertools 0.14.0",
  "serde",
- "slop-algebra 6.2.4",
- "slop-bn254 6.2.4",
- "slop-symmetric 6.2.4",
+ "slop-algebra 6.4.0",
+ "slop-bn254 6.4.0",
+ "slop-symmetric 6.4.0",
  "sp1-core-machine",
  "sp1-hypercube",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.4.0",
  "sp1-recursion-executor",
  "tracing",
  "vec_map",
@@ -7077,7 +6807,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-executor"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -7085,10 +6815,10 @@ dependencies = [
  "itertools 0.14.0",
  "range-set-blaze",
  "serde",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.4.0",
  "slop-maybe-rayon",
- "slop-poseidon2 6.2.4",
- "slop-symmetric 6.2.4",
+ "slop-poseidon2 6.4.0",
+ "slop-symmetric 6.4.0",
  "smallvec",
  "sp1-derive",
  "sp1-hypercube",
@@ -7099,7 +6829,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-ffi"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -7109,10 +6839,10 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-algebra 6.2.4",
- "slop-symmetric 6.2.4",
+ "slop-algebra 6.4.0",
+ "slop-symmetric 6.4.0",
  "sp1-hypercube",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.4.0",
  "sp1-recursion-compiler",
  "sp1-verifier",
  "tempfile",
@@ -7121,19 +6851,19 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-machine"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.6",
  "slop-air",
- "slop-algebra 6.2.4",
+ "slop-algebra 6.4.0",
  "slop-basefold",
  "slop-matrix",
  "slop-maybe-rayon",
- "slop-symmetric 6.2.4",
+ "slop-symmetric 6.4.0",
  "sp1-derive",
  "sp1-hypercube",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.4.0",
  "sp1-recursion-executor",
  "strum",
  "tracing",
@@ -7141,7 +6871,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-sdk"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -7174,7 +6904,7 @@ dependencies = [
  "sp1-core-machine",
  "sp1-cuda",
  "sp1-hypercube",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.4.0",
  "sp1-prover",
  "sp1-prover-types",
  "sp1-recursion-executor",
@@ -7191,7 +6921,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-verifier"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -7201,12 +6931,12 @@ dependencies = [
  "lazy_static",
  "serde",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-algebra 6.2.4",
- "slop-challenger 6.2.4",
- "slop-primitives 6.2.4",
- "slop-symmetric 6.2.4",
+ "slop-algebra 6.4.0",
+ "slop-challenger 6.4.0",
+ "slop-primitives 6.4.0",
+ "slop-symmetric 6.4.0",
  "sp1-hypercube",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.4.0",
  "sp1-recursion-executor",
  "sp1-recursion-machine",
  "strum",
@@ -7216,7 +6946,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.2.4"
+version = "6.4.0"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -7226,7 +6956,7 @@ dependencies = [
  "lazy_static",
  "rand 0.8.6",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp1-primitives 6.2.4",
+ "sp1-primitives 6.4.0",
 ]
 
 [[package]]
@@ -8920,33 +8650,6 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "zkhash"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4352d1081da6922701401cdd4cbf29a2723feb4cfabb5771f6fee8e9276da1c7"
-dependencies = [
- "ark-ff 0.4.2",
- "ark-std 0.4.0",
- "bitvec",
- "blake2",
- "bls12_381 0.7.1",
- "byteorder",
- "cfg-if",
- "group 0.12.1",
- "group 0.13.0",
- "halo2",
- "hex",
- "jubjub",
- "lazy_static",
- "pasta_curves 0.5.1",
- "rand 0.8.6",
- "serde",
- "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha3",
- "subtle",
 ]
 
 [[package]]

--- a/zkevm/libzkevm-cabi/Cargo.lock
+++ b/zkevm/libzkevm-cabi/Cargo.lock
@@ -786,7 +786,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libzkevm"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "bls12_381 0.8.0",
  "k256",
@@ -1537,7 +1537,7 @@ dependencies = [
 
 [[package]]
 name = "slop-algebra"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "itertools 0.14.0",
  "p3-field 0.4.3-succinct",
@@ -1562,15 +1562,15 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "ff 0.13.1",
  "p3-bn254-fr 0.4.3-succinct",
  "serde",
- "slop-algebra 6.3.1",
- "slop-challenger 6.3.1",
- "slop-poseidon2 6.3.1",
- "slop-symmetric 6.3.1",
+ "slop-algebra 6.4.0",
+ "slop-challenger 6.4.0",
+ "slop-poseidon2 6.4.0",
+ "slop-symmetric 6.4.0",
 ]
 
 [[package]]
@@ -1588,13 +1588,13 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "futures",
  "p3-challenger 0.4.3-succinct",
  "serde",
- "slop-algebra 6.3.1",
- "slop-symmetric 6.3.1",
+ "slop-algebra 6.4.0",
+ "slop-symmetric 6.4.0",
 ]
 
 [[package]]
@@ -1614,15 +1614,15 @@ dependencies = [
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "lazy_static",
  "p3-koala-bear 0.4.3-succinct",
  "serde",
- "slop-algebra 6.3.1",
- "slop-challenger 6.3.1",
- "slop-poseidon2 6.3.1",
- "slop-symmetric 6.3.1",
+ "slop-algebra 6.4.0",
+ "slop-challenger 6.4.0",
+ "slop-poseidon2 6.4.0",
+ "slop-symmetric 6.4.0",
 ]
 
 [[package]]
@@ -1636,7 +1636,7 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "p3-poseidon2 0.4.3-succinct",
 ]
@@ -1652,9 +1652,9 @@ dependencies = [
 
 [[package]]
 name = "slop-primitives"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
- "slop-algebra 6.3.1",
+ "slop-algebra 6.4.0",
 ]
 
 [[package]]
@@ -1668,7 +1668,7 @@ dependencies = [
 
 [[package]]
 name = "slop-symmetric"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "p3-symmetric 0.4.3-succinct",
 ]
@@ -1717,7 +1717,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -1728,18 +1728,18 @@ dependencies = [
  "num-bigint 0.4.6",
  "serde",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-algebra 6.3.1",
- "slop-bn254 6.3.1",
- "slop-challenger 6.3.1",
- "slop-koala-bear 6.3.1",
- "slop-poseidon2 6.3.1",
- "slop-primitives 6.3.1",
- "slop-symmetric 6.3.1",
+ "slop-algebra 6.4.0",
+ "slop-bn254 6.4.0",
+ "slop-challenger 6.4.0",
+ "slop-koala-bear 6.4.0",
+ "slop-poseidon2 6.4.0",
+ "slop-primitives 6.4.0",
+ "slop-symmetric 6.4.0",
 ]
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.3.1"
+version = "6.4.0"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -1749,7 +1749,7 @@ dependencies = [
  "lazy_static",
  "rand",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp1-primitives 6.3.1",
+ "sp1-primitives 6.4.0",
 ]
 
 [[package]]


### PR DESCRIPTION
## What

- Bump the SP1 workspace and internal package versions from v6.3.1 to v6.4.0 with `./set-version.sh`.
- Refresh the affected workspace, guest, example, patch-test, and ZK-EVM lockfiles.

## Why

Publish the mainline SDK, verifier, and prover changes merged after v6.3.1 for downstream applications. This includes #2914, #2909, and #2877. Tracked in [ENG-434](https://linear.app/succinct/issue/ENG-434/cut-sp1-v640-for-application-sdk-fixes).

## Validation

- Stable and nightly formatting and Cargo check matrices.
- Clippy for all features and targets with warnings denied.
- Examples and test-artifact checks.
- `sp1-verifier` for `wasm32-unknown-unknown` with `--no-default-features`.
- Non-GPU CPU workspace release tests, including proving, node E2E, recursion, SDK, and doctests.
- Verifier VK root, VK, doctest, and isolated Groth16 tests.

## Notes

- The full verifier suite and an isolated PLONK test exceeded local macOS memory. The CI verifier job remains a merge gate.
- GPU, Linux, Docker Gnark, patch-cycle, and dedicated ZK-EVM checks remain CI gates.
- The release workflow and crates.io publication run after this PR merges.