### PR TITLE
fix(sdk): use reserved mode for private proving

### DIFF
--- a/crates/sdk/src/blocking/network/builder.rs
+++ b/crates/sdk/src/blocking/network/builder.rs
@@ -106,6 +106,7 @@ impl NetworkProverBuilder {
     #[must_use]
     pub fn private(mut self) -> Self {
         self.rpc_url = Some(TEE_NETWORK_RPC_URL.to_string());
+        self.network_mode = Some(NetworkMode::Reserved);
         self
     }
 
@@ -196,5 +197,18 @@ impl NetworkProverBuilder {
         };
         let prover = crate::blocking::block_on(async_builder.build());
         NetworkProver { prover }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_private_sets_reserved_mode() {
+        let builder = NetworkProverBuilder::new().private();
+
+        assert_eq!(builder.rpc_url, Some(TEE_NETWORK_RPC_URL.to_string()));
+        assert_eq!(builder.network_mode, Some(NetworkMode::Reserved));
     }
 }

--- a/crates/sdk/src/network/builder.rs
+++ b/crates/sdk/src/network/builder.rs
@@ -108,6 +108,7 @@ impl NetworkProverBuilder {
     #[must_use]
     pub fn private(mut self) -> Self {
         self.rpc_url = Some(TEE_NETWORK_RPC_URL.to_string());
+        self.network_mode = Some(NetworkMode::Reserved);
         self
     }
 
@@ -316,5 +317,13 @@ mod tests {
             .build()
             .await;
         assert!(prover.client.bearer_token.is_some());
+    }
+
+    #[test]
+    fn test_private_sets_reserved_mode() {
+        let builder = NetworkProverBuilder::new().private();
+
+        assert_eq!(builder.rpc_url, Some(TEE_NETWORK_RPC_URL.to_string()));
+        assert_eq!(builder.network_mode, Some(NetworkMode::Reserved));
     }
 }


### PR DESCRIPTION
## Motivation

`ProverClient::builder().network().private()` points the SDK at the TEE RPC URL, but it still left the network mode at the default value. With the default mainnet mode, proof requests use the auction path by default, and the private proving path rejects that because TEE proving only accepts reserved fulfillment.

## Solution

Set `NetworkMode::Reserved` when `.private()` is selected, in both the async and blocking network builders. Added small regression tests for both builders so the TEE RPC URL and network mode stay in sync.

## Checks

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p sp1-sdk test_private_sets_reserved_mode` could not complete locally because `protoc` is not available on PATH. The build stopped in `sp1-prover-types` before reaching these tests.
