### PR TITLE
fix(sdk): require HTTPS for bearer tokens

### DIFF
--- a/crates/sdk/src/blocking/network/builder.rs
+++ b/crates/sdk/src/blocking/network/builder.rs
@@ -161,6 +161,7 @@ impl NetworkProverBuilder {
     }
 
     /// Sets the bearer token added to Prover Network and Artifact Store requests.
+    /// Bearer tokens require an HTTPS RPC URL.
     #[must_use]
     pub fn bearer_token(mut self, bearer_token: NetworkBearerToken) -> Self {
         self.bearer_token = Some(bearer_token);

--- a/crates/sdk/src/network/builder.rs
+++ b/crates/sdk/src/network/builder.rs
@@ -185,6 +185,7 @@ impl NetworkProverBuilder {
     }
 
     /// Sets the bearer token added to Prover Network and Artifact Store requests.
+    /// Bearer tokens require an HTTPS RPC URL.
     #[must_use]
     pub fn bearer_token(mut self, bearer_token: NetworkBearerToken) -> Self {
         self.bearer_token = Some(bearer_token);

--- a/crates/sdk/src/network/client.rs
+++ b/crates/sdk/src/network/client.rs
@@ -915,8 +915,12 @@ impl NetworkClient {
         self.channel
             .get_or_try_init(|| async {
                 tracing::debug!(rpc_url = %self.rpc_url, "establishing gRPC channel");
-                Ok(grpc::configure_endpoint(&self.rpc_url, self.client_identity.clone())?
-                    .connect_lazy())
+                Ok(grpc::configure_endpoint(
+                    &self.rpc_url,
+                    self.client_identity.clone(),
+                    self.bearer_token.is_some(),
+                )?
+                .connect_lazy())
             })
             .await
             .cloned()

--- a/crates/sdk/src/network/grpc.rs
+++ b/crates/sdk/src/network/grpc.rs
@@ -5,10 +5,17 @@ use tonic::transport::{ClientTlsConfig, Endpoint, Identity};
 /// Configures the endpoint for the gRPC client.
 ///
 /// Sets reasonable settings to handle timeouts and keep-alive.
-pub fn configure_endpoint(addr: &str, identity: Option<Identity>) -> Result<Endpoint> {
+pub fn configure_endpoint(
+    addr: &str,
+    identity: Option<Identity>,
+    has_bearer_token: bool,
+) -> Result<Endpoint> {
     let has_identity = identity.is_some();
     if has_identity && !addr.starts_with("https://") {
         bail!("mTLS client identity requires an HTTPS RPC URL");
+    }
+    if has_bearer_token && !addr.starts_with("https://") {
+        bail!("bearer token requires an HTTPS RPC URL");
     }
 
     let mut endpoint = Endpoint::new(addr.to_string())?
@@ -64,28 +71,47 @@ dSxHF4iabbGMIRh5PCJzea9TuW0pcgiOFg==
     #[test]
     fn configures_standard_tls_without_client_identity() {
         let _ = rustls::crypto::ring::default_provider().install_default();
-        configure_endpoint("https://localhost", None).unwrap();
+        configure_endpoint("https://localhost", None, false).unwrap();
+    }
+
+    #[test]
+    fn configures_plaintext_without_credentials() {
+        configure_endpoint("http://localhost", None, false).unwrap();
     }
 
     #[test]
     fn configures_mtls_with_explicit_client_identity() {
         let _ = rustls::crypto::ring::default_provider().install_default();
         let identity = Identity::from_pem(TEST_CERT, TEST_KEY);
-        configure_endpoint("https://localhost", Some(identity)).unwrap();
+        configure_endpoint("https://localhost", Some(identity), false).unwrap();
     }
 
     #[test]
     fn rejects_invalid_client_identity() {
         let _ = rustls::crypto::ring::default_provider().install_default();
         let identity = Identity::from_pem("not a certificate", "not a key");
-        let err = configure_endpoint("https://localhost", Some(identity)).unwrap_err().to_string();
+        let err =
+            configure_endpoint("https://localhost", Some(identity), false).unwrap_err().to_string();
         assert!(err.contains("configuring mTLS client identity"));
     }
 
     #[test]
     fn rejects_client_identity_without_https() {
         let identity = Identity::from_pem(TEST_CERT, TEST_KEY);
-        let err = configure_endpoint("http://localhost", Some(identity)).unwrap_err().to_string();
+        let err =
+            configure_endpoint("http://localhost", Some(identity), false).unwrap_err().to_string();
         assert!(err.contains("requires an HTTPS RPC URL"));
+    }
+
+    #[test]
+    fn configures_bearer_token_over_https() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        configure_endpoint("https://localhost", None, true).unwrap();
+    }
+
+    #[test]
+    fn rejects_bearer_token_without_https() {
+        let err = configure_endpoint("http://localhost", None, true).unwrap_err().to_string();
+        assert!(err.contains("bearer token requires an HTTPS RPC URL"));
     }
 }


### PR DESCRIPTION
## Summary

* reject plaintext RPC URLs when a bearer token is configured
* preserve plaintext endpoints for clients without transport credential
* document the HTTPS requirement on the async and blocking network prover builders

## Motivation

`NetworkProverBuilder` supports both custom RPC URLs and bearer-token authentication. before this pr, combining a bearer token with an `http://` RPC URL caused the SDK to send the reusable `Authorization` credential over a plaintext HTTP/2 connection, so a malicious network observer would have been able to recover the token and use any privileges it grants until it expires or is refreshed..

the endpoint already requires HTTPS for mTLS client identities, so this change applies the same transport requirement to bearer tokens and returns an error before creating the plaintext connection.