### PR TITLE
feat(sdk): derive serde for SP1ProvingKey

### DIFF
--- a/crates/primitives/src/types.rs
+++ b/crates/primitives/src/types.rs
@@ -70,11 +70,22 @@ impl Default for Buffer {
 pub enum Elf {
     /// The ELF binary for the program.
     Static(&'static [u8]),
-    /// The ELF binary for the test program.
+    /// ELF bytes owned at runtime, read from disk or deserialized.
     Dynamic(Arc<[u8]>),
 }
 
-// todo!(n): implement serde for the ELF type.
+impl Serialize for Elf {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        <[u8]>::serialize(self, serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for Elf {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let bytes: Vec<u8> = Deserialize::deserialize(deserializer)?;
+        Ok(Self::Dynamic(bytes.into()))
+    }
+}
 
 impl From<Arc<[u8]>> for Elf {
     fn from(elf: Arc<[u8]>) -> Self {
@@ -101,6 +112,21 @@ impl core::ops::Deref for Elf {
         match self {
             Self::Static(elf) => elf,
             Self::Dynamic(elf) => elf.as_ref(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_elf_serde_roundtrip() {
+        for elf in [Elf::Static(&[1, 2, 3]), Elf::from(alloc::vec![4, 5, 6])] {
+            let bytes = bincode::serialize(&elf).unwrap();
+            let decoded: Elf = bincode::deserialize(&bytes).unwrap();
+            assert!(matches!(decoded, Elf::Dynamic(_)), "{elf:?}");
+            assert_eq!(&*decoded, &*elf, "{elf:?}");
         }
     }
 }

--- a/crates/sdk/src/prover/prove.rs
+++ b/crates/sdk/src/prover/prove.rs
@@ -1,11 +1,12 @@
 use super::{IntoSendFutureResult, Prover};
 use crate::{ProvingKey, SP1ProofMode, SP1ProofWithPublicValues, StatusCode};
+use serde::{Deserialize, Serialize};
 use sp1_build::Elf;
 use sp1_core_executor::SP1ContextBuilder;
 use sp1_core_machine::io::SP1Stdin;
 use sp1_prover::SP1VerifyingKey;
 
-#[derive(Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 /// A proving key for the SP1 prover.
 ///
 /// Contains only the minimal information required to implement the `ProvingKey` trait.

--- a/crates/sdk/src/prover/prove.rs
+++ b/crates/sdk/src/prover/prove.rs
@@ -5,7 +5,7 @@ use sp1_core_executor::SP1ContextBuilder;
 use sp1_core_machine::io::SP1Stdin;
 use sp1_prover::SP1VerifyingKey;
 
-#[derive(Clone)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 /// A proving key for the SP1 prover.
 ///
 /// Contains only the minimal information required to implement the `ProvingKey` trait.


### PR DESCRIPTION
## Summary

- Add Serialize and Deserialize support to Elf with the same byte-sequence format.
- Return `Elf::Dynamic` after deserialization and test both source variants.
- Derive both serde traits for `SP1ProvingKey`.