### PR TITLE
chore(cli): use Rust 1.96 toolchain

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -9,7 +9,7 @@ use tokio::time::sleep;
 pub const RUSTUP_TOOLCHAIN_NAME: &str = "succinct";
 
 /// The latest version (github tag) of the toolchain that is supported by our build system.
-pub const LATEST_SUPPORTED_TOOLCHAIN_VERSION_TAG: &str = "succinct-1.94.0-64bit";
+pub const LATEST_SUPPORTED_TOOLCHAIN_VERSION_TAG: &str = "succinct-1.96.0-64bit-v2";
 
 pub const SP1_VERSION_MESSAGE: &str =
     concat!("sp1", " (", env!("VERGEN_GIT_SHA"), " ", env!("VERGEN_BUILD_TIMESTAMP"), ")");


### PR DESCRIPTION
## Summary

Update the CLI's shared toolchain tag to [`succinct-1.96.0-64bit-v2`](https://github.com/succinctlabs/rust/releases/tag/succinct-1.96.0-64bit-v2).
This selects Rust 1.96 for downloaded and source-built toolchains.
Existing CI and Docker builds use the same CLI selection.

## Motivation

Support guest dependencies that require Rust versions newer than the current Rust 1.94 compiler.
Keep the `succinct` toolchain name and installation commands unchanged.

## Validation

- Formatting, strict CLI Clippy, five CLI tests and three build-helper tests passed with host Rust 1.98.0.
- An isolated Linux installation through the changed CLI matched the published archive SHA256 and compiled `no_std` objects for RV32 and RV64.
- Full guest execution, proof tests and all-feature checks remain for the existing PR CI.
