### PR TITLE
chore: bump mti to 1.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -333,7 +333,7 @@ thousands = "0.2.0"
 tracing-opentelemetry = "0.24.0"
 transpose = "0.2.3"
 twirp = { package = "twirp-rs", version = "0.13.0-succinct" }
-mti = "1.0.7-beta.1"
+mti = "1.1.1"
 typenum = "1.17.0"
 uuid = "1.17.0"
 vec_map = "0.8.2"

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3389,9 +3389,9 @@ dependencies = [
 
 [[package]]
 name = "mti"
-version = "1.0.7-beta.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e89058909957124fd8271ac984c38733f080e0f0edd93322f82d7bd6a0010a"
+checksum = "f9563a7d5556636e74bbd8773241fbcbc5c89b9f6bfdc97b29b56e740c2c74b9"
 dependencies = [
  "typeid_prefix",
  "typeid_suffix",
@@ -8103,15 +8103,15 @@ checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typeid_prefix"
-version = "1.1.1-beta.1"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "257608c6fd0cbb5a8e00fe11ef14e9c285eb02f9e29624aaaba79e59a829a9e2"
+checksum = "a9da1387307fdee46aa441e4f08a1b491e659fcac1aca9cd71f2c624a0de5d1b"
 
 [[package]]
 name = "typeid_suffix"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d46b723d74f5ede0160048deba99670a898b7905682a7a77be7cf8e8b75df50"
+checksum = "77b55e96f110c6db5d1a2f24072552537f0091dc90cebeaa679540bac93e7405"
 dependencies = [
  "uuid",
 ]


### PR DESCRIPTION
## Motivation

I am the author of the `mti` crate. SP1 currently declares the beta version `1.0.7-beta.1`, while `mti` 1.1.1 is the stable release published on crates.io.

## Solution

Update the workspace dependency requirement to `mti = "1.1.1"` and refresh the examples lockfile, including stable `typeid_prefix` and `typeid_suffix` transitive dependencies.

Validation:

- `cargo check -p sp1-prover-types -p sp1-prover`
- `cargo clippy -p sp1-prover-types -p sp1-prover -- -D warnings`
- `cargo +nightly fmt --all -- --check`

Test-target compilation was also attempted with `cargo test -p sp1-prover-types -p sp1-prover --no-run`, but the local environment does not have SP1's custom `succinct` Rust toolchain installed. The failure occurred while building `test-artifacts`, not while compiling `mti` or its direct consumers.

## PR Checklist

- [ ] Added Tests (not applicable: dependency-only change)
- [ ] Added Documentation (not applicable)
- [ ] Breaking changes (none)