### PR TITLE
fix(ci): publish multi-platform Gnark release tags

### DIFF
--- a/.github/workflows/docker-publish-gnark.yml
+++ b/.github/workflows/docker-publish-gnark.yml
@@ -55,15 +55,44 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push AMD64 image
+      - name: Build and push image
         uses: docker/build-push-action@v5
         with:
           context: .
           file: ./Dockerfile.gnark-ffi
           platforms: ${{ matrix.platform }}
           push: ${{ inputs.dry-run != true }}
-          tags: |
-            ghcr.io/succinctlabs/sp1-gnark:${{ inputs.docker-tag }}
-            ghcr.io/succinctlabs/sp1-gnark:${{ github.sha }}-${{ matrix.arch }}
+          tags: ghcr.io/succinctlabs/sp1-gnark:${{ github.sha }}-${{ matrix.arch }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  create-manifest:
+    name: create-multi-platform-manifest
+    if: ${{ inputs.dry-run != true }}
+    needs: [docker-publish-gnark]
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+
+    steps:
+      - name: Set up Docker BuildX
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log into registry ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and verify multi-platform image
+        env:
+          IMAGE: ghcr.io/succinctlabs/sp1-gnark:${{ inputs.docker-tag }}
+          AMD64_IMAGE: ghcr.io/succinctlabs/sp1-gnark:${{ github.sha }}-amd64
+          ARM64_IMAGE: ghcr.io/succinctlabs/sp1-gnark:${{ github.sha }}-arm64
+        run: |
+          docker buildx imagetools create --tag "$IMAGE" "$AMD64_IMAGE" "$ARM64_IMAGE"
+          docker buildx imagetools inspect "$IMAGE" --raw | jq -e '
+            [.manifests[].platform | select(.os == "linux") | .architecture]
+            | unique == ["amd64", "arm64"]
+          '


### PR DESCRIPTION
## Summary

- Publish each Gnark architecture under a commit-specific tag.
- Create the release tag after both builds complete.
- Fail the workflow unless the release tag contains Linux AMD64 and ARM64 images.

## Motivation

The parallel build jobs wrote the same release tag. The last job replaced the other architecture.

## Validation

- Actionlint 1.7.12 passed. Existing custom runner-label warnings were excluded.
- A dry-run manifest built from the v6.5.0 architecture tags passed the platform assertion.