### PR TITLE
chore(release): bump SP1 to v6.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4090,7 +4090,7 @@ dependencies = [
 
 [[package]]
 name = "libzkevm"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bls12_381",
  "hex",
@@ -6493,7 +6493,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slop-air"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-air",
 ]
@@ -6511,7 +6511,7 @@ dependencies = [
 
 [[package]]
 name = "slop-algebra"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -6521,42 +6521,42 @@ dependencies = [
 
 [[package]]
 name = "slop-alloc"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "serde",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "slop-baby-bear"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "lazy_static",
  "p3-baby-bear",
  "serde",
- "slop-algebra 6.6.0",
- "slop-challenger 6.6.0",
- "slop-poseidon2 6.6.0",
- "slop-symmetric 6.6.0",
+ "slop-algebra 6.7.0",
+ "slop-challenger 6.7.0",
+ "slop-poseidon2 6.7.0",
+ "slop-symmetric 6.7.0",
 ]
 
 [[package]]
 name = "slop-basefold"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
  "serde",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-alloc",
  "slop-baby-bear",
- "slop-bn254 6.6.0",
- "slop-challenger 6.6.0",
- "slop-koala-bear 6.6.0",
+ "slop-bn254 6.7.0",
+ "slop-challenger 6.7.0",
+ "slop-koala-bear 6.7.0",
  "slop-merkle-tree",
  "slop-multilinear",
- "slop-primitives 6.6.0",
+ "slop-primitives 6.7.0",
  "slop-tensor",
  "slop-utils",
  "thiserror 1.0.69",
@@ -6564,22 +6564,22 @@ dependencies = [
 
 [[package]]
 name = "slop-basefold-prover"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
  "rand 0.8.6",
  "serde",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-alloc",
  "slop-baby-bear",
  "slop-basefold",
- "slop-challenger 6.6.0",
+ "slop-challenger 6.7.0",
  "slop-commit",
  "slop-dft",
  "slop-fri",
  "slop-futures",
- "slop-koala-bear 6.6.0",
+ "slop-koala-bear 6.7.0",
  "slop-merkle-tree",
  "slop-multilinear",
  "slop-tensor",
@@ -6603,15 +6603,15 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "ff",
  "p3-bn254-fr",
  "serde",
- "slop-algebra 6.6.0",
- "slop-challenger 6.6.0",
- "slop-poseidon2 6.6.0",
- "slop-symmetric 6.6.0",
+ "slop-algebra 6.7.0",
+ "slop-challenger 6.7.0",
+ "slop-poseidon2 6.7.0",
+ "slop-symmetric 6.7.0",
 ]
 
 [[package]]
@@ -6629,17 +6629,17 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-challenger",
  "serde",
- "slop-algebra 6.6.0",
- "slop-symmetric 6.6.0",
+ "slop-algebra 6.7.0",
+ "slop-symmetric 6.7.0",
 ]
 
 [[package]]
 name = "slop-commit"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-commit",
  "serde",
@@ -6648,11 +6648,11 @@ dependencies = [
 
 [[package]]
 name = "slop-dft"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-dft",
  "serde",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-alloc",
  "slop-matrix",
  "slop-tensor",
@@ -6660,14 +6660,14 @@ dependencies = [
 
 [[package]]
 name = "slop-fri"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-fri",
 ]
 
 [[package]]
 name = "slop-futures"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "crossbeam",
  "futures",
@@ -6681,27 +6681,27 @@ dependencies = [
 
 [[package]]
 name = "slop-jagged"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "itertools 0.14.0",
  "num_cpus",
  "rand 0.8.6",
  "rayon",
  "serde",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-alloc",
  "slop-baby-bear",
  "slop-basefold",
  "slop-basefold-prover",
- "slop-bn254 6.6.0",
- "slop-challenger 6.6.0",
+ "slop-bn254 6.7.0",
+ "slop-challenger 6.7.0",
  "slop-commit",
- "slop-koala-bear 6.6.0",
+ "slop-koala-bear 6.7.0",
  "slop-merkle-tree",
  "slop-multilinear",
  "slop-stacked",
  "slop-sumcheck",
- "slop-symmetric 6.6.0",
+ "slop-symmetric 6.7.0",
  "slop-tensor",
  "slop-utils",
  "thiserror 1.0.69",
@@ -6710,7 +6710,7 @@ dependencies = [
 
 [[package]]
 name = "slop-keccak-air"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-keccak-air",
 ]
@@ -6732,49 +6732,49 @@ dependencies = [
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
  "serde",
- "slop-algebra 6.6.0",
- "slop-challenger 6.6.0",
- "slop-poseidon2 6.6.0",
- "slop-symmetric 6.6.0",
+ "slop-algebra 6.7.0",
+ "slop-challenger 6.7.0",
+ "slop-poseidon2 6.7.0",
+ "slop-symmetric 6.7.0",
 ]
 
 [[package]]
 name = "slop-matrix"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-matrix",
 ]
 
 [[package]]
 name = "slop-maybe-rayon"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-maybe-rayon",
 ]
 
 [[package]]
 name = "slop-merkle-tree"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "itertools 0.14.0",
  "p3-merkle-tree",
  "rand 0.8.6",
  "serde",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-alloc",
  "slop-baby-bear",
- "slop-bn254 6.6.0",
- "slop-challenger 6.6.0",
+ "slop-bn254 6.7.0",
+ "slop-challenger 6.7.0",
  "slop-commit",
  "slop-futures",
- "slop-koala-bear 6.6.0",
+ "slop-koala-bear 6.7.0",
  "slop-matrix",
- "slop-symmetric 6.6.0",
+ "slop-symmetric 6.7.0",
  "slop-tensor",
  "slop-utils",
  "thiserror 1.0.69",
@@ -6782,7 +6782,7 @@ dependencies = [
 
 [[package]]
 name = "slop-multilinear"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "derive-where",
  "num_cpus",
@@ -6790,10 +6790,10 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-alloc",
  "slop-baby-bear",
- "slop-challenger 6.6.0",
+ "slop-challenger 6.7.0",
  "slop-commit",
  "slop-matrix",
  "slop-tensor",
@@ -6801,15 +6801,15 @@ dependencies = [
 
 [[package]]
 name = "slop-pgspcs"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "rand 0.8.6",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-alloc",
  "slop-baby-bear",
  "slop-basefold",
  "slop-basefold-prover",
- "slop-challenger 6.6.0",
+ "slop-challenger 6.7.0",
  "slop-commit",
  "slop-merkle-tree",
  "slop-multilinear",
@@ -6827,7 +6827,7 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-poseidon2",
 ]
@@ -6843,18 +6843,18 @@ dependencies = [
 
 [[package]]
 name = "slop-primitives"
-version = "6.6.0"
+version = "6.7.0"
 
 [[package]]
 name = "slop-spartan"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.6",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-alloc",
  "slop-baby-bear",
- "slop-challenger 6.6.0",
+ "slop-challenger 6.7.0",
  "slop-merkle-tree",
  "slop-multilinear",
  "slop-pgspcs",
@@ -6864,18 +6864,18 @@ dependencies = [
 
 [[package]]
 name = "slop-stacked"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
  "rand 0.8.6",
  "serde",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-alloc",
  "slop-baby-bear",
  "slop-basefold",
  "slop-basefold-prover",
- "slop-challenger 6.6.0",
+ "slop-challenger 6.7.0",
  "slop-commit",
  "slop-merkle-tree",
  "slop-multilinear",
@@ -6885,16 +6885,16 @@ dependencies = [
 
 [[package]]
 name = "slop-sumcheck"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.6",
  "rayon",
  "serde",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-alloc",
  "slop-baby-bear",
- "slop-challenger 6.6.0",
+ "slop-challenger 6.7.0",
  "slop-multilinear",
  "thiserror 1.0.69",
 ]
@@ -6910,14 +6910,14 @@ dependencies = [
 
 [[package]]
 name = "slop-symmetric"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-symmetric",
 ]
 
 [[package]]
 name = "slop-tensor"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "arrayvec",
  "derive-where",
@@ -6926,7 +6926,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-alloc",
  "slop-baby-bear",
  "slop-matrix",
@@ -6936,14 +6936,14 @@ dependencies = [
 
 [[package]]
 name = "slop-uni-stark"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-uni-stark",
 ]
 
 [[package]]
 name = "slop-utils"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-util",
  "tracing-forest",
@@ -6952,7 +6952,7 @@ dependencies = [
 
 [[package]]
 name = "slop-veil"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "derive-where",
@@ -6961,16 +6961,16 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rayon",
  "serde",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-alloc",
  "slop-basefold",
  "slop-basefold-prover",
- "slop-challenger 6.6.0",
+ "slop-challenger 6.7.0",
  "slop-commit",
  "slop-dft",
  "slop-futures",
  "slop-jagged",
- "slop-koala-bear 6.6.0",
+ "slop-koala-bear 6.7.0",
  "slop-matrix",
  "slop-merkle-tree",
  "slop-multilinear",
@@ -6984,7 +6984,7 @@ dependencies = [
 
 [[package]]
 name = "slop-whir"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "derive-where",
@@ -6992,14 +6992,14 @@ dependencies = [
  "rand 0.8.6",
  "rayon",
  "serde",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-alloc",
  "slop-baby-bear",
- "slop-challenger 6.6.0",
+ "slop-challenger 6.7.0",
  "slop-commit",
  "slop-dft",
  "slop-jagged",
- "slop-koala-bear 6.6.0",
+ "slop-koala-bear 6.7.0",
  "slop-matrix",
  "slop-merkle-tree",
  "slop-multilinear",
@@ -7050,19 +7050,19 @@ dependencies = [
 
 [[package]]
 name = "sp1-build"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
  "chrono",
  "clap",
  "dirs",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
 ]
 
 [[package]]
 name = "sp1-cli"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -7083,19 +7083,19 @@ dependencies = [
 
 [[package]]
 name = "sp1-constraint-compiler"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "clap",
  "serde_json",
  "slop-air",
  "sp1-core-machine",
  "sp1-hypercube",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
 ]
 
 [[package]]
 name = "sp1-core-executor"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "cfg-if",
@@ -7116,13 +7116,13 @@ dependencies = [
  "serde_arrays",
  "serde_json",
  "slop-air",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-maybe-rayon",
- "slop-symmetric 6.6.0",
+ "slop-symmetric 6.7.0",
  "sp1-curves",
  "sp1-hypercube",
  "sp1-jit",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
  "sp1-zkvm",
  "strum",
  "subenum",
@@ -7136,7 +7136,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor-runner"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -7149,7 +7149,7 @@ dependencies = [
  "sp1-core-executor-runner-binary",
  "sp1-core-machine",
  "sp1-jit",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
  "sysinfo 0.30.13",
  "test-artifacts",
  "tokio",
@@ -7159,7 +7159,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor-runner-binary"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "crash-handler",
@@ -7172,7 +7172,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-machine"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "cfg-if",
@@ -7188,10 +7188,10 @@ dependencies = [
  "serde",
  "serde_json",
  "slop-air",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-alloc",
  "slop-basefold",
- "slop-challenger 6.6.0",
+ "slop-challenger 6.7.0",
  "slop-keccak-air",
  "slop-matrix",
  "slop-maybe-rayon",
@@ -7204,7 +7204,7 @@ dependencies = [
  "sp1-derive",
  "sp1-hypercube",
  "sp1-jit",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
  "static_assertions",
  "struct-reflection",
  "strum",
@@ -7221,7 +7221,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cuda"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "bytes",
@@ -7230,7 +7230,7 @@ dependencies = [
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-hypercube",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
  "sp1-prover",
  "sp1-prover-types",
  "thiserror 1.0.69",
@@ -7240,7 +7240,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "cfg-if",
  "curve25519-dalek",
@@ -7255,15 +7255,15 @@ dependencies = [
  "rand 0.8.6",
  "rug",
  "serde",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "snowbridge-amcl",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
  "typenum",
 ]
 
 [[package]]
 name = "sp1-derive"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7272,42 +7272,42 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-air"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "lazy_static",
  "slop-air",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-matrix",
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-hypercube",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
 ]
 
 [[package]]
 name = "sp1-gpu-basefold"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "futures",
  "itertools 0.14.0",
  "rand 0.8.6",
  "serde",
  "serial_test",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-alloc",
  "slop-basefold",
  "slop-basefold-prover",
- "slop-bn254 6.6.0",
- "slop-challenger 6.6.0",
+ "slop-bn254 6.7.0",
+ "slop-challenger 6.7.0",
  "slop-commit",
  "slop-dft",
  "slop-futures",
- "slop-koala-bear 6.6.0",
+ "slop-koala-bear 6.7.0",
  "slop-merkle-tree",
  "slop-multilinear",
- "slop-poseidon2 6.6.0",
+ "slop-poseidon2 6.7.0",
  "slop-stacked",
- "slop-symmetric 6.6.0",
+ "slop-symmetric 6.7.0",
  "slop-tensor",
  "sp1-core-machine",
  "sp1-gpu-challenger",
@@ -7319,7 +7319,7 @@ dependencies = [
  "sp1-gpu-tracegen",
  "sp1-gpu-utils",
  "sp1-hypercube",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
  "sp1-recursion-circuit",
  "sp1-recursion-compiler",
  "sp1-sdk",
@@ -7331,38 +7331,38 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-challenger"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-alloc",
- "slop-challenger 6.6.0",
- "slop-koala-bear 6.6.0",
- "slop-poseidon2 6.6.0",
- "slop-symmetric 6.6.0",
+ "slop-challenger 6.7.0",
+ "slop-koala-bear 6.7.0",
+ "slop-poseidon2 6.7.0",
+ "slop-symmetric 6.7.0",
  "sp1-gpu-cudart",
  "sp1-hypercube",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
  "tokio",
 ]
 
 [[package]]
 name = "sp1-gpu-commit"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "criterion",
  "itertools 0.14.0",
  "rand 0.8.6",
  "serial_test",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-alloc",
- "slop-challenger 6.6.0",
+ "slop-challenger 6.7.0",
  "slop-dft",
  "slop-futures",
  "slop-jagged",
- "slop-koala-bear 6.6.0",
+ "slop-koala-bear 6.7.0",
  "slop-merkle-tree",
  "slop-stacked",
- "slop-symmetric 6.6.0",
+ "slop-symmetric 6.7.0",
  "slop-tensor",
  "sp1-core-machine",
  "sp1-gpu-basefold",
@@ -7374,7 +7374,7 @@ dependencies = [
  "sp1-gpu-tracegen",
  "sp1-gpu-utils",
  "sp1-hypercube",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
  "sp1-recursion-circuit",
  "sp1-recursion-compiler",
  "sp1-sdk",
@@ -7386,28 +7386,28 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-cudart"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "crossbeam",
  "futures",
  "itertools 0.14.0",
  "pin-project",
  "rand 0.8.6",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-alloc",
  "slop-basefold",
- "slop-challenger 6.6.0",
+ "slop-challenger 6.7.0",
  "slop-commit",
  "slop-futures",
  "slop-jagged",
- "slop-koala-bear 6.6.0",
+ "slop-koala-bear 6.7.0",
  "slop-multilinear",
  "slop-stacked",
  "slop-sumcheck",
  "slop-tensor",
  "sp1-gpu-sys",
  "sp1-hypercube",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -7415,28 +7415,28 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-jagged-assist"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "futures",
  "itertools 0.14.0",
  "rand 0.8.6",
  "serde",
  "serial_test",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-alloc",
  "slop-basefold",
- "slop-bn254 6.6.0",
- "slop-challenger 6.6.0",
+ "slop-bn254 6.7.0",
+ "slop-challenger 6.7.0",
  "slop-commit",
  "slop-jagged",
- "slop-koala-bear 6.6.0",
+ "slop-koala-bear 6.7.0",
  "slop-multilinear",
  "slop-sumcheck",
  "slop-tensor",
  "sp1-gpu-challenger",
  "sp1-gpu-cudart",
  "sp1-gpu-tracing",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
  "sp1-prover",
  "tokio",
  "tracing",
@@ -7444,7 +7444,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-jagged-sumcheck"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "criterion",
  "futures",
@@ -7453,9 +7453,9 @@ dependencies = [
  "rand 0.8.6",
  "rayon",
  "serial_test",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-alloc",
- "slop-challenger 6.6.0",
+ "slop-challenger 6.7.0",
  "slop-futures",
  "slop-jagged",
  "slop-multilinear",
@@ -7478,7 +7478,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-jagged-tracegen"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "criterion",
  "futures",
@@ -7489,9 +7489,9 @@ dependencies = [
  "serde_json",
  "serial_test",
  "slop-air",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-alloc",
- "slop-challenger 6.6.0",
+ "slop-challenger 6.7.0",
  "slop-futures",
  "slop-jagged",
  "slop-multilinear",
@@ -7518,7 +7518,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-logup-gkr"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "criterion",
  "futures",
@@ -7529,19 +7529,19 @@ dependencies = [
  "serde_json",
  "serial_test",
  "slop-air",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-alloc",
  "slop-basefold-prover",
- "slop-bn254 6.6.0",
- "slop-challenger 6.6.0",
+ "slop-bn254 6.7.0",
+ "slop-challenger 6.7.0",
  "slop-commit",
  "slop-dft",
  "slop-futures",
- "slop-koala-bear 6.6.0",
+ "slop-koala-bear 6.7.0",
  "slop-merkle-tree",
  "slop-multilinear",
  "slop-sumcheck",
- "slop-symmetric 6.6.0",
+ "slop-symmetric 6.7.0",
  "slop-tensor",
  "sp1-core-executor",
  "sp1-core-machine",
@@ -7551,7 +7551,7 @@ dependencies = [
  "sp1-gpu-utils",
  "sp1-gpu-zerocheck",
  "sp1-hypercube",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
  "sp1-recursion-circuit",
  "sp1-sdk",
  "test-artifacts",
@@ -7564,20 +7564,20 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-merkle-tree"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "serial_test",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-alloc",
- "slop-bn254 6.6.0",
- "slop-challenger 6.6.0",
+ "slop-bn254 6.7.0",
+ "slop-challenger 6.7.0",
  "slop-commit",
  "slop-futures",
- "slop-koala-bear 6.6.0",
+ "slop-koala-bear 6.7.0",
  "slop-merkle-tree",
  "slop-multilinear",
  "slop-stacked",
- "slop-symmetric 6.6.0",
+ "slop-symmetric 6.7.0",
  "slop-tensor",
  "sp1-core-machine",
  "sp1-gpu-cudart",
@@ -7586,7 +7586,7 @@ dependencies = [
  "sp1-gpu-tracegen",
  "sp1-gpu-utils",
  "sp1-hypercube",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
  "sp1-recursion-circuit",
  "sp1-recursion-compiler",
  "test-artifacts",
@@ -7597,7 +7597,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-perf"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "clap",
@@ -7611,7 +7611,7 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "serde_json",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-gpu-cudart",
@@ -7619,7 +7619,7 @@ dependencies = [
  "sp1-gpu-shard-prover",
  "sp1-gpu-tracing",
  "sp1-hypercube",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
  "sp1-prover",
  "sp1-prover-types",
  "sp1-recursion-circuit",
@@ -7637,18 +7637,18 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-prover"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "clap",
  "serde",
  "slop-air",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-basefold",
- "slop-bn254 6.6.0",
- "slop-challenger 6.6.0",
+ "slop-bn254 6.7.0",
+ "slop-challenger 6.7.0",
  "slop-futures",
  "slop-jagged",
- "slop-koala-bear 6.6.0",
+ "slop-koala-bear 6.7.0",
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-gpu-air",
@@ -7662,7 +7662,7 @@ dependencies = [
  "sp1-gpu-shard-prover",
  "sp1-gpu-tracegen",
  "sp1-hypercube",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
  "sp1-prover",
  "sp1-prover-types",
  "sysinfo 0.31.4",
@@ -7671,7 +7671,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-server"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "clap",
@@ -7681,7 +7681,7 @@ dependencies = [
  "sp1-cuda",
  "sp1-gpu-cudart",
  "sp1-gpu-prover",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
  "sp1-prover",
  "sp1-prover-types",
  "sp1-recursion-gnark-ffi",
@@ -7693,17 +7693,17 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-shard-prover"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "criterion",
  "rand 0.8.6",
  "serde_json",
  "serial_test",
  "slop-air",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-alloc",
  "slop-basefold",
- "slop-challenger 6.6.0",
+ "slop-challenger 6.7.0",
  "slop-commit",
  "slop-futures",
  "slop-jagged",
@@ -7726,7 +7726,7 @@ dependencies = [
  "sp1-gpu-utils",
  "sp1-gpu-zerocheck",
  "sp1-hypercube",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
  "sp1-recursion-circuit",
  "sp1-recursion-compiler",
  "test-artifacts",
@@ -7738,39 +7738,39 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-sys"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "cbindgen",
  "cmake",
  "pathdiff",
- "slop-koala-bear 6.6.0",
+ "slop-koala-bear 6.7.0",
  "sp1-core-executor",
  "sp1-core-machine",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
  "sp1-recursion-executor",
  "sp1-recursion-machine",
 ]
 
 [[package]]
 name = "sp1-gpu-tracegen"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "futures",
  "rand 0.8.6",
  "rayon",
  "slop-air",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-alloc",
  "slop-futures",
- "slop-koala-bear 6.6.0",
+ "slop-koala-bear 6.7.0",
  "slop-multilinear",
- "slop-symmetric 6.6.0",
+ "slop-symmetric 6.7.0",
  "slop-tensor",
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-gpu-cudart",
  "sp1-hypercube",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
  "sp1-recursion-executor",
  "sp1-recursion-machine",
  "tokio",
@@ -7779,7 +7779,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-tracing"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "sp1-gpu-cudart",
  "tracing",
@@ -7788,18 +7788,18 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-utils"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "rand 0.8.6",
  "serial_test",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-alloc",
- "slop-koala-bear 6.6.0",
+ "slop-koala-bear 6.7.0",
  "slop-stacked",
  "slop-tensor",
  "sp1-gpu-cudart",
  "sp1-gpu-prover",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
  "sp1-recursion-circuit",
  "sp1-recursion-compiler",
  "sp1-sdk",
@@ -7808,19 +7808,19 @@ dependencies = [
 
 [[package]]
 name = "sp1-gpu-zerocheck"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "criterion",
  "itertools 0.14.0",
  "rand 0.8.6",
  "serial_test",
  "slop-air",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-alloc",
- "slop-challenger 6.6.0",
+ "slop-challenger 6.7.0",
  "slop-commit",
  "slop-futures",
- "slop-koala-bear 6.6.0",
+ "slop-koala-bear 6.7.0",
  "slop-matrix",
  "slop-multilinear",
  "slop-stacked",
@@ -7836,7 +7836,7 @@ dependencies = [
  "sp1-gpu-tracegen",
  "sp1-gpu-utils",
  "sp1-hypercube",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
  "sp1-recursion-circuit",
  "sp1-recursion-compiler",
  "sp1-sdk",
@@ -7849,14 +7849,14 @@ dependencies = [
 
 [[package]]
 name = "sp1-helper"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "sp1-build",
 ]
 
 [[package]]
 name = "sp1-hypercube"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "arrayref",
  "deepsize2",
@@ -7871,27 +7871,27 @@ dependencies = [
  "rayon-scan",
  "serde",
  "slop-air",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-alloc",
  "slop-basefold",
- "slop-bn254 6.6.0",
- "slop-challenger 6.6.0",
+ "slop-bn254 6.7.0",
+ "slop-challenger 6.7.0",
  "slop-commit",
  "slop-futures",
  "slop-jagged",
- "slop-koala-bear 6.6.0",
+ "slop-koala-bear 6.7.0",
  "slop-matrix",
  "slop-merkle-tree",
  "slop-multilinear",
- "slop-poseidon2 6.6.0",
+ "slop-poseidon2 6.7.0",
  "slop-stacked",
  "slop-sumcheck",
- "slop-symmetric 6.6.0",
+ "slop-symmetric 6.7.0",
  "slop-tensor",
  "slop-uni-stark",
  "slop-whir",
  "sp1-derive",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
  "sp1-zkvm",
  "struct-reflection",
  "strum",
@@ -7903,7 +7903,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-jit"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "dynasmrt",
@@ -7912,7 +7912,7 @@ dependencies = [
  "memfd",
  "memmap2",
  "serde",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
  "tracing",
  "uuid",
 ]
@@ -7931,17 +7931,17 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "elliptic-curve",
  "serde",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
 ]
 
 [[package]]
 name = "sp1-perf"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -7950,12 +7950,12 @@ dependencies = [
  "clap",
  "dotenv",
  "rustyline",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-cuda",
  "sp1-hypercube",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
  "sp1-prover",
  "sp1-prover-types",
  "sp1-sdk",
@@ -7991,7 +7991,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -8002,18 +8002,18 @@ dependencies = [
  "num-bigint 0.4.6",
  "serde",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-algebra 6.6.0",
- "slop-bn254 6.6.0",
- "slop-challenger 6.6.0",
- "slop-koala-bear 6.6.0",
- "slop-poseidon2 6.6.0",
- "slop-primitives 6.6.0",
- "slop-symmetric 6.6.0",
+ "slop-algebra 6.7.0",
+ "slop-bn254 6.7.0",
+ "slop-challenger 6.7.0",
+ "slop-koala-bear 6.7.0",
+ "slop-poseidon2 6.7.0",
+ "slop-primitives 6.7.0",
+ "slop-symmetric 6.7.0",
 ]
 
 [[package]]
 name = "sp1-prover"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8038,18 +8038,18 @@ dependencies = [
  "serial_test",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "slop-air",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-basefold",
- "slop-bn254 6.6.0",
- "slop-challenger 6.6.0",
+ "slop-bn254 6.7.0",
+ "slop-challenger 6.7.0",
  "slop-futures",
- "slop-symmetric 6.6.0",
+ "slop-symmetric 6.7.0",
  "sp1-core-executor",
  "sp1-core-executor-runner",
  "sp1-core-machine",
  "sp1-hypercube",
  "sp1-jit",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
  "sp1-prover-types",
  "sp1-recursion-circuit",
  "sp1-recursion-compiler",
@@ -8069,7 +8069,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover-types"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -8082,7 +8082,7 @@ dependencies = [
  "serde",
  "sp1-core-machine",
  "sp1-hypercube",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
  "tokio",
  "tonic 0.12.3",
  "tonic-build",
@@ -8091,7 +8091,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-circuit"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "itertools 0.14.0",
@@ -8099,29 +8099,29 @@ dependencies = [
  "rayon",
  "serde",
  "slop-air",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-alloc",
  "slop-basefold",
  "slop-basefold-prover",
- "slop-bn254 6.6.0",
- "slop-challenger 6.6.0",
+ "slop-bn254 6.7.0",
+ "slop-challenger 6.7.0",
  "slop-commit",
  "slop-dft",
  "slop-jagged",
- "slop-koala-bear 6.6.0",
+ "slop-koala-bear 6.7.0",
  "slop-matrix",
  "slop-merkle-tree",
  "slop-multilinear",
  "slop-stacked",
  "slop-sumcheck",
- "slop-symmetric 6.6.0",
+ "slop-symmetric 6.7.0",
  "slop-tensor",
  "slop-whir",
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-derive",
  "sp1-hypercube",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
  "sp1-recursion-compiler",
  "sp1-recursion-executor",
  "sp1-recursion-gnark-ffi",
@@ -8133,19 +8133,19 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-compiler"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "backtrace",
  "cfg-if",
  "itertools 0.14.0",
  "rand 0.8.6",
  "serde",
- "slop-algebra 6.6.0",
- "slop-bn254 6.6.0",
- "slop-symmetric 6.6.0",
+ "slop-algebra 6.7.0",
+ "slop-bn254 6.7.0",
+ "slop-symmetric 6.7.0",
  "sp1-core-machine",
  "sp1-hypercube",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
  "sp1-recursion-executor",
  "tracing",
  "vec_map",
@@ -8153,7 +8153,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-executor"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -8161,10 +8161,10 @@ dependencies = [
  "itertools 0.14.0",
  "range-set-blaze",
  "serde",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-maybe-rayon",
- "slop-poseidon2 6.6.0",
- "slop-symmetric 6.6.0",
+ "slop-poseidon2 6.7.0",
+ "slop-symmetric 6.7.0",
  "smallvec",
  "sp1-derive",
  "sp1-hypercube",
@@ -8175,7 +8175,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-cli"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "clap",
@@ -8184,7 +8184,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-ffi"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8194,10 +8194,10 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-algebra 6.6.0",
- "slop-symmetric 6.6.0",
+ "slop-algebra 6.7.0",
+ "slop-symmetric 6.7.0",
  "sp1-hypercube",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
  "sp1-recursion-compiler",
  "sp1-verifier",
  "tempfile",
@@ -8206,21 +8206,21 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-machine"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.6",
  "slop-air",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-basefold",
- "slop-challenger 6.6.0",
+ "slop-challenger 6.7.0",
  "slop-matrix",
  "slop-maybe-rayon",
- "slop-symmetric 6.6.0",
+ "slop-symmetric 6.7.0",
  "sp1-core-machine",
  "sp1-derive",
  "sp1-hypercube",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
  "sp1-recursion-executor",
  "strum",
  "tokio",
@@ -8229,7 +8229,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-sdk"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -8260,7 +8260,7 @@ dependencies = [
  "sp1-core-machine",
  "sp1-cuda",
  "sp1-hypercube",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
  "sp1-prover",
  "sp1-prover-types",
  "sp1-recursion-executor",
@@ -8279,7 +8279,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-verifier"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -8295,12 +8295,12 @@ dependencies = [
  "serde",
  "serial_test",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-algebra 6.6.0",
- "slop-challenger 6.6.0",
- "slop-primitives 6.6.0",
- "slop-symmetric 6.6.0",
+ "slop-algebra 6.7.0",
+ "slop-challenger 6.7.0",
+ "slop-primitives 6.7.0",
+ "slop-symmetric 6.7.0",
  "sp1-hypercube",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
  "sp1-recursion-executor",
  "sp1-recursion-machine",
  "sp1-sdk",
@@ -8313,7 +8313,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "blake3",
  "cfg-if",
@@ -8324,9 +8324,9 @@ dependencies = [
  "libm",
  "rand 0.8.6",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-algebra 6.6.0",
- "sp1-lib 6.6.0",
- "sp1-primitives 6.6.0",
+ "slop-algebra 6.7.0",
+ "sp1-lib 6.7.0",
+ "sp1-primitives 6.7.0",
 ]
 
 [[package]]
@@ -8600,7 +8600,7 @@ dependencies = [
 
 [[package]]
 name = "test-artifacts"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "sp1-build",
 ]
@@ -10260,7 +10260,7 @@ dependencies = [
 
 [[package]]
 name = "zkevm-build-sdk"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "sp1-build",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "6.6.0"
+version = "6.7.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/succinctlabs/sp1"
@@ -118,53 +118,53 @@ debug = true
 debug-assertions = true
 
 [workspace.dependencies]
-sp1-build = { version = "6.6.0", path = "crates/build" }
-sp1-cli = { version = "6.6.0", path = "crates/cli", default-features = false }
-sp1-core-executor = { version = "6.6.0", path = "crates/core/executor" }
-sp1-core-executor-runner = { version = "6.6.0", path = "crates/core/runner" }
-sp1-core-executor-runner-binary = { version = "6.6.0", path = "crates/core/runner-binary" }
-sp1-core-machine = { version = "6.6.0", path = "crates/core/machine" }
-sp1-cuda = { version = "6.6.0", path = "crates/cuda" }
-sp1-curves = { version = "6.6.0", path = "crates/curves" }
-sp1-derive = { version = "6.6.0", path = "crates/derive" }
-# sp1-eval = { version = "6.6.0", path = "crates/eval" }
-sp1-helper = { version = "6.6.0", path = "crates/helper", default-features = false }
-sp1-hypercube = { version = "6.6.0", path = "crates/hypercube" }
-sp1-jit = { version = "6.6.0", path = "crates/core/jit" }
-sp1-lib = { version = "6.6.0", path = "crates/zkvm/lib", default-features = false }
-sp1-primitives = { version = "6.6.0", path = "crates/primitives" }
-sp1-prover = { version = "6.6.0", path = "crates/prover" }
-sp1-prover-types = { version = "6.6.0", path = "crates/prover-types" }
-sp1-recursion-circuit = { version = "6.6.0", path = "crates/recursion/circuit", default-features = false }
-sp1-recursion-compiler = { version = "6.6.0", path = "crates/recursion/compiler" }
-sp1-recursion-executor = { version = "6.6.0", path = "crates/recursion/executor", default-features = false }
-sp1-recursion-gnark-ffi = { version = "6.6.0", path = "crates/recursion/gnark-ffi", default-features = false }
-sp1-recursion-machine = { version = "6.6.0", path = "crates/recursion/machine", default-features = false }
-sp1-sdk = { version = "6.6.0", path = "crates/sdk", default-features = false }
-sp1-verifier = { version = "6.6.0", path = "crates/verifier", default-features = false, features = ["full"] }
-sp1-zkvm = { version = "6.6.0", path = "crates/zkvm/entrypoint", default-features = false }
+sp1-build = { version = "6.7.0", path = "crates/build" }
+sp1-cli = { version = "6.7.0", path = "crates/cli", default-features = false }
+sp1-core-executor = { version = "6.7.0", path = "crates/core/executor" }
+sp1-core-executor-runner = { version = "6.7.0", path = "crates/core/runner" }
+sp1-core-executor-runner-binary = { version = "6.7.0", path = "crates/core/runner-binary" }
+sp1-core-machine = { version = "6.7.0", path = "crates/core/machine" }
+sp1-cuda = { version = "6.7.0", path = "crates/cuda" }
+sp1-curves = { version = "6.7.0", path = "crates/curves" }
+sp1-derive = { version = "6.7.0", path = "crates/derive" }
+# sp1-eval = { version = "6.7.0", path = "crates/eval" }
+sp1-helper = { version = "6.7.0", path = "crates/helper", default-features = false }
+sp1-hypercube = { version = "6.7.0", path = "crates/hypercube" }
+sp1-jit = { version = "6.7.0", path = "crates/core/jit" }
+sp1-lib = { version = "6.7.0", path = "crates/zkvm/lib", default-features = false }
+sp1-primitives = { version = "6.7.0", path = "crates/primitives" }
+sp1-prover = { version = "6.7.0", path = "crates/prover" }
+sp1-prover-types = { version = "6.7.0", path = "crates/prover-types" }
+sp1-recursion-circuit = { version = "6.7.0", path = "crates/recursion/circuit", default-features = false }
+sp1-recursion-compiler = { version = "6.7.0", path = "crates/recursion/compiler" }
+sp1-recursion-executor = { version = "6.7.0", path = "crates/recursion/executor", default-features = false }
+sp1-recursion-gnark-ffi = { version = "6.7.0", path = "crates/recursion/gnark-ffi", default-features = false }
+sp1-recursion-machine = { version = "6.7.0", path = "crates/recursion/machine", default-features = false }
+sp1-sdk = { version = "6.7.0", path = "crates/sdk", default-features = false }
+sp1-verifier = { version = "6.7.0", path = "crates/verifier", default-features = false, features = ["full"] }
+sp1-zkvm = { version = "6.7.0", path = "crates/zkvm/entrypoint", default-features = false }
 test-artifacts = { path = "crates/test-artifacts" }
 
 # sp1-gpu crates
-sp1-gpu-air = { version = "6.6.0", path = "sp1-gpu/crates/air" }
-sp1-gpu-basefold = { version = "6.6.0", path = "sp1-gpu/crates/basefold" }
-sp1-gpu-challenger = { version = "6.6.0", path = "sp1-gpu/crates/challenger" }
-sp1-gpu-commit = { version = "6.6.0", path = "sp1-gpu/crates/commit" }
-sp1-gpu-cudart = { version = "6.6.0", path = "sp1-gpu/crates/cuda" }
-sp1-gpu-jagged-assist = { version = "6.6.0", path = "sp1-gpu/crates/jagged_assist" }
-sp1-gpu-jagged-sumcheck = { version = "6.6.0", path = "sp1-gpu/crates/jagged_sumcheck" }
-sp1-gpu-jagged-tracegen = { version = "6.6.0", path = "sp1-gpu/crates/jagged_tracegen" }
-sp1-gpu-logup-gkr = { version = "6.6.0", path = "sp1-gpu/crates/logup_gkr" }
-sp1-gpu-merkle-tree = { version = "6.6.0", path = "sp1-gpu/crates/merkle_tree" }
-sp1-gpu-perf = { version = "6.6.0", path = "sp1-gpu/crates/perf" }
-sp1-gpu-prover = { version = "6.6.0", path = "sp1-gpu/crates/prover_components" }
-sp1-gpu-server = { version = "6.6.0", path = "sp1-gpu/crates/server" }
-sp1-gpu-shard-prover = { version = "6.6.0", path = "sp1-gpu/crates/shard_prover" }
-sp1-gpu-sys = { version = "6.6.0", path = "sp1-gpu/crates/sys" }
-sp1-gpu-tracegen = { version = "6.6.0", path = "sp1-gpu/crates/tracegen" }
-sp1-gpu-tracing = { version = "6.6.0", path = "sp1-gpu/crates/tracing" }
-sp1-gpu-utils = { version = "6.6.0", path = "sp1-gpu/crates/utils" }
-sp1-gpu-zerocheck = { version = "6.6.0", path = "sp1-gpu/crates/zerocheck" }
+sp1-gpu-air = { version = "6.7.0", path = "sp1-gpu/crates/air" }
+sp1-gpu-basefold = { version = "6.7.0", path = "sp1-gpu/crates/basefold" }
+sp1-gpu-challenger = { version = "6.7.0", path = "sp1-gpu/crates/challenger" }
+sp1-gpu-commit = { version = "6.7.0", path = "sp1-gpu/crates/commit" }
+sp1-gpu-cudart = { version = "6.7.0", path = "sp1-gpu/crates/cuda" }
+sp1-gpu-jagged-assist = { version = "6.7.0", path = "sp1-gpu/crates/jagged_assist" }
+sp1-gpu-jagged-sumcheck = { version = "6.7.0", path = "sp1-gpu/crates/jagged_sumcheck" }
+sp1-gpu-jagged-tracegen = { version = "6.7.0", path = "sp1-gpu/crates/jagged_tracegen" }
+sp1-gpu-logup-gkr = { version = "6.7.0", path = "sp1-gpu/crates/logup_gkr" }
+sp1-gpu-merkle-tree = { version = "6.7.0", path = "sp1-gpu/crates/merkle_tree" }
+sp1-gpu-perf = { version = "6.7.0", path = "sp1-gpu/crates/perf" }
+sp1-gpu-prover = { version = "6.7.0", path = "sp1-gpu/crates/prover_components" }
+sp1-gpu-server = { version = "6.7.0", path = "sp1-gpu/crates/server" }
+sp1-gpu-shard-prover = { version = "6.7.0", path = "sp1-gpu/crates/shard_prover" }
+sp1-gpu-sys = { version = "6.7.0", path = "sp1-gpu/crates/sys" }
+sp1-gpu-tracegen = { version = "6.7.0", path = "sp1-gpu/crates/tracegen" }
+sp1-gpu-tracing = { version = "6.7.0", path = "sp1-gpu/crates/tracing" }
+sp1-gpu-utils = { version = "6.7.0", path = "sp1-gpu/crates/utils" }
+sp1-gpu-zerocheck = { version = "6.7.0", path = "sp1-gpu/crates/zerocheck" }
 
 p3-air = "=0.4.3-succinct"
 p3-baby-bear = "=0.4.3-succinct"
@@ -184,37 +184,37 @@ p3-symmetric = "=0.4.3-succinct"
 p3-uni-stark = "=0.4.3-succinct"
 p3-util = "=0.4.3-succinct"
 
-slop-air = { version = "6.6.0", path = "./slop/crates/air" }
-slop-algebra = { version = "6.6.0", path = "./slop/crates/algebra" }
-slop-alloc = { version = "6.6.0", path = "./slop/crates/alloc" }
-slop-baby-bear = { version = "6.6.0", path = "./slop/crates/baby-bear" }
-slop-basefold = { version = "6.6.0", path = "./slop/crates/basefold" }
-slop-basefold-prover = { version = "6.6.0", path = "./slop/crates/basefold-prover" }
-slop-bn254 = { version = "6.6.0", path = "./slop/crates/bn254" }
-slop-challenger = { version = "6.6.0", path = "./slop/crates/challenger" }
-slop-commit = { version = "6.6.0", path = "./slop/crates/commit" }
-slop-dft = { version = "6.6.0", path = "./slop/crates/dft" }
-slop-fri = { version = "6.6.0", path = "./slop/crates/fri" }
-slop-futures = { version = "6.6.0", path = "./slop/crates/futures" }
-slop-jagged = { version = "6.6.0", path = "./slop/crates/jagged" }
-slop-keccak-air = { version = "6.6.0", path = "./slop/crates/keccak-air" }
-slop-koala-bear = { version = "6.6.0", path = "./slop/crates/koala-bear" }
-slop-matrix = { version = "6.6.0", path = "./slop/crates/matrix" }
-slop-maybe-rayon = { version = "6.6.0", path = "./slop/crates/maybe-rayon" }
-slop-merkle-tree = { version = "6.6.0", path = "./slop/crates/merkle-tree" }
-slop-multilinear = { version = "6.6.0", path = "./slop/crates/multilinear" }
-slop-pgspcs = { version = "6.6.0", path = "./slop/crates/pgspcs" }
-slop-primitives = { version = "6.6.0", path = "./slop/crates/primitives" }
-slop-poseidon2 = { version = "6.6.0", path = "./slop/crates/poseidon2" }
-slop-spartan = { version = "6.6.0", path = "./slop/crates/spartan" }
-slop-stacked = { version = "6.6.0", path = "./slop/crates/stacked" }
-slop-sumcheck = { version = "6.6.0", path = "./slop/crates/sumcheck" }
-slop-symmetric = { version = "6.6.0", path = "./slop/crates/symmetric" }
-slop-tensor = { version = "6.6.0", path = "./slop/crates/tensor" }
-slop-uni-stark = { version = "6.6.0", path = "./slop/crates/uni-stark" }
-slop-utils = { version = "6.6.0", path = "./slop/crates/utils" }
-slop-veil = { version = "6.6.0", path = "./slop/crates/veil" }
-slop-whir = { version = "6.6.0", path = "./slop/crates/whir" }
+slop-air = { version = "6.7.0", path = "./slop/crates/air" }
+slop-algebra = { version = "6.7.0", path = "./slop/crates/algebra" }
+slop-alloc = { version = "6.7.0", path = "./slop/crates/alloc" }
+slop-baby-bear = { version = "6.7.0", path = "./slop/crates/baby-bear" }
+slop-basefold = { version = "6.7.0", path = "./slop/crates/basefold" }
+slop-basefold-prover = { version = "6.7.0", path = "./slop/crates/basefold-prover" }
+slop-bn254 = { version = "6.7.0", path = "./slop/crates/bn254" }
+slop-challenger = { version = "6.7.0", path = "./slop/crates/challenger" }
+slop-commit = { version = "6.7.0", path = "./slop/crates/commit" }
+slop-dft = { version = "6.7.0", path = "./slop/crates/dft" }
+slop-fri = { version = "6.7.0", path = "./slop/crates/fri" }
+slop-futures = { version = "6.7.0", path = "./slop/crates/futures" }
+slop-jagged = { version = "6.7.0", path = "./slop/crates/jagged" }
+slop-keccak-air = { version = "6.7.0", path = "./slop/crates/keccak-air" }
+slop-koala-bear = { version = "6.7.0", path = "./slop/crates/koala-bear" }
+slop-matrix = { version = "6.7.0", path = "./slop/crates/matrix" }
+slop-maybe-rayon = { version = "6.7.0", path = "./slop/crates/maybe-rayon" }
+slop-merkle-tree = { version = "6.7.0", path = "./slop/crates/merkle-tree" }
+slop-multilinear = { version = "6.7.0", path = "./slop/crates/multilinear" }
+slop-pgspcs = { version = "6.7.0", path = "./slop/crates/pgspcs" }
+slop-primitives = { version = "6.7.0", path = "./slop/crates/primitives" }
+slop-poseidon2 = { version = "6.7.0", path = "./slop/crates/poseidon2" }
+slop-spartan = { version = "6.7.0", path = "./slop/crates/spartan" }
+slop-stacked = { version = "6.7.0", path = "./slop/crates/stacked" }
+slop-sumcheck = { version = "6.7.0", path = "./slop/crates/sumcheck" }
+slop-symmetric = { version = "6.7.0", path = "./slop/crates/symmetric" }
+slop-tensor = { version = "6.7.0", path = "./slop/crates/tensor" }
+slop-uni-stark = { version = "6.7.0", path = "./slop/crates/uni-stark" }
+slop-utils = { version = "6.7.0", path = "./slop/crates/utils" }
+slop-veil = { version = "6.7.0", path = "./slop/crates/veil" }
+slop-whir = { version = "6.7.0", path = "./slop/crates/whir" }
 
 # For testing.
 tokio-test = "0.4.4"

--- a/crates/test-artifacts/programs/Cargo.lock
+++ b/crates/test-artifacts/programs/Cargo.lock
@@ -406,7 +406,7 @@ version = "1.1.0"
 dependencies = [
  "common-test-utils",
  "sp1-curves",
- "sp1-lib 6.6.0",
+ "sp1-lib 6.7.0",
  "sp1-zkvm",
 ]
 
@@ -449,7 +449,7 @@ name = "bls12381-mul-test"
 version = "1.1.0"
 dependencies = [
  "sp1-derive",
- "sp1-lib 6.6.0",
+ "sp1-lib 6.7.0",
  "sp1-zkvm",
 ]
 
@@ -459,7 +459,7 @@ version = "1.1.0"
 dependencies = [
  "common-test-utils",
  "sp1-curves",
- "sp1-lib 6.6.0",
+ "sp1-lib 6.7.0",
  "sp1-zkvm",
 ]
 
@@ -502,7 +502,7 @@ name = "bn254-mul-test"
 version = "1.1.0"
 dependencies = [
  "sp1-derive",
- "sp1-lib 6.6.0",
+ "sp1-lib 6.7.0",
  "sp1-zkvm",
 ]
 
@@ -572,7 +572,7 @@ name = "common-test-utils"
 version = "1.1.0"
 dependencies = [
  "num-bigint 0.4.6",
- "sp1-lib 6.6.0",
+ "sp1-lib 6.7.0",
 ]
 
 [[package]]
@@ -710,7 +710,7 @@ dependencies = [
  "digest 0.10.7",
  "fiat-crypto",
  "rustc_version 0.4.1",
- "sp1-lib 6.6.0",
+ "sp1-lib 6.7.0",
  "subtle",
  "zeroize",
 ]
@@ -2473,7 +2473,7 @@ version = "1.1.0"
 dependencies = [
  "common-test-utils",
  "sp1-curves",
- "sp1-lib 6.6.0",
+ "sp1-lib 6.7.0",
  "sp1-zkvm",
 ]
 
@@ -2509,7 +2509,7 @@ dependencies = [
  "num",
  "p256",
  "sp1-curves",
- "sp1-lib 6.6.0",
+ "sp1-lib 6.7.0",
  "sp1-zkvm",
 ]
 
@@ -2530,7 +2530,7 @@ dependencies = [
  "num",
  "p256",
  "sp1-curves",
- "sp1-lib 6.6.0",
+ "sp1-lib 6.7.0",
  "sp1-zkvm",
 ]
 
@@ -2748,7 +2748,7 @@ dependencies = [
 
 [[package]]
 name = "slop-algebra"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -2757,7 +2757,7 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "ff",
  "p3-bn254-fr",
@@ -2770,7 +2770,7 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-challenger",
  "serde",
@@ -2780,7 +2780,7 @@ dependencies = [
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -2793,18 +2793,18 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-poseidon2",
 ]
 
 [[package]]
 name = "slop-primitives"
-version = "6.6.0"
+version = "6.7.0"
 
 [[package]]
 name = "slop-symmetric"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-symmetric",
 ]
@@ -2821,7 +2821,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "cfg-if",
  "curve25519-dalek 4.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2842,7 +2842,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-derive"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2861,7 +2861,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "elliptic-curve",
@@ -2871,7 +2871,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -2893,7 +2893,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -2904,7 +2904,7 @@ dependencies = [
  "rand 0.8.5",
  "sha2 0.10.9",
  "slop-algebra",
- "sp1-lib 6.6.0",
+ "sp1-lib 6.7.0",
  "sp1-primitives",
 ]
 
@@ -3153,7 +3153,7 @@ source = "git+https://github.com/sp1-patches/tiny-keccak?tag=patch-2.0.2-sp1-6.2
 dependencies = [
  "cfg-if",
  "crunchy",
- "sp1-lib 6.6.0",
+ "sp1-lib 6.7.0",
 ]
 
 [[package]]

--- a/crates/test-artifacts/programs/fibonacci-blake3/Cargo.lock
+++ b/crates/test-artifacts/programs/fibonacci-blake3/Cargo.lock
@@ -647,7 +647,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "slop-algebra"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -656,7 +656,7 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "ff",
  "p3-bn254-fr",
@@ -669,7 +669,7 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-challenger",
  "serde",
@@ -679,7 +679,7 @@ dependencies = [
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -692,25 +692,25 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-poseidon2",
 ]
 
 [[package]]
 name = "slop-primitives"
-version = "6.6.0"
+version = "6.7.0"
 
 [[package]]
 name = "slop-symmetric"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-symmetric",
 ]
 
 [[package]]
 name = "sp1-lib"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "serde",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "blake3",
  "cfg-if",

--- a/crates/test-artifacts/programs/trap-exec/Cargo.lock
+++ b/crates/test-artifacts/programs/trap-exec/Cargo.lock
@@ -656,7 +656,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "slop-algebra"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -665,7 +665,7 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "ff",
  "p3-bn254-fr",
@@ -678,7 +678,7 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-challenger",
  "serde",
@@ -688,7 +688,7 @@ dependencies = [
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -701,25 +701,25 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-poseidon2",
 ]
 
 [[package]]
 name = "slop-primitives"
-version = "6.6.0"
+version = "6.7.0"
 
 [[package]]
 name = "slop-symmetric"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-symmetric",
 ]
 
 [[package]]
 name = "sp1-derive"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -728,7 +728,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "serde",
@@ -737,7 +737,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "cfg-if",
  "critical-section",

--- a/crates/test-artifacts/programs/trap-load-store/Cargo.lock
+++ b/crates/test-artifacts/programs/trap-load-store/Cargo.lock
@@ -656,7 +656,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "slop-algebra"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -665,7 +665,7 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "ff",
  "p3-bn254-fr",
@@ -678,7 +678,7 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-challenger",
  "serde",
@@ -688,7 +688,7 @@ dependencies = [
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -701,25 +701,25 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-poseidon2",
 ]
 
 [[package]]
 name = "slop-primitives"
-version = "6.6.0"
+version = "6.7.0"
 
 [[package]]
 name = "slop-symmetric"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-symmetric",
 ]
 
 [[package]]
 name = "sp1-derive"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -728,7 +728,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "serde",
@@ -737,7 +737,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "cfg-if",
  "critical-section",

--- a/crates/verifier/guest-verify-programs/Cargo.lock
+++ b/crates/verifier/guest-verify-programs/Cargo.lock
@@ -796,7 +796,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "slop-algebra"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "ff",
  "p3-bn254-fr",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-challenger",
  "serde",
@@ -828,7 +828,7 @@ dependencies = [
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -841,25 +841,25 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-poseidon2",
 ]
 
 [[package]]
 name = "slop-primitives"
-version = "6.6.0"
+version = "6.7.0"
 
 [[package]]
 name = "slop-symmetric"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-symmetric",
 ]
 
 [[package]]
 name = "sp1-lib"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "elliptic-curve",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-verifier"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "blake3",
  "cfg-if",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "blake3",
  "cfg-if",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -6222,14 +6222,14 @@ checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "slop-air"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-air",
 ]
 
 [[package]]
 name = "slop-algebra"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -6238,7 +6238,7 @@ dependencies = [
 
 [[package]]
 name = "slop-alloc"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "serde",
  "slop-algebra",
@@ -6247,7 +6247,7 @@ dependencies = [
 
 [[package]]
 name = "slop-baby-bear"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "lazy_static",
  "p3-baby-bear",
@@ -6260,7 +6260,7 @@ dependencies = [
 
 [[package]]
 name = "slop-basefold"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -6281,7 +6281,7 @@ dependencies = [
 
 [[package]]
 name = "slop-basefold-prover"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -6305,7 +6305,7 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "ff",
  "p3-bn254-fr",
@@ -6318,7 +6318,7 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-challenger",
  "serde",
@@ -6328,7 +6328,7 @@ dependencies = [
 
 [[package]]
 name = "slop-commit"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-commit",
  "serde",
@@ -6337,7 +6337,7 @@ dependencies = [
 
 [[package]]
 name = "slop-dft"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-dft",
  "serde",
@@ -6349,14 +6349,14 @@ dependencies = [
 
 [[package]]
 name = "slop-fri"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-fri",
 ]
 
 [[package]]
 name = "slop-futures"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "crossbeam",
  "futures",
@@ -6369,7 +6369,7 @@ dependencies = [
 
 [[package]]
 name = "slop-jagged"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "itertools 0.14.0",
  "num_cpus",
@@ -6398,14 +6398,14 @@ dependencies = [
 
 [[package]]
 name = "slop-keccak-air"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-keccak-air",
 ]
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -6418,21 +6418,21 @@ dependencies = [
 
 [[package]]
 name = "slop-matrix"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-matrix",
 ]
 
 [[package]]
 name = "slop-maybe-rayon"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-maybe-rayon",
 ]
 
 [[package]]
 name = "slop-merkle-tree"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "itertools 0.14.0",
  "p3-merkle-tree",
@@ -6454,7 +6454,7 @@ dependencies = [
 
 [[package]]
 name = "slop-multilinear"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "derive-where",
  "num_cpus",
@@ -6471,18 +6471,18 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-poseidon2",
 ]
 
 [[package]]
 name = "slop-primitives"
-version = "6.6.0"
+version = "6.7.0"
 
 [[package]]
 name = "slop-stacked"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -6501,7 +6501,7 @@ dependencies = [
 
 [[package]]
 name = "slop-sumcheck"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "itertools 0.14.0",
  "rayon",
@@ -6516,14 +6516,14 @@ dependencies = [
 
 [[package]]
 name = "slop-symmetric"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-symmetric",
 ]
 
 [[package]]
 name = "slop-tensor"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "arrayvec 0.7.6",
  "derive-where",
@@ -6540,14 +6540,14 @@ dependencies = [
 
 [[package]]
 name = "slop-uni-stark"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-uni-stark",
 ]
 
 [[package]]
 name = "slop-utils"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-util",
  "tracing-forest",
@@ -6556,7 +6556,7 @@ dependencies = [
 
 [[package]]
 name = "slop-whir"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -6620,7 +6620,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-build"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -6632,7 +6632,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "cfg-if",
@@ -6668,7 +6668,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor-runner"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -6688,7 +6688,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor-runner-binary"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "crash-handler",
@@ -6701,7 +6701,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-machine"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "cfg-if",
@@ -6743,7 +6743,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cuda"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "bytes",
@@ -6762,7 +6762,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "cfg-if",
  "curve25519-dalek",
@@ -6783,7 +6783,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-derive"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6792,7 +6792,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-hypercube"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "arrayref",
  "deepsize2",
@@ -6837,7 +6837,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-jit"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "dynasmrt",
  "hashbrown 0.14.5",
@@ -6852,7 +6852,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "elliptic-curve",
@@ -6862,7 +6862,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -6884,7 +6884,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6939,7 +6939,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover-types"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -6961,7 +6961,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-circuit"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "itertools 0.14.0",
@@ -6999,7 +6999,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-compiler"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -7018,7 +7018,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-executor"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -7040,7 +7040,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-ffi"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -7061,7 +7061,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-machine"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.5",
@@ -7081,7 +7081,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-sdk"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7113,7 +7113,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-verifier"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -7137,7 +7137,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "cfg-if",
  "critical-section",

--- a/patch-testing/Cargo.lock
+++ b/patch-testing/Cargo.lock
@@ -4237,14 +4237,14 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slop-air"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-air",
 ]
 
 [[package]]
 name = "slop-algebra"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -4253,7 +4253,7 @@ dependencies = [
 
 [[package]]
 name = "slop-alloc"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "serde",
  "slop-algebra",
@@ -4262,7 +4262,7 @@ dependencies = [
 
 [[package]]
 name = "slop-baby-bear"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "lazy_static",
  "p3-baby-bear",
@@ -4275,7 +4275,7 @@ dependencies = [
 
 [[package]]
 name = "slop-basefold"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -4296,7 +4296,7 @@ dependencies = [
 
 [[package]]
 name = "slop-basefold-prover"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -4320,7 +4320,7 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "ff",
  "p3-bn254-fr",
@@ -4333,7 +4333,7 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-challenger",
  "serde",
@@ -4343,7 +4343,7 @@ dependencies = [
 
 [[package]]
 name = "slop-commit"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-commit",
  "serde",
@@ -4352,7 +4352,7 @@ dependencies = [
 
 [[package]]
 name = "slop-dft"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-dft",
  "serde",
@@ -4364,14 +4364,14 @@ dependencies = [
 
 [[package]]
 name = "slop-fri"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-fri",
 ]
 
 [[package]]
 name = "slop-futures"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "crossbeam",
  "futures",
@@ -4384,7 +4384,7 @@ dependencies = [
 
 [[package]]
 name = "slop-jagged"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "itertools 0.14.0",
  "num_cpus",
@@ -4413,14 +4413,14 @@ dependencies = [
 
 [[package]]
 name = "slop-keccak-air"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-keccak-air",
 ]
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -4433,21 +4433,21 @@ dependencies = [
 
 [[package]]
 name = "slop-matrix"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-matrix",
 ]
 
 [[package]]
 name = "slop-maybe-rayon"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-maybe-rayon",
 ]
 
 [[package]]
 name = "slop-merkle-tree"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "itertools 0.14.0",
  "p3-merkle-tree",
@@ -4469,7 +4469,7 @@ dependencies = [
 
 [[package]]
 name = "slop-multilinear"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "derive-where",
  "num_cpus",
@@ -4486,18 +4486,18 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-poseidon2",
 ]
 
 [[package]]
 name = "slop-primitives"
-version = "6.6.0"
+version = "6.7.0"
 
 [[package]]
 name = "slop-stacked"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -4516,7 +4516,7 @@ dependencies = [
 
 [[package]]
 name = "slop-sumcheck"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "itertools 0.14.0",
  "rayon",
@@ -4531,14 +4531,14 @@ dependencies = [
 
 [[package]]
 name = "slop-symmetric"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-symmetric",
 ]
 
 [[package]]
 name = "slop-tensor"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "arrayvec",
  "derive-where",
@@ -4555,14 +4555,14 @@ dependencies = [
 
 [[package]]
 name = "slop-uni-stark"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-uni-stark",
 ]
 
 [[package]]
 name = "slop-utils"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-util",
  "tracing-forest",
@@ -4571,7 +4571,7 @@ dependencies = [
 
 [[package]]
 name = "slop-whir"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -4635,7 +4635,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-build"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -4647,7 +4647,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "cfg-if",
@@ -4683,7 +4683,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor-runner"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -4703,7 +4703,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor-runner-binary"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "crash-handler",
@@ -4716,7 +4716,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-machine"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "cfg-if",
@@ -4758,7 +4758,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cuda"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "bytes",
@@ -4777,7 +4777,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "cfg-if",
  "curve25519-dalek 4.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4798,7 +4798,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-derive"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4807,7 +4807,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-hypercube"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "arrayref",
  "deepsize2",
@@ -4852,7 +4852,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-jit"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "dynasmrt",
  "hashbrown 0.14.5",
@@ -4867,7 +4867,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "elliptic-curve",
@@ -4877,7 +4877,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -4899,7 +4899,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4954,7 +4954,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover-types"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -4976,7 +4976,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-circuit"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "itertools 0.14.0",
@@ -5014,7 +5014,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-compiler"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -5033,7 +5033,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-executor"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-ffi"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -5076,7 +5076,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-machine"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.5",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-sdk"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5155,7 +5155,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-verifier"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -5179,7 +5179,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "cfg-if",
  "critical-section",

--- a/patch-testing/secp256k1/program-v0.29.1/Cargo.lock
+++ b/patch-testing/secp256k1/program-v0.29.1/Cargo.lock
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "slop-algebra"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "ff",
  "p3-bn254-fr",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-challenger",
  "serde",
@@ -852,7 +852,7 @@ dependencies = [
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -865,25 +865,25 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-poseidon2",
 ]
 
 [[package]]
 name = "slop-primitives"
-version = "6.6.0"
+version = "6.7.0"
 
 [[package]]
 name = "slop-symmetric"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-symmetric",
 ]
 
 [[package]]
 name = "sp1-lib"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "elliptic-curve",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "cfg-if",
  "critical-section",

--- a/patch-testing/secp256k1/program-v0.30.0/Cargo.lock
+++ b/patch-testing/secp256k1/program-v0.30.0/Cargo.lock
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "slop-algebra"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "ff",
  "p3-bn254-fr",
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-challenger",
  "serde",
@@ -878,7 +878,7 @@ dependencies = [
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -891,25 +891,25 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-poseidon2",
 ]
 
 [[package]]
 name = "slop-primitives"
-version = "6.6.0"
+version = "6.7.0"
 
 [[package]]
 name = "slop-symmetric"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-symmetric",
 ]
 
 [[package]]
 name = "sp1-lib"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "elliptic-curve",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "cfg-if",
  "critical-section",

--- a/zkevm/examples/Cargo.lock
+++ b/zkevm/examples/Cargo.lock
@@ -3697,7 +3697,7 @@ dependencies = [
 
 [[package]]
 name = "libzkevm"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bls12_381",
  "k256 0.13.4 (git+https://github.com/sp1-patches/elliptic-curves?tag=patch-k256-13.4-sp1-6.2.0)",
@@ -5901,7 +5901,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slop-air"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-air",
 ]
@@ -5919,7 +5919,7 @@ dependencies = [
 
 [[package]]
 name = "slop-algebra"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -5928,42 +5928,42 @@ dependencies = [
 
 [[package]]
 name = "slop-alloc"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "serde",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "slop-baby-bear"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "lazy_static",
  "p3-baby-bear",
  "serde",
- "slop-algebra 6.6.0",
- "slop-challenger 6.6.0",
- "slop-poseidon2 6.6.0",
- "slop-symmetric 6.6.0",
+ "slop-algebra 6.7.0",
+ "slop-challenger 6.7.0",
+ "slop-poseidon2 6.7.0",
+ "slop-symmetric 6.7.0",
 ]
 
 [[package]]
 name = "slop-basefold"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
  "serde",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-alloc",
  "slop-baby-bear",
- "slop-bn254 6.6.0",
- "slop-challenger 6.6.0",
- "slop-koala-bear 6.6.0",
+ "slop-bn254 6.7.0",
+ "slop-challenger 6.7.0",
+ "slop-koala-bear 6.7.0",
  "slop-merkle-tree",
  "slop-multilinear",
- "slop-primitives 6.6.0",
+ "slop-primitives 6.7.0",
  "slop-tensor",
  "slop-utils",
  "thiserror 1.0.69",
@@ -5971,22 +5971,22 @@ dependencies = [
 
 [[package]]
 name = "slop-basefold-prover"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
  "rand 0.8.6",
  "serde",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-alloc",
  "slop-baby-bear",
  "slop-basefold",
- "slop-challenger 6.6.0",
+ "slop-challenger 6.7.0",
  "slop-commit",
  "slop-dft",
  "slop-fri",
  "slop-futures",
- "slop-koala-bear 6.6.0",
+ "slop-koala-bear 6.7.0",
  "slop-merkle-tree",
  "slop-multilinear",
  "slop-tensor",
@@ -6010,15 +6010,15 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "ff",
  "p3-bn254-fr",
  "serde",
- "slop-algebra 6.6.0",
- "slop-challenger 6.6.0",
- "slop-poseidon2 6.6.0",
- "slop-symmetric 6.6.0",
+ "slop-algebra 6.7.0",
+ "slop-challenger 6.7.0",
+ "slop-poseidon2 6.7.0",
+ "slop-symmetric 6.7.0",
 ]
 
 [[package]]
@@ -6036,17 +6036,17 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-challenger",
  "serde",
- "slop-algebra 6.6.0",
- "slop-symmetric 6.6.0",
+ "slop-algebra 6.7.0",
+ "slop-symmetric 6.7.0",
 ]
 
 [[package]]
 name = "slop-commit"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-commit",
  "serde",
@@ -6055,11 +6055,11 @@ dependencies = [
 
 [[package]]
 name = "slop-dft"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-dft",
  "serde",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-alloc",
  "slop-matrix",
  "slop-tensor",
@@ -6067,14 +6067,14 @@ dependencies = [
 
 [[package]]
 name = "slop-fri"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-fri",
 ]
 
 [[package]]
 name = "slop-futures"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "crossbeam",
  "futures",
@@ -6087,27 +6087,27 @@ dependencies = [
 
 [[package]]
 name = "slop-jagged"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "itertools 0.14.0",
  "num_cpus",
  "rand 0.8.6",
  "rayon",
  "serde",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-alloc",
  "slop-baby-bear",
  "slop-basefold",
  "slop-basefold-prover",
- "slop-bn254 6.6.0",
- "slop-challenger 6.6.0",
+ "slop-bn254 6.7.0",
+ "slop-challenger 6.7.0",
  "slop-commit",
- "slop-koala-bear 6.6.0",
+ "slop-koala-bear 6.7.0",
  "slop-merkle-tree",
  "slop-multilinear",
  "slop-stacked",
  "slop-sumcheck",
- "slop-symmetric 6.6.0",
+ "slop-symmetric 6.7.0",
  "slop-tensor",
  "slop-utils",
  "thiserror 1.0.69",
@@ -6116,7 +6116,7 @@ dependencies = [
 
 [[package]]
 name = "slop-keccak-air"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-keccak-air",
 ]
@@ -6138,48 +6138,48 @@ dependencies = [
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
  "serde",
- "slop-algebra 6.6.0",
- "slop-challenger 6.6.0",
- "slop-poseidon2 6.6.0",
- "slop-symmetric 6.6.0",
+ "slop-algebra 6.7.0",
+ "slop-challenger 6.7.0",
+ "slop-poseidon2 6.7.0",
+ "slop-symmetric 6.7.0",
 ]
 
 [[package]]
 name = "slop-matrix"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-matrix",
 ]
 
 [[package]]
 name = "slop-maybe-rayon"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-maybe-rayon",
 ]
 
 [[package]]
 name = "slop-merkle-tree"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "itertools 0.14.0",
  "p3-merkle-tree",
  "serde",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-alloc",
  "slop-baby-bear",
- "slop-bn254 6.6.0",
- "slop-challenger 6.6.0",
+ "slop-bn254 6.7.0",
+ "slop-challenger 6.7.0",
  "slop-commit",
  "slop-futures",
- "slop-koala-bear 6.6.0",
+ "slop-koala-bear 6.7.0",
  "slop-matrix",
- "slop-symmetric 6.6.0",
+ "slop-symmetric 6.7.0",
  "slop-tensor",
  "slop-utils",
  "thiserror 1.0.69",
@@ -6187,16 +6187,16 @@ dependencies = [
 
 [[package]]
 name = "slop-multilinear"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "derive-where",
  "num_cpus",
  "rand 0.8.6",
  "rayon",
  "serde",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-alloc",
- "slop-challenger 6.6.0",
+ "slop-challenger 6.7.0",
  "slop-commit",
  "slop-matrix",
  "slop-tensor",
@@ -6213,7 +6213,7 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-poseidon2",
 ]
@@ -6229,20 +6229,20 @@ dependencies = [
 
 [[package]]
 name = "slop-primitives"
-version = "6.6.0"
+version = "6.7.0"
 
 [[package]]
 name = "slop-stacked"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
  "serde",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-alloc",
  "slop-basefold",
  "slop-basefold-prover",
- "slop-challenger 6.6.0",
+ "slop-challenger 6.7.0",
  "slop-commit",
  "slop-merkle-tree",
  "slop-multilinear",
@@ -6252,15 +6252,15 @@ dependencies = [
 
 [[package]]
 name = "slop-sumcheck"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "itertools 0.14.0",
  "rayon",
  "serde",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-alloc",
  "slop-baby-bear",
- "slop-challenger 6.6.0",
+ "slop-challenger 6.7.0",
  "slop-multilinear",
  "thiserror 1.0.69",
 ]
@@ -6276,14 +6276,14 @@ dependencies = [
 
 [[package]]
 name = "slop-symmetric"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-symmetric",
 ]
 
 [[package]]
 name = "slop-tensor"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "arrayvec",
  "derive-where",
@@ -6291,7 +6291,7 @@ dependencies = [
  "rand 0.8.6",
  "rayon",
  "serde",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-alloc",
  "slop-matrix",
  "thiserror 1.0.69",
@@ -6300,14 +6300,14 @@ dependencies = [
 
 [[package]]
 name = "slop-uni-stark"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-uni-stark",
 ]
 
 [[package]]
 name = "slop-utils"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-util",
  "tracing-forest",
@@ -6316,21 +6316,21 @@ dependencies = [
 
 [[package]]
 name = "slop-whir"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
  "rand 0.8.6",
  "rayon",
  "serde",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-alloc",
  "slop-baby-bear",
- "slop-challenger 6.6.0",
+ "slop-challenger 6.7.0",
  "slop-commit",
  "slop-dft",
  "slop-jagged",
- "slop-koala-bear 6.6.0",
+ "slop-koala-bear 6.7.0",
  "slop-matrix",
  "slop-merkle-tree",
  "slop-multilinear",
@@ -6380,19 +6380,19 @@ dependencies = [
 
 [[package]]
 name = "sp1-build"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
  "chrono",
  "clap",
  "dirs",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
 ]
 
 [[package]]
 name = "sp1-core-executor"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "cfg-if",
@@ -6410,13 +6410,13 @@ dependencies = [
  "serde_arrays",
  "serde_json",
  "slop-air",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-maybe-rayon",
- "slop-symmetric 6.6.0",
+ "slop-symmetric 6.7.0",
  "sp1-curves",
  "sp1-hypercube",
  "sp1-jit",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
  "strum",
  "subenum",
  "thiserror 1.0.69",
@@ -6428,7 +6428,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor-runner"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -6440,7 +6440,7 @@ dependencies = [
  "sp1-core-executor",
  "sp1-core-executor-runner-binary",
  "sp1-jit",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
  "sysinfo",
  "tracing",
  "uuid",
@@ -6448,7 +6448,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor-runner-binary"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "crash-handler",
@@ -6461,7 +6461,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-machine"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "cfg-if",
@@ -6476,8 +6476,8 @@ dependencies = [
  "serde",
  "serde_json",
  "slop-air",
- "slop-algebra 6.6.0",
- "slop-challenger 6.6.0",
+ "slop-algebra 6.7.0",
+ "slop-challenger 6.7.0",
  "slop-keccak-air",
  "slop-matrix",
  "slop-maybe-rayon",
@@ -6488,7 +6488,7 @@ dependencies = [
  "sp1-derive",
  "sp1-hypercube",
  "sp1-jit",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
  "static_assertions",
  "struct-reflection",
  "strum",
@@ -6503,7 +6503,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-cuda"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "bytes",
@@ -6512,7 +6512,7 @@ dependencies = [
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-hypercube",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
  "sp1-prover",
  "sp1-prover-types",
  "thiserror 1.0.69",
@@ -6522,7 +6522,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "cfg-if",
  "curve25519-dalek",
@@ -6535,15 +6535,15 @@ dependencies = [
  "num",
  "p256 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "snowbridge-amcl",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
  "typenum",
 ]
 
 [[package]]
 name = "sp1-derive"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6552,7 +6552,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-hypercube"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "arrayref",
  "deepsize2",
@@ -6566,27 +6566,27 @@ dependencies = [
  "rayon-scan",
  "serde",
  "slop-air",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-alloc",
  "slop-basefold",
- "slop-bn254 6.6.0",
- "slop-challenger 6.6.0",
+ "slop-bn254 6.7.0",
+ "slop-challenger 6.7.0",
  "slop-commit",
  "slop-futures",
  "slop-jagged",
- "slop-koala-bear 6.6.0",
+ "slop-koala-bear 6.7.0",
  "slop-matrix",
  "slop-merkle-tree",
  "slop-multilinear",
- "slop-poseidon2 6.6.0",
+ "slop-poseidon2 6.7.0",
  "slop-stacked",
  "slop-sumcheck",
- "slop-symmetric 6.6.0",
+ "slop-symmetric 6.7.0",
  "slop-tensor",
  "slop-uni-stark",
  "slop-whir",
  "sp1-derive",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
  "struct-reflection",
  "strum",
  "thiserror 1.0.69",
@@ -6597,7 +6597,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-jit"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "dynasmrt",
  "hashbrown 0.14.5",
@@ -6605,7 +6605,7 @@ dependencies = [
  "memfd",
  "memmap2",
  "serde",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
  "tracing",
  "uuid",
 ]
@@ -6648,7 +6648,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -6659,18 +6659,18 @@ dependencies = [
  "num-bigint 0.4.6",
  "serde",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-algebra 6.6.0",
- "slop-bn254 6.6.0",
- "slop-challenger 6.6.0",
- "slop-koala-bear 6.6.0",
- "slop-poseidon2 6.6.0",
- "slop-primitives 6.6.0",
- "slop-symmetric 6.6.0",
+ "slop-algebra 6.7.0",
+ "slop-bn254 6.7.0",
+ "slop-challenger 6.7.0",
+ "slop-koala-bear 6.7.0",
+ "slop-poseidon2 6.7.0",
+ "slop-primitives 6.7.0",
+ "slop-symmetric 6.7.0",
 ]
 
 [[package]]
 name = "sp1-prover"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6695,18 +6695,18 @@ dependencies = [
  "serial_test",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "slop-air",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-basefold",
- "slop-bn254 6.6.0",
- "slop-challenger 6.6.0",
+ "slop-bn254 6.7.0",
+ "slop-challenger 6.7.0",
  "slop-futures",
- "slop-symmetric 6.6.0",
+ "slop-symmetric 6.7.0",
  "sp1-core-executor",
  "sp1-core-executor-runner",
  "sp1-core-machine",
  "sp1-hypercube",
  "sp1-jit",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
  "sp1-prover-types",
  "sp1-recursion-circuit",
  "sp1-recursion-compiler",
@@ -6725,7 +6725,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover-types"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -6738,7 +6738,7 @@ dependencies = [
  "serde",
  "sp1-core-machine",
  "sp1-hypercube",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
  "tokio",
  "tonic",
  "tonic-build",
@@ -6747,7 +6747,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-circuit"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "itertools 0.14.0",
@@ -6755,28 +6755,28 @@ dependencies = [
  "rayon",
  "serde",
  "slop-air",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-alloc",
  "slop-basefold",
  "slop-basefold-prover",
- "slop-bn254 6.6.0",
- "slop-challenger 6.6.0",
+ "slop-bn254 6.7.0",
+ "slop-challenger 6.7.0",
  "slop-commit",
  "slop-jagged",
- "slop-koala-bear 6.6.0",
+ "slop-koala-bear 6.7.0",
  "slop-matrix",
  "slop-merkle-tree",
  "slop-multilinear",
  "slop-stacked",
  "slop-sumcheck",
- "slop-symmetric 6.6.0",
+ "slop-symmetric 6.7.0",
  "slop-tensor",
  "slop-whir",
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-derive",
  "sp1-hypercube",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
  "sp1-recursion-compiler",
  "sp1-recursion-executor",
  "sp1-recursion-machine",
@@ -6785,18 +6785,18 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-compiler"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "backtrace",
  "cfg-if",
  "itertools 0.14.0",
  "serde",
- "slop-algebra 6.6.0",
- "slop-bn254 6.6.0",
- "slop-symmetric 6.6.0",
+ "slop-algebra 6.7.0",
+ "slop-bn254 6.7.0",
+ "slop-symmetric 6.7.0",
  "sp1-core-machine",
  "sp1-hypercube",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
  "sp1-recursion-executor",
  "tracing",
  "vec_map",
@@ -6804,7 +6804,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-executor"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -6812,10 +6812,10 @@ dependencies = [
  "itertools 0.14.0",
  "range-set-blaze",
  "serde",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-maybe-rayon",
- "slop-poseidon2 6.6.0",
- "slop-symmetric 6.6.0",
+ "slop-poseidon2 6.7.0",
+ "slop-symmetric 6.7.0",
  "smallvec",
  "sp1-derive",
  "sp1-hypercube",
@@ -6826,7 +6826,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-ffi"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6835,10 +6835,10 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-algebra 6.6.0",
- "slop-symmetric 6.6.0",
+ "slop-algebra 6.7.0",
+ "slop-symmetric 6.7.0",
  "sp1-hypercube",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
  "sp1-recursion-compiler",
  "sp1-verifier",
  "tempfile",
@@ -6847,19 +6847,19 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-machine"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.6",
  "slop-air",
- "slop-algebra 6.6.0",
+ "slop-algebra 6.7.0",
  "slop-basefold",
  "slop-matrix",
  "slop-maybe-rayon",
- "slop-symmetric 6.6.0",
+ "slop-symmetric 6.7.0",
  "sp1-derive",
  "sp1-hypercube",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
  "sp1-recursion-executor",
  "strum",
  "tracing",
@@ -6867,7 +6867,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-sdk"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -6897,7 +6897,7 @@ dependencies = [
  "sp1-core-machine",
  "sp1-cuda",
  "sp1-hypercube",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
  "sp1-prover",
  "sp1-prover-types",
  "sp1-recursion-executor",
@@ -6913,7 +6913,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-verifier"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -6922,12 +6922,12 @@ dependencies = [
  "lazy_static",
  "serde",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-algebra 6.6.0",
- "slop-challenger 6.6.0",
- "slop-primitives 6.6.0",
- "slop-symmetric 6.6.0",
+ "slop-algebra 6.7.0",
+ "slop-challenger 6.7.0",
+ "slop-primitives 6.7.0",
+ "slop-symmetric 6.7.0",
  "sp1-hypercube",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
  "sp1-recursion-executor",
  "sp1-recursion-machine",
  "strum",
@@ -6937,7 +6937,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -6946,7 +6946,7 @@ dependencies = [
  "getrandom 0.3.4",
  "rand 0.8.6",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
 ]
 
 [[package]]

--- a/zkevm/libzkevm-cabi/Cargo.lock
+++ b/zkevm/libzkevm-cabi/Cargo.lock
@@ -786,7 +786,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libzkevm"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bls12_381 0.8.0",
  "k256",
@@ -1537,7 +1537,7 @@ dependencies = [
 
 [[package]]
 name = "slop-algebra"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "itertools 0.14.0",
  "p3-field 0.4.3-succinct",
@@ -1562,15 +1562,15 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "ff 0.13.1",
  "p3-bn254-fr 0.4.3-succinct",
  "serde",
- "slop-algebra 6.6.0",
- "slop-challenger 6.6.0",
- "slop-poseidon2 6.6.0",
- "slop-symmetric 6.6.0",
+ "slop-algebra 6.7.0",
+ "slop-challenger 6.7.0",
+ "slop-poseidon2 6.7.0",
+ "slop-symmetric 6.7.0",
 ]
 
 [[package]]
@@ -1588,12 +1588,12 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-challenger 0.4.3-succinct",
  "serde",
- "slop-algebra 6.6.0",
- "slop-symmetric 6.6.0",
+ "slop-algebra 6.7.0",
+ "slop-symmetric 6.7.0",
 ]
 
 [[package]]
@@ -1613,15 +1613,15 @@ dependencies = [
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "lazy_static",
  "p3-koala-bear 0.4.3-succinct",
  "serde",
- "slop-algebra 6.6.0",
- "slop-challenger 6.6.0",
- "slop-poseidon2 6.6.0",
- "slop-symmetric 6.6.0",
+ "slop-algebra 6.7.0",
+ "slop-challenger 6.7.0",
+ "slop-poseidon2 6.7.0",
+ "slop-symmetric 6.7.0",
 ]
 
 [[package]]
@@ -1635,7 +1635,7 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-poseidon2 0.4.3-succinct",
 ]
@@ -1651,7 +1651,7 @@ dependencies = [
 
 [[package]]
 name = "slop-primitives"
-version = "6.6.0"
+version = "6.7.0"
 
 [[package]]
 name = "slop-symmetric"
@@ -1664,7 +1664,7 @@ dependencies = [
 
 [[package]]
 name = "slop-symmetric"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "p3-symmetric 0.4.3-succinct",
 ]
@@ -1713,7 +1713,7 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -1724,18 +1724,18 @@ dependencies = [
  "num-bigint 0.4.6",
  "serde",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-algebra 6.6.0",
- "slop-bn254 6.6.0",
- "slop-challenger 6.6.0",
- "slop-koala-bear 6.6.0",
- "slop-poseidon2 6.6.0",
- "slop-primitives 6.6.0",
- "slop-symmetric 6.6.0",
+ "slop-algebra 6.7.0",
+ "slop-bn254 6.7.0",
+ "slop-challenger 6.7.0",
+ "slop-koala-bear 6.7.0",
+ "slop-poseidon2 6.7.0",
+ "slop-primitives 6.7.0",
+ "slop-symmetric 6.7.0",
 ]
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.6.0"
+version = "6.7.0"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -1744,7 +1744,7 @@ dependencies = [
  "getrandom 0.3.4",
  "rand",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp1-primitives 6.6.0",
+ "sp1-primitives 6.7.0",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Set the workspace and local dependency versions to 6.7.0 with `set-version.sh`.
Refresh the tracked lockfiles with Cargo.
External dependency versions and source revisions remain unchanged.

## Motivation

Prepare v6.7.0 for refreshable bearer tokens (#2956), the `error_trace` protocol update (#2953), and multi-platform Gnark tags (#2949).

## Validation

- Confirmed that the diff contains only version changes.
- All tracked lockfiles pass `cargo metadata --locked --offline --no-deps`.
- `cargo fmt --all -- --check` and `git diff --check` pass.
- The full CPU/GPU test matrix will run in PR CI; it was not run locally for this version bump.
