### PR TITLE
fix(sdk): classify malformed Groth16 exit codes correctly

### DIFF
--- a/crates/sdk/src/prover.rs
+++ b/crates/sdk/src/prover.rs
@@ -239,7 +239,7 @@ pub(crate) fn verify_proof(
 
         SP1Proof::Groth16(proof) => {
             let exit_code = BigUint::from_str(&proof.public_inputs[2])
-                .map_err(|e| SP1VerificationError::Plonk(anyhow::anyhow!(e)))?;
+                .map_err(|e| SP1VerificationError::Groth16(anyhow::anyhow!(e)))?;
 
             let exit_code_u32 =
                 u32::try_from(&exit_code).map_err(|_| SP1VerificationError::InvalidPublicValues)?;
@@ -260,4 +260,46 @@ pub(crate) fn verify_proof(
         SP1Proof::Plonk(_) => SP1VerificationError::Plonk(e),
         SP1Proof::Groth16(_) => SP1VerificationError::Groth16(e),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{LightProver, Prover, SP1PublicValues};
+    use sp1_hypercube::septic_digest::SepticDigest;
+    use sp1_hypercube::{MachineVerifyingKey, PrimeField32, UntrustedConfig};
+    use sp1_primitives::{SP1Field, SP1GlobalContext};
+    use sp1_prover::Groth16Bn254Proof;
+
+    #[tokio::test]
+    async fn malformed_groth16_exit_code_is_classified_as_groth16() {
+        let prover = LightProver::new().await;
+        let vkey = SP1VerifyingKey {
+            vk: MachineVerifyingKey::<SP1GlobalContext> {
+                pc_start: [SP1Field::zero(); 3],
+                initial_global_cumulative_sum: SepticDigest::zero(),
+                preprocessed_commit: [SP1Field::zero(); 8],
+                untrusted_config: UntrustedConfig::zero(),
+            },
+        };
+        let proof = SP1ProofWithPublicValues::new(
+            SP1Proof::Groth16(Groth16Bn254Proof {
+                public_inputs: [
+                    String::new(),
+                    String::new(),
+                    "invalid-exit-code".to_string(),
+                    String::new(),
+                    String::new(),
+                ],
+                encoded_proof: String::new(),
+                raw_proof: String::new(),
+                groth16_vkey_hash: [0; 32],
+            }),
+            SP1PublicValues::new(),
+            prover.version().to_string(),
+        );
+
+        let err = prover.verify(&proof, &vkey, None).unwrap_err();
+        assert!(matches!(err, SP1VerificationError::Groth16(_)));
+    }
 }


### PR DESCRIPTION
## Motivation

`verify_proof` parses the exit code from `public_inputs[2]` for Plonk and Groth16 proofs.

In the Groth16 branch, parsing errors are incorrectly mapped to `SP1VerificationError::Plonk` due to a copy-paste error. This causes callers to receive the wrong public error category when classifying verification failures.

This does not affect cryptographic verification correctness. It only affects the SDK's error classification and downstream logging, retry, and diagnostic logic.

## Solution

- Map malformed Groth16 exit-code parsing errors to `SP1VerificationError::Groth16`.
- Add a regression test that constructs a Groth16 proof with `public_inputs[2] = "invalid-exit-code"` and verifies that the SDK returns the `Groth16` error variant.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes