### PR TITLE
feat(sdk): support refreshable bearer tokens

### DIFF
--- a/crates/sdk/src/blocking/client.rs
+++ b/crates/sdk/src/blocking/client.rs
@@ -172,6 +172,7 @@ impl ProverClientBuilder {
             tee_signers: None,
             network_mode: Some(mode),
             client_identity: None,
+            bearer_token: None,
             hosted: false,
             machine: self.machine.clone(),
         }

--- a/crates/sdk/src/blocking/network/builder.rs
+++ b/crates/sdk/src/blocking/network/builder.rs
@@ -9,7 +9,7 @@ use sp1_primitives::SP1Field;
 use tonic::transport::Identity;
 
 use super::NetworkProver;
-use crate::network::{signer::NetworkSigner, NetworkMode, TEE_NETWORK_RPC_URL};
+use crate::network::{signer::NetworkSigner, NetworkBearerToken, NetworkMode, TEE_NETWORK_RPC_URL};
 
 /// A builder for the blocking [`NetworkProver`].
 ///
@@ -21,6 +21,7 @@ pub struct NetworkProverBuilder {
     pub(crate) signer: Option<NetworkSigner>,
     pub(crate) network_mode: Option<NetworkMode>,
     pub(crate) client_identity: Option<Identity>,
+    pub(crate) bearer_token: Option<NetworkBearerToken>,
     pub(crate) hosted: bool,
     pub(crate) machine: Machine<SP1Field, RiscvAir<SP1Field>>,
 }
@@ -48,6 +49,7 @@ impl NetworkProverBuilder {
             signer: None,
             network_mode: None,
             client_identity: None,
+            bearer_token: None,
             hosted: false,
             machine,
         }
@@ -158,6 +160,13 @@ impl NetworkProverBuilder {
         self
     }
 
+    /// Sets the bearer token added to Prover Network and Artifact Store requests.
+    #[must_use]
+    pub fn bearer_token(mut self, bearer_token: NetworkBearerToken) -> Self {
+        self.bearer_token = Some(bearer_token);
+        self
+    }
+
     /// Builds a blocking [`NetworkProver`].
     ///
     /// # Details
@@ -181,6 +190,7 @@ impl NetworkProverBuilder {
             signer: self.signer,
             network_mode: self.network_mode,
             client_identity: self.client_identity,
+            bearer_token: self.bearer_token,
             hosted: self.hosted,
             machine: self.machine,
         };

--- a/crates/sdk/src/client.rs
+++ b/crates/sdk/src/client.rs
@@ -210,6 +210,7 @@ impl ProverClientBuilder {
             tee_signers: None,
             network_mode: Some(mode),
             client_identity: None,
+            bearer_token: None,
             hosted: false,
             machine: self.machine.clone(),
         }

--- a/crates/sdk/src/network/auth.rs
+++ b/crates/sdk/src/network/auth.rs
@@ -1,0 +1,104 @@
+use thiserror::Error;
+use tokio::sync::watch;
+use tonic::{metadata::AsciiMetadataValue, service::Interceptor, Request, Status};
+
+/// A bearer token that can be updated without rebuilding the network prover.
+///
+/// The caller is responsible for acquiring and refreshing the token. Retain a clone to update the
+/// value after passing it to a network prover builder.
+#[derive(Clone)]
+pub struct NetworkBearerToken {
+    current: watch::Sender<AsciiMetadataValue>,
+}
+
+impl NetworkBearerToken {
+    /// Creates a bearer token from its raw value, without the `Bearer` prefix.
+    pub fn new(token: impl AsRef<str>) -> Result<Self, InvalidBearerToken> {
+        let (current, _) = watch::channel(parse_bearer_token(token.as_ref())?);
+        Ok(Self { current })
+    }
+
+    /// Updates the value used by subsequent network requests.
+    pub fn update(&self, token: impl AsRef<str>) -> Result<(), InvalidBearerToken> {
+        self.current.send_replace(parse_bearer_token(token.as_ref())?);
+        Ok(())
+    }
+
+    fn subscribe(&self) -> watch::Receiver<AsciiMetadataValue> {
+        self.current.subscribe()
+    }
+}
+
+/// The supplied bearer token is empty or cannot be encoded as request metadata.
+#[derive(Debug, Error, PartialEq, Eq)]
+#[error("bearer token must be non-empty ASCII without whitespace")]
+pub struct InvalidBearerToken;
+
+fn parse_bearer_token(token: &str) -> Result<AsciiMetadataValue, InvalidBearerToken> {
+    if token.is_empty() || !token.is_ascii() || token.bytes().any(|byte| byte.is_ascii_whitespace())
+    {
+        return Err(InvalidBearerToken);
+    }
+
+    let mut value: AsciiMetadataValue =
+        format!("Bearer {token}").parse().map_err(|_| InvalidBearerToken)?;
+    value.set_sensitive(true);
+    Ok(value)
+}
+
+#[derive(Clone)]
+pub(crate) struct BearerTokenInterceptor {
+    current: Option<watch::Receiver<AsciiMetadataValue>>,
+}
+
+impl BearerTokenInterceptor {
+    pub(crate) fn new(token: Option<&NetworkBearerToken>) -> Self {
+        Self { current: token.map(NetworkBearerToken::subscribe) }
+    }
+}
+
+impl Interceptor for BearerTokenInterceptor {
+    fn call(&mut self, mut request: Request<()>) -> Result<Request<()>, Status> {
+        if let Some(current) = &self.current {
+            request.metadata_mut().insert("authorization", current.borrow().clone());
+        }
+        Ok(request)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn adds_and_updates_bearer_token() {
+        let token = NetworkBearerToken::new("first.token").unwrap();
+        let mut interceptor = BearerTokenInterceptor::new(Some(&token));
+
+        let request = interceptor.call(Request::new(())).unwrap();
+        assert_eq!(request.metadata().get("authorization").unwrap(), "Bearer first.token");
+        assert!(request.metadata().get("authorization").unwrap().is_sensitive());
+
+        token.update("second.token").unwrap();
+        let request = interceptor.call(Request::new(())).unwrap();
+        assert_eq!(request.metadata().get("authorization").unwrap(), "Bearer second.token");
+
+        assert_eq!(token.update("invalid token"), Err(InvalidBearerToken));
+        let request = interceptor.call(Request::new(())).unwrap();
+        assert_eq!(request.metadata().get("authorization").unwrap(), "Bearer second.token");
+    }
+
+    #[test]
+    fn omits_authorization_without_a_token() {
+        let mut interceptor = BearerTokenInterceptor::new(None);
+        let request = interceptor.call(Request::new(())).unwrap();
+        assert!(request.metadata().get("authorization").is_none());
+    }
+
+    #[test]
+    fn rejects_invalid_tokens() {
+        assert_eq!(NetworkBearerToken::new("").err(), Some(InvalidBearerToken));
+        assert_eq!(NetworkBearerToken::new("two tokens").err(), Some(InvalidBearerToken));
+        assert_eq!(NetworkBearerToken::new("é").err(), Some(InvalidBearerToken));
+    }
+}

--- a/crates/sdk/src/network/builder.rs
+++ b/crates/sdk/src/network/builder.rs
@@ -9,7 +9,7 @@ use sp1_primitives::SP1Field;
 use tonic::transport::Identity;
 
 use crate::{
-    network::{signer::NetworkSigner, NetworkMode, TEE_NETWORK_RPC_URL},
+    network::{signer::NetworkSigner, NetworkBearerToken, NetworkMode, TEE_NETWORK_RPC_URL},
     NetworkProver,
 };
 
@@ -23,6 +23,7 @@ pub struct NetworkProverBuilder {
     pub(crate) signer: Option<NetworkSigner>,
     pub(crate) network_mode: Option<NetworkMode>,
     pub(crate) client_identity: Option<Identity>,
+    pub(crate) bearer_token: Option<NetworkBearerToken>,
     pub(crate) hosted: bool,
     pub(crate) machine: Machine<SP1Field, RiscvAir<SP1Field>>,
 }
@@ -50,6 +51,7 @@ impl NetworkProverBuilder {
             signer: None,
             network_mode: None,
             client_identity: None,
+            bearer_token: None,
             hosted: false,
             machine,
         }
@@ -182,6 +184,13 @@ impl NetworkProverBuilder {
         self
     }
 
+    /// Sets the bearer token added to Prover Network and Artifact Store requests.
+    #[must_use]
+    pub fn bearer_token(mut self, bearer_token: NetworkBearerToken) -> Self {
+        self.bearer_token = Some(bearer_token);
+        self
+    }
+
     /// Builds a [`NetworkProver`].
     ///
     /// # Details
@@ -262,6 +271,7 @@ impl NetworkProverBuilder {
             .await
             .with_tee_signers(tee_signers)
             .with_client_identity(self.client_identity)
+            .with_bearer_token(self.bearer_token)
             .with_hosted(self.hosted)
     }
 }
@@ -294,5 +304,17 @@ mod tests {
             .build()
             .await;
         assert!(prover.client.client_identity.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_bearer_token_is_injected() {
+        let private_key = hex::encode(alloy_signer_local::PrivateKeySigner::random().to_bytes());
+        let bearer_token = NetworkBearerToken::new("token").unwrap();
+        let prover = NetworkProverBuilder::new()
+            .private_key(&private_key)
+            .bearer_token(bearer_token)
+            .build()
+            .await;
+        assert!(prover.client.bearer_token.is_some());
     }
 }

--- a/crates/sdk/src/network/client.rs
+++ b/crates/sdk/src/network/client.rs
@@ -18,11 +18,13 @@ use sp1_core_machine::io::SP1Stdin;
 use sp1_prover::{HashableKey, SP1VerifyingKey};
 use tokio::sync::OnceCell;
 use tonic::{
+    codegen::InterceptedService,
     transport::{Channel, Identity},
     Code,
 };
 
 use super::{
+    auth::{BearerTokenInterceptor, NetworkBearerToken},
     grpc,
     retry::{self, RetryableRpc, DEFAULT_RETRY_TIMEOUT},
     signer::NetworkSigner,
@@ -77,6 +79,8 @@ use crate::network::proto::{
     RequestProofResponse,
 };
 
+type AuthenticatedChannel = InterceptedService<Channel, BearerTokenInterceptor>;
+
 /// Current market `max_price_per_pgu` returned by [`NetworkClient::get_market_price_per_pgu`].
 /// Returned to callers who want the raw market signal; the SDK's own auto-default path
 /// uses `GetProofRequestParams.max_price_per_pgu` instead and does not consume this type.
@@ -109,6 +113,7 @@ pub struct NetworkClient {
     pub(crate) rpc_url: String,
     pub(crate) network_mode: NetworkMode,
     pub(crate) client_identity: Option<Identity>,
+    pub(crate) bearer_token: Option<NetworkBearerToken>,
     /// Lazily-established gRPC channel, shared across clones and reused across calls.
     pub(crate) channel: Arc<OnceCell<Channel>>,
 }
@@ -159,6 +164,7 @@ impl NetworkClient {
             rpc_url: rpc_url.into(),
             network_mode,
             client_identity: None,
+            bearer_token: None,
             channel: Arc::new(OnceCell::new()),
         }
     }
@@ -893,7 +899,7 @@ impl NetworkClient {
     // Auction client for operations whose schemas are wire-compatible across network modes.
     pub(crate) async fn prover_network_client(
         &self,
-    ) -> Result<AuctionProverNetworkClient<Channel>> {
+    ) -> Result<AuctionProverNetworkClient<AuthenticatedChannel>> {
         // For shared operations, we use the auction client type as it provides the default types.
         // The actual network routing is handled by the RPC URL which is correctly set based on
         // network_mode.
@@ -919,18 +925,29 @@ impl NetworkClient {
     // Helper methods for runtime proto type selection.
     pub(crate) async fn auction_prover_network_client(
         &self,
-    ) -> Result<AuctionProverNetworkClient<Channel>> {
-        Ok(AuctionProverNetworkClient::new(self.channel().await?))
+    ) -> Result<AuctionProverNetworkClient<AuthenticatedChannel>> {
+        Ok(AuctionProverNetworkClient::with_interceptor(
+            self.channel().await?,
+            BearerTokenInterceptor::new(self.bearer_token.as_ref()),
+        ))
     }
 
     pub(crate) async fn base_prover_network_client(
         &self,
-    ) -> Result<BaseProverNetworkClient<Channel>> {
-        Ok(BaseProverNetworkClient::new(self.channel().await?))
+    ) -> Result<BaseProverNetworkClient<AuthenticatedChannel>> {
+        Ok(BaseProverNetworkClient::with_interceptor(
+            self.channel().await?,
+            BearerTokenInterceptor::new(self.bearer_token.as_ref()),
+        ))
     }
 
-    pub(crate) async fn artifact_store_client(&self) -> Result<ArtifactStoreClient<Channel>> {
-        Ok(ArtifactStoreClient::new(self.channel().await?))
+    pub(crate) async fn artifact_store_client(
+        &self,
+    ) -> Result<ArtifactStoreClient<AuthenticatedChannel>> {
+        Ok(ArtifactStoreClient::with_interceptor(
+            self.channel().await?,
+            BearerTokenInterceptor::new(self.bearer_token.as_ref()),
+        ))
     }
 
     pub(crate) async fn create_artifact_with_content<T: Serialize + Send + Sync>(

--- a/crates/sdk/src/network/mod.rs
+++ b/crates/sdk/src/network/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! A library for interacting with the SP1 prover over the network.
 
+mod auth;
 pub mod client;
 pub mod prover;
 #[rustfmt::skip]
@@ -23,6 +24,7 @@ pub mod utils;
 use std::time::Duration;
 
 pub use crate::network::{
+    auth::{InvalidBearerToken, NetworkBearerToken},
     client::{MarketPrice, NetworkClient},
     proto::types::FulfillmentStrategy,
 };

--- a/crates/sdk/src/network/prover.rs
+++ b/crates/sdk/src/network/prover.rs
@@ -248,6 +248,15 @@ impl NetworkProver {
         self
     }
 
+    #[must_use]
+    pub(crate) fn with_bearer_token(
+        mut self,
+        bearer_token: Option<super::NetworkBearerToken>,
+    ) -> Self {
+        self.client.bearer_token = bearer_token;
+        self
+    }
+
     /// Sets whether this prover uses hosted defaults (skip simulation, max cycle and gas limits).
     ///
     /// See [`NetworkProver::hosted`] for details.


### PR DESCRIPTION
## Summary

- Add an optional bearer token to the async and blocking network prover builders.
- Send the current token with Prover Network and Artifact Store gRPC requests.
- Let callers replace the token without rebuilding the prover or its shared channel.

## Motivation

Long-running clients need to replace short-lived access tokens while they keep active network connections.
The caller remains responsible for token acquisition and refresh.
Clients without a token keep the current behavior.

## Validation

- `cargo +1.98.0 test -p sp1-sdk --features network,blocking --lib network::` (35 passed)
- `cargo +1.98.0 clippy --all-features --all-targets -- -D warnings -A incomplete-features`
- `cargo +1.98.0 check --all-targets --all-features --tests`
- `cargo +1.98.0 fmt --all -- --check`
