### PR TITLE
ci(gpu): guard the CUDA Poseidon2 constants against drift

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7776,6 +7776,8 @@ dependencies = [
  "cbindgen",
  "cmake",
  "pathdiff",
+ "slop-algebra 6.4.0",
+ "slop-bn254 6.4.0",
  "slop-koala-bear 6.4.0",
  "sp1-core-executor",
  "sp1-core-machine",

--- a/slop/crates/bn254/src/lib.rs
+++ b/slop/crates/bn254/src/lib.rs
@@ -11,12 +11,13 @@
 #![allow(clippy::disallowed_types)]
 use std::marker::PhantomData;
 
+use ff::PrimeField as FFPrimeField;
 pub use p3_bn254_fr::*;
 use serde::{Deserialize, Serialize};
-use slop_algebra::{ExtensionField, PrimeField31};
+use slop_algebra::{AbstractField, ExtensionField, PrimeField31};
 use slop_challenger::{IopCtx, MultiField32Challenger};
 use slop_poseidon2::{Poseidon2, Poseidon2ExternalMatrixGeneral};
-use slop_symmetric::{Hash, MultiField32PaddingFreeSponge, TruncatedPermutation};
+use slop_symmetric::{Hash, MultiField32PaddingFreeSponge, Permutation, TruncatedPermutation};
 
 mod poseidon2_rc;
 
@@ -63,6 +64,41 @@ pub fn bn254_poseidon2_rc3() -> Vec<[Bn254Fr; 3]> {
             [bn254_from_be_hex(row[0]), bn254_from_be_hex(row[1]), bn254_from_be_hex(row[2])]
         })
         .collect()
+}
+
+/// The Montgomery representation of `x`, as eight little-endian 32-bit limbs.
+///
+/// `halo2curves` keeps its limbs private and `to_repr` returns canonical bytes, so this goes the
+/// long way round: `x * R` is an ordinary field element whose canonical bytes are the limbs wanted.
+///
+/// Public so the CUDA headers' hand-copied round constants, written as Montgomery limbs, can be
+/// checked against this crate.
+pub fn bn254_montgomery_limbs(x: Bn254Fr) -> [u32; 8] {
+    // R = 2^256 mod r, reached by eight squarings of two since 2^(2^8) = 2^256.
+    let mut r = Bn254Fr::two();
+    for _ in 0..8 {
+        r = r.square();
+    }
+    let repr = (x * r).value.to_repr();
+    core::array::from_fn(|i| u32::from_le_bytes(repr.0[4 * i..4 * i + 4].try_into().unwrap()))
+}
+
+/// The internal (partial-round) diagonal of the width-3 BN254 Poseidon2 permutation.
+///
+/// `p3-bn254-fr` keeps the table private, so it is read back out of the permutation instead:
+/// `matmul_internal` is `state[i] * d[i] + Σ state`, so probing with `e_i` returns `d[i] + 1`.
+/// That sees the layer only at zero and one, which is why
+/// `internal_layer_has_the_form_the_diagonal_recovery_assumes` pins the form separately.
+///
+/// Public for the CUDA drift guard, which has to check this table: the BN254 header reads its
+/// diagonal every internal round, unlike the KoalaBear one.
+pub fn bn254_internal_diagonal() -> [Bn254Fr; OUTER_CHALLENGER_STATE_WIDTH] {
+    core::array::from_fn(|i| {
+        let mut state = [Bn254Fr::zero(); OUTER_CHALLENGER_STATE_WIDTH];
+        state[i] = Bn254Fr::one();
+        DiffusionMatrixBN254.permute_mut(&mut state);
+        state[i] - Bn254Fr::one()
+    })
 }
 
 impl<F: PrimeField31, EF: ExtensionField<F>> IopCtx for Poseidon2Bn254GlobalConfig<F, EF> {
@@ -113,3 +149,275 @@ impl<F: PrimeField31, EF: ExtensionField<F>> IopCtx for Poseidon2Bn254GlobalConf
 }
 
 pub type BNGC<F, EF> = Poseidon2Bn254GlobalConfig<F, EF>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pins the encoding against the published BN254 Montgomery constant. The drift guard exercises it
+    /// for real, but only where the CUDA header is present.
+    #[test]
+    fn montgomery_limbs_match_published_r() {
+        // R = 2^256 mod r = 0x0e0a77c19a07df2f666ea36f7879462e36fc76959f60cd29ac96341c4ffffffb,
+        // as eight little-endian 32-bit limbs. The Montgomery form of one is R itself.
+        const R_LIMBS: [u32; 8] = [
+            1342177275, 2895524892, 2673921321, 922515093, 2021213742, 1718526831, 2584207151,
+            235567041,
+        ];
+        assert_eq!(bn254_montgomery_limbs(Bn254Fr::one()), R_LIMBS);
+        assert_eq!(bn254_montgomery_limbs(Bn254Fr::zero()), [0; 8]);
+    }
+
+    /// Pins the recovered diagonal against the one `p3-bn254-fr` builds.
+    #[test]
+    fn internal_diagonal_matches_plonky3() {
+        assert_eq!(bn254_internal_diagonal(), [Bn254Fr::one(), Bn254Fr::one(), Bn254Fr::two()]);
+    }
+
+    /// Probe states, none of them the zero/one pattern a basis vector produces.
+    fn probe_states() -> Vec<[Bn254Fr; OUTER_CHALLENGER_STATE_WIDTH]> {
+        let mut states = vec![
+            [Bn254Fr::zero(); OUTER_CHALLENGER_STATE_WIDTH],
+            [Bn254Fr::two(), Bn254Fr::zero(), Bn254Fr::zero()],
+            [Bn254Fr::zero() - Bn254Fr::one(); OUTER_CHALLENGER_STATE_WIDTH],
+            [Bn254Fr::two(), Bn254Fr::from_canonical_u64(3), Bn254Fr::from_canonical_u64(5)],
+        ];
+
+        let mut x = Bn254Fr::from_canonical_u64(7);
+        let mut walk = Vec::with_capacity(24);
+        for _ in 0..24 {
+            x = x.square().square() * x + Bn254Fr::from_canonical_u64(3);
+            walk.push(x);
+        }
+        states.extend(walk.chunks_exact(OUTER_CHALLENGER_STATE_WIDTH).map(|c| [c[0], c[1], c[2]]));
+        states
+    }
+
+    /// Pins the internal layer as `state[i] * d[i] + Σ state` on arbitrary states.
+    ///
+    /// The diagonal recovery is a special case of that identity, and on its own cannot check it: basis
+    /// vectors see the layer only at zero and one, so any elementwise `f` with `f(0) = 0` and
+    /// `f(1) = 1` ahead of the diagonal multiply recovers the same table from a different permutation.
+    #[test]
+    fn internal_layer_has_the_form_the_diagonal_recovery_assumes() {
+        let diagonal = bn254_internal_diagonal();
+        for state in probe_states() {
+            let sum = state[0] + state[1] + state[2];
+            let expected: [Bn254Fr; OUTER_CHALLENGER_STATE_WIDTH] =
+                core::array::from_fn(|i| state[i] * diagonal[i] + sum);
+
+            let mut got = state;
+            DiffusionMatrixBN254.permute_mut(&mut got);
+
+            assert_eq!(
+                got, expected,
+                "DiffusionMatrixBN254 is no longer `state[i] * d[i] + sum`, so recovering its \
+                 diagonal from basis vectors no longer describes it"
+            );
+        }
+    }
+
+    /// Pins the round split against the shape of the constants.
+    ///
+    /// [`outer_perm`] keeps only lane zero of each internal round and discards the rest unexamined,
+    /// which is safe only while those lanes are empty. A split off by one row would silently drop two
+    /// live external constants, and the build script reconstructs the same split, so it would move too.
+    #[test]
+    fn the_round_split_lands_where_the_constants_say_it_does() {
+        const ROUNDS_F: usize = 8;
+        const ROUNDS_P: usize = 56;
+
+        let rounds = bn254_poseidon2_rc3();
+        assert_eq!(rounds.len(), ROUNDS_F + ROUNDS_P);
+        let internal_start = ROUNDS_F / 2;
+        let internal_end = internal_start + ROUNDS_P;
+
+        for (i, round) in rounds.iter().enumerate() {
+            if (internal_start..internal_end).contains(&i) {
+                assert_eq!(
+                    [round[1], round[2]],
+                    [Bn254Fr::zero(); 2],
+                    "round {i} is treated as internal, but carries a constant outside lane zero \
+                     that `outer_perm` would discard"
+                );
+            } else {
+                assert!(
+                    round.iter().all(|c| *c != Bn254Fr::zero()),
+                    "round {i} is treated as external, but looks like an internal round"
+                );
+            }
+        }
+    }
+
+    /// Pins the CUDA driver against [`outer_perm`].
+    ///
+    /// The drift guard only compares tables. Round order, S-box degree, the lane the internal constant
+    /// lands on, and where the external constants split are conventions it never looks at, and identical
+    /// tables can still compute different permutations. `poseidon2.cuh` and `poseidon2_bn254_3.cuh` are
+    /// transcribed here rather than executed, so this catches drift only if the transcription is kept
+    /// in step with the header.
+    #[test]
+    fn the_cuda_driver_agrees_with_outer_perm() {
+        const ROUNDS_F: usize = 8;
+        const ROUNDS_P: usize = 56;
+        const D: u64 = 5;
+
+        // `poseidon2_bn254_3.cuh`, `Bn254::externalLinearLayer`.
+        fn external_linear_layer(state: &mut [Bn254Fr; OUTER_CHALLENGER_STATE_WIDTH]) {
+            let sum = state[0] + state[1] + state[2];
+            for lane in state.iter_mut() {
+                *lane += sum;
+            }
+        }
+
+        // `poseidon2_bn254_3.cuh`, `Bn254::internalLinearLayer`, which reads the class constant
+        // rather than its parameters.
+        fn internal_linear_layer(
+            state: &mut [Bn254Fr; OUTER_CHALLENGER_STATE_WIDTH],
+            diagonal: &[Bn254Fr; OUTER_CHALLENGER_STATE_WIDTH],
+        ) {
+            let sum = state[0] + state[1] + state[2];
+            for (lane, d) in state.iter_mut().zip(diagonal) {
+                *lane = *lane * *d + sum;
+            }
+        }
+
+        // `poseidon2.cuh`, `sbox`, which raises each lane to `Params::D`.
+        fn sbox(x: Bn254Fr) -> Bn254Fr {
+            assert_eq!(D, 5, "the transcription below is written for the degree-five S-box");
+            x.square().square() * x
+        }
+
+        let rounds = bn254_poseidon2_rc3();
+        let internal_start = ROUNDS_F / 2;
+        let internal_end = internal_start + ROUNDS_P;
+        let external: Vec<[Bn254Fr; OUTER_CHALLENGER_STATE_WIDTH]> =
+            rounds[..internal_start].iter().chain(&rounds[internal_end..]).copied().collect();
+        let internal: Vec<Bn254Fr> =
+            rounds[internal_start..internal_end].iter().map(|round| round[0]).collect();
+        let diagonal = bn254_internal_diagonal();
+
+        // `poseidon2.cuh`, `Hasher::permute`.
+        let cuda_permute = |input: [Bn254Fr; OUTER_CHALLENGER_STATE_WIDTH]| {
+            let mut state = input;
+            external_linear_layer(&mut state);
+
+            let rounds_f_half = ROUNDS_F / 2;
+            for round in &external[..rounds_f_half] {
+                for (lane, rc) in state.iter_mut().zip(round) {
+                    *lane += *rc;
+                }
+                state = core::array::from_fn(|i| sbox(state[i]));
+                external_linear_layer(&mut state);
+            }
+
+            for rc in &internal {
+                state[0] += *rc;
+                state[0] = sbox(state[0]);
+                internal_linear_layer(&mut state, &diagonal);
+            }
+
+            for round in &external[rounds_f_half..] {
+                for (lane, rc) in state.iter_mut().zip(round) {
+                    *lane += *rc;
+                }
+                state = core::array::from_fn(|i| sbox(state[i]));
+                external_linear_layer(&mut state);
+            }
+
+            state
+        };
+
+        let perm = outer_perm();
+        for state in probe_states() {
+            assert_eq!(
+                cuda_permute(state),
+                perm.permute(state),
+                "the CUDA driver and `outer_perm` disagree, so the two sides run different \
+                 permutations even where their constant tables match"
+            );
+        }
+    }
+
+    /// Checks the encoding away from the two points [`montgomery_limbs_match_published_r`] pins.
+    ///
+    /// `R` is derived a second way, by doubling rather than squaring, since an off-by-one in the
+    /// squarings lands on another perfectly good field element. Additivity then rules out `to_repr`
+    /// returning the internal limbs, which would scale everything by `R` a second time.
+    #[test]
+    fn montgomery_encoding_is_consistent_off_the_pinned_point() {
+        let mut doubled = Bn254Fr::one();
+        for _ in 0..256 {
+            doubled = doubled + doubled;
+        }
+        // `doubled` is R, so its canonical limbs are what the encoding of one must be. Encoding
+        // it again would ask for `R * R`.
+        assert_eq!(
+            bn254_montgomery_limbs(Bn254Fr::one()),
+            canonical_limbs(doubled),
+            "R by repeated squaring and R by repeated doubling disagree"
+        );
+
+        // Read back as one 256-bit little-endian integer, the encoding has to carry field
+        // addition. The prime is not written down here: it is `(-1) + 1`, taken from the field.
+        let modulus = add_limbs(canonical_limbs(Bn254Fr::zero() - Bn254Fr::one()), ONE)
+            .expect("r - 1 sits below 2^256");
+        for state in probe_states() {
+            let (x, y) = (state[0], state[1]);
+            let sum = add_limbs(bn254_montgomery_limbs(x), bn254_montgomery_limbs(y))
+                .expect("two residues below r sum below 2^256");
+            let reduced = if less_than(sum, modulus) {
+                sum
+            } else {
+                sub_limbs(sum, modulus).expect("a sum at least r stays non-negative less r")
+            };
+            assert_eq!(
+                reduced,
+                bn254_montgomery_limbs(x + y),
+                "the Montgomery encoding does not carry field addition, so the limbs are not \
+                 the residue they are read as"
+            );
+        }
+    }
+
+    const ONE: [u32; 8] = [1, 0, 0, 0, 0, 0, 0, 0];
+
+    /// The canonical residue of `x`, as eight little-endian 32-bit limbs.
+    fn canonical_limbs(x: Bn254Fr) -> [u32; 8] {
+        let repr = x.value.to_repr();
+        core::array::from_fn(|i| u32::from_le_bytes(repr.0[4 * i..4 * i + 4].try_into().unwrap()))
+    }
+
+    /// Little-endian 256-bit addition, `None` on overflow past `2^256`.
+    fn add_limbs(a: [u32; 8], b: [u32; 8]) -> Option<[u32; 8]> {
+        let mut out = [0u32; 8];
+        let mut carry = 0u64;
+        for i in 0..8 {
+            let wide = u64::from(a[i]) + u64::from(b[i]) + carry;
+            out[i] = wide as u32;
+            carry = wide >> 32;
+        }
+        (carry == 0).then_some(out)
+    }
+
+    /// Little-endian 256-bit subtraction, `None` on borrow out of the top limb.
+    fn sub_limbs(a: [u32; 8], b: [u32; 8]) -> Option<[u32; 8]> {
+        let mut out = [0u32; 8];
+        let mut borrow = 0i64;
+        for i in 0..8 {
+            let wide = i64::from(a[i]) - i64::from(b[i]) - borrow;
+            out[i] = wide as u32;
+            borrow = i64::from(wide < 0);
+        }
+        (borrow == 0).then_some(out)
+    }
+
+    fn less_than(a: [u32; 8], b: [u32; 8]) -> bool {
+        for i in (0..8).rev() {
+            if a[i] != b[i] {
+                return a[i] < b[i];
+            }
+        }
+        false
+    }
+}

--- a/slop/crates/koala-bear/src/lib.rs
+++ b/slop/crates/koala-bear/src/lib.rs
@@ -2,3 +2,221 @@
 pub use p3_koala_bear::*;
 mod koala_bear_poseidon2;
 pub use koala_bear_poseidon2::*;
+
+#[cfg(test)]
+mod tests {
+    use p3_koala_bear::{
+        DiffusionMatrixKoalaBear, KoalaBear, MONTY_INVERSE,
+        POSEIDON2_INTERNAL_MATRIX_DIAG_16_KOALABEAR_MONTY,
+    };
+    use slop_algebra::{AbstractField, Field, PrimeField32};
+    use slop_symmetric::Permutation;
+
+    const WIDTH: usize = 16;
+
+    /// The prime, as the field itself reports it.
+    fn prime() -> u64 {
+        u64::from(KoalaBear::ORDER_U32)
+    }
+
+    /// The Montgomery radix `R`, derived rather than written down: the shift trick depends on what it
+    /// is, so it is checked in [`the_radix_is_a_power_of_two_and_monty_inverse_undoes_it`].
+    fn montgomery_radix() -> KoalaBear {
+        let mut r = KoalaBear::two();
+        for _ in 0..5 {
+            r = r.square();
+        }
+        r
+    }
+
+    /// The word actually stored for `x`. `KoalaBear::value` is `pub(crate)` upstream; this reaches the
+    /// same number without it.
+    fn montgomery_word(x: KoalaBear) -> u32 {
+        (x * montgomery_radix()).as_canonical_u32()
+    }
+
+    fn internal_diagonal() -> [KoalaBear; WIDTH] {
+        POSEIDON2_INTERNAL_MATRIX_DIAG_16_KOALABEAR_MONTY
+    }
+
+    /// The shift amounts, derived from the diagonal. Panics unless every entry is a power of two, which
+    /// is the precondition the whole optimisation rests on.
+    fn internal_shifts() -> [u32; WIDTH - 1] {
+        core::array::from_fn(|i| {
+            let entry = internal_diagonal()[i + 1].as_canonical_u32();
+            assert!(
+                entry.is_power_of_two(),
+                "diagonal entry {} is {entry}, which is not a power of two, so it cannot be \
+                 applied as a shift",
+                i + 1
+            );
+            entry.trailing_zeros()
+        })
+    }
+
+    /// Probe states, including lane zero at zero, where the CUDA path's `v0 == 0 ? 0 : MOD - v0`
+    /// takes its other branch, and lane zero at its largest, the worst case for its subtraction.
+    fn probe_states() -> Vec<[KoalaBear; WIDTH]> {
+        let mut states = vec![
+            [KoalaBear::zero(); WIDTH],
+            {
+                let mut s = [KoalaBear::one(); WIDTH];
+                s[0] = KoalaBear::zero();
+                s
+            },
+            {
+                let mut s = [KoalaBear::zero(); WIDTH];
+                s[0] = KoalaBear::zero() - KoalaBear::one();
+                s
+            },
+        ];
+
+        let mut x = KoalaBear::from_canonical_u32(7);
+        let mut walk = Vec::with_capacity(WIDTH * 4);
+        for _ in 0..(WIDTH * 4) {
+            x = x.cube() + KoalaBear::from_canonical_u32(3);
+            walk.push(x);
+        }
+        states.extend(walk.chunks_exact(WIDTH).map(|c| {
+            let mut s = [KoalaBear::zero(); WIDTH];
+            s.copy_from_slice(c);
+            s
+        }));
+        states
+    }
+
+    /// Pins `R = 2^32` and `MONTY_INVERSE` as the scalar undoing it.
+    ///
+    /// Upstream writes `MONTY_INVERSE` as `KoalaBear { value: 1 }`, which names `R^-1` only if you
+    /// already know the convention, so it is pinned from the outside here.
+    #[test]
+    fn the_radix_is_a_power_of_two_and_monty_inverse_undoes_it() {
+        let radix = montgomery_radix();
+        assert_eq!(
+            u64::from(radix.as_canonical_u32()),
+            (1u64 << 32) % prime(),
+            "the Montgomery radix is not 2^32, so shifting a stored word is not scaling it"
+        );
+        assert_eq!(montgomery_word(KoalaBear::one()), radix.as_canonical_u32());
+
+        assert_eq!(montgomery_word(MONTY_INVERSE), 1, "MONTY_INVERSE is not the element R^-1");
+        assert_eq!(MONTY_INVERSE * radix, KoalaBear::one());
+        assert_eq!(
+            MONTY_INVERSE.as_canonical_u32(),
+            1_057_030_144,
+            "the literal `kb31_t(1057030144)` in poseidon2_kb31_16.cuh no longer names R^-1"
+        );
+    }
+
+    /// Pins the diagonal as shifts, and lane zero as the `-2` that is not one.
+    ///
+    /// The derived shifts are also the `SH` table hardcoded in `poseidon2_kb31_16.cuh`. That table is
+    /// live on the GPU side and the drift guard checks neither it nor `MAT_INTERNAL_DIAG_M1`.
+    #[test]
+    fn the_internal_diagonal_is_made_of_shifts() {
+        assert_eq!(
+            internal_diagonal()[0],
+            KoalaBear::zero() - KoalaBear::two(),
+            "lane zero is no longer -2, so the non-negative rewrite it needs may not apply"
+        );
+        assert_eq!(
+            internal_shifts(),
+            [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15],
+            "the derived shifts no longer match the `SH` table in poseidon2_kb31_16.cuh"
+        );
+    }
+
+    /// Pins the internal layer as `R^-1 * (J + diag(D))`, which is not `J + diag(D)`.
+    ///
+    /// Stored words carry a factor of `R` into the sum and the shifts, and REDC divides by `R` on the
+    /// way out. Rather than spend a multiply putting it back, the `R^-1` is defined into the layer;
+    /// scaling an internal matrix by a nonzero constant leaves a valid Poseidon2 instance. Read
+    /// backwards this looks like an off-by-`R` bug, so both halves are asserted.
+    #[test]
+    fn the_internal_layer_has_r_inverse_folded_into_it() {
+        let diagonal = internal_diagonal();
+        let r_inverse = montgomery_radix().inverse();
+
+        for state in probe_states() {
+            let sum = state.iter().fold(KoalaBear::zero(), |acc, x| acc + *x);
+            let textbook: [KoalaBear; WIDTH] =
+                core::array::from_fn(|i| sum + diagonal[i] * state[i]);
+            let scaled: [KoalaBear; WIDTH] = core::array::from_fn(|i| textbook[i] * r_inverse);
+
+            let mut got = state;
+            DiffusionMatrixKoalaBear.permute_mut(&mut got);
+
+            assert_eq!(
+                got, scaled,
+                "the internal layer is not `R^-1 * (J + diag(D))`, so the reduction is no longer \
+                 paying for itself"
+            );
+            if textbook.iter().any(|x| *x != KoalaBear::zero()) {
+                assert_ne!(
+                    got, textbook,
+                    "the internal layer became the textbook one, which means someone put the R \
+                     back and the two sides now disagree"
+                );
+            }
+        }
+    }
+
+    /// Pins the REDC precondition against the live width and shifts, rather than quoting the bound.
+    /// Widening the state or adding a larger shift fails here.
+    #[test]
+    fn the_redc_precondition_has_room_for_the_widest_shift() {
+        let p = u128::from(prime());
+        let max_shift = internal_shifts().iter().copied().max().expect("the diagonal is non-empty");
+
+        let sum_bound = WIDTH as u128 * p;
+        let shifted_bound = p << max_shift;
+        let largest_input = sum_bound + shifted_bound;
+        let redc_limit = p << 32;
+
+        assert!(
+            largest_input < redc_limit,
+            "an internal-layer input can reach {largest_input}, at or past the REDC limit of \
+             {redc_limit}"
+        );
+    }
+
+    /// Pins the non-negative rewrite lane zero needs.
+    ///
+    /// `sum - 2 * v0` is computed in unsigned 64-bit and goes negative when the other lanes are small,
+    /// wrapping to something REDC will happily reduce to the wrong answer. `(sum - v0) + (p - v0)`
+    /// cannot: `v0` is one of the terms of `sum`, and `p - v0` stands in for `-v0`.
+    #[test]
+    fn lane_zero_avoids_the_unsigned_underflow() {
+        let p = prime();
+        let mut underflows_seen = 0;
+
+        for state in probe_states() {
+            let words: Vec<u64> = state.iter().map(|x| u64::from(montgomery_word(*x))).collect();
+            let v0 = words[0];
+            let part_sum: u64 = words[1..].iter().sum();
+            let full_sum = part_sum + v0;
+
+            let naive = i128::from(full_sum) - 2 * i128::from(v0);
+            if naive < 0 {
+                underflows_seen += 1;
+                assert!(
+                    full_sum.checked_sub(2 * v0).is_none(),
+                    "the naive form was expected to underflow u64 here"
+                );
+            }
+
+            let rewritten = part_sum + (p - v0);
+            assert_eq!(
+                i128::from(rewritten).rem_euclid(i128::from(p)),
+                naive.rem_euclid(i128::from(p)),
+                "the non-negative rewrite is not congruent to `sum - 2 * v0`"
+            );
+            assert!(u128::from(rewritten) < u128::from(p) << 32, "the rewrite left the REDC bound");
+        }
+
+        assert!(
+            underflows_seen > 0,
+            "no probe state reached the underflow, so this test proved nothing"
+        );
+    }
+}

--- a/sp1-gpu/crates/sys/Cargo.toml
+++ b/sp1-gpu/crates/sys/Cargo.toml
@@ -13,6 +13,9 @@ slop-koala-bear = { workspace = true }
 sp1-primitives = { workspace = true }
 
 [build-dependencies]
+slop-algebra = { workspace = true }
+slop-bn254 = { workspace = true }
+slop-koala-bear = { workspace = true }
 sp1-core-executor = { workspace = true }
 sp1-core-machine = { workspace = true }
 sp1-recursion-executor = { workspace = true }

--- a/sp1-gpu/crates/sys/build.rs
+++ b/sp1-gpu/crates/sys/build.rs
@@ -194,39 +194,30 @@ fn compare_table(path: &str, name: &str, found: &[Vec<u32>], expected: &[Vec<u32
 
 /// Guard the CUDA copies of the Poseidon2 constants against drifting from the Rust ones.
 ///
-/// Both headers hold a hand-copied duplicate of constants this workspace already derives, with the
-/// round constants laid out in the order the kernel walks them: the beginning half of the external
-/// rounds, then the ending half, then the internal rounds. `StaticHasher` in `poseidon2.cuh` binds
-/// these tables directly, so they are what every GPU hash actually uses.
+/// Both headers hand-copy constants this workspace already derives, ordered as the kernel walks
+/// them (beginning external, ending external, internal) and bound directly by `StaticHasher` in
+/// `poseidon2.cuh`. Only what is read is checked, and that differs between the two headers even
+/// where they declare the same names; each function below says which of its tables are live.
 ///
-/// What is checked is what is read, and that differs between the two headers even where they
-/// declare the same names. Each function below says which of its tables are live and why.
-///
-/// This is a build-script check rather than a test because the CPU CI jobs exclude every
-/// `sp1-gpu-*` crate from `cargo test`, and a test binary here cannot link without a CUDA build
-/// anyway. Build scripts still run under `cargo check` and `cargo clippy`, which do cover the
-/// whole workspace, so running the comparison here is what gets it onto a non-GPU runner.
+/// A build script rather than a test: CPU CI excludes `sp1-gpu-*` from `cargo test` and a test
+/// binary here cannot link without CUDA, but build scripts still run under `cargo check`.
 fn check_poseidon2_constants(crate_dir: &Path) {
     check_kb31_constants(crate_dir);
     check_bn254_constants(crate_dir);
 }
 
-/// The KoalaBear table holds canonical values, so the parsed entries compare against
-/// `as_canonical_u32()` and not against `KoalaBear`'s inner Montgomery value.
+/// The KoalaBear table holds canonical values, so entries compare against `as_canonical_u32()`
+/// rather than `KoalaBear`'s inner Montgomery value.
 ///
-/// That is a consequence of C++ overload resolution, not a stylistic choice. `kb31_t` declares both
-/// `kb31_t(uint32_t)`, which stores its argument raw into the Montgomery field, and `kb31_t(int)`,
-/// which converts with `(a << 32) % MOD`. A decimal literal is `int` unless it exceeds `INT_MAX`,
-/// and every canonical KoalaBear value is below `MOD` (0x7f000001), which is itself below `INT_MAX`,
-/// so these literals always bind to the converting constructor. Contrast `bn254_t`, whose only
-/// matching constructor copies limbs verbatim; see `check_bn254_constants`.
+/// That follows from overload resolution: `kb31_t(uint32_t)` stores its argument raw while
+/// `kb31_t(int)` converts with `(a << 32) % MOD`, and a decimal literal below `INT_MAX` is `int`.
+/// Every canonical value is below `MOD` (0x7f000001), so these bind the converting one. `bn254_t`'s
+/// only matching constructor copies limbs verbatim instead.
 ///
-/// `MAT_INTERNAL_DIAG_M1` and `MONTY_INVERSE` are deliberately not checked, because this header
-/// genuinely never reads either. `KoalaBear::internalLinearLayer` takes both as unnamed parameters
-/// and applies the diagonal as shifts against a hardcoded `SH` table, so the declared copy is dead
-/// weight; the header even carries two `#if`-selected versions of it, both equally unread. The
-/// BN254 header spells its constants the same way but does read its diagonal, so do not carry this
-/// paragraph across; see `check_bn254_constants`.
+/// `MAT_INTERNAL_DIAG_M1` and `MONTY_INVERSE` are not checked: this header reads neither, applying
+/// the diagonal as shifts against a hardcoded `SH` table. `SH` is live and unchecked, the same
+/// exposure in a different table. The BN254 header does read its diagonal; see
+/// `check_bn254_constants`.
 fn check_kb31_constants(crate_dir: &Path) {
     let path = crate_dir.join(KB31_HEADER);
     let header = fs::read_to_string(&path)
@@ -249,29 +240,22 @@ fn check_kb31_constants(crate_dir: &Path) {
     }
 }
 
-/// Unlike the KoalaBear table, the BN254 one is written out in Montgomery form, as eight
-/// little-endian `uint32_t` limbs per constant, so the comparison goes through
-/// `bn254_montgomery_limbs`.
+/// The BN254 table is written in Montgomery form, eight little-endian `uint32_t` limbs per constant,
+/// so the comparison goes through `bn254_montgomery_limbs`. `bn254_t` is `mont_t<...>`, whose
+/// eight-argument constructor assigns into `even[0..8]` with no conversion, so the header text is
+/// already the stored representation.
 ///
-/// The reason the two headers differ is the constructor each field type offers. `bn254_t` is
-/// `mont_t<...>`, whose eight-argument constructor assigns straight into `even[0..8]` with no
-/// conversion, so whatever is written in the header is already the stored representation.
+/// `bn254_poseidon2_rc3` returns all 64 rounds in Plonky3's flat order; the split below is
+/// `outer_perm`'s, and the kernel's begin-then-end external layout is that split concatenated.
 ///
-/// `bn254_poseidon2_rc3` hands back all 64 rounds in Plonky3's flat order. `outer_perm` splits that
-/// into external and internal exactly as below, and the kernel's begin-then-end external layout is
-/// that same split with the two halves concatenated.
+/// `MAT_INTERNAL_DIAG_M1` is checked here though the KoalaBear one is not, and the headers looking
+/// parallel is the trap. `Bn254::internalLinearLayer` ignores its parameters but has no shift path:
+/// it multiplies lane `i` by the class constant on all 56 internal rounds. `bn254_internal_diagonal`
+/// reads that diagonal back out of `DiffusionMatrixBN254`, so the comparison is against CPU
+/// behaviour rather than a third transcription.
 ///
-/// `MAT_INTERNAL_DIAG_M1` is checked here even though the KoalaBear one is not, and the two headers
-/// looking parallel is exactly the trap. `Bn254::internalLinearLayer` does ignore both parameters
-/// it is handed, but it does not fall back to a shift path: it multiplies lane `i` by the class
-/// constant `MAT_INTERNAL_DIAG_M1[i]` on every one of the 56 internal rounds. That table is live,
-/// hand-copied, and would otherwise change every BN254 hash silently. `bn254_internal_diagonal`
-/// reads the same diagonal back out of `DiffusionMatrixBN254`, the internal layer `outer_perm`
-/// runs, so the comparison is against CPU behaviour rather than against a third transcription.
-///
-/// `MONTY_INVERSE` is left unchecked in both headers. Nothing reads it: the only places it appears
-/// are the two `internalLinearLayer` call sites, which pass it into a parameter neither
-/// implementation names.
+/// `MONTY_INVERSE` is unchecked in both headers; the only mentions are the two
+/// `internalLinearLayer` call sites, passing it into a parameter neither implementation names.
 fn check_bn254_constants(crate_dir: &Path) {
     /// Full rounds, half at the start of the permutation and half at the end.
     const ROUNDS_F: usize = 8;

--- a/sp1-gpu/crates/sys/build.rs
+++ b/sp1-gpu/crates/sys/build.rs
@@ -1,5 +1,11 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::{env, fs};
+
+use slop_algebra::PrimeField32;
+use slop_bn254::{bn254_internal_diagonal, bn254_montgomery_limbs, bn254_poseidon2_rc3};
+use slop_koala_bear::{
+    KoalaBear_BEGIN_EXT_CONSTS, KoalaBear_END_EXT_CONSTS, KoalaBear_PARTIAL_CONSTS,
+};
 
 fn cbindgen_builder() -> cbindgen::Builder {
     /// The warning placed in the cbindgen header.
@@ -129,6 +135,186 @@ fn detect_cuda() -> bool {
     false
 }
 
+/// The CUDA headers holding the Poseidon2 round constants, relative to the crate root.
+const KB31_HEADER: &str = "include/poseidon2/poseidon2_kb31_16.cuh";
+const BN254_HEADER: &str = "include/poseidon2/poseidon2_bn254_3.cuh";
+
+/// Pull the integer literals out of every `ctor(...)` initializer in the `__constant__` table
+/// declared as `decl`, one inner `Vec` per table entry.
+///
+/// Neither header nests braces inside one of these initializer lists, so the first `}` after the
+/// declaration is its terminator.
+fn parse_table(header: &str, path: &str, ctor: &str, decl: &str) -> Vec<Vec<u32>> {
+    let body =
+        header.split_once(decl).unwrap_or_else(|| panic!("{path}: no declaration of `{decl}`")).1;
+    let end =
+        body.find('}').unwrap_or_else(|| panic!("{path}: `{decl}` initializer is unterminated"));
+    body[..end]
+        .split(&format!("{ctor}("))
+        .skip(1)
+        .map(|tail| {
+            let inner = tail
+                .split_once(')')
+                .unwrap_or_else(|| panic!("{path}: `{decl}` has an unclosed `{ctor}(`"))
+                .0;
+            assert!(
+                inner.chars().all(|c| c.is_ascii_digit() || c.is_whitespace() || c == ','),
+                "{path}: `{decl}` has a non-literal entry at `{ctor}({inner:.32}`"
+            );
+            inner
+                .split(|c: char| !c.is_ascii_digit())
+                .filter(|run| !run.is_empty())
+                .map(|run| {
+                    run.parse().unwrap_or_else(|_| {
+                        panic!("{path}: `{decl}` has an out-of-range literal `{run}`")
+                    })
+                })
+                .collect()
+        })
+        .collect()
+}
+
+/// Compare one parsed CUDA table against the values this workspace derives for it.
+fn compare_table(path: &str, name: &str, found: &[Vec<u32>], expected: &[Vec<u32>]) {
+    assert_eq!(
+        found.len(),
+        expected.len(),
+        "{path}: {name} has {} entries, but Rust supplies {}",
+        found.len(),
+        expected.len()
+    );
+    for (i, (cuda, rust)) in found.iter().zip(expected).enumerate() {
+        assert_eq!(
+            cuda, rust,
+            "{path}: {name}[{i}] is {cuda:?}, but Rust has {rust:?}. The CUDA and Rust Poseidon2 \
+             constants have drifted; fix whichever side changed."
+        );
+    }
+}
+
+/// Guard the CUDA copies of the Poseidon2 constants against drifting from the Rust ones.
+///
+/// Both headers hold a hand-copied duplicate of constants this workspace already derives, with the
+/// round constants laid out in the order the kernel walks them: the beginning half of the external
+/// rounds, then the ending half, then the internal rounds. `StaticHasher` in `poseidon2.cuh` binds
+/// these tables directly, so they are what every GPU hash actually uses.
+///
+/// What is checked is what is read, and that differs between the two headers even where they
+/// declare the same names. Each function below says which of its tables are live and why.
+///
+/// This is a build-script check rather than a test because the CPU CI jobs exclude every
+/// `sp1-gpu-*` crate from `cargo test`, and a test binary here cannot link without a CUDA build
+/// anyway. Build scripts still run under `cargo check` and `cargo clippy`, which do cover the
+/// whole workspace, so running the comparison here is what gets it onto a non-GPU runner.
+fn check_poseidon2_constants(crate_dir: &Path) {
+    check_kb31_constants(crate_dir);
+    check_bn254_constants(crate_dir);
+}
+
+/// The KoalaBear table holds canonical values, so the parsed entries compare against
+/// `as_canonical_u32()` and not against `KoalaBear`'s inner Montgomery value.
+///
+/// That is a consequence of C++ overload resolution, not a stylistic choice. `kb31_t` declares both
+/// `kb31_t(uint32_t)`, which stores its argument raw into the Montgomery field, and `kb31_t(int)`,
+/// which converts with `(a << 32) % MOD`. A decimal literal is `int` unless it exceeds `INT_MAX`,
+/// and every canonical KoalaBear value is below `MOD` (0x7f000001), which is itself below `INT_MAX`,
+/// so these literals always bind to the converting constructor. Contrast `bn254_t`, whose only
+/// matching constructor copies limbs verbatim; see `check_bn254_constants`.
+///
+/// `MAT_INTERNAL_DIAG_M1` and `MONTY_INVERSE` are deliberately not checked, because this header
+/// genuinely never reads either. `KoalaBear::internalLinearLayer` takes both as unnamed parameters
+/// and applies the diagonal as shifts against a hardcoded `SH` table, so the declared copy is dead
+/// weight; the header even carries two `#if`-selected versions of it, both equally unread. The
+/// BN254 header spells its constants the same way but does read its diagonal, so do not carry this
+/// paragraph across; see `check_bn254_constants`.
+fn check_kb31_constants(crate_dir: &Path) {
+    let path = crate_dir.join(KB31_HEADER);
+    let header = fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()));
+
+    let external: Vec<Vec<u32>> = KoalaBear_BEGIN_EXT_CONSTS
+        .iter()
+        .chain(KoalaBear_END_EXT_CONSTS.iter())
+        .flat_map(|round| round.iter().map(|c| vec![c.as_canonical_u32()]))
+        .collect();
+    let internal: Vec<Vec<u32>> =
+        KoalaBear_PARTIAL_CONSTS.iter().map(|c| vec![c.as_canonical_u32()]).collect();
+
+    for (name, decl, expected) in [
+        ("EXTERNAL_ROUND_CONSTANTS", "EXTERNAL_ROUND_CONSTANTS[ROUNDS_F * WIDTH]", external),
+        ("INTERNAL_ROUND_CONSTANTS", "INTERNAL_ROUND_CONSTANTS[ROUNDS_P]", internal),
+    ] {
+        let found = parse_table(&header, KB31_HEADER, "kb31_t", decl);
+        compare_table(KB31_HEADER, name, &found, &expected);
+    }
+}
+
+/// Unlike the KoalaBear table, the BN254 one is written out in Montgomery form, as eight
+/// little-endian `uint32_t` limbs per constant, so the comparison goes through
+/// `bn254_montgomery_limbs`.
+///
+/// The reason the two headers differ is the constructor each field type offers. `bn254_t` is
+/// `mont_t<...>`, whose eight-argument constructor assigns straight into `even[0..8]` with no
+/// conversion, so whatever is written in the header is already the stored representation.
+///
+/// `bn254_poseidon2_rc3` hands back all 64 rounds in Plonky3's flat order. `outer_perm` splits that
+/// into external and internal exactly as below, and the kernel's begin-then-end external layout is
+/// that same split with the two halves concatenated.
+///
+/// `MAT_INTERNAL_DIAG_M1` is checked here even though the KoalaBear one is not, and the two headers
+/// looking parallel is exactly the trap. `Bn254::internalLinearLayer` does ignore both parameters
+/// it is handed, but it does not fall back to a shift path: it multiplies lane `i` by the class
+/// constant `MAT_INTERNAL_DIAG_M1[i]` on every one of the 56 internal rounds. That table is live,
+/// hand-copied, and would otherwise change every BN254 hash silently. `bn254_internal_diagonal`
+/// reads the same diagonal back out of `DiffusionMatrixBN254`, the internal layer `outer_perm`
+/// runs, so the comparison is against CPU behaviour rather than against a third transcription.
+///
+/// `MONTY_INVERSE` is left unchecked in both headers. Nothing reads it: the only places it appears
+/// are the two `internalLinearLayer` call sites, which pass it into a parameter neither
+/// implementation names.
+fn check_bn254_constants(crate_dir: &Path) {
+    /// Full rounds, half at the start of the permutation and half at the end.
+    const ROUNDS_F: usize = 8;
+    /// Partial rounds, sitting between the two halves.
+    const ROUNDS_P: usize = 56;
+
+    let path = crate_dir.join(BN254_HEADER);
+    let header = fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()));
+
+    let rounds = bn254_poseidon2_rc3();
+    assert_eq!(
+        rounds.len(),
+        ROUNDS_F + ROUNDS_P,
+        "slop-bn254 supplies {} rounds, but {BN254_HEADER} is built for {}",
+        rounds.len(),
+        ROUNDS_F + ROUNDS_P
+    );
+    let internal_start = ROUNDS_F / 2;
+    let internal_end = internal_start + ROUNDS_P;
+
+    let external: Vec<Vec<u32>> = rounds[..internal_start]
+        .iter()
+        .chain(&rounds[internal_end..])
+        .flat_map(|round| round.iter().map(|c| bn254_montgomery_limbs(*c).to_vec()))
+        .collect();
+    let internal: Vec<Vec<u32>> = rounds[internal_start..internal_end]
+        .iter()
+        .map(|round| bn254_montgomery_limbs(round[0]).to_vec())
+        .collect();
+    let diagonal: Vec<Vec<u32>> =
+        bn254_internal_diagonal().iter().map(|d| bn254_montgomery_limbs(*d).to_vec()).collect();
+
+    for (name, decl, expected) in [
+        ("EXTERNAL_ROUND_CONSTANTS", "EXTERNAL_ROUND_CONSTANTS[ROUNDS_F * WIDTH]", external),
+        ("INTERNAL_ROUND_CONSTANTS", "INTERNAL_ROUND_CONSTANTS[ROUNDS_P]", internal),
+        ("MAT_INTERNAL_DIAG_M1", "MAT_INTERNAL_DIAG_M1[WIDTH]", diagonal),
+    ] {
+        let found = parse_table(&header, BN254_HEADER, "bn254_t", decl);
+        compare_table(BN254_HEADER, name, &found, &expected);
+    }
+}
+
 fn main() {
     // Directives for tracking changes in folders
     println!("cargo:rerun-if-changed=include/");
@@ -144,6 +330,10 @@ fn main() {
 
     // The crate directory.
     let crate_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+
+    // Fail fast if the CUDA copy of the Poseidon2 round constants has drifted from the
+    // Rust one. Ahead of everything below so it still runs where nvcc is absent.
+    check_poseidon2_constants(&crate_dir);
 
     // The output directory, where built artifacts should be placed.
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());


### PR DESCRIPTION
## Motivation

both `poseidon2_kb331_16.cuh` and `poseidon2_bn254_3.cuh` hold duplicate of Poseidon2 constants
the rust side (vs the fact that `StaticHasher` in `poseidon2.cuh` binds those tables directly) already derives.. 

Something had to tie these two copies together. Editing a constant on one side produces no compile error and no test failure. The GPU simply computes a different permutation than the CPU, and the first symptom is a proof that does not verify.

## Solution

Parse the constant tables out of both headers in `sp1-gpu-sys`'s build script and compare them against `slop-koala-bear` and `slop-bn254`. A drifted constant becomes a build failure naming the exact entry:

```
include/poseidon2/poseidon2_bn254_3.cuh: MAT_INTERNAL_DIAG_M1[2] is
[..., 471134084], but Rust has [..., 471134083]. The CUDA and Rust Poseidon2
constants have drifted; fix whichever side changed.
```
### Verification

- `cargo test -p slop-bn254` passes, including two tests pinning the new helpers to `R` and to `[one, one, two]`.
- `cargo check -p sp1-gpu-sys` runs the guard against the real headers on a machine with no CUDA.
- Perturbing one limb of `MAT_INTERNAL_DIAG_M1[2]` fails the build with the message above.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation