### PR TITLE
chore(release): bump SP1 to v6.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4090,7 +4090,7 @@ dependencies = [
 
 [[package]]
 name = "libzkevm"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "bls12_381",
  "hex",
@@ -6493,7 +6493,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slop-air"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "p3-air",
 ]
@@ -6511,7 +6511,7 @@ dependencies = [
 
 [[package]]
 name = "slop-algebra"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -6521,42 +6521,42 @@ dependencies = [
 
 [[package]]
 name = "slop-alloc"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "serde",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "slop-baby-bear"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "lazy_static",
  "p3-baby-bear",
  "serde",
- "slop-algebra 6.4.0",
- "slop-challenger 6.4.0",
- "slop-poseidon2 6.4.0",
- "slop-symmetric 6.4.0",
+ "slop-algebra 6.5.0",
+ "slop-challenger 6.5.0",
+ "slop-poseidon2 6.5.0",
+ "slop-symmetric 6.5.0",
 ]
 
 [[package]]
 name = "slop-basefold"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
  "serde",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
  "slop-baby-bear",
- "slop-bn254 6.4.0",
- "slop-challenger 6.4.0",
- "slop-koala-bear 6.4.0",
+ "slop-bn254 6.5.0",
+ "slop-challenger 6.5.0",
+ "slop-koala-bear 6.5.0",
  "slop-merkle-tree",
  "slop-multilinear",
- "slop-primitives 6.4.0",
+ "slop-primitives 6.5.0",
  "slop-tensor",
  "slop-utils",
  "thiserror 1.0.69",
@@ -6564,24 +6564,24 @@ dependencies = [
 
 [[package]]
 name = "slop-basefold-prover"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "derive-where",
  "futures",
  "itertools 0.14.0",
  "rand 0.8.6",
  "serde",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
  "slop-baby-bear",
  "slop-basefold",
- "slop-bn254 6.4.0",
- "slop-challenger 6.4.0",
+ "slop-bn254 6.5.0",
+ "slop-challenger 6.5.0",
  "slop-commit",
  "slop-dft",
  "slop-fri",
  "slop-futures",
- "slop-koala-bear 6.4.0",
+ "slop-koala-bear 6.5.0",
  "slop-merkle-tree",
  "slop-multilinear",
  "slop-tensor",
@@ -6605,15 +6605,15 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "ff",
  "p3-bn254-fr",
  "serde",
- "slop-algebra 6.4.0",
- "slop-challenger 6.4.0",
- "slop-poseidon2 6.4.0",
- "slop-symmetric 6.4.0",
+ "slop-algebra 6.5.0",
+ "slop-challenger 6.5.0",
+ "slop-poseidon2 6.5.0",
+ "slop-symmetric 6.5.0",
 ]
 
 [[package]]
@@ -6631,18 +6631,18 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "futures",
  "p3-challenger",
  "serde",
- "slop-algebra 6.4.0",
- "slop-symmetric 6.4.0",
+ "slop-algebra 6.5.0",
+ "slop-symmetric 6.5.0",
 ]
 
 [[package]]
 name = "slop-commit"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "p3-commit",
  "serde",
@@ -6651,11 +6651,11 @@ dependencies = [
 
 [[package]]
 name = "slop-dft"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "p3-dft",
  "serde",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
  "slop-matrix",
  "slop-tensor",
@@ -6663,14 +6663,14 @@ dependencies = [
 
 [[package]]
 name = "slop-fri"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "p3-fri",
 ]
 
 [[package]]
 name = "slop-futures"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "crossbeam",
  "futures",
@@ -6684,7 +6684,7 @@ dependencies = [
 
 [[package]]
 name = "slop-jagged"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "derive-where",
  "futures",
@@ -6693,21 +6693,21 @@ dependencies = [
  "rand 0.8.6",
  "rayon",
  "serde",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
  "slop-baby-bear",
  "slop-basefold",
  "slop-basefold-prover",
- "slop-bn254 6.4.0",
- "slop-challenger 6.4.0",
+ "slop-bn254 6.5.0",
+ "slop-challenger 6.5.0",
  "slop-commit",
  "slop-futures",
- "slop-koala-bear 6.4.0",
+ "slop-koala-bear 6.5.0",
  "slop-merkle-tree",
  "slop-multilinear",
  "slop-stacked",
  "slop-sumcheck",
- "slop-symmetric 6.4.0",
+ "slop-symmetric 6.5.0",
  "slop-tensor",
  "slop-utils",
  "thiserror 1.0.69",
@@ -6716,7 +6716,7 @@ dependencies = [
 
 [[package]]
 name = "slop-keccak-air"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "p3-keccak-air",
 ]
@@ -6738,51 +6738,51 @@ dependencies = [
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
  "serde",
- "slop-algebra 6.4.0",
- "slop-challenger 6.4.0",
- "slop-poseidon2 6.4.0",
- "slop-symmetric 6.4.0",
+ "slop-algebra 6.5.0",
+ "slop-challenger 6.5.0",
+ "slop-poseidon2 6.5.0",
+ "slop-symmetric 6.5.0",
 ]
 
 [[package]]
 name = "slop-matrix"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "p3-matrix",
 ]
 
 [[package]]
 name = "slop-maybe-rayon"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "p3-maybe-rayon",
 ]
 
 [[package]]
 name = "slop-merkle-tree"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
  "p3-merkle-tree",
  "rand 0.8.6",
  "serde",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
  "slop-baby-bear",
- "slop-bn254 6.4.0",
- "slop-challenger 6.4.0",
+ "slop-bn254 6.5.0",
+ "slop-challenger 6.5.0",
  "slop-commit",
  "slop-futures",
- "slop-koala-bear 6.4.0",
+ "slop-koala-bear 6.5.0",
  "slop-matrix",
- "slop-poseidon2 6.4.0",
- "slop-symmetric 6.4.0",
+ "slop-poseidon2 6.5.0",
+ "slop-symmetric 6.5.0",
  "slop-tensor",
  "slop-utils",
  "thiserror 1.0.69",
@@ -6790,7 +6790,7 @@ dependencies = [
 
 [[package]]
 name = "slop-multilinear"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "derive-where",
  "futures",
@@ -6799,10 +6799,10 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
  "slop-baby-bear",
- "slop-challenger 6.4.0",
+ "slop-challenger 6.5.0",
  "slop-commit",
  "slop-futures",
  "slop-matrix",
@@ -6811,16 +6811,16 @@ dependencies = [
 
 [[package]]
 name = "slop-pgspcs"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "futures",
  "rand 0.8.6",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
  "slop-baby-bear",
  "slop-basefold",
  "slop-basefold-prover",
- "slop-challenger 6.4.0",
+ "slop-challenger 6.5.0",
  "slop-commit",
  "slop-merkle-tree",
  "slop-multilinear",
@@ -6838,7 +6838,7 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "p3-poseidon2",
 ]
@@ -6854,22 +6854,22 @@ dependencies = [
 
 [[package]]
 name = "slop-primitives"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
 ]
 
 [[package]]
 name = "slop-spartan"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "futures",
  "itertools 0.14.0",
  "rand 0.8.6",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
  "slop-baby-bear",
- "slop-challenger 6.4.0",
+ "slop-challenger 6.5.0",
  "slop-merkle-tree",
  "slop-multilinear",
  "slop-pgspcs",
@@ -6879,19 +6879,19 @@ dependencies = [
 
 [[package]]
 name = "slop-stacked"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "derive-where",
  "futures",
  "itertools 0.14.0",
  "rand 0.8.6",
  "serde",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
  "slop-baby-bear",
  "slop-basefold",
  "slop-basefold-prover",
- "slop-challenger 6.4.0",
+ "slop-challenger 6.5.0",
  "slop-commit",
  "slop-futures",
  "slop-merkle-tree",
@@ -6902,17 +6902,17 @@ dependencies = [
 
 [[package]]
 name = "slop-sumcheck"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "futures",
  "itertools 0.14.0",
  "rand 0.8.6",
  "rayon",
  "serde",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
  "slop-baby-bear",
- "slop-challenger 6.4.0",
+ "slop-challenger 6.5.0",
  "slop-multilinear",
  "thiserror 1.0.69",
 ]
@@ -6928,14 +6928,14 @@ dependencies = [
 
 [[package]]
 name = "slop-symmetric"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "p3-symmetric",
 ]
 
 [[package]]
 name = "slop-tensor"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "arrayvec",
  "derive-where",
@@ -6944,7 +6944,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
  "slop-baby-bear",
  "slop-futures",
@@ -6955,14 +6955,14 @@ dependencies = [
 
 [[package]]
 name = "slop-uni-stark"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "p3-uni-stark",
 ]
 
 [[package]]
 name = "slop-utils"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "p3-util",
  "tracing-forest",
@@ -6971,7 +6971,7 @@ dependencies = [
 
 [[package]]
 name = "slop-veil"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "bincode",
  "derive-where",
@@ -6981,23 +6981,23 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rayon",
  "serde",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
  "slop-basefold",
  "slop-basefold-prover",
- "slop-challenger 6.4.0",
+ "slop-challenger 6.5.0",
  "slop-commit",
  "slop-dft",
  "slop-futures",
  "slop-jagged",
- "slop-koala-bear 6.4.0",
+ "slop-koala-bear 6.5.0",
  "slop-matrix",
  "slop-merkle-tree",
  "slop-multilinear",
- "slop-poseidon2 6.4.0",
+ "slop-poseidon2 6.5.0",
  "slop-stacked",
  "slop-sumcheck",
- "slop-symmetric 6.4.0",
+ "slop-symmetric 6.5.0",
  "slop-tensor",
  "slop-utils",
  "thiserror 1.0.69",
@@ -7006,7 +7006,7 @@ dependencies = [
 
 [[package]]
 name = "slop-whir"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "bincode",
  "derive-where",
@@ -7015,15 +7015,15 @@ dependencies = [
  "rand 0.8.6",
  "rayon",
  "serde",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
  "slop-baby-bear",
  "slop-basefold",
- "slop-challenger 6.4.0",
+ "slop-challenger 6.5.0",
  "slop-commit",
  "slop-dft",
  "slop-jagged",
- "slop-koala-bear 6.4.0",
+ "slop-koala-bear 6.5.0",
  "slop-matrix",
  "slop-merkle-tree",
  "slop-multilinear",
@@ -7075,19 +7075,19 @@ dependencies = [
 
 [[package]]
 name = "sp1-build"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
  "chrono",
  "clap",
  "dirs",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
 ]
 
 [[package]]
 name = "sp1-cli"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -7108,19 +7108,19 @@ dependencies = [
 
 [[package]]
 name = "sp1-constraint-compiler"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "clap",
  "serde_json",
  "slop-air",
  "sp1-core-machine",
  "sp1-hypercube",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
 ]
 
 [[package]]
 name = "sp1-core-executor"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -7144,13 +7144,13 @@ dependencies = [
  "serde_arrays",
  "serde_json",
  "slop-air",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-maybe-rayon",
- "slop-symmetric 6.4.0",
+ "slop-symmetric 6.5.0",
  "sp1-curves",
  "sp1-hypercube",
  "sp1-jit",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "sp1-zkvm",
  "strum",
  "subenum",
@@ -7164,7 +7164,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor-runner"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -7177,7 +7177,7 @@ dependencies = [
  "sp1-core-executor-runner-binary",
  "sp1-core-machine",
  "sp1-jit",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "sysinfo 0.30.13",
  "test-artifacts",
  "tracing",
@@ -7186,7 +7186,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor-runner-binary"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "bincode",
  "crash-handler",
@@ -7199,7 +7199,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-machine"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "bincode",
  "cfg-if",
@@ -7217,10 +7217,10 @@ dependencies = [
  "serde",
  "serde_json",
  "slop-air",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
  "slop-basefold",
- "slop-challenger 6.4.0",
+ "slop-challenger 6.5.0",
  "slop-futures",
  "slop-keccak-air",
  "slop-matrix",
@@ -7235,7 +7235,7 @@ dependencies = [
  "sp1-derive",
  "sp1-hypercube",
  "sp1-jit",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "static_assertions",
  "struct-reflection",
  "strum",
@@ -7253,7 +7253,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cuda"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "bincode",
  "bytes",
@@ -7263,7 +7263,7 @@ dependencies = [
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-hypercube",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "sp1-prover",
  "sp1-prover-types",
  "thiserror 1.0.69",
@@ -7273,7 +7273,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "cfg-if",
  "curve25519-dalek",
@@ -7288,15 +7288,15 @@ dependencies = [
  "rand 0.8.6",
  "rug",
  "serde",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "snowbridge-amcl",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "typenum",
 ]
 
 [[package]]
 name = "sp1-derive"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7305,42 +7305,42 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-air"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "lazy_static",
  "slop-air",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-matrix",
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-hypercube",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
 ]
 
 [[package]]
 name = "sp1-gpu-basefold"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "futures",
  "itertools 0.14.0",
  "rand 0.8.6",
  "serde",
  "serial_test",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
  "slop-basefold",
  "slop-basefold-prover",
- "slop-bn254 6.4.0",
- "slop-challenger 6.4.0",
+ "slop-bn254 6.5.0",
+ "slop-challenger 6.5.0",
  "slop-commit",
  "slop-dft",
  "slop-futures",
- "slop-koala-bear 6.4.0",
+ "slop-koala-bear 6.5.0",
  "slop-merkle-tree",
  "slop-multilinear",
- "slop-poseidon2 6.4.0",
+ "slop-poseidon2 6.5.0",
  "slop-stacked",
- "slop-symmetric 6.4.0",
+ "slop-symmetric 6.5.0",
  "slop-tensor",
  "sp1-core-machine",
  "sp1-gpu-challenger",
@@ -7352,7 +7352,7 @@ dependencies = [
  "sp1-gpu-tracegen",
  "sp1-gpu-utils",
  "sp1-hypercube",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "sp1-recursion-circuit",
  "sp1-recursion-compiler",
  "sp1-sdk",
@@ -7364,38 +7364,38 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-challenger"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
- "slop-challenger 6.4.0",
- "slop-koala-bear 6.4.0",
- "slop-poseidon2 6.4.0",
- "slop-symmetric 6.4.0",
+ "slop-challenger 6.5.0",
+ "slop-koala-bear 6.5.0",
+ "slop-poseidon2 6.5.0",
+ "slop-symmetric 6.5.0",
  "sp1-gpu-cudart",
  "sp1-hypercube",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "tokio",
 ]
 
 [[package]]
 name = "sp1-gpu-commit"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "criterion",
  "itertools 0.14.0",
  "rand 0.8.6",
  "serial_test",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
- "slop-challenger 6.4.0",
+ "slop-challenger 6.5.0",
  "slop-dft",
  "slop-futures",
  "slop-jagged",
- "slop-koala-bear 6.4.0",
+ "slop-koala-bear 6.5.0",
  "slop-merkle-tree",
  "slop-stacked",
- "slop-symmetric 6.4.0",
+ "slop-symmetric 6.5.0",
  "slop-tensor",
  "sp1-core-machine",
  "sp1-gpu-basefold",
@@ -7407,7 +7407,7 @@ dependencies = [
  "sp1-gpu-tracegen",
  "sp1-gpu-utils",
  "sp1-hypercube",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "sp1-recursion-circuit",
  "sp1-recursion-compiler",
  "sp1-sdk",
@@ -7419,28 +7419,28 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-cudart"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "crossbeam",
  "futures",
  "itertools 0.14.0",
  "pin-project",
  "rand 0.8.6",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
  "slop-basefold",
- "slop-challenger 6.4.0",
+ "slop-challenger 6.5.0",
  "slop-commit",
  "slop-futures",
  "slop-jagged",
- "slop-koala-bear 6.4.0",
+ "slop-koala-bear 6.5.0",
  "slop-multilinear",
  "slop-stacked",
  "slop-sumcheck",
  "slop-tensor",
  "sp1-gpu-sys",
  "sp1-hypercube",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -7448,28 +7448,28 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-jagged-assist"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "futures",
  "itertools 0.14.0",
  "rand 0.8.6",
  "serde",
  "serial_test",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
  "slop-basefold",
- "slop-bn254 6.4.0",
- "slop-challenger 6.4.0",
+ "slop-bn254 6.5.0",
+ "slop-challenger 6.5.0",
  "slop-commit",
  "slop-jagged",
- "slop-koala-bear 6.4.0",
+ "slop-koala-bear 6.5.0",
  "slop-multilinear",
  "slop-sumcheck",
  "slop-tensor",
  "sp1-gpu-challenger",
  "sp1-gpu-cudart",
  "sp1-gpu-tracing",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "sp1-prover",
  "tokio",
  "tracing",
@@ -7477,7 +7477,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-jagged-sumcheck"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "criterion",
  "futures",
@@ -7486,9 +7486,9 @@ dependencies = [
  "rand 0.8.6",
  "rayon",
  "serial_test",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
- "slop-challenger 6.4.0",
+ "slop-challenger 6.5.0",
  "slop-futures",
  "slop-jagged",
  "slop-multilinear",
@@ -7511,7 +7511,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-jagged-tracegen"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "criterion",
  "futures",
@@ -7522,9 +7522,9 @@ dependencies = [
  "serde_json",
  "serial_test",
  "slop-air",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
- "slop-challenger 6.4.0",
+ "slop-challenger 6.5.0",
  "slop-futures",
  "slop-jagged",
  "slop-multilinear",
@@ -7551,7 +7551,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-logup-gkr"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "criterion",
  "futures",
@@ -7562,19 +7562,19 @@ dependencies = [
  "serde_json",
  "serial_test",
  "slop-air",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
  "slop-basefold-prover",
- "slop-bn254 6.4.0",
- "slop-challenger 6.4.0",
+ "slop-bn254 6.5.0",
+ "slop-challenger 6.5.0",
  "slop-commit",
  "slop-dft",
  "slop-futures",
- "slop-koala-bear 6.4.0",
+ "slop-koala-bear 6.5.0",
  "slop-merkle-tree",
  "slop-multilinear",
  "slop-sumcheck",
- "slop-symmetric 6.4.0",
+ "slop-symmetric 6.5.0",
  "slop-tensor",
  "sp1-core-executor",
  "sp1-core-machine",
@@ -7584,7 +7584,7 @@ dependencies = [
  "sp1-gpu-utils",
  "sp1-gpu-zerocheck",
  "sp1-hypercube",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "sp1-recursion-circuit",
  "sp1-sdk",
  "test-artifacts",
@@ -7597,20 +7597,20 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-merkle-tree"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "serial_test",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
- "slop-bn254 6.4.0",
- "slop-challenger 6.4.0",
+ "slop-bn254 6.5.0",
+ "slop-challenger 6.5.0",
  "slop-commit",
  "slop-futures",
- "slop-koala-bear 6.4.0",
+ "slop-koala-bear 6.5.0",
  "slop-merkle-tree",
  "slop-multilinear",
  "slop-stacked",
- "slop-symmetric 6.4.0",
+ "slop-symmetric 6.5.0",
  "slop-tensor",
  "sp1-core-machine",
  "sp1-gpu-cudart",
@@ -7619,7 +7619,7 @@ dependencies = [
  "sp1-gpu-tracegen",
  "sp1-gpu-utils",
  "sp1-hypercube",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "sp1-recursion-circuit",
  "sp1-recursion-compiler",
  "test-artifacts",
@@ -7630,7 +7630,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-perf"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "bincode",
  "clap",
@@ -7644,7 +7644,7 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "serde_json",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-gpu-cudart",
@@ -7652,7 +7652,7 @@ dependencies = [
  "sp1-gpu-shard-prover",
  "sp1-gpu-tracing",
  "sp1-hypercube",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "sp1-prover",
  "sp1-prover-types",
  "sp1-recursion-circuit",
@@ -7670,18 +7670,18 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-prover"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "clap",
  "serde",
  "slop-air",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-basefold",
- "slop-bn254 6.4.0",
- "slop-challenger 6.4.0",
+ "slop-bn254 6.5.0",
+ "slop-challenger 6.5.0",
  "slop-futures",
  "slop-jagged",
- "slop-koala-bear 6.4.0",
+ "slop-koala-bear 6.5.0",
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-gpu-air",
@@ -7695,7 +7695,7 @@ dependencies = [
  "sp1-gpu-shard-prover",
  "sp1-gpu-tracegen",
  "sp1-hypercube",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "sp1-prover",
  "sp1-prover-types",
  "sysinfo 0.31.4",
@@ -7704,7 +7704,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-server"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "bincode",
  "clap",
@@ -7714,7 +7714,7 @@ dependencies = [
  "sp1-cuda",
  "sp1-gpu-cudart",
  "sp1-gpu-prover",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "sp1-prover",
  "sp1-prover-types",
  "sp1-recursion-gnark-ffi",
@@ -7726,17 +7726,17 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-shard-prover"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "criterion",
  "rand 0.8.6",
  "serde_json",
  "serial_test",
  "slop-air",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
  "slop-basefold",
- "slop-challenger 6.4.0",
+ "slop-challenger 6.5.0",
  "slop-commit",
  "slop-futures",
  "slop-jagged",
@@ -7759,7 +7759,7 @@ dependencies = [
  "sp1-gpu-utils",
  "sp1-gpu-zerocheck",
  "sp1-hypercube",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "sp1-recursion-circuit",
  "sp1-recursion-compiler",
  "test-artifacts",
@@ -7771,39 +7771,39 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-sys"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "cbindgen",
  "cmake",
  "pathdiff",
- "slop-koala-bear 6.4.0",
+ "slop-koala-bear 6.5.0",
  "sp1-core-executor",
  "sp1-core-machine",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "sp1-recursion-executor",
  "sp1-recursion-machine",
 ]
 
 [[package]]
 name = "sp1-gpu-tracegen"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "futures",
  "rand 0.8.6",
  "rayon",
  "slop-air",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
  "slop-futures",
- "slop-koala-bear 6.4.0",
+ "slop-koala-bear 6.5.0",
  "slop-multilinear",
- "slop-symmetric 6.4.0",
+ "slop-symmetric 6.5.0",
  "slop-tensor",
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-gpu-cudart",
  "sp1-hypercube",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "sp1-recursion-executor",
  "sp1-recursion-machine",
  "tokio",
@@ -7812,7 +7812,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-tracing"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "sp1-gpu-cudart",
  "tracing",
@@ -7821,18 +7821,18 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-utils"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "rand 0.8.6",
  "serial_test",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
- "slop-koala-bear 6.4.0",
+ "slop-koala-bear 6.5.0",
  "slop-stacked",
  "slop-tensor",
  "sp1-gpu-cudart",
  "sp1-gpu-prover",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "sp1-recursion-circuit",
  "sp1-recursion-compiler",
  "sp1-sdk",
@@ -7841,19 +7841,19 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-zerocheck"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "criterion",
  "itertools 0.14.0",
  "rand 0.8.6",
  "serial_test",
  "slop-air",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
- "slop-challenger 6.4.0",
+ "slop-challenger 6.5.0",
  "slop-commit",
  "slop-futures",
- "slop-koala-bear 6.4.0",
+ "slop-koala-bear 6.5.0",
  "slop-matrix",
  "slop-multilinear",
  "slop-stacked",
@@ -7869,7 +7869,7 @@ dependencies = [
  "sp1-gpu-tracegen",
  "sp1-gpu-utils",
  "sp1-hypercube",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "sp1-recursion-circuit",
  "sp1-recursion-compiler",
  "sp1-sdk",
@@ -7882,14 +7882,14 @@ dependencies = [
 
 [[package]]
 name = "sp1-helper"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "sp1-build",
 ]
 
 [[package]]
 name = "sp1-hypercube"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "arrayref",
  "deepsize2",
@@ -7905,28 +7905,28 @@ dependencies = [
  "rayon-scan",
  "serde",
  "slop-air",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
  "slop-basefold",
  "slop-basefold-prover",
- "slop-bn254 6.4.0",
- "slop-challenger 6.4.0",
+ "slop-bn254 6.5.0",
+ "slop-challenger 6.5.0",
  "slop-commit",
  "slop-futures",
  "slop-jagged",
- "slop-koala-bear 6.4.0",
+ "slop-koala-bear 6.5.0",
  "slop-matrix",
  "slop-merkle-tree",
  "slop-multilinear",
- "slop-poseidon2 6.4.0",
+ "slop-poseidon2 6.5.0",
  "slop-stacked",
  "slop-sumcheck",
- "slop-symmetric 6.4.0",
+ "slop-symmetric 6.5.0",
  "slop-tensor",
  "slop-uni-stark",
  "slop-whir",
  "sp1-derive",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "sp1-zkvm",
  "struct-reflection",
  "strum",
@@ -7938,7 +7938,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-jit"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "bincode",
  "dynasmrt",
@@ -7947,7 +7947,7 @@ dependencies = [
  "memfd",
  "memmap2",
  "serde",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "tracing",
  "uuid",
 ]
@@ -7966,17 +7966,17 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "bincode",
  "elliptic-curve",
  "serde",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
 ]
 
 [[package]]
 name = "sp1-perf"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -7986,12 +7986,12 @@ dependencies = [
  "dotenv",
  "rand 0.8.6",
  "rustyline",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-cuda",
  "sp1-hypercube",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "sp1-prover",
  "sp1-prover-types",
  "sp1-sdk",
@@ -8027,7 +8027,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -8038,18 +8038,18 @@ dependencies = [
  "num-bigint 0.4.6",
  "serde",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-algebra 6.4.0",
- "slop-bn254 6.4.0",
- "slop-challenger 6.4.0",
- "slop-koala-bear 6.4.0",
- "slop-poseidon2 6.4.0",
- "slop-primitives 6.4.0",
- "slop-symmetric 6.4.0",
+ "slop-algebra 6.5.0",
+ "slop-bn254 6.5.0",
+ "slop-challenger 6.5.0",
+ "slop-koala-bear 6.5.0",
+ "slop-poseidon2 6.5.0",
+ "slop-primitives 6.5.0",
+ "slop-symmetric 6.5.0",
 ]
 
 [[package]]
 name = "sp1-prover"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8076,22 +8076,22 @@ dependencies = [
  "serial_test",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "slop-air",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-basefold",
- "slop-bn254 6.4.0",
- "slop-challenger 6.4.0",
+ "slop-bn254 6.5.0",
+ "slop-challenger 6.5.0",
  "slop-futures",
  "slop-jagged",
  "slop-multilinear",
  "slop-stacked",
- "slop-symmetric 6.4.0",
+ "slop-symmetric 6.5.0",
  "sp1-core-executor",
  "sp1-core-executor-runner",
  "sp1-core-machine",
  "sp1-derive",
  "sp1-hypercube",
  "sp1-jit",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "sp1-prover-types",
  "sp1-recursion-circuit",
  "sp1-recursion-compiler",
@@ -8113,7 +8113,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover-types"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -8126,7 +8126,7 @@ dependencies = [
  "serde",
  "sp1-core-machine",
  "sp1-hypercube",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "tokio",
  "tonic 0.12.3",
  "tonic-build",
@@ -8135,7 +8135,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-circuit"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "bincode",
  "futures",
@@ -8144,29 +8144,29 @@ dependencies = [
  "rayon",
  "serde",
  "slop-air",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
  "slop-basefold",
  "slop-basefold-prover",
- "slop-bn254 6.4.0",
- "slop-challenger 6.4.0",
+ "slop-bn254 6.5.0",
+ "slop-challenger 6.5.0",
  "slop-commit",
  "slop-dft",
  "slop-jagged",
- "slop-koala-bear 6.4.0",
+ "slop-koala-bear 6.5.0",
  "slop-matrix",
  "slop-merkle-tree",
  "slop-multilinear",
  "slop-stacked",
  "slop-sumcheck",
- "slop-symmetric 6.4.0",
+ "slop-symmetric 6.5.0",
  "slop-tensor",
  "slop-whir",
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-derive",
  "sp1-hypercube",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "sp1-recursion-compiler",
  "sp1-recursion-executor",
  "sp1-recursion-gnark-ffi",
@@ -8178,19 +8178,19 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-compiler"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "backtrace",
  "cfg-if",
  "itertools 0.14.0",
  "rand 0.8.6",
  "serde",
- "slop-algebra 6.4.0",
- "slop-bn254 6.4.0",
- "slop-symmetric 6.4.0",
+ "slop-algebra 6.5.0",
+ "slop-bn254 6.5.0",
+ "slop-symmetric 6.5.0",
  "sp1-core-machine",
  "sp1-hypercube",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "sp1-recursion-executor",
  "tracing",
  "vec_map",
@@ -8198,7 +8198,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-executor"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -8206,10 +8206,10 @@ dependencies = [
  "itertools 0.14.0",
  "range-set-blaze",
  "serde",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-maybe-rayon",
- "slop-poseidon2 6.4.0",
- "slop-symmetric 6.4.0",
+ "slop-poseidon2 6.5.0",
+ "slop-symmetric 6.5.0",
  "smallvec",
  "sp1-derive",
  "sp1-hypercube",
@@ -8220,7 +8220,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-cli"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "bincode",
  "clap",
@@ -8229,7 +8229,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-ffi"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8240,10 +8240,10 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-algebra 6.4.0",
- "slop-symmetric 6.4.0",
+ "slop-algebra 6.5.0",
+ "slop-symmetric 6.5.0",
  "sp1-hypercube",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "sp1-recursion-compiler",
  "sp1-verifier",
  "tempfile",
@@ -8252,21 +8252,21 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-machine"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.6",
  "slop-air",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-basefold",
- "slop-challenger 6.4.0",
+ "slop-challenger 6.5.0",
  "slop-matrix",
  "slop-maybe-rayon",
- "slop-symmetric 6.4.0",
+ "slop-symmetric 6.5.0",
  "sp1-core-machine",
  "sp1-derive",
  "sp1-hypercube",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "sp1-recursion-executor",
  "strum",
  "tokio",
@@ -8275,7 +8275,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-sdk"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -8309,7 +8309,7 @@ dependencies = [
  "sp1-core-machine",
  "sp1-cuda",
  "sp1-hypercube",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "sp1-prover",
  "sp1-prover-types",
  "sp1-recursion-executor",
@@ -8329,7 +8329,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-verifier"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -8346,12 +8346,12 @@ dependencies = [
  "serde",
  "serial_test",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-algebra 6.4.0",
- "slop-challenger 6.4.0",
- "slop-primitives 6.4.0",
- "slop-symmetric 6.4.0",
+ "slop-algebra 6.5.0",
+ "slop-challenger 6.5.0",
+ "slop-primitives 6.5.0",
+ "slop-symmetric 6.5.0",
  "sp1-hypercube",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "sp1-recursion-executor",
  "sp1-recursion-machine",
  "sp1-sdk",
@@ -8364,7 +8364,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "blake3",
  "cfg-if",
@@ -8376,9 +8376,9 @@ dependencies = [
  "libm",
  "rand 0.8.6",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-algebra 6.4.0",
- "sp1-lib 6.4.0",
- "sp1-primitives 6.4.0",
+ "slop-algebra 6.5.0",
+ "sp1-lib 6.5.0",
+ "sp1-primitives 6.5.0",
 ]
 
 [[package]]
@@ -8658,7 +8658,7 @@ dependencies = [
 
 [[package]]
 name = "test-artifacts"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "sp1-build",
 ]
@@ -10334,7 +10334,7 @@ dependencies = [
 
 [[package]]
 name = "zkevm-build-sdk"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "sp1-build",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "6.4.0"
+version = "6.5.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/succinctlabs/sp1"
@@ -118,53 +118,53 @@ debug = true
 debug-assertions = true
 
 [workspace.dependencies]
-sp1-build = { version = "6.4.0", path = "crates/build" }
-sp1-cli = { version = "6.4.0", path = "crates/cli", default-features = false }
-sp1-core-executor = { version = "6.4.0", path = "crates/core/executor" }
-sp1-core-executor-runner = { version = "6.4.0", path = "crates/core/runner" }
-sp1-core-executor-runner-binary = { version = "6.4.0", path = "crates/core/runner-binary" }
-sp1-core-machine = { version = "6.4.0", path = "crates/core/machine" }
-sp1-cuda = { version = "6.4.0", path = "crates/cuda" }
-sp1-curves = { version = "6.4.0", path = "crates/curves" }
-sp1-derive = { version = "6.4.0", path = "crates/derive" }
-# sp1-eval = { version = "6.4.0", path = "crates/eval" }
-sp1-helper = { version = "6.4.0", path = "crates/helper", default-features = false }
-sp1-hypercube = { version = "6.4.0", path = "crates/hypercube" }
-sp1-jit = { version = "6.4.0", path = "crates/core/jit" }
-sp1-lib = { version = "6.4.0", path = "crates/zkvm/lib", default-features = false }
-sp1-primitives = { version = "6.4.0", path = "crates/primitives" }
-sp1-prover = { version = "6.4.0", path = "crates/prover" }
-sp1-prover-types = { version = "6.4.0", path = "crates/prover-types" }
-sp1-recursion-circuit = { version = "6.4.0", path = "crates/recursion/circuit", default-features = false }
-sp1-recursion-compiler = { version = "6.4.0", path = "crates/recursion/compiler" }
-sp1-recursion-executor = { version = "6.4.0", path = "crates/recursion/executor", default-features = false }
-sp1-recursion-gnark-ffi = { version = "6.4.0", path = "crates/recursion/gnark-ffi", default-features = false }
-sp1-recursion-machine = { version = "6.4.0", path = "crates/recursion/machine", default-features = false }
-sp1-sdk = { version = "6.4.0", path = "crates/sdk", default-features = false }
-sp1-verifier = { version = "6.4.0", path = "crates/verifier", default-features = false, features = ["full"] }
-sp1-zkvm = { version = "6.4.0", path = "crates/zkvm/entrypoint", default-features = false }
+sp1-build = { version = "6.5.0", path = "crates/build" }
+sp1-cli = { version = "6.5.0", path = "crates/cli", default-features = false }
+sp1-core-executor = { version = "6.5.0", path = "crates/core/executor" }
+sp1-core-executor-runner = { version = "6.5.0", path = "crates/core/runner" }
+sp1-core-executor-runner-binary = { version = "6.5.0", path = "crates/core/runner-binary" }
+sp1-core-machine = { version = "6.5.0", path = "crates/core/machine" }
+sp1-cuda = { version = "6.5.0", path = "crates/cuda" }
+sp1-curves = { version = "6.5.0", path = "crates/curves" }
+sp1-derive = { version = "6.5.0", path = "crates/derive" }
+# sp1-eval = { version = "6.5.0", path = "crates/eval" }
+sp1-helper = { version = "6.5.0", path = "crates/helper", default-features = false }
+sp1-hypercube = { version = "6.5.0", path = "crates/hypercube" }
+sp1-jit = { version = "6.5.0", path = "crates/core/jit" }
+sp1-lib = { version = "6.5.0", path = "crates/zkvm/lib", default-features = false }
+sp1-primitives = { version = "6.5.0", path = "crates/primitives" }
+sp1-prover = { version = "6.5.0", path = "crates/prover" }
+sp1-prover-types = { version = "6.5.0", path = "crates/prover-types" }
+sp1-recursion-circuit = { version = "6.5.0", path = "crates/recursion/circuit", default-features = false }
+sp1-recursion-compiler = { version = "6.5.0", path = "crates/recursion/compiler" }
+sp1-recursion-executor = { version = "6.5.0", path = "crates/recursion/executor", default-features = false }
+sp1-recursion-gnark-ffi = { version = "6.5.0", path = "crates/recursion/gnark-ffi", default-features = false }
+sp1-recursion-machine = { version = "6.5.0", path = "crates/recursion/machine", default-features = false }
+sp1-sdk = { version = "6.5.0", path = "crates/sdk", default-features = false }
+sp1-verifier = { version = "6.5.0", path = "crates/verifier", default-features = false, features = ["full"] }
+sp1-zkvm = { version = "6.5.0", path = "crates/zkvm/entrypoint", default-features = false }
 test-artifacts = { path = "crates/test-artifacts" }
 
 # sp1-gpu crates
-sp1-gpu-air = { version = "6.4.0", path = "sp1-gpu/crates/air" }
-sp1-gpu-basefold = { version = "6.4.0", path = "sp1-gpu/crates/basefold" }
-sp1-gpu-challenger = { version = "6.4.0", path = "sp1-gpu/crates/challenger" }
-sp1-gpu-commit = { version = "6.4.0", path = "sp1-gpu/crates/commit" }
-sp1-gpu-cudart = { version = "6.4.0", path = "sp1-gpu/crates/cuda" }
-sp1-gpu-jagged-assist = { version = "6.4.0", path = "sp1-gpu/crates/jagged_assist" }
-sp1-gpu-jagged-sumcheck = { version = "6.4.0", path = "sp1-gpu/crates/jagged_sumcheck" }
-sp1-gpu-jagged-tracegen = { version = "6.4.0", path = "sp1-gpu/crates/jagged_tracegen" }
-sp1-gpu-logup-gkr = { version = "6.4.0", path = "sp1-gpu/crates/logup_gkr" }
-sp1-gpu-merkle-tree = { version = "6.4.0", path = "sp1-gpu/crates/merkle_tree" }
-sp1-gpu-perf = { version = "6.4.0", path = "sp1-gpu/crates/perf" }
-sp1-gpu-prover = { version = "6.4.0", path = "sp1-gpu/crates/prover_components" }
-sp1-gpu-server = { version = "6.4.0", path = "sp1-gpu/crates/server" }
-sp1-gpu-shard-prover = { version = "6.4.0", path = "sp1-gpu/crates/shard_prover" }
-sp1-gpu-sys = { version = "6.4.0", path = "sp1-gpu/crates/sys" }
-sp1-gpu-tracegen = { version = "6.4.0", path = "sp1-gpu/crates/tracegen" }
-sp1-gpu-tracing = { version = "6.4.0", path = "sp1-gpu/crates/tracing" }
-sp1-gpu-utils = { version = "6.4.0", path = "sp1-gpu/crates/utils" }
-sp1-gpu-zerocheck = { version = "6.4.0", path = "sp1-gpu/crates/zerocheck" }
+sp1-gpu-air = { version = "6.5.0", path = "sp1-gpu/crates/air" }
+sp1-gpu-basefold = { version = "6.5.0", path = "sp1-gpu/crates/basefold" }
+sp1-gpu-challenger = { version = "6.5.0", path = "sp1-gpu/crates/challenger" }
+sp1-gpu-commit = { version = "6.5.0", path = "sp1-gpu/crates/commit" }
+sp1-gpu-cudart = { version = "6.5.0", path = "sp1-gpu/crates/cuda" }
+sp1-gpu-jagged-assist = { version = "6.5.0", path = "sp1-gpu/crates/jagged_assist" }
+sp1-gpu-jagged-sumcheck = { version = "6.5.0", path = "sp1-gpu/crates/jagged_sumcheck" }
+sp1-gpu-jagged-tracegen = { version = "6.5.0", path = "sp1-gpu/crates/jagged_tracegen" }
+sp1-gpu-logup-gkr = { version = "6.5.0", path = "sp1-gpu/crates/logup_gkr" }
+sp1-gpu-merkle-tree = { version = "6.5.0", path = "sp1-gpu/crates/merkle_tree" }
+sp1-gpu-perf = { version = "6.5.0", path = "sp1-gpu/crates/perf" }
+sp1-gpu-prover = { version = "6.5.0", path = "sp1-gpu/crates/prover_components" }
+sp1-gpu-server = { version = "6.5.0", path = "sp1-gpu/crates/server" }
+sp1-gpu-shard-prover = { version = "6.5.0", path = "sp1-gpu/crates/shard_prover" }
+sp1-gpu-sys = { version = "6.5.0", path = "sp1-gpu/crates/sys" }
+sp1-gpu-tracegen = { version = "6.5.0", path = "sp1-gpu/crates/tracegen" }
+sp1-gpu-tracing = { version = "6.5.0", path = "sp1-gpu/crates/tracing" }
+sp1-gpu-utils = { version = "6.5.0", path = "sp1-gpu/crates/utils" }
+sp1-gpu-zerocheck = { version = "6.5.0", path = "sp1-gpu/crates/zerocheck" }
 
 p3-air = "=0.4.3-succinct"
 p3-baby-bear = "=0.4.3-succinct"
@@ -184,37 +184,37 @@ p3-symmetric = "=0.4.3-succinct"
 p3-uni-stark = "=0.4.3-succinct"
 p3-util = "=0.4.3-succinct"
 
-slop-air = { version = "6.4.0", path = "./slop/crates/air" }
-slop-algebra = { version = "6.4.0", path = "./slop/crates/algebra" }
-slop-alloc = { version = "6.4.0", path = "./slop/crates/alloc" }
-slop-baby-bear = { version = "6.4.0", path = "./slop/crates/baby-bear" }
-slop-basefold = { version = "6.4.0", path = "./slop/crates/basefold" }
-slop-basefold-prover = { version = "6.4.0", path = "./slop/crates/basefold-prover" }
-slop-bn254 = { version = "6.4.0", path = "./slop/crates/bn254" }
-slop-challenger = { version = "6.4.0", path = "./slop/crates/challenger" }
-slop-commit = { version = "6.4.0", path = "./slop/crates/commit" }
-slop-dft = { version = "6.4.0", path = "./slop/crates/dft" }
-slop-fri = { version = "6.4.0", path = "./slop/crates/fri" }
-slop-futures = { version = "6.4.0", path = "./slop/crates/futures" }
-slop-jagged = { version = "6.4.0", path = "./slop/crates/jagged" }
-slop-keccak-air = { version = "6.4.0", path = "./slop/crates/keccak-air" }
-slop-koala-bear = { version = "6.4.0", path = "./slop/crates/koala-bear" }
-slop-matrix = { version = "6.4.0", path = "./slop/crates/matrix" }
-slop-maybe-rayon = { version = "6.4.0", path = "./slop/crates/maybe-rayon" }
-slop-merkle-tree = { version = "6.4.0", path = "./slop/crates/merkle-tree" }
-slop-multilinear = { version = "6.4.0", path = "./slop/crates/multilinear" }
-slop-pgspcs = { version = "6.4.0", path = "./slop/crates/pgspcs" }
-slop-primitives = { version = "6.4.0", path = "./slop/crates/primitives" }
-slop-poseidon2 = { version = "6.4.0", path = "./slop/crates/poseidon2" }
-slop-spartan = { version = "6.4.0", path = "./slop/crates/spartan" }
-slop-stacked = { version = "6.4.0", path = "./slop/crates/stacked" }
-slop-sumcheck = { version = "6.4.0", path = "./slop/crates/sumcheck" }
-slop-symmetric = { version = "6.4.0", path = "./slop/crates/symmetric" }
-slop-tensor = { version = "6.4.0", path = "./slop/crates/tensor" }
-slop-uni-stark = { version = "6.4.0", path = "./slop/crates/uni-stark" }
-slop-utils = { version = "6.4.0", path = "./slop/crates/utils" }
-slop-veil = { version = "6.4.0", path = "./slop/crates/veil" }
-slop-whir = { version = "6.4.0", path = "./slop/crates/whir" }
+slop-air = { version = "6.5.0", path = "./slop/crates/air" }
+slop-algebra = { version = "6.5.0", path = "./slop/crates/algebra" }
+slop-alloc = { version = "6.5.0", path = "./slop/crates/alloc" }
+slop-baby-bear = { version = "6.5.0", path = "./slop/crates/baby-bear" }
+slop-basefold = { version = "6.5.0", path = "./slop/crates/basefold" }
+slop-basefold-prover = { version = "6.5.0", path = "./slop/crates/basefold-prover" }
+slop-bn254 = { version = "6.5.0", path = "./slop/crates/bn254" }
+slop-challenger = { version = "6.5.0", path = "./slop/crates/challenger" }
+slop-commit = { version = "6.5.0", path = "./slop/crates/commit" }
+slop-dft = { version = "6.5.0", path = "./slop/crates/dft" }
+slop-fri = { version = "6.5.0", path = "./slop/crates/fri" }
+slop-futures = { version = "6.5.0", path = "./slop/crates/futures" }
+slop-jagged = { version = "6.5.0", path = "./slop/crates/jagged" }
+slop-keccak-air = { version = "6.5.0", path = "./slop/crates/keccak-air" }
+slop-koala-bear = { version = "6.5.0", path = "./slop/crates/koala-bear" }
+slop-matrix = { version = "6.5.0", path = "./slop/crates/matrix" }
+slop-maybe-rayon = { version = "6.5.0", path = "./slop/crates/maybe-rayon" }
+slop-merkle-tree = { version = "6.5.0", path = "./slop/crates/merkle-tree" }
+slop-multilinear = { version = "6.5.0", path = "./slop/crates/multilinear" }
+slop-pgspcs = { version = "6.5.0", path = "./slop/crates/pgspcs" }
+slop-primitives = { version = "6.5.0", path = "./slop/crates/primitives" }
+slop-poseidon2 = { version = "6.5.0", path = "./slop/crates/poseidon2" }
+slop-spartan = { version = "6.5.0", path = "./slop/crates/spartan" }
+slop-stacked = { version = "6.5.0", path = "./slop/crates/stacked" }
+slop-sumcheck = { version = "6.5.0", path = "./slop/crates/sumcheck" }
+slop-symmetric = { version = "6.5.0", path = "./slop/crates/symmetric" }
+slop-tensor = { version = "6.5.0", path = "./slop/crates/tensor" }
+slop-uni-stark = { version = "6.5.0", path = "./slop/crates/uni-stark" }
+slop-utils = { version = "6.5.0", path = "./slop/crates/utils" }
+slop-veil = { version = "6.5.0", path = "./slop/crates/veil" }
+slop-whir = { version = "6.5.0", path = "./slop/crates/whir" }
 
 # For testing.
 tokio-test = "0.4.4"

--- a/crates/test-artifacts/programs/Cargo.lock
+++ b/crates/test-artifacts/programs/Cargo.lock
@@ -406,7 +406,7 @@ version = "1.1.0"
 dependencies = [
  "common-test-utils",
  "sp1-curves",
- "sp1-lib 6.4.0",
+ "sp1-lib 6.5.0",
  "sp1-zkvm",
 ]
 
@@ -449,7 +449,7 @@ name = "bls12381-mul-test"
 version = "1.1.0"
 dependencies = [
  "sp1-derive",
- "sp1-lib 6.4.0",
+ "sp1-lib 6.5.0",
  "sp1-zkvm",
 ]
 
@@ -459,7 +459,7 @@ version = "1.1.0"
 dependencies = [
  "common-test-utils",
  "sp1-curves",
- "sp1-lib 6.4.0",
+ "sp1-lib 6.5.0",
  "sp1-zkvm",
 ]
 
@@ -502,7 +502,7 @@ name = "bn254-mul-test"
 version = "1.1.0"
 dependencies = [
  "sp1-derive",
- "sp1-lib 6.4.0",
+ "sp1-lib 6.5.0",
  "sp1-zkvm",
 ]
 
@@ -572,7 +572,7 @@ name = "common-test-utils"
 version = "1.1.0"
 dependencies = [
  "num-bigint 0.4.6",
- "sp1-lib 6.4.0",
+ "sp1-lib 6.5.0",
 ]
 
 [[package]]
@@ -710,7 +710,7 @@ dependencies = [
  "digest 0.10.7",
  "fiat-crypto",
  "rustc_version 0.4.1",
- "sp1-lib 6.4.0",
+ "sp1-lib 6.5.0",
  "subtle",
  "zeroize",
 ]
@@ -2501,7 +2501,7 @@ version = "1.1.0"
 dependencies = [
  "common-test-utils",
  "sp1-curves",
- "sp1-lib 6.4.0",
+ "sp1-lib 6.5.0",
  "sp1-zkvm",
 ]
 
@@ -2537,7 +2537,7 @@ dependencies = [
  "num",
  "p256",
  "sp1-curves",
- "sp1-lib 6.4.0",
+ "sp1-lib 6.5.0",
  "sp1-zkvm",
 ]
 
@@ -2558,7 +2558,7 @@ dependencies = [
  "num",
  "p256",
  "sp1-curves",
- "sp1-lib 6.4.0",
+ "sp1-lib 6.5.0",
  "sp1-zkvm",
 ]
 
@@ -2782,7 +2782,7 @@ checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "slop-algebra"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -2791,7 +2791,7 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "ff",
  "p3-bn254-fr",
@@ -2804,7 +2804,7 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "futures",
  "p3-challenger",
@@ -2815,7 +2815,7 @@ dependencies = [
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -2828,21 +2828,21 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "p3-poseidon2",
 ]
 
 [[package]]
 name = "slop-primitives"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "slop-algebra",
 ]
 
 [[package]]
 name = "slop-symmetric"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "p3-symmetric",
 ]
@@ -2859,7 +2859,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "cfg-if",
  "curve25519-dalek 4.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2880,7 +2880,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-derive"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2899,7 +2899,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "bincode",
  "elliptic-curve",
@@ -2909,7 +2909,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -2931,7 +2931,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -2943,7 +2943,7 @@ dependencies = [
  "rand 0.8.5",
  "sha2 0.10.9",
  "slop-algebra",
- "sp1-lib 6.4.0",
+ "sp1-lib 6.5.0",
  "sp1-primitives",
 ]
 
@@ -3192,7 +3192,7 @@ source = "git+https://github.com/sp1-patches/tiny-keccak?tag=patch-2.0.2-sp1-6.2
 dependencies = [
  "cfg-if",
  "crunchy",
- "sp1-lib 6.4.0",
+ "sp1-lib 6.5.0",
 ]
 
 [[package]]

--- a/crates/test-artifacts/programs/fibonacci-blake3/Cargo.lock
+++ b/crates/test-artifacts/programs/fibonacci-blake3/Cargo.lock
@@ -754,7 +754,7 @@ checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "slop-algebra"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -763,7 +763,7 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "ff",
  "p3-bn254-fr",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "futures",
  "p3-challenger",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -800,28 +800,28 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "p3-poseidon2",
 ]
 
 [[package]]
 name = "slop-primitives"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "slop-algebra",
 ]
 
 [[package]]
 name = "slop-symmetric"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "p3-symmetric",
 ]
 
 [[package]]
 name = "sp1-lib"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "bincode",
  "serde",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -852,7 +852,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "blake3",
  "cfg-if",

--- a/crates/test-artifacts/programs/trap-exec/Cargo.lock
+++ b/crates/test-artifacts/programs/trap-exec/Cargo.lock
@@ -756,7 +756,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slop-algebra"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "ff",
  "p3-bn254-fr",
@@ -778,7 +778,7 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "futures",
  "p3-challenger",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -802,28 +802,28 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "p3-poseidon2",
 ]
 
 [[package]]
 name = "slop-primitives"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "slop-algebra",
 ]
 
 [[package]]
 name = "slop-symmetric"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "p3-symmetric",
 ]
 
 [[package]]
 name = "sp1-derive"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "bincode",
  "serde",
@@ -841,7 +841,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "cfg-if",
  "critical-section",

--- a/crates/test-artifacts/programs/trap-load-store/Cargo.lock
+++ b/crates/test-artifacts/programs/trap-load-store/Cargo.lock
@@ -756,7 +756,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slop-algebra"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "ff",
  "p3-bn254-fr",
@@ -778,7 +778,7 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "futures",
  "p3-challenger",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -802,28 +802,28 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "p3-poseidon2",
 ]
 
 [[package]]
 name = "slop-primitives"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "slop-algebra",
 ]
 
 [[package]]
 name = "slop-symmetric"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "p3-symmetric",
 ]
 
 [[package]]
 name = "sp1-derive"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "bincode",
  "serde",
@@ -841,7 +841,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "cfg-if",
  "critical-section",

--- a/crates/verifier/guest-verify-programs/Cargo.lock
+++ b/crates/verifier/guest-verify-programs/Cargo.lock
@@ -943,7 +943,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slop-algebra"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "ff",
  "p3-bn254-fr",
@@ -965,7 +965,7 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "futures",
  "p3-challenger",
@@ -976,7 +976,7 @@ dependencies = [
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -989,28 +989,28 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "p3-poseidon2",
 ]
 
 [[package]]
 name = "slop-primitives"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "slop-algebra",
 ]
 
 [[package]]
 name = "slop-symmetric"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "p3-symmetric",
 ]
 
 [[package]]
 name = "sp1-lib"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "bincode",
  "elliptic-curve",
@@ -1020,7 +1020,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -1042,7 +1042,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-verifier"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "blake3",
  "cfg-if",
@@ -1056,7 +1056,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "blake3",
  "cfg-if",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1455,6 +1455,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "git+https://github.com/sp1-patches/curve25519-dalek?tag=patch-4.1.3-sp1-6.2.0#b251b2a155f859d00375f73bc2c937f025f7b4b4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "fiat-crypto",
+ "group",
+ "rand_core 0.6.4",
+ "rustc_version 0.4.1",
+ "sp1-lib",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "git+https://github.com/sp1-patches/curve25519-dalek?tag=patch-4.1.3-sp1-6.2.0#b251b2a155f859d00375f73bc2c937f025f7b4b4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "curve25519-dalek-ng"
 version = "4.1.1"
 source = "git+https://github.com/sp1-patches/curve25519-dalek-ng?tag=patch-4.1.1-sp1-6.2.0#3c58f6af72122ec3cb6c15731c958c541a910050"
@@ -2159,6 +2185,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "fibonacci-cuda-program"
@@ -6190,14 +6222,14 @@ checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "slop-air"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "p3-air",
 ]
 
 [[package]]
 name = "slop-algebra"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -6206,7 +6238,7 @@ dependencies = [
 
 [[package]]
 name = "slop-alloc"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "serde",
  "slop-algebra",
@@ -6215,7 +6247,7 @@ dependencies = [
 
 [[package]]
 name = "slop-baby-bear"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "lazy_static",
  "p3-baby-bear",
@@ -6228,7 +6260,7 @@ dependencies = [
 
 [[package]]
 name = "slop-basefold"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -6249,7 +6281,7 @@ dependencies = [
 
 [[package]]
 name = "slop-basefold-prover"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -6274,7 +6306,7 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "ff",
  "p3-bn254-fr",
@@ -6287,7 +6319,7 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "futures",
  "p3-challenger",
@@ -6298,7 +6330,7 @@ dependencies = [
 
 [[package]]
 name = "slop-commit"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "p3-commit",
  "serde",
@@ -6307,7 +6339,7 @@ dependencies = [
 
 [[package]]
 name = "slop-dft"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "p3-dft",
  "serde",
@@ -6319,14 +6351,14 @@ dependencies = [
 
 [[package]]
 name = "slop-fri"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "p3-fri",
 ]
 
 [[package]]
 name = "slop-futures"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "crossbeam",
  "futures",
@@ -6339,7 +6371,7 @@ dependencies = [
 
 [[package]]
 name = "slop-jagged"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "derive-where",
  "futures",
@@ -6371,14 +6403,14 @@ dependencies = [
 
 [[package]]
 name = "slop-keccak-air"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "p3-keccak-air",
 ]
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -6391,21 +6423,21 @@ dependencies = [
 
 [[package]]
 name = "slop-matrix"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "p3-matrix",
 ]
 
 [[package]]
 name = "slop-maybe-rayon"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "p3-maybe-rayon",
 ]
 
 [[package]]
 name = "slop-merkle-tree"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -6429,7 +6461,7 @@ dependencies = [
 
 [[package]]
 name = "slop-multilinear"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "derive-where",
  "futures",
@@ -6448,21 +6480,21 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "p3-poseidon2",
 ]
 
 [[package]]
 name = "slop-primitives"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "slop-algebra",
 ]
 
 [[package]]
 name = "slop-stacked"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "derive-where",
  "futures",
@@ -6483,7 +6515,7 @@ dependencies = [
 
 [[package]]
 name = "slop-sumcheck"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -6499,14 +6531,14 @@ dependencies = [
 
 [[package]]
 name = "slop-symmetric"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "p3-symmetric",
 ]
 
 [[package]]
 name = "slop-tensor"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "arrayvec 0.7.6",
  "derive-where",
@@ -6524,14 +6556,14 @@ dependencies = [
 
 [[package]]
 name = "slop-uni-stark"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "p3-uni-stark",
 ]
 
 [[package]]
 name = "slop-utils"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "p3-util",
  "tracing-forest",
@@ -6540,7 +6572,7 @@ dependencies = [
 
 [[package]]
 name = "slop-whir"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "derive-where",
  "futures",
@@ -6607,7 +6639,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-build"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -6619,7 +6651,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -6658,7 +6690,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor-runner"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -6678,7 +6710,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor-runner-binary"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "bincode",
  "crash-handler",
@@ -6691,7 +6723,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-machine"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "bincode",
  "cfg-if",
@@ -6738,7 +6770,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cuda"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "bincode",
  "bytes",
@@ -6758,12 +6790,14 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "cfg-if",
+ "curve25519-dalek",
  "dashu",
  "elliptic-curve",
  "generic-array 1.1.0",
+ "group",
  "itertools 0.14.0",
  "k256",
  "num",
@@ -6777,7 +6811,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-derive"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6786,7 +6820,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-hypercube"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "arrayref",
  "deepsize2",
@@ -6833,7 +6867,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-jit"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "dynasmrt",
  "hashbrown 0.14.5",
@@ -6848,7 +6882,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "bincode",
  "elliptic-curve",
@@ -6858,7 +6892,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -6880,7 +6914,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6943,7 +6977,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover-types"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -6965,7 +6999,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-circuit"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "bincode",
  "itertools 0.14.0",
@@ -7003,7 +7037,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-compiler"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -7022,7 +7056,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-executor"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -7044,7 +7078,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-ffi"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -7066,7 +7100,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-machine"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.5",
@@ -7086,7 +7120,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-sdk"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7122,7 +7156,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-verifier"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -7147,7 +7181,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -8927,11 +8961,6 @@ name = "zmij"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fc5a66a20078bf1251bde995aa2fdcc4b800c70b5d92dd2c62abc5c60f679f8"
-
-[[patch.unused]]
-name = "curve25519-dalek"
-version = "4.1.3"
-source = "git+https://github.com/sp1-patches/curve25519-dalek?tag=patch-4.1.3-sp1-6.2.0#b251b2a155f859d00375f73bc2c937f025f7b4b4"
 
 [[patch.unused]]
 name = "sha2"

--- a/patch-testing/secp256k1/program-v0.29.1/Cargo.lock
+++ b/patch-testing/secp256k1/program-v0.29.1/Cargo.lock
@@ -927,7 +927,7 @@ checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "slop-algebra"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "ff",
  "p3-bn254-fr",
@@ -949,7 +949,7 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "futures",
  "p3-challenger",
@@ -960,7 +960,7 @@ dependencies = [
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -973,28 +973,28 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "p3-poseidon2",
 ]
 
 [[package]]
 name = "slop-primitives"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "slop-algebra",
 ]
 
 [[package]]
 name = "slop-symmetric"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "p3-symmetric",
 ]
 
 [[package]]
 name = "sp1-lib"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "bincode",
  "elliptic-curve",
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "cfg-if",
  "critical-section",

--- a/zkevm/examples/Cargo.lock
+++ b/zkevm/examples/Cargo.lock
@@ -2025,6 +2025,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "fiat-crypto",
+ "group",
+ "rand_core 0.6.4",
+ "rustc_version 0.4.1",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2616,6 +2643,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "fibonacci"
@@ -3664,7 +3697,7 @@ dependencies = [
 
 [[package]]
 name = "libzkevm"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "bls12_381",
  "k256 0.13.4 (git+https://github.com/sp1-patches/elliptic-curves?tag=patch-k256-13.4-sp1-6.2.0)",
@@ -5868,16 +5901,16 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slop-air"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "p3-air",
 ]
 
 [[package]]
 name = "slop-algebra"
-version = "6.3.1"
+version = "6.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c112cafd4c5c374d267a48c8976d12fca3b0f2cc2e44e6fb1343808310b4fc6"
+checksum = "546efc4c8df95113752bce97387423a67ebe9ee5dd01170819dc1ca467d006d4"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -5886,7 +5919,7 @@ dependencies = [
 
 [[package]]
 name = "slop-algebra"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -5895,42 +5928,42 @@ dependencies = [
 
 [[package]]
 name = "slop-alloc"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "serde",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "slop-baby-bear"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "lazy_static",
  "p3-baby-bear",
  "serde",
- "slop-algebra 6.4.0",
- "slop-challenger 6.4.0",
- "slop-poseidon2 6.4.0",
- "slop-symmetric 6.4.0",
+ "slop-algebra 6.5.0",
+ "slop-challenger 6.5.0",
+ "slop-poseidon2 6.5.0",
+ "slop-symmetric 6.5.0",
 ]
 
 [[package]]
 name = "slop-basefold"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
  "serde",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
  "slop-baby-bear",
- "slop-bn254 6.4.0",
- "slop-challenger 6.4.0",
- "slop-koala-bear 6.4.0",
+ "slop-bn254 6.5.0",
+ "slop-challenger 6.5.0",
+ "slop-koala-bear 6.5.0",
  "slop-merkle-tree",
  "slop-multilinear",
- "slop-primitives 6.4.0",
+ "slop-primitives 6.5.0",
  "slop-tensor",
  "slop-utils",
  "thiserror 1.0.69",
@@ -5938,23 +5971,23 @@ dependencies = [
 
 [[package]]
 name = "slop-basefold-prover"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
  "rand 0.8.6",
  "serde",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
  "slop-baby-bear",
  "slop-basefold",
- "slop-bn254 6.4.0",
- "slop-challenger 6.4.0",
+ "slop-bn254 6.5.0",
+ "slop-challenger 6.5.0",
  "slop-commit",
  "slop-dft",
  "slop-fri",
  "slop-futures",
- "slop-koala-bear 6.4.0",
+ "slop-koala-bear 6.5.0",
  "slop-merkle-tree",
  "slop-multilinear",
  "slop-tensor",
@@ -5963,22 +5996,9 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea991a652ea2e55f0523649f5c9efbfb32cf9fdcc2bf3b3580b4343a94379503"
-dependencies = [
- "ff",
- "p3-bn254-fr",
- "serde",
- "slop-algebra 6.3.1",
- "slop-challenger 6.3.1",
- "slop-poseidon2 6.3.1",
- "slop-symmetric 6.3.1",
-]
-
-[[package]]
-name = "slop-bn254"
 version = "6.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44aed289b288c6f60d31b89124d97e0424cfee33a7ddcbc8c650df032594cf8a"
 dependencies = [
  "ff",
  "p3-bn254-fr",
@@ -5990,21 +6010,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "slop-challenger"
-version = "6.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b33f1eaadcd4159157758b0edcf1c14f470915f85c648e660e4740ff83e921"
+name = "slop-bn254"
+version = "6.5.0"
 dependencies = [
- "futures",
- "p3-challenger",
+ "ff",
+ "p3-bn254-fr",
  "serde",
- "slop-algebra 6.3.1",
- "slop-symmetric 6.3.1",
+ "slop-algebra 6.5.0",
+ "slop-challenger 6.5.0",
+ "slop-poseidon2 6.5.0",
+ "slop-symmetric 6.5.0",
 ]
 
 [[package]]
 name = "slop-challenger"
 version = "6.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a472bd4cf17c6fdd5090955290ee0de883f34c7707871ee099a4840d8736dc71"
 dependencies = [
  "futures",
  "p3-challenger",
@@ -6014,8 +6036,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "slop-challenger"
+version = "6.5.0"
+dependencies = [
+ "futures",
+ "p3-challenger",
+ "serde",
+ "slop-algebra 6.5.0",
+ "slop-symmetric 6.5.0",
+]
+
+[[package]]
 name = "slop-commit"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "p3-commit",
  "serde",
@@ -6024,11 +6057,11 @@ dependencies = [
 
 [[package]]
 name = "slop-dft"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "p3-dft",
  "serde",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
  "slop-matrix",
  "slop-tensor",
@@ -6036,14 +6069,14 @@ dependencies = [
 
 [[package]]
 name = "slop-fri"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "p3-fri",
 ]
 
 [[package]]
 name = "slop-futures"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "crossbeam",
  "futures",
@@ -6056,7 +6089,7 @@ dependencies = [
 
 [[package]]
 name = "slop-jagged"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "derive-where",
  "futures",
@@ -6065,21 +6098,21 @@ dependencies = [
  "rand 0.8.6",
  "rayon",
  "serde",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
  "slop-baby-bear",
  "slop-basefold",
  "slop-basefold-prover",
- "slop-bn254 6.4.0",
- "slop-challenger 6.4.0",
+ "slop-bn254 6.5.0",
+ "slop-challenger 6.5.0",
  "slop-commit",
  "slop-futures",
- "slop-koala-bear 6.4.0",
+ "slop-koala-bear 6.5.0",
  "slop-merkle-tree",
  "slop-multilinear",
  "slop-stacked",
  "slop-sumcheck",
- "slop-symmetric 6.4.0",
+ "slop-symmetric 6.5.0",
  "slop-tensor",
  "slop-utils",
  "thiserror 1.0.69",
@@ -6088,29 +6121,16 @@ dependencies = [
 
 [[package]]
 name = "slop-keccak-air"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "p3-keccak-air",
 ]
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8795ee9a92ecf0a604c0e3ed20e80bbc38772310c0622f94a2e1b66ca2455cb8"
-dependencies = [
- "lazy_static",
- "p3-koala-bear",
- "serde",
- "slop-algebra 6.3.1",
- "slop-challenger 6.3.1",
- "slop-poseidon2 6.3.1",
- "slop-symmetric 6.3.1",
-]
-
-[[package]]
-name = "slop-koala-bear"
 version = "6.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cf01dc278c282f732ba67e8bb90a710d4779778f1a195cdae92baacae8f8d6a"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -6122,38 +6142,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "slop-koala-bear"
+version = "6.5.0"
+dependencies = [
+ "lazy_static",
+ "p3-koala-bear",
+ "serde",
+ "slop-algebra 6.5.0",
+ "slop-challenger 6.5.0",
+ "slop-poseidon2 6.5.0",
+ "slop-symmetric 6.5.0",
+]
+
+[[package]]
 name = "slop-matrix"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "p3-matrix",
 ]
 
 [[package]]
 name = "slop-maybe-rayon"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "p3-maybe-rayon",
 ]
 
 [[package]]
 name = "slop-merkle-tree"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
  "p3-merkle-tree",
  "serde",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
  "slop-baby-bear",
- "slop-bn254 6.4.0",
- "slop-challenger 6.4.0",
+ "slop-bn254 6.5.0",
+ "slop-challenger 6.5.0",
  "slop-commit",
  "slop-futures",
- "slop-koala-bear 6.4.0",
+ "slop-koala-bear 6.5.0",
  "slop-matrix",
- "slop-poseidon2 6.4.0",
- "slop-symmetric 6.4.0",
+ "slop-poseidon2 6.5.0",
+ "slop-symmetric 6.5.0",
  "slop-tensor",
  "slop-utils",
  "thiserror 1.0.69",
@@ -6161,7 +6194,7 @@ dependencies = [
 
 [[package]]
 name = "slop-multilinear"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "derive-where",
  "futures",
@@ -6169,9 +6202,9 @@ dependencies = [
  "rand 0.8.6",
  "rayon",
  "serde",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
- "slop-challenger 6.4.0",
+ "slop-challenger 6.5.0",
  "slop-commit",
  "slop-futures",
  "slop-matrix",
@@ -6180,49 +6213,49 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.3.1"
+version = "6.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25561d9ecf4bcf1aa2e800560ac557bff6dad943b9dc5cd0e8427fceca1e8c65"
+checksum = "f27ec95c66d641b84741af6d8071b207625d191ae9026c7cedcfabf57f519a59"
 dependencies = [
  "p3-poseidon2",
 ]
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "p3-poseidon2",
 ]
 
 [[package]]
 name = "slop-primitives"
-version = "6.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6b24ad70b49f40d6acfe7b1ccf042db25820abe305a4c2232f15204f63f0227"
-dependencies = [
- "slop-algebra 6.3.1",
-]
-
-[[package]]
-name = "slop-primitives"
 version = "6.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dd98992a3dd8b608fd94d1b8f96d392478f6fd613cbe5db1017f8c97d6d3e13"
 dependencies = [
  "slop-algebra 6.4.0",
 ]
 
 [[package]]
+name = "slop-primitives"
+version = "6.5.0"
+dependencies = [
+ "slop-algebra 6.5.0",
+]
+
+[[package]]
 name = "slop-stacked"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "derive-where",
  "futures",
  "itertools 0.14.0",
  "serde",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
  "slop-basefold",
  "slop-basefold-prover",
- "slop-challenger 6.4.0",
+ "slop-challenger 6.5.0",
  "slop-commit",
  "slop-futures",
  "slop-merkle-tree",
@@ -6233,39 +6266,39 @@ dependencies = [
 
 [[package]]
 name = "slop-sumcheck"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "futures",
  "itertools 0.14.0",
  "rayon",
  "serde",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
  "slop-baby-bear",
- "slop-challenger 6.4.0",
+ "slop-challenger 6.5.0",
  "slop-multilinear",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "slop-symmetric"
-version = "6.3.1"
+version = "6.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e580d03bb5383aca1c12579a8a24b838afb12eb356439e740cba34904b6864"
+checksum = "95ea707679a9bee285392aa505aa353f8f473502a4f0776eec944c0b3baf4929"
 dependencies = [
  "p3-symmetric",
 ]
 
 [[package]]
 name = "slop-symmetric"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "p3-symmetric",
 ]
 
 [[package]]
 name = "slop-tensor"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "arrayvec",
  "derive-where",
@@ -6273,7 +6306,7 @@ dependencies = [
  "rand 0.8.6",
  "rayon",
  "serde",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
  "slop-futures",
  "slop-matrix",
@@ -6283,14 +6316,14 @@ dependencies = [
 
 [[package]]
 name = "slop-uni-stark"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "p3-uni-stark",
 ]
 
 [[package]]
 name = "slop-utils"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "p3-util",
  "tracing-forest",
@@ -6299,7 +6332,7 @@ dependencies = [
 
 [[package]]
 name = "slop-whir"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "derive-where",
  "futures",
@@ -6307,15 +6340,15 @@ dependencies = [
  "rand 0.8.6",
  "rayon",
  "serde",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
  "slop-baby-bear",
  "slop-basefold",
- "slop-challenger 6.4.0",
+ "slop-challenger 6.5.0",
  "slop-commit",
  "slop-dft",
  "slop-jagged",
- "slop-koala-bear 6.4.0",
+ "slop-koala-bear 6.5.0",
  "slop-matrix",
  "slop-merkle-tree",
  "slop-multilinear",
@@ -6366,19 +6399,19 @@ dependencies = [
 
 [[package]]
 name = "sp1-build"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
  "chrono",
  "clap",
  "dirs",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
 ]
 
 [[package]]
 name = "sp1-core-executor"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -6399,13 +6432,13 @@ dependencies = [
  "serde_arrays",
  "serde_json",
  "slop-air",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-maybe-rayon",
- "slop-symmetric 6.4.0",
+ "slop-symmetric 6.5.0",
  "sp1-curves",
  "sp1-hypercube",
  "sp1-jit",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "strum",
  "subenum",
  "thiserror 1.0.69",
@@ -6417,7 +6450,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor-runner"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -6429,7 +6462,7 @@ dependencies = [
  "sp1-core-executor",
  "sp1-core-executor-runner-binary",
  "sp1-jit",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "sysinfo",
  "tracing",
  "uuid",
@@ -6437,7 +6470,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor-runner-binary"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "bincode",
  "crash-handler",
@@ -6450,7 +6483,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-machine"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "bincode",
  "cfg-if",
@@ -6467,8 +6500,8 @@ dependencies = [
  "serde",
  "serde_json",
  "slop-air",
- "slop-algebra 6.4.0",
- "slop-challenger 6.4.0",
+ "slop-algebra 6.5.0",
+ "slop-challenger 6.5.0",
  "slop-futures",
  "slop-keccak-air",
  "slop-matrix",
@@ -6481,7 +6514,7 @@ dependencies = [
  "sp1-derive",
  "sp1-hypercube",
  "sp1-jit",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "static_assertions",
  "struct-reflection",
  "strum",
@@ -6497,7 +6530,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cuda"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "bincode",
  "bytes",
@@ -6507,7 +6540,7 @@ dependencies = [
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-hypercube",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "sp1-prover",
  "sp1-prover-types",
  "thiserror 1.0.69",
@@ -6517,26 +6550,28 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "cfg-if",
+ "curve25519-dalek",
  "dashu",
  "elliptic-curve",
  "generic-array 1.1.0",
+ "group",
  "itertools 0.14.0",
  "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "num",
  "p256 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "snowbridge-amcl",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "typenum",
 ]
 
 [[package]]
 name = "sp1-derive"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6545,7 +6580,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-hypercube"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "arrayref",
  "deepsize2",
@@ -6560,28 +6595,28 @@ dependencies = [
  "rayon-scan",
  "serde",
  "slop-air",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
  "slop-basefold",
  "slop-basefold-prover",
- "slop-bn254 6.4.0",
- "slop-challenger 6.4.0",
+ "slop-bn254 6.5.0",
+ "slop-challenger 6.5.0",
  "slop-commit",
  "slop-futures",
  "slop-jagged",
- "slop-koala-bear 6.4.0",
+ "slop-koala-bear 6.5.0",
  "slop-matrix",
  "slop-merkle-tree",
  "slop-multilinear",
- "slop-poseidon2 6.4.0",
+ "slop-poseidon2 6.5.0",
  "slop-stacked",
  "slop-sumcheck",
- "slop-symmetric 6.4.0",
+ "slop-symmetric 6.5.0",
  "slop-tensor",
  "slop-uni-stark",
  "slop-whir",
  "sp1-derive",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "struct-reflection",
  "strum",
  "thiserror 1.0.69",
@@ -6592,7 +6627,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-jit"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "dynasmrt",
  "hashbrown 0.14.5",
@@ -6600,50 +6635,28 @@ dependencies = [
  "memfd",
  "memmap2",
  "serde",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "tracing",
  "uuid",
 ]
 
 [[package]]
 name = "sp1-lib"
-version = "6.3.1"
+version = "6.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "629b673d6aa3c666b41e14d699323413fa90195c906365ba8c49d1b8e4531151"
+checksum = "27ac4a731d44d3588c59c320e9c4fa8cb6d1aca8be822f2d125f42887213e420"
 dependencies = [
  "bincode",
  "elliptic-curve",
  "serde",
- "sp1-primitives 6.3.1",
-]
-
-[[package]]
-name = "sp1-primitives"
-version = "6.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "421b4590a89bf7c263f8a64844a4034ee8cb73c351498911ce0acd18da6b5ed2"
-dependencies = [
- "bincode",
- "blake3",
- "elf",
- "hex",
- "itertools 0.14.0",
- "lazy_static",
- "num-bigint 0.4.6",
- "serde",
- "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-algebra 6.3.1",
- "slop-bn254 6.3.1",
- "slop-challenger 6.3.1",
- "slop-koala-bear 6.3.1",
- "slop-poseidon2 6.3.1",
- "slop-primitives 6.3.1",
- "slop-symmetric 6.3.1",
+ "sp1-primitives 6.4.0",
 ]
 
 [[package]]
 name = "sp1-primitives"
 version = "6.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab9b6b5cc2f53c2c96b3ef611781ea151c61d541a90c467041ce3aac476001fe"
 dependencies = [
  "bincode",
  "blake3",
@@ -6664,8 +6677,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp1-primitives"
+version = "6.5.0"
+dependencies = [
+ "bincode",
+ "blake3",
+ "elf",
+ "hex",
+ "itertools 0.14.0",
+ "lazy_static",
+ "num-bigint 0.4.6",
+ "serde",
+ "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slop-algebra 6.5.0",
+ "slop-bn254 6.5.0",
+ "slop-challenger 6.5.0",
+ "slop-koala-bear 6.5.0",
+ "slop-poseidon2 6.5.0",
+ "slop-primitives 6.5.0",
+ "slop-symmetric 6.5.0",
+]
+
+[[package]]
 name = "sp1-prover"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6692,22 +6727,22 @@ dependencies = [
  "serial_test",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "slop-air",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-basefold",
- "slop-bn254 6.4.0",
- "slop-challenger 6.4.0",
+ "slop-bn254 6.5.0",
+ "slop-challenger 6.5.0",
  "slop-futures",
  "slop-jagged",
  "slop-multilinear",
  "slop-stacked",
- "slop-symmetric 6.4.0",
+ "slop-symmetric 6.5.0",
  "sp1-core-executor",
  "sp1-core-executor-runner",
  "sp1-core-machine",
  "sp1-derive",
  "sp1-hypercube",
  "sp1-jit",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "sp1-prover-types",
  "sp1-recursion-circuit",
  "sp1-recursion-compiler",
@@ -6728,7 +6763,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover-types"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -6741,7 +6776,7 @@ dependencies = [
  "serde",
  "sp1-core-machine",
  "sp1-hypercube",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "tokio",
  "tonic",
  "tonic-build",
@@ -6750,7 +6785,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-circuit"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "bincode",
  "itertools 0.14.0",
@@ -6758,28 +6793,28 @@ dependencies = [
  "rayon",
  "serde",
  "slop-air",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
  "slop-basefold",
  "slop-basefold-prover",
- "slop-bn254 6.4.0",
- "slop-challenger 6.4.0",
+ "slop-bn254 6.5.0",
+ "slop-challenger 6.5.0",
  "slop-commit",
  "slop-jagged",
- "slop-koala-bear 6.4.0",
+ "slop-koala-bear 6.5.0",
  "slop-matrix",
  "slop-merkle-tree",
  "slop-multilinear",
  "slop-stacked",
  "slop-sumcheck",
- "slop-symmetric 6.4.0",
+ "slop-symmetric 6.5.0",
  "slop-tensor",
  "slop-whir",
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-derive",
  "sp1-hypercube",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "sp1-recursion-compiler",
  "sp1-recursion-executor",
  "sp1-recursion-machine",
@@ -6788,18 +6823,18 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-compiler"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "backtrace",
  "cfg-if",
  "itertools 0.14.0",
  "serde",
- "slop-algebra 6.4.0",
- "slop-bn254 6.4.0",
- "slop-symmetric 6.4.0",
+ "slop-algebra 6.5.0",
+ "slop-bn254 6.5.0",
+ "slop-symmetric 6.5.0",
  "sp1-core-machine",
  "sp1-hypercube",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "sp1-recursion-executor",
  "tracing",
  "vec_map",
@@ -6807,7 +6842,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-executor"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -6815,10 +6850,10 @@ dependencies = [
  "itertools 0.14.0",
  "range-set-blaze",
  "serde",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-maybe-rayon",
- "slop-poseidon2 6.4.0",
- "slop-symmetric 6.4.0",
+ "slop-poseidon2 6.5.0",
+ "slop-symmetric 6.5.0",
  "smallvec",
  "sp1-derive",
  "sp1-hypercube",
@@ -6829,7 +6864,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-ffi"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6839,10 +6874,10 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-algebra 6.4.0",
- "slop-symmetric 6.4.0",
+ "slop-algebra 6.5.0",
+ "slop-symmetric 6.5.0",
  "sp1-hypercube",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "sp1-recursion-compiler",
  "sp1-verifier",
  "tempfile",
@@ -6851,19 +6886,19 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-machine"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.6",
  "slop-air",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-basefold",
  "slop-matrix",
  "slop-maybe-rayon",
- "slop-symmetric 6.4.0",
+ "slop-symmetric 6.5.0",
  "sp1-derive",
  "sp1-hypercube",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "sp1-recursion-executor",
  "strum",
  "tracing",
@@ -6871,7 +6906,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-sdk"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -6904,7 +6939,7 @@ dependencies = [
  "sp1-core-machine",
  "sp1-cuda",
  "sp1-hypercube",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "sp1-prover",
  "sp1-prover-types",
  "sp1-recursion-executor",
@@ -6921,7 +6956,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-verifier"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -6931,12 +6966,12 @@ dependencies = [
  "lazy_static",
  "serde",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-algebra 6.4.0",
- "slop-challenger 6.4.0",
- "slop-primitives 6.4.0",
- "slop-symmetric 6.4.0",
+ "slop-algebra 6.5.0",
+ "slop-challenger 6.5.0",
+ "slop-primitives 6.5.0",
+ "slop-symmetric 6.5.0",
  "sp1-hypercube",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "sp1-recursion-executor",
  "sp1-recursion-machine",
  "strum",
@@ -6946,7 +6981,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -6956,7 +6991,7 @@ dependencies = [
  "lazy_static",
  "rand 0.8.6",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
 ]
 
 [[package]]

--- a/zkevm/libzkevm-cabi/Cargo.lock
+++ b/zkevm/libzkevm-cabi/Cargo.lock
@@ -786,7 +786,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libzkevm"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "bls12_381 0.8.0",
  "k256",
@@ -1537,7 +1537,7 @@ dependencies = [
 
 [[package]]
 name = "slop-algebra"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "itertools 0.14.0",
  "p3-field 0.4.3-succinct",
@@ -1562,15 +1562,15 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "ff 0.13.1",
  "p3-bn254-fr 0.4.3-succinct",
  "serde",
- "slop-algebra 6.4.0",
- "slop-challenger 6.4.0",
- "slop-poseidon2 6.4.0",
- "slop-symmetric 6.4.0",
+ "slop-algebra 6.5.0",
+ "slop-challenger 6.5.0",
+ "slop-poseidon2 6.5.0",
+ "slop-symmetric 6.5.0",
 ]
 
 [[package]]
@@ -1588,13 +1588,13 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "futures",
  "p3-challenger 0.4.3-succinct",
  "serde",
- "slop-algebra 6.4.0",
- "slop-symmetric 6.4.0",
+ "slop-algebra 6.5.0",
+ "slop-symmetric 6.5.0",
 ]
 
 [[package]]
@@ -1614,15 +1614,15 @@ dependencies = [
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "lazy_static",
  "p3-koala-bear 0.4.3-succinct",
  "serde",
- "slop-algebra 6.4.0",
- "slop-challenger 6.4.0",
- "slop-poseidon2 6.4.0",
- "slop-symmetric 6.4.0",
+ "slop-algebra 6.5.0",
+ "slop-challenger 6.5.0",
+ "slop-poseidon2 6.5.0",
+ "slop-symmetric 6.5.0",
 ]
 
 [[package]]
@@ -1636,7 +1636,7 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "p3-poseidon2 0.4.3-succinct",
 ]
@@ -1652,9 +1652,9 @@ dependencies = [
 
 [[package]]
 name = "slop-primitives"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
 ]
 
 [[package]]
@@ -1668,7 +1668,7 @@ dependencies = [
 
 [[package]]
 name = "slop-symmetric"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "p3-symmetric 0.4.3-succinct",
 ]
@@ -1717,7 +1717,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -1728,18 +1728,18 @@ dependencies = [
  "num-bigint 0.4.6",
  "serde",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-algebra 6.4.0",
- "slop-bn254 6.4.0",
- "slop-challenger 6.4.0",
- "slop-koala-bear 6.4.0",
- "slop-poseidon2 6.4.0",
- "slop-primitives 6.4.0",
- "slop-symmetric 6.4.0",
+ "slop-algebra 6.5.0",
+ "slop-bn254 6.5.0",
+ "slop-challenger 6.5.0",
+ "slop-koala-bear 6.5.0",
+ "slop-poseidon2 6.5.0",
+ "slop-primitives 6.5.0",
+ "slop-symmetric 6.5.0",
 ]
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -1749,7 +1749,7 @@ dependencies = [
  "lazy_static",
  "rand",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Bump the SP1 workspace and internal package versions from v6.4.0 to v6.5.0.
- Refresh the affected workspace, guest, example, patch-test, and ZK-EVM lockfiles.

## Motivation

Publish the changes merged after v6.4.0 for downstream applications.
This release includes the Edwards arithmetic update in #2941 and SDK mTLS client identity support in #2947.

## Validation

- `cargo +1.98.0 fmt --all -- --check`
- `cargo +1.98.0 check -p test-artifacts`
- `cargo +1.98.0 clippy --all-features --all-targets -- -D warnings -A incomplete-features`
- Stable workspace checks with no, default, and all features
- Nightly workspace checks with no, default, and all features
- Examples workspace check with all targets and features
- Verifier WebAssembly `no_std` check

CPU, GPU, Linux, verifier, and patch-cycle tests remain pull request CI gates.
The release workflow and crates.io publication will run after this pull request merges.
