### PR TITLE
feat(sdk): Allow creating blocking LightProver within tokio runtime

### DIFF
--- a/crates/prover/src/worker/node/light.rs
+++ b/crates/prover/src/worker/node/light.rs
@@ -59,26 +59,31 @@ impl SP1LightNode {
         opts: SP1CoreOpts,
     ) -> Self {
         // Initializing the merkle tree is blocking, so we need to spawn in on a blocking task.
-        tokio::task::spawn_blocking(move || {
-            // Get a core prover for the light node to be able to do the setup step
-            let core_verifier = CpuSP1ProverComponents::core_verifier(machine.clone());
-            let core_air_prover =
-                Arc::new(CpuShardProver::new(core_verifier.shard_verifier().clone()));
-            let permits = ProverSemaphore::new(1);
+        tokio::task::spawn_blocking(move || Self::with_opts_and_machine_sync(machine, opts))
+            .await
+            .expect("failed to initialize light node")
+    }
 
-            #[cfg(feature = "mprotect")]
-            let verifier_vks =
-                RecursionVks::new(None, DEFAULT_MAX_COMPOSE_ARITY, false).to_verifier_vks();
-            #[cfg(not(feature = "mprotect"))]
-            let verifier_vks = VerifierRecursionVks::default();
-            let verifier = SP1Verifier::new_with_machine(verifier_vks, machine);
-            // Create a new core node for the light node
-            let core = SP1NodeCore::new(verifier, opts);
+    /// Create a new light node with custom options and a given machine.
+    pub fn with_opts_and_machine_sync(
+        machine: Machine<SP1Field, RiscvAir<SP1Field>>,
+        opts: SP1CoreOpts,
+    ) -> Self {
+        // Get a core prover for the light node to be able to do the setup step
+        let core_verifier = CpuSP1ProverComponents::core_verifier(machine.clone());
+        let core_air_prover = Arc::new(CpuShardProver::new(core_verifier.shard_verifier().clone()));
+        let permits = ProverSemaphore::new(1);
 
-            Self { inner: Arc::new(SP1LightNodeInner { core, core_air_prover, permits }) }
-        })
-        .await
-        .expect("failed to initialize light node")
+        #[cfg(feature = "mprotect")]
+        let verifier_vks =
+            RecursionVks::new(None, DEFAULT_MAX_COMPOSE_ARITY, false).to_verifier_vks();
+        #[cfg(not(feature = "mprotect"))]
+        let verifier_vks = VerifierRecursionVks::default();
+        let verifier = SP1Verifier::new_with_machine(verifier_vks, machine);
+        // Create a new core node for the light node
+        let core = SP1NodeCore::new(verifier, opts);
+
+        Self { inner: Arc::new(SP1LightNodeInner { core, core_air_prover, permits }) }
     }
 
     pub async fn setup(&self, elf: &[u8]) -> anyhow::Result<SP1VerifyingKey> {

--- a/crates/sdk/src/blocking/cuda/builder.rs
+++ b/crates/sdk/src/blocking/cuda/builder.rs
@@ -10,8 +10,6 @@ use sp1_hypercube::Machine;
 use sp1_primitives::SP1Field;
 use sp1_prover::worker::SP1LightNode;
 
-use crate::blocking::block_on;
-
 /// A builder for the [`CudaProver`].
 ///
 /// The builder is used to configure the [`CudaProver`] before it is built.
@@ -107,10 +105,10 @@ impl CudaProverBuilder {
     #[must_use]
     pub fn build(self) -> CudaProver {
         tracing::info!("initializing cuda prover");
-        let node = block_on(SP1LightNode::with_opts_and_machine(
+        let node = SP1LightNode::with_opts_and_machine_sync(
             self.machine,
             self.core_opts.unwrap_or_default(),
-        ));
+        );
         let cuda_prover = match self.cuda_device_id {
             Some(id) => crate::blocking::block_on(CudaProverImpl::new_with_id(id)),
             None => crate::blocking::block_on(CudaProverImpl::new()),

--- a/crates/sdk/src/blocking/light/builder.rs
+++ b/crates/sdk/src/blocking/light/builder.rs
@@ -9,8 +9,6 @@ use sp1_hypercube::Machine;
 use sp1_primitives::SP1Field;
 use sp1_prover::worker::SP1LightNode;
 
-use crate::blocking::block_on;
-
 /// A builder for the blocking [`LightProver`].
 pub struct LightProverBuilder {
     /// Optional core options to configure the prover.
@@ -55,10 +53,10 @@ impl LightProverBuilder {
     #[must_use]
     pub fn build(self) -> LightProver {
         tracing::info!("initializing light prover");
-        let node = match self.core_opts {
-            Some(opts) => block_on(SP1LightNode::with_opts_and_machine(self.machine, opts)),
-            None => block_on(SP1LightNode::new_with_machine(self.machine)),
-        };
+        let node = SP1LightNode::with_opts_and_machine_sync(
+            self.machine,
+            self.core_opts.unwrap_or_default(),
+        );
         LightProver::from_node(node)
     }
 }

--- a/crates/sdk/src/blocking/light/mod.rs
+++ b/crates/sdk/src/blocking/light/mod.rs
@@ -42,7 +42,7 @@ impl LightProver {
     #[must_use]
     pub fn new_with_machine(machine: Machine<SP1Field, RiscvAir<SP1Field>>) -> Self {
         tracing::info!("initializing light prover");
-        let node = block_on(SP1LightNode::new_with_machine(machine));
+        let node = SP1LightNode::with_opts_and_machine_sync(machine, Default::default());
         Self { inner: node }
     }
 

--- a/crates/sdk/src/blocking/light/mod.rs
+++ b/crates/sdk/src/blocking/light/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod builder;
 
+use sp1_core_executor::SP1CoreOpts;
 use sp1_core_machine::io::SP1Stdin;
 use sp1_core_machine::riscv::RiscvAir;
 use sp1_hypercube::Machine;
@@ -42,7 +43,7 @@ impl LightProver {
     #[must_use]
     pub fn new_with_machine(machine: Machine<SP1Field, RiscvAir<SP1Field>>) -> Self {
         tracing::info!("initializing light prover");
-        let node = SP1LightNode::with_opts_and_machine_sync(machine, Default::default());
+        let node = SP1LightNode::with_opts_and_machine_sync(machine, SP1CoreOpts::default());
         Self { inner: node }
     }
 

--- a/crates/sdk/src/blocking/light/mod.rs
+++ b/crates/sdk/src/blocking/light/mod.rs
@@ -105,6 +105,12 @@ mod tests {
 
     use super::LightProver;
 
+    /// The blocking LightProver constructor must not create or `block_on` a Tokio runtime.
+    #[tokio::test]
+    async fn test_constructs_inside_tokio_runtime() {
+        let _prover = LightProver::new();
+    }
+
     /// Test that execute works and prove errors.
     #[test]
     fn test_light_execute_and_prove() {

--- a/crates/sdk/src/blocking/light/mod.rs
+++ b/crates/sdk/src/blocking/light/mod.rs
@@ -105,7 +105,7 @@ mod tests {
 
     use super::LightProver;
 
-    /// The blocking LightProver constructor must not create or `block_on` a Tokio runtime.
+    /// The blocking `LightProver` constructor must not create or `block_on` a Tokio runtime.
     #[tokio::test]
     async fn test_constructs_inside_tokio_runtime() {
         let _prover = LightProver::new();

--- a/crates/sdk/src/blocking/mock/builder.rs
+++ b/crates/sdk/src/blocking/mock/builder.rs
@@ -9,8 +9,6 @@ use sp1_hypercube::Machine;
 use sp1_primitives::SP1Field;
 use sp1_prover::worker::SP1LightNode;
 
-use crate::blocking::block_on;
-
 /// A builder for the blocking [`MockProver`].
 pub struct MockProverBuilder {
     /// Optional core options to configure the prover.
@@ -55,10 +53,10 @@ impl MockProverBuilder {
     #[must_use]
     pub fn build(self) -> MockProver {
         tracing::info!("initializing mock prover");
-        let node = match self.core_opts {
-            Some(opts) => block_on(SP1LightNode::with_opts_and_machine(self.machine, opts)),
-            None => block_on(SP1LightNode::new_with_machine(self.machine)),
-        };
+        let node = SP1LightNode::with_opts_and_machine_sync(
+            self.machine,
+            self.core_opts.unwrap_or_default(),
+        );
         MockProver::from_node(node)
     }
 }

--- a/crates/sdk/src/blocking/mock/mod.rs
+++ b/crates/sdk/src/blocking/mock/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod builder;
 
+use sp1_core_executor::SP1CoreOpts;
 use sp1_core_machine::io::SP1Stdin;
 use sp1_core_machine::riscv::RiscvAir;
 use sp1_hypercube::Machine;
@@ -46,7 +47,7 @@ impl MockProver {
     #[must_use]
     pub fn new_with_machine(machine: Machine<SP1Field, RiscvAir<SP1Field>>) -> Self {
         tracing::info!("initializing mock prover");
-        Self { inner: SP1LightNode::with_opts_and_machine_sync(machine, Default::default()) }
+        Self { inner: SP1LightNode::with_opts_and_machine_sync(machine, SP1CoreOpts::default()) }
     }
 
     /// Create a mock prover from an existing light node.

--- a/crates/sdk/src/blocking/mock/mod.rs
+++ b/crates/sdk/src/blocking/mock/mod.rs
@@ -46,7 +46,7 @@ impl MockProver {
     #[must_use]
     pub fn new_with_machine(machine: Machine<SP1Field, RiscvAir<SP1Field>>) -> Self {
         tracing::info!("initializing mock prover");
-        Self { inner: block_on(SP1LightNode::new_with_machine(machine)) }
+        Self { inner: SP1LightNode::with_opts_and_machine_sync(machine, Default::default()) }
     }
 
     /// Create a mock prover from an existing light node.


### PR DESCRIPTION
## Motivation

- You can't construct a blocking `LightProver` within a tokio runtime, due to a single use of `tokio::task::spawn_blocking` further down in the stack, and this is an unnecessary limitation.

## Solution

- Makes `sp1_sdk::blocking::LightProver` possible to use within an async function/tokio runtime

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes