### PR TITLE
ci: allow manual RunsOn environment selection

### DIFF
--- a/.github/scripts/check-runner-routing.rb
+++ b/.github/scripts/check-runner-routing.rb
@@ -1,0 +1,38 @@
+require "yaml"
+
+workflow = YAML.load_file(ARGV.fetch(0, ".github/workflows/pr.yml"))
+triggers = workflow.fetch("on") { workflow.fetch(true) }
+inputs = triggers.fetch("workflow_dispatch").fetch("inputs")
+raise "Default runner environment changed" unless inputs.fetch("runs_on_environment").fetch("default") == ""
+raise "Missing volume input" unless inputs.fetch("runs_on_volume").fetch("type") == "string"
+
+manual_group = "${{ github.event_name == 'workflow_dispatch' && format('-manual-{0}', inputs.runs_on_environment) || '' }}"
+raise "Manual runs can cancel ordinary CI" unless workflow.fetch("concurrency").fetch("group").end_with?(manual_group)
+
+jobs = workflow.fetch("jobs").select { |_, job| job.fetch("runs-on", "").start_with?("runs-on=") }
+raise "Expected all nine runner jobs" unless jobs.size == 9
+
+jobs.each do |name, job|
+  label = job.fetch("runs-on")
+  prefix = "runs-on=${{ github.run_id }}-${{ github.run_attempt }}-#{name}/"
+  raise "Missing job/attempt isolation: #{name}" unless label.start_with?(prefix)
+
+  gpu = name.start_with?("test-gpu")
+  arch = label.include?("linux-arm64") ? "arm64" : "x64"
+  selected = gpu ? "env={0}/volume={1}" : "env={0}/image=ubuntu22-full-#{arch}/volume={1}"
+  legacy = gpu ? "hdd=200" : "disk=large"
+  branch = "${{ inputs.runs_on_environment && format('#{selected}', inputs.runs_on_environment, inputs.runs_on_volume) || '#{legacy}' }}"
+  raise "Incorrect environment selection: #{name}" unless label.scan(branch).size == 1
+
+  default_label = label.sub(branch, legacy)
+  selected_label = label.sub(branch, selected.sub("{0}", "test-v3").sub("{1}", "200gb:gp3:750mbps:4000iops"))
+  raise "Default routing changed: #{name}" if default_label.include?("/env=") || default_label.include?("/volume=")
+  raise "Legacy storage used on v3: #{name}" if selected_label.match?(%r{/(disk|hdd)=})
+  raise "On-demand selection changed: #{name}" unless default_label.include?("/spot=false")
+  if gpu
+    raise "GPU type changed: #{name}" unless label.include?("/family=g6.4xlarge/")
+    raise "GPU image changed: #{name}" unless label.include?("/ami=ami-0a63dc9cb9e934ba3/")
+  end
+end
+
+puts "All nine job labels keep default routing and support isolated v3 selection."

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,20 +15,39 @@ on:
       - "Cargo.toml"
       - ".github/workflows/**"
       - ".github/actions/**"
+      - ".github/scripts/check-runner-routing.rb"
   merge_group:
+  workflow_dispatch:
+    inputs:
+      runs_on_environment:
+        description: "RunsOn v3 environment (empty keeps the default runners)"
+        type: string
+        default: ""
+      runs_on_volume:
+        description: "Root volume for the selected v3 environment"
+        type: string
+        default: "200gb:gp3:750mbps:4000iops"
 
 env:
   SP1_CI_IN_PROGRESS: "true"
   SP1_CIRCUIT_MODE: "release"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}${{ github.event_name == 'workflow_dispatch' && format('-manual-{0}', inputs.runs_on_environment) || '' }}
   cancel-in-progress: true
 
 jobs:
+  runner-routing:
+    name: Runner routing
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - run: ruby .github/scripts/check-runner-routing.rb
+
   test-x86:
     name: Test (x86-64)
-    runs-on: runs-on=${{ github.run_id }}-${{ github.run_attempt }}-test-x86/runner=64cpu-linux-x64/spot=false/disk=large
+    runs-on: runs-on=${{ github.run_id }}-${{ github.run_attempt }}-test-x86/runner=64cpu-linux-x64/spot=false/${{ inputs.runs_on_environment && format('env={0}/image=ubuntu22-full-x64/volume={1}', inputs.runs_on_environment, inputs.runs_on_volume) || 'disk=large' }}
     env:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
@@ -100,7 +119,7 @@ jobs:
 
   test-arm:
     name: Test (ARM)
-    runs-on: runs-on=${{ github.run_id }}-${{ github.run_attempt }}-test-arm/runner=64cpu-linux-arm64/spot=false/disk=large
+    runs-on: runs-on=${{ github.run_id }}-${{ github.run_attempt }}-test-arm/runner=64cpu-linux-arm64/spot=false/${{ inputs.runs_on_environment && format('env={0}/image=ubuntu22-full-arm64/volume={1}', inputs.runs_on_environment, inputs.runs_on_volume) || 'disk=large' }}
     env:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
@@ -167,7 +186,7 @@ jobs:
 
   test-verifier:
     name: Test Verifier Crate
-    runs-on: runs-on=${{ github.run_id }}-${{ github.run_attempt }}-test-verifier/runner=64cpu-linux-arm64/spot=false/disk=large
+    runs-on: runs-on=${{ github.run_id }}-${{ github.run_attempt }}-test-verifier/runner=64cpu-linux-arm64/spot=false/${{ inputs.runs_on_environment && format('env={0}/image=ubuntu22-full-arm64/volume={1}', inputs.runs_on_environment, inputs.runs_on_volume) || 'disk=large' }}
     env:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
@@ -212,7 +231,7 @@ jobs:
 
   lint:
     name: Formatting & Clippy
-    runs-on: runs-on=${{ github.run_id }}-${{ github.run_attempt }}-lint/runner=16cpu-linux-x64/disk=large/spot=false
+    runs-on: runs-on=${{ github.run_id }}-${{ github.run_attempt }}-lint/runner=16cpu-linux-x64/${{ inputs.runs_on_environment && format('env={0}/image=ubuntu22-full-x64/volume={1}', inputs.runs_on_environment, inputs.runs_on_volume) || 'disk=large' }}/spot=false
     env:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
@@ -251,7 +270,7 @@ jobs:
 
   check:
     name: Cargo Check
-    runs-on: runs-on=${{ github.run_id }}-${{ github.run_attempt }}-check/runner=16cpu-linux-x64/disk=large/spot=false
+    runs-on: runs-on=${{ github.run_id }}-${{ github.run_attempt }}-check/runner=16cpu-linux-x64/${{ inputs.runs_on_environment && format('env={0}/image=ubuntu22-full-x64/volume={1}', inputs.runs_on_environment, inputs.runs_on_volume) || 'disk=large' }}/spot=false
     env:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
       RUSTFLAGS: "--cfg sp1_debug_constraints"
@@ -292,7 +311,7 @@ jobs:
 
   check-nightly:
     name: Cargo Check (Nightly)
-    runs-on: runs-on=${{ github.run_id }}-${{ github.run_attempt }}-check-nightly/runner=16cpu-linux-x64/disk=large/spot=false
+    runs-on: runs-on=${{ github.run_id }}-${{ github.run_attempt }}-check-nightly/runner=16cpu-linux-x64/${{ inputs.runs_on_environment && format('env={0}/image=ubuntu22-full-x64/volume={1}', inputs.runs_on_environment, inputs.runs_on_volume) || 'disk=large' }}/spot=false
     env:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
@@ -333,7 +352,7 @@ jobs:
 
   examples:
     name: Examples
-    runs-on: runs-on=${{ github.run_id }}-${{ github.run_attempt }}-examples/runner=64cpu-linux-x64/disk=large/spot=false
+    runs-on: runs-on=${{ github.run_id }}-${{ github.run_attempt }}-examples/runner=64cpu-linux-x64/${{ inputs.runs_on_environment && format('env={0}/image=ubuntu22-full-x64/volume={1}', inputs.runs_on_environment, inputs.runs_on_volume) || 'disk=large' }}/spot=false
     env:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
@@ -447,7 +466,7 @@ jobs:
   # GPU Unit Tests
   test-gpu:
     name: Test (GPU)
-    runs-on: runs-on=${{ github.run_id }}-${{ github.run_attempt }}-test-gpu/family=g6.4xlarge/hdd=200/ami=ami-0a63dc9cb9e934ba3/spot=false
+    runs-on: runs-on=${{ github.run_id }}-${{ github.run_attempt }}-test-gpu/family=g6.4xlarge/${{ inputs.runs_on_environment && format('env={0}/volume={1}', inputs.runs_on_environment, inputs.runs_on_volume) || 'hdd=200' }}/ami=ami-0a63dc9cb9e934ba3/spot=false
     env:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
@@ -507,7 +526,7 @@ jobs:
   # GPU E2E Test
   test-gpu-e2e:
     name: GPU E2E (node)
-    runs-on: runs-on=${{ github.run_id }}-${{ github.run_attempt }}-test-gpu-e2e/family=g6.4xlarge/hdd=200/ami=ami-0a63dc9cb9e934ba3/spot=false
+    runs-on: runs-on=${{ github.run_id }}-${{ github.run_attempt }}-test-gpu-e2e/family=g6.4xlarge/${{ inputs.runs_on_environment && format('env={0}/volume={1}', inputs.runs_on_environment, inputs.runs_on_volume) || 'hdd=200' }}/ami=ami-0a63dc9cb9e934ba3/spot=false
     env:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:


### PR DESCRIPTION
## Summary

Allow manual PR-workflow runs to select a RunsOn v3 environment and root volume.
Selected runs use explicit volumes, retain the GPU type and AMI, and keep CPU jobs on Ubuntu 22.04.
Ordinary PR and push runs keep their existing labels, resources, and test commands.

## Motivation

This lets us test runner compatibility with the existing CI jobs.
Manual runs use a separate concurrency group so they cannot cancel ordinary CI.

## Validation

The routing check passed and rejected four broken-label mutations.
A comparison against main confirmed that the default path preserves all existing job steps and runner settings.
Actionlint found no new diagnostics; the existing deprecated cargo-action diagnostics remain.
Full CPU and GPU tests are delegated to PR CI.

## Caveats

The selected v3 path has not run on an actual runner yet.
The existing manual setup path skips sccache, so cache validation still needs a PR or push run.
