### PR TITLE
fix(sdk): preserve network simulation errors

### DIFF
--- a/crates/sdk/src/network/error.rs
+++ b/crates/sdk/src/network/error.rs
@@ -5,8 +5,8 @@ use tonic::Status;
 #[derive(Error, Debug)]
 pub enum Error {
     /// The program execution failed.
-    #[error("Program simulation failed")]
-    SimulationFailed,
+    #[error("Program simulation failed: {0:#}")]
+    SimulationFailed(#[source] anyhow::Error),
 
     /// The proof request is unexecutable.
     #[error("Proof request 0x{} is unexecutable", hex::encode(.request_id))]
@@ -57,4 +57,18 @@ pub enum Error {
     /// An unknown error occurred.
     #[error("Other error: {0}")]
     Other(#[from] anyhow::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Error;
+
+    #[test]
+    fn simulation_failure_preserves_its_source() {
+        let source = anyhow::anyhow!("executor failed").context("guest panicked");
+        let error = Error::SimulationFailed(source);
+
+        assert_eq!(error.to_string(), "Program simulation failed: guest panicked: executor failed");
+        assert!(std::error::Error::source(&error).is_some());
+    }
 }

--- a/crates/sdk/src/network/error.rs
+++ b/crates/sdk/src/network/error.rs
@@ -5,8 +5,8 @@ use tonic::Status;
 #[derive(Error, Debug)]
 pub enum Error {
     /// The program execution failed.
-    #[error("Program simulation failed: {0:#}")]
-    SimulationFailed(#[source] anyhow::Error),
+    #[error("Program simulation failed")]
+    SimulationFailed,
 
     /// The proof request is unexecutable.
     #[error("Proof request 0x{} is unexecutable", hex::encode(.request_id))]
@@ -65,10 +65,11 @@ mod tests {
 
     #[test]
     fn simulation_failure_preserves_its_source() {
-        let source = anyhow::anyhow!("executor failed").context("guest panicked");
-        let error = Error::SimulationFailed(source);
+        let error = anyhow::anyhow!("executor failed")
+            .context("guest panicked")
+            .context(Error::SimulationFailed);
 
         assert_eq!(error.to_string(), "Program simulation failed: guest panicked: executor failed");
-        assert!(std::error::Error::source(&error).is_some());
+        assert!(error.source().is_some());
     }
 }

--- a/crates/sdk/src/network/error.rs
+++ b/crates/sdk/src/network/error.rs
@@ -69,7 +69,10 @@ mod tests {
             .context("guest panicked")
             .context(Error::SimulationFailed);
 
-        assert_eq!(error.to_string(), "Program simulation failed: guest panicked: executor failed");
+        assert_eq!(
+            format!("{error:#}"),
+            "Program simulation failed: guest panicked: executor failed"
+        );
         assert!(error.source().is_some());
     }
 }

--- a/crates/sdk/src/network/prover.rs
+++ b/crates/sdk/src/network/prover.rs
@@ -890,7 +890,7 @@ impl NetworkProver {
             .node
             .execute(elf, stdin.clone(), SP1Context::builder().calculate_gas(true).build())
             .await
-            .map_err(|_| Error::SimulationFailed)?;
+            .map_err(Error::SimulationFailed)?;
 
         let (_, committed_value_digest, report) = execute_result;
 

--- a/crates/sdk/src/network/prover.rs
+++ b/crates/sdk/src/network/prover.rs
@@ -890,7 +890,7 @@ impl NetworkProver {
             .node
             .execute(elf, stdin.clone(), SP1Context::builder().calculate_gas(true).build())
             .await
-            .map_err(Error::SimulationFailed)?;
+            .context(Error::SimulationFailed)?;
 
         let (_, committed_value_digest, report) = execute_result;
 


### PR DESCRIPTION
## Motivation

Network proof requests discard the underlying local simulation error and return only `Program simulation failed`. This makes guest panics and executor failures difficult to diagnose.

## Solution

Preserve the original `anyhow::Error` as the source of `SimulationFailed` and include its error chain in the displayed message. Add a unit test covering the resulting message and source.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [x] Breaking changes

`Error::SimulationFailed` changes from a unit variant to a tuple variant containing the source error.