### PR TITLE
feat(sdk): add mTLS client identity support

### DIFF
--- a/crates/sdk/src/blocking/client.rs
+++ b/crates/sdk/src/blocking/client.rs
@@ -171,6 +171,7 @@ impl ProverClientBuilder {
             rpc_url: None,
             tee_signers: None,
             network_mode: Some(mode),
+            client_identity: None,
             hosted: false,
             machine: self.machine.clone(),
         }

--- a/crates/sdk/src/blocking/network/builder.rs
+++ b/crates/sdk/src/blocking/network/builder.rs
@@ -6,6 +6,7 @@ use alloy_primitives::Address;
 use sp1_core_machine::riscv::RiscvAir;
 use sp1_hypercube::Machine;
 use sp1_primitives::SP1Field;
+use tonic::transport::Identity;
 
 use super::NetworkProver;
 use crate::network::{signer::NetworkSigner, NetworkMode, TEE_NETWORK_RPC_URL};
@@ -19,6 +20,7 @@ pub struct NetworkProverBuilder {
     pub(crate) tee_signers: Option<Vec<Address>>,
     pub(crate) signer: Option<NetworkSigner>,
     pub(crate) network_mode: Option<NetworkMode>,
+    pub(crate) client_identity: Option<Identity>,
     pub(crate) hosted: bool,
     pub(crate) machine: Machine<SP1Field, RiscvAir<SP1Field>>,
 }
@@ -45,6 +47,7 @@ impl NetworkProverBuilder {
             tee_signers: None,
             signer: None,
             network_mode: None,
+            client_identity: None,
             hosted: false,
             machine,
         }
@@ -144,6 +147,17 @@ impl NetworkProverBuilder {
         self
     }
 
+    /// Sets the PEM-encoded certificate and private key used for mutual TLS authentication.
+    #[must_use]
+    pub fn client_identity(
+        mut self,
+        certificate: impl AsRef<[u8]>,
+        private_key: impl AsRef<[u8]>,
+    ) -> Self {
+        self.client_identity = Some(Identity::from_pem(certificate, private_key));
+        self
+    }
+
     /// Builds a blocking [`NetworkProver`].
     ///
     /// # Details
@@ -166,6 +180,7 @@ impl NetworkProverBuilder {
             tee_signers: self.tee_signers,
             signer: self.signer,
             network_mode: self.network_mode,
+            client_identity: self.client_identity,
             hosted: self.hosted,
             machine: self.machine,
         };

--- a/crates/sdk/src/client.rs
+++ b/crates/sdk/src/client.rs
@@ -209,6 +209,7 @@ impl ProverClientBuilder {
             rpc_url: None,
             tee_signers: None,
             network_mode: Some(mode),
+            client_identity: None,
             hosted: false,
             machine: self.machine.clone(),
         }

--- a/crates/sdk/src/network/builder.rs
+++ b/crates/sdk/src/network/builder.rs
@@ -6,6 +6,7 @@ use alloy_primitives::Address;
 use sp1_core_machine::riscv::RiscvAir;
 use sp1_hypercube::Machine;
 use sp1_primitives::SP1Field;
+use tonic::transport::Identity;
 
 use crate::{
     network::{signer::NetworkSigner, NetworkMode, TEE_NETWORK_RPC_URL},
@@ -21,6 +22,7 @@ pub struct NetworkProverBuilder {
     pub(crate) tee_signers: Option<Vec<Address>>,
     pub(crate) signer: Option<NetworkSigner>,
     pub(crate) network_mode: Option<NetworkMode>,
+    pub(crate) client_identity: Option<Identity>,
     pub(crate) hosted: bool,
     pub(crate) machine: Machine<SP1Field, RiscvAir<SP1Field>>,
 }
@@ -47,6 +49,7 @@ impl NetworkProverBuilder {
             tee_signers: None,
             signer: None,
             network_mode: None,
+            client_identity: None,
             hosted: false,
             machine,
         }
@@ -168,6 +171,17 @@ impl NetworkProverBuilder {
         self
     }
 
+    /// Sets the PEM-encoded certificate and private key used for mutual TLS authentication.
+    #[must_use]
+    pub fn client_identity(
+        mut self,
+        certificate: impl AsRef<[u8]>,
+        private_key: impl AsRef<[u8]>,
+    ) -> Self {
+        self.client_identity = Some(Identity::from_pem(certificate, private_key));
+        self
+    }
+
     /// Builds a [`NetworkProver`].
     ///
     /// # Details
@@ -247,6 +261,7 @@ impl NetworkProverBuilder {
         NetworkProver::new_with_machine(signer, &rpc_url, network_mode, self.machine)
             .await
             .with_tee_signers(tee_signers)
+            .with_client_identity(self.client_identity)
             .with_hosted(self.hosted)
     }
 }
@@ -268,5 +283,16 @@ mod tests {
         assert!(builder.hosted);
         // Hosted proving always runs in reserved mode.
         assert_eq!(builder.network_mode, Some(NetworkMode::Reserved));
+    }
+
+    #[tokio::test]
+    async fn test_client_identity_is_injected() {
+        let private_key = hex::encode(alloy_signer_local::PrivateKeySigner::random().to_bytes());
+        let prover = NetworkProverBuilder::new()
+            .private_key(&private_key)
+            .client_identity("certificate", "private key")
+            .build()
+            .await;
+        assert!(prover.client.client_identity.is_some());
     }
 }

--- a/crates/sdk/src/network/client.rs
+++ b/crates/sdk/src/network/client.rs
@@ -17,7 +17,10 @@ use serde::{de::DeserializeOwned, Serialize};
 use sp1_core_machine::io::SP1Stdin;
 use sp1_prover::{HashableKey, SP1VerifyingKey};
 use tokio::sync::OnceCell;
-use tonic::{transport::Channel, Code};
+use tonic::{
+    transport::{Channel, Identity},
+    Code,
+};
 
 use super::{
     grpc,
@@ -105,6 +108,7 @@ pub struct NetworkClient {
     pub(crate) http: HttpClientWithMiddleware,
     pub(crate) rpc_url: String,
     pub(crate) network_mode: NetworkMode,
+    pub(crate) client_identity: Option<Identity>,
     /// Lazily-established gRPC channel, shared across clones and reused across calls.
     pub(crate) channel: Arc<OnceCell<Channel>>,
 }
@@ -154,6 +158,7 @@ impl NetworkClient {
             http: client.into(),
             rpc_url: rpc_url.into(),
             network_mode,
+            client_identity: None,
             channel: Arc::new(OnceCell::new()),
         }
     }
@@ -902,7 +907,8 @@ impl NetworkClient {
         self.channel
             .get_or_try_init(|| async {
                 tracing::debug!(rpc_url = %self.rpc_url, "establishing gRPC channel");
-                Ok(grpc::configure_endpoint(&self.rpc_url)?.connect_lazy())
+                Ok(grpc::configure_endpoint(&self.rpc_url, self.client_identity.clone())?
+                    .connect_lazy())
             })
             .await
             .cloned()

--- a/crates/sdk/src/network/grpc.rs
+++ b/crates/sdk/src/network/grpc.rs
@@ -5,7 +5,12 @@ use tonic::transport::{ClientTlsConfig, Endpoint, Identity};
 /// Configures the endpoint for the gRPC client.
 ///
 /// Sets reasonable settings to handle timeouts and keep-alive.
-pub fn configure_endpoint(addr: &str) -> Result<Endpoint> {
+pub fn configure_endpoint(addr: &str, identity: Option<Identity>) -> Result<Endpoint> {
+    let has_identity = identity.is_some();
+    if has_identity && !addr.starts_with("https://") {
+        bail!("mTLS client identity requires an HTTPS RPC URL");
+    }
+
     let mut endpoint = Endpoint::new(addr.to_string())?
         .timeout(Duration::from_secs(60))
         .connect_timeout(Duration::from_secs(15))
@@ -21,30 +26,66 @@ pub fn configure_endpoint(addr: &str) -> Result<Endpoint> {
         let mut tls_config = ClientTlsConfig::new().with_webpki_roots();
         #[cfg(not(target_os = "ios"))]
         let mut tls_config = ClientTlsConfig::new().with_enabled_roots();
-        if let Some(identity) = client_identity_from_env()? {
+        if let Some(identity) = identity {
             tls_config = tls_config.identity(identity);
         }
-        endpoint = endpoint.tls_config(tls_config)?;
+        endpoint = if has_identity {
+            endpoint.tls_config(tls_config).context("configuring mTLS client identity")?
+        } else {
+            endpoint.tls_config(tls_config)?
+        };
     }
 
     Ok(endpoint)
 }
 
-/// Private networks that require mTLS reject the handshake without a client identity.
-fn client_identity_from_env() -> Result<Option<Identity>> {
-    let cert_path = std::env::var("NETWORK_MTLS_CERT_PATH").ok().filter(|v| !v.is_empty());
-    let key_path = std::env::var("NETWORK_MTLS_KEY_PATH").ok().filter(|v| !v.is_empty());
-    match (cert_path, key_path) {
-        (Some(cert_path), Some(key_path)) => {
-            let cert = std::fs::read(&cert_path)
-                .with_context(|| format!("reading NETWORK_MTLS_CERT_PATH ({cert_path})"))?;
-            let key = std::fs::read(&key_path)
-                .with_context(|| format!("reading NETWORK_MTLS_KEY_PATH ({key_path})"))?;
-            Ok(Some(Identity::from_pem(cert, key)))
-        }
-        (None, None) => Ok(None),
-        _ => bail!(
-            "NETWORK_MTLS_CERT_PATH and NETWORK_MTLS_KEY_PATH must be set together; only one is set"
-        ),
+#[cfg(test)]
+mod tests {
+    use super::configure_endpoint;
+    use tonic::transport::Identity;
+
+    const TEST_CERT: &str = r"-----BEGIN CERTIFICATE-----
+MIIBjTCCATOgAwIBAgIUWY3Lq5dQkeZfxcTF4UuUAIUR0TUwCgYIKoZIzj0EAwIw
+HDEaMBgGA1UEAwwRc3AxLXNkay1tdGxzLXRlc3QwHhcNMjYwODI1MDMwOTI4WhcN
+MzYwODIyMDMwOTI4WjAcMRowGAYDVQQDDBFzcDEtc2RrLW10bHMtdGVzdDBZMBMG
+ByqGSM49AgEGCCqGSM49AwEHA0IABLmtBB72z7cVnDhCra+5wXBczh+OymKEw7/5
+C/qzcuH/dKYxuQdn6nUsRxeImm2xjCEYeTwic3mvU7ltKXIIjhajUzBRMB0GA1Ud
+DgQWBBRlnNprvNjkxoFk4/bBtWO+UnfBkTAfBgNVHSMEGDAWgBRlnNprvNjkxoFk
+4/bBtWO+UnfBkTAPBgNVHRMBAf8EBTADAQH/MAoGCCqGSM49BAMCA0gAMEUCIDlS
+IHMpHDa0hGwtMkYZfhXZyDzm1lfMStVOwoV3Ind7AiEA4hp+5F+JII2Fp9E3M6lK
+8VDrpentDG8GZv3LLOhoKXo=
+-----END CERTIFICATE-----";
+    const TEST_KEY: &str = r"-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIL8Af/fX1VefNox2ZkOQZEe3XEDYfCxEYq2E22VU91j1oAoGCCqGSM49
+AwEHoUQDQgAEua0EHvbPtxWcOEKtr7nBcFzOH47KYoTDv/kL+rNy4f90pjG5B2fq
+dSxHF4iabbGMIRh5PCJzea9TuW0pcgiOFg==
+-----END EC PRIVATE KEY-----";
+
+    #[test]
+    fn configures_standard_tls_without_client_identity() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        configure_endpoint("https://localhost", None).unwrap();
+    }
+
+    #[test]
+    fn configures_mtls_with_explicit_client_identity() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let identity = Identity::from_pem(TEST_CERT, TEST_KEY);
+        configure_endpoint("https://localhost", Some(identity)).unwrap();
+    }
+
+    #[test]
+    fn rejects_invalid_client_identity() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let identity = Identity::from_pem("not a certificate", "not a key");
+        let err = configure_endpoint("https://localhost", Some(identity)).unwrap_err().to_string();
+        assert!(err.contains("configuring mTLS client identity"));
+    }
+
+    #[test]
+    fn rejects_client_identity_without_https() {
+        let identity = Identity::from_pem(TEST_CERT, TEST_KEY);
+        let err = configure_endpoint("http://localhost", Some(identity)).unwrap_err().to_string();
+        assert!(err.contains("requires an HTTPS RPC URL"));
     }
 }

--- a/crates/sdk/src/network/grpc.rs
+++ b/crates/sdk/src/network/grpc.rs
@@ -1,10 +1,11 @@
+use anyhow::{bail, Context, Result};
 use std::time::Duration;
-use tonic::transport::{ClientTlsConfig, Endpoint, Error};
+use tonic::transport::{ClientTlsConfig, Endpoint, Identity};
 
 /// Configures the endpoint for the gRPC client.
 ///
 /// Sets reasonable settings to handle timeouts and keep-alive.
-pub fn configure_endpoint(addr: &str) -> Result<Endpoint, Error> {
+pub fn configure_endpoint(addr: &str) -> Result<Endpoint> {
     let mut endpoint = Endpoint::new(addr.to_string())?
         .timeout(Duration::from_secs(60))
         .connect_timeout(Duration::from_secs(15))
@@ -17,11 +18,33 @@ pub fn configure_endpoint(addr: &str) -> Result<Endpoint, Error> {
     // Configure TLS if using HTTPS.
     if addr.starts_with("https://") {
         #[cfg(target_os = "ios")]
-        let tls_config = ClientTlsConfig::new().with_webpki_roots();
+        let mut tls_config = ClientTlsConfig::new().with_webpki_roots();
         #[cfg(not(target_os = "ios"))]
-        let tls_config = ClientTlsConfig::new().with_enabled_roots();
+        let mut tls_config = ClientTlsConfig::new().with_enabled_roots();
+        if let Some(identity) = client_identity_from_env()? {
+            tls_config = tls_config.identity(identity);
+        }
         endpoint = endpoint.tls_config(tls_config)?;
     }
 
     Ok(endpoint)
+}
+
+/// Private networks that require mTLS reject the handshake without a client identity.
+fn client_identity_from_env() -> Result<Option<Identity>> {
+    let cert_path = std::env::var("NETWORK_MTLS_CERT_PATH").ok().filter(|v| !v.is_empty());
+    let key_path = std::env::var("NETWORK_MTLS_KEY_PATH").ok().filter(|v| !v.is_empty());
+    match (cert_path, key_path) {
+        (Some(cert_path), Some(key_path)) => {
+            let cert = std::fs::read(&cert_path)
+                .with_context(|| format!("reading NETWORK_MTLS_CERT_PATH ({cert_path})"))?;
+            let key = std::fs::read(&key_path)
+                .with_context(|| format!("reading NETWORK_MTLS_KEY_PATH ({key_path})"))?;
+            Ok(Some(Identity::from_pem(cert, key)))
+        }
+        (None, None) => Ok(None),
+        _ => bail!(
+            "NETWORK_MTLS_CERT_PATH and NETWORK_MTLS_KEY_PATH must be set together; only one is set"
+        ),
+    }
 }

--- a/crates/sdk/src/network/prover.rs
+++ b/crates/sdk/src/network/prover.rs
@@ -41,6 +41,7 @@ use sp1_prover::worker::{SP1LightNode, SP1NodeCore};
 use sp1_prover::SP1_CIRCUIT_VERSION;
 
 use tokio::time::sleep;
+use tonic::transport::Identity;
 
 /// An implementation of [`crate::ProverClient`] that can generate proofs on a remote RPC server.
 #[derive(Clone)]
@@ -238,6 +239,12 @@ impl NetworkProver {
     #[must_use]
     pub fn with_tee_signers(mut self, tee_signers: Vec<Address>) -> Self {
         self.tee_signers = tee_signers;
+        self
+    }
+
+    #[must_use]
+    pub(crate) fn with_client_identity(mut self, client_identity: Option<Identity>) -> Self {
+        self.client.client_identity = client_identity;
         self
     }
 


### PR DESCRIPTION
## Summary

- Add explicit async and blocking builder methods for an optional mutual TLS client identity.
- Pass the identity through the network prover and lazy gRPC channel without reading environment variables or files in the SDK.
- Keep the existing standard TLS path unchanged when no identity is provided.
- Reject malformed identities and mutual TLS over a non-HTTPS RPC URL.

## Motivation

The SDK should own transport configuration, while each application should own its environment variables, secret files, and startup policy. This lets callers load credentials from their own secret source and inject the certificate and private key explicitly.

## Validation

- `cargo +1.98.0 fmt --all -- --check`
- `cargo +1.98.0 check -p test-artifacts`
- `cargo +1.98.0 clippy --all-features --all-targets -- -D warnings -A incomplete-features`
- `cargo +1.98.0 test -p sp1-sdk --features network,blocking --lib`, 53 passed

The macOS host cannot link the optional GPU feature because the `icicle_*` native libraries are unavailable. Pull request CI covers the GPU-linked jobs.