### PR TITLE
ci(release): install CUDA setup prerequisite

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -259,6 +259,11 @@ jobs:
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           rustup install stable
 
+      - name: Install CUDA prerequisites
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y software-properties-common
+
       - name: Install CUDA
         uses: Jimver/cuda-toolkit@v0.2.23
         id: cuda-toolkit


### PR DESCRIPTION
## What
- Install `software-properties-common` before CUDA setup in the GPU server release job.

## Why
The current RunsOn Ubuntu image does not include `add-apt-repository`, causing [v6.4.0 release run #31601240218](https://github.com/succinctlabs/sp1/actions/runs/31601240218) to fail in `Jimver/cuda-toolkit`.

## Validation
- `git diff --check`
- Parsed `.github/workflows/release.yml` with Ruby YAML
- `actionlint`
- Verified `software-properties-common` provides `add-apt-repository` in an Ubuntu 22.04 container